### PR TITLE
Legg til deploy-fil for kafka-manager

### DIFF
--- a/.nais/kafka-manager.yaml
+++ b/.nais/kafka-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: team-mulighetsrommet
 spec:
-  image: docker.pkg.github.com/navikt/kafka-manager/kafka-manager:2.2022.01.13_14.52-999e3c414924 # See https://github.com/navikt/kafka-manager/packages
+  image: docker.pkg.github.com/navikt/kafka-manager/kafka-manager:2.2021.05.31_08.41-622e72c02ee1 # See https://github.com/navikt/kafka-manager/packages
   port: 8080
   webproxy: true
   ingresses:
@@ -38,6 +38,8 @@ spec:
       claims:
         groups:
           - id: team-mulighetsrommet # Required for authorization
+  secureLogs:
+    enabled: true
   kafka: # Optional. Required for Aiven
     pool: nav-dev
   env:
@@ -50,6 +52,30 @@ spec:
               "location": "AIVEN",
               "keyDeserializerType": "STRING",
               "valueDeserializerType": "STRING"
-            }
+            },
+            {
+              "name": "teamarenanais.aapen-arena-tiltakdeltakerendret-v1-q2",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamarenanais.aapen-arena-tiltaksgruppeendret-v1-q2",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamarenanais.aapen-arena-tiltakendret-v1-q2",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamarenanais.aapen-arena-avtaleinfoendret-v1-q2",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
           ]
         }

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ Mulighetsrommet er en applikasjonsportfølje som skal hjelpe både brukere og ve
 | README          | https://github.com/navikt/mulighetsrommet/blob/dev/backend/README.md |
 | Url (dev-miljø) | https://mulighetsrommet-api.dev.intern.nav.no/                       |
 | API             | https://mulighetsrommet-api.dev.intern.nav.no/swagger-ui             |
+
+### `mulighetsrommet-kafka-manager`
+
+Denne kjøres kun opp ved egen kommando `kubectl apply -f .nais/mulighetsrommet-kafka-manager.yaml`. Se README for mer detaljer.
+| | |
+| --------------- | -------------------------------------------------------- |
+| README | https://github.com/navikt/kafka-manager |
+| Url (dev-miljø) | https://mulighetsrommet-kafka-manager.dev.intern.nav.no/ |


### PR DESCRIPTION
La til deployment-fil for `mulighetsrommet-kafka-manager`. Denne kjøres opp via kuberenets med `kubectl apply -f .nais/mulighetsrommet-kafka-manager.yaml`. Lagde en mappe `.nais` på rot-nivå, tok ikke stilling her og nå om vi skal flytte de andre deployment-filene opp hit. Det får vi ta i en egen oppgave.