### PR TITLE
Update kafka-manager.yaml

### DIFF
--- a/.nais/kafka-manager.yaml
+++ b/.nais/kafka-manager.yaml
@@ -38,7 +38,7 @@ spec:
       tenant: nav.no
       claims:
         groups:
-          - id: team-mulighetsrommet # Required for authorization
+          - id: 676673aa-ec8f-4606-8399-723dce26b361 # Required for authorization
   secureLogs:
     enabled: true
   kafka: # Optional. Required for Aiven


### PR DESCRIPTION
Hilsen Gård: Oppsettet til nais krever at man bruker object IDen til AAD, hvis man setter noe annet der så blir autoriseringen ignorert slik at alle på NAV har tilgang til å logge seg inn selv om manageren egentlig kun er ment for deres team