### PR TITLE
Feature/prepare for personflatefs

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/index.html
+++ b/frontend/mulighetsrommet-veileder-flate/index.html
@@ -24,7 +24,19 @@
       <div id="modal-a11y-wrapper">
         <div id="root"></div>
       </div>
+
       <script type="module" src="./src/index.tsx"></script>
+
+      <script type="module">
+        import ReactDOM from 'react-dom';
+        import React from 'react';
+        import Navspa from '@navikt/navspa';
+        import { APPLICATION_NAME } from './src/constants';
+
+        const MulighetsrommetVeilederFlate = Navspa.importer(APPLICATION_NAME);
+
+        ReactDOM.render(React.createElement(MulighetsrommetVeilederFlate), document.getElementById('root'));
+      </script>
     </main>
   </body>
 </html>

--- a/frontend/mulighetsrommet-veileder-flate/index.html
+++ b/frontend/mulighetsrommet-veileder-flate/index.html
@@ -21,7 +21,9 @@
       <img src="/internflate20211122.png" id="veilarbpersonflatefs-root" alt="veilarbpersonflate-bilde" />
     </header>
     <main id="applikasjon" class="app">
-      <div id="mulighetsrommet-root"></div>
+      <div id="modal-a11y-wrapper">
+        <div id="root"></div>
+      </div>
       <script type="module" src="./src/index.tsx"></script>
     </main>
   </body>

--- a/frontend/mulighetsrommet-veileder-flate/package.json
+++ b/frontend/mulighetsrommet-veileder-flate/package.json
@@ -7,6 +7,7 @@
     "build:labs": "cross-env VITE_DEV=true VITE_ENABLE_MOCK=true eslint && tsc && vite build",
     "clean": "rimraf build",
     "lint": "eslint src --ext .js,.ts,.tsx",
+    "prettier": "prettier --write 'src/**/*.ts{,x}'",
     "start": "cross-env VITE_ENABLE_MOCK=true VITE_BACKEND_API_ROOT='' vite",
     "backend": "cross-env VITE_DEV=true VITE_BACKEND_API_ROOT='http://localhost:8080' vite",
     "serve": "vite preview"

--- a/frontend/mulighetsrommet-veileder-flate/src/App.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/App.tsx
@@ -7,11 +7,12 @@ import Routes from './Routes';
 import 'react-toastify/dist/ReactToastify.css';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { Modal } from '@navikt/ds-react';
-
-const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false } } });
+import { MODAL_ACCESSIBILITY_WRAPPER } from './constants';
 
 // Trengs for at tab og fokus ikke skal gå utenfor modal når den er åpen.
-Modal.setAppElement?.('#mulighetsrommet-root');
+Modal.setAppElement?.(`#${MODAL_ACCESSIBILITY_WRAPPER}`);
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false } } });
 
 function App() {
   return (

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/InnsatsgruppeFilter.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/InnsatsgruppeFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Accordion, Alert, Checkbox, CheckboxGroup, Loader } from '@navikt/ds-react';
 import { useInnsatsgrupper } from '../../hooks/tiltakstype/useInnsatsgrupper';
-import { Innsatsgruppe } from "../../../../mulighetsrommet-api";
+import { Innsatsgruppe } from '../../../../mulighetsrommet-api';
 
 interface InnsatsgruppeFilterProps {
   innsatsgruppefilter: Innsatsgruppe[];

--- a/frontend/mulighetsrommet-veileder-flate/src/constants.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/constants.ts
@@ -1,0 +1,7 @@
+export const APPLICATION_NAME = 'mulighetsrommet-veileder-flate';
+
+/**
+ * The id references an HTML tag available through `veilarbpersonflatefs`, in which this application
+ * gets mounted.
+ */
+export const MODAL_ACCESSIBILITY_WRAPPER = 'modal-a11y-wrapper';

--- a/frontend/mulighetsrommet-veileder-flate/src/index.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import App from './App';
 import '@navikt/ds-css';
 import './index.less';
@@ -12,7 +11,6 @@ OpenAPI.BASE = String(import.meta.env.VITE_BACKEND_API_ROOT ?? '');
 
 if (import.meta.env.VITE_ENABLE_MOCK === 'true') {
   worker.start();
-  ReactDOM.render(<App />, document.getElementById('root'));
-} else {
-  Navspa.eksporter(APPLICATION_NAME, App);
 }
+
+Navspa.eksporter(APPLICATION_NAME, App);

--- a/frontend/mulighetsrommet-veileder-flate/src/index.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/index.tsx
@@ -6,12 +6,13 @@ import './index.less';
 import { OpenAPI } from 'mulighetsrommet-api';
 import Navspa from '@navikt/navspa';
 import { worker } from './mock/worker';
+import { APPLICATION_NAME } from './constants';
 
 OpenAPI.BASE = String(import.meta.env.VITE_BACKEND_API_ROOT ?? '');
 
 if (import.meta.env.VITE_ENABLE_MOCK === 'true') {
   worker.start();
-  ReactDOM.render(<App />, document.getElementById('mulighetsrommet-root'));
-// } else {
-//   Navspa.eksporter('mulighetsrommet-veileder-flate', App);
+  ReactDOM.render(<App />, document.getElementById('root'));
+} else {
+  Navspa.eksporter(APPLICATION_NAME, App);
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/entities/tiltakstype.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/entities/tiltakstype.ts
@@ -16,6 +16,6 @@ export function toTiltakstype(entity: TiltakstypeEntity): Tiltakstype {
     createdBy: entity.createdBy,
     createdAt: entity.createdAt,
     updatedBy: entity.updatedBy,
-    updatedAt: entity.updatedAt
+    updatedAt: entity.updatedAt,
   };
 }

--- a/frontend/mulighetsrommet-veileder-flate/vite.config.ts
+++ b/frontend/mulighetsrommet-veileder-flate/vite.config.ts
@@ -6,4 +6,8 @@ export default defineConfig({
   build: {
     manifest: 'asset-manifest.json',
   },
+  define: {
+    // Polyfill the window.global object used by `@navikt/navspa`
+    global: {},
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -36942,7 +36942,7 @@
         "node-forge": "^1.2.1",
         "nth-check": "^2.0.1",
         "postcss": "^8.4.6",
-        "prettier": "^2.5.1",
+        "prettier": "^2.6.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-collapse": "^5.1.0",


### PR DESCRIPTION
PR inneholder noen endringer i `vite` config som måtte på plass for å støtte navspa og veilarbpersonflatefs.

I tilleg blir `ReactDOM.render` nå kjørt fra `index.html` i stedet, og der blir applikasjonen lastet via navspa på omtrent samme måte som den blir gjennom veilarbpersonflatefs, det gjør at vi ikke trenger noen conditional renders i `src/index.tsx` basert på om det er lokal utvikling eller ikke.