### PR TITLE
Oppdatert mg-kafka til ktor 2.0.0 official

### DIFF
--- a/mulighetsrommet-kafka/build.gradle.kts
+++ b/mulighetsrommet-kafka/build.gradle.kts
@@ -40,7 +40,7 @@ repositories {
 }
 
 dependencies {
-    val ktorVersion = "2.0.0-beta-1"
+    val ktorVersion = "2.0.0"
     val kotestVersion = "5.2.2"
     val hopliteVersion = "1.4.16"
     implementation(project(":mulighetsrommet-domain"))


### PR DESCRIPTION
Oppdaterer `mulighetsrommet-kafka` Ktor til 2.0.0 siden den offisielt er ute. For `mulighetsrommet-api` venter vi fortsatt på at `koin` skal oppdatere sin støtte noe dem driver å loker med her: https://github.com/InsertKoinIO/koin/pull/1266#issuecomment-1101219247