### PR TITLE
Separer egene kafka/arena-endepunkter

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -48,5 +48,6 @@ fun Application.configure(config: AppConfig) {
         tiltakstypeRoutes()
         tiltaksgjennomforingRoutes()
         innsatsgruppeRoutes()
+        arenaRoutes()
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -4,6 +4,7 @@ import io.ktor.application.*
 import no.nav.mulighetsrommet.api.AppConfig
 import no.nav.mulighetsrommet.api.DatabaseConfig
 import no.nav.mulighetsrommet.api.database.Database
+import no.nav.mulighetsrommet.api.services.ArenaService
 import no.nav.mulighetsrommet.api.services.InnsatsgruppeService
 import no.nav.mulighetsrommet.api.services.TiltaksgjennomforingService
 import no.nav.mulighetsrommet.api.services.TiltakstypeService
@@ -27,6 +28,7 @@ private fun db(databaseConfig: DatabaseConfig): Module {
 }
 
 private fun services(logger: Logger) = module {
+    single { ArenaService(get(), logger) }
     single { TiltaksgjennomforingService(get(), logger) }
     single { TiltakstypeService(get(), logger) }
     single { InnsatsgruppeService(get(), logger) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/ArenaRoutes.kt
@@ -1,0 +1,66 @@
+package no.nav.mulighetsrommet.api.routes
+
+import io.ktor.application.call
+import io.ktor.http.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.mulighetsrommet.api.services.ArenaService
+import no.nav.mulighetsrommet.api.services.InnsatsgruppeService
+import no.nav.mulighetsrommet.api.services.TiltaksgjennomforingService
+import no.nav.mulighetsrommet.api.services.TiltakstypeService
+import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing
+import no.nav.mulighetsrommet.domain.Tiltakskode
+import no.nav.mulighetsrommet.domain.Tiltakstype
+import org.koin.ktor.ext.inject
+
+fun Route.arenaRoutes() {
+
+    val arenaService: ArenaService by inject()
+
+    post("/api/arena/tiltakstyper") {
+        runCatching {
+            val tiltakstype = call.receive<Tiltakstype>()
+            arenaService.createTiltakstype(tiltakstype)
+        }.onSuccess { createdTiltakstype ->
+            call.response.status(HttpStatusCode.Created)
+            call.respond(createdTiltakstype)
+        }.onFailure {
+            call.respondText("Kunne ikke opprette tiltakstype", status = HttpStatusCode.InternalServerError)
+        }
+    }
+    put("/api/arena/tiltakstyper/{tiltakskode}") {
+        runCatching {
+            val tiltakskode = Tiltakskode.valueOf(call.parameters["tiltakskode"]!!)
+            val tiltakstype = call.receive<Tiltakstype>()
+            arenaService.updateTiltakstype(tiltakskode, tiltakstype)
+        }.onSuccess { updatedTiltakstype ->
+            call.respond(updatedTiltakstype)
+        }.onFailure {
+            call.respondText("Kunne ikke oppdatere tiltakstype", status = HttpStatusCode.InternalServerError)
+        }
+    }
+    post("/api/arena/tiltaksgjennomforinger") {
+        runCatching {
+            val tiltaksgjennomforing = call.receive<Tiltaksgjennomforing>()
+            arenaService.createTiltaksgjennomforing(tiltaksgjennomforing)
+        }.onSuccess { createdTiltakstype ->
+            call.response.status(HttpStatusCode.Created)
+            call.respond(createdTiltakstype)
+        }.onFailure {
+            call.respondText("Kunne ikke opprette tiltaksgjennomføring", status = HttpStatusCode.InternalServerError)
+        }
+    }
+    put("/api/arena/tiltaksgjennomforinger/{arenaId}") {
+        runCatching {
+            val arenaId = call.parameters["id"]!!.toInt()
+            val tiltaksgjennomforing = call.receive<Tiltaksgjennomforing>()
+            arenaService.updateTiltaksgjennomforing(arenaId, tiltaksgjennomforing)
+        }.onSuccess { updatedTiltakstype ->
+            call.respond(updatedTiltakstype)
+        }.onFailure {
+            call.respondText("Kunne ikke oppdatere tiltaksgjennomføring", status = HttpStatusCode.InternalServerError)
+        }
+    }
+
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/ArenaRoutes.kt
@@ -44,20 +44,20 @@ fun Route.arenaRoutes() {
         runCatching {
             val tiltaksgjennomforing = call.receive<Tiltaksgjennomforing>()
             arenaService.createTiltaksgjennomforing(tiltaksgjennomforing)
-        }.onSuccess { createdTiltakstype ->
+        }.onSuccess { createdTiltaksgjennomforing ->
             call.response.status(HttpStatusCode.Created)
-            call.respond(createdTiltakstype)
+            call.respond(createdTiltaksgjennomforing)
         }.onFailure {
             call.respondText("Kunne ikke opprette tiltaksgjennomføring", status = HttpStatusCode.InternalServerError)
         }
     }
     put("/api/arena/tiltaksgjennomforinger/{arenaId}") {
         runCatching {
-            val arenaId = call.parameters["id"]!!.toInt()
+            val arenaId = call.parameters["arenaId"]!!.toInt()
             val tiltaksgjennomforing = call.receive<Tiltaksgjennomforing>()
             arenaService.updateTiltaksgjennomforing(arenaId, tiltaksgjennomforing)
-        }.onSuccess { updatedTiltakstype ->
-            call.respond(updatedTiltakstype)
+        }.onSuccess { updatedTiltaksgjennomforing ->
+            call.respond(updatedTiltaksgjennomforing)
         }.onFailure {
             call.respondText("Kunne ikke oppdatere tiltaksgjennomføring", status = HttpStatusCode.InternalServerError)
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
@@ -2,7 +2,7 @@ package no.nav.mulighetsrommet.api.services
 
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.database.Database
-import no.nav.mulighetsrommet.api.utils.DatabaseUtils
+import no.nav.mulighetsrommet.api.utils.DatabaseMapper
 import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.Tiltakskode
 import no.nav.mulighetsrommet.domain.Tiltakstype
@@ -22,7 +22,7 @@ class ArenaService(private val db: Database, private val logger: Logger) {
             tiltakstype.tiltakskode.name,
             tiltakstype.fraDato,
             tiltakstype.tilDato
-        ).asExecute.query.map { DatabaseUtils.toTiltakstype(it) }.asSingle
+        ).asExecute.query.map { DatabaseMapper.toTiltakstype(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 
@@ -38,7 +38,7 @@ class ArenaService(private val db: Database, private val logger: Logger) {
             tiltakstype.fraDato,
             tiltakstype.tilDato,
             tiltakskode.name
-        ).asExecute.query.map { DatabaseUtils.toTiltakstype(it) }.asSingle
+        ).asExecute.query.map { DatabaseMapper.toTiltakstype(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 
@@ -57,7 +57,7 @@ class ArenaService(private val db: Database, private val logger: Logger) {
             tiltaksgjennomforing.fraDato,
             tiltaksgjennomforing.tilDato,
             tiltaksgjennomforing.sakId
-        ).asExecute.query.map { DatabaseUtils.toTiltaksgjennomforing(it) }.asSingle
+        ).asExecute.query.map { DatabaseMapper.toTiltaksgjennomforing(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 
@@ -74,7 +74,7 @@ class ArenaService(private val db: Database, private val logger: Logger) {
             tiltaksgjennomforing.fraDato,
             tiltaksgjennomforing.tilDato,
             arenaId
-        ).asExecute.query.map { DatabaseUtils.toTiltaksgjennomforing(it) }.asSingle
+        ).asExecute.query.map { DatabaseMapper.toTiltaksgjennomforing(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/InnsatsgruppeService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/InnsatsgruppeService.kt
@@ -3,6 +3,7 @@ package no.nav.mulighetsrommet.api.services
 import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.database.Database
+import no.nav.mulighetsrommet.api.utils.DatabaseUtils
 import no.nav.mulighetsrommet.domain.Innsatsgruppe
 import org.slf4j.Logger
 
@@ -12,13 +13,7 @@ class InnsatsgruppeService(private val db: Database, private val logger: Logger)
         val query = """
             select id, tittel, beskrivelse from innsatsgruppe
         """.trimIndent()
-        val queryResult = queryOf(query).map { toInnsatsgruppe(it) }.asList
+        val queryResult = queryOf(query).map { DatabaseUtils.toInnsatsgruppe(it) }.asList
         return db.session.run(queryResult)
     }
-
-    private fun toInnsatsgruppe(row: Row): Innsatsgruppe = Innsatsgruppe(
-        id = row.int("id"),
-        tittel = row.string("tittel"),
-        beskrivelse = row.string("beskrivelse")
-    )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/InnsatsgruppeService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/InnsatsgruppeService.kt
@@ -1,9 +1,8 @@
 package no.nav.mulighetsrommet.api.services
 
-import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.database.Database
-import no.nav.mulighetsrommet.api.utils.DatabaseUtils
+import no.nav.mulighetsrommet.api.utils.DatabaseMapper
 import no.nav.mulighetsrommet.domain.Innsatsgruppe
 import org.slf4j.Logger
 
@@ -13,7 +12,7 @@ class InnsatsgruppeService(private val db: Database, private val logger: Logger)
         val query = """
             select id, tittel, beskrivelse from innsatsgruppe
         """.trimIndent()
-        val queryResult = queryOf(query).map { DatabaseUtils.toInnsatsgruppe(it) }.asList
+        val queryResult = queryOf(query).map { DatabaseMapper.toInnsatsgruppe(it) }.asList
         return db.session.run(queryResult)
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -1,9 +1,8 @@
 package no.nav.mulighetsrommet.api.services
 
-import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.database.Database
-import no.nav.mulighetsrommet.api.utils.DatabaseUtils
+import no.nav.mulighetsrommet.api.utils.DatabaseMapper
 import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.Tiltakskode
 import org.slf4j.Logger
@@ -14,7 +13,7 @@ class TiltaksgjennomforingService(private val db: Database, private val logger: 
         val query = """
             select id, tittel, beskrivelse, tiltaksnummer, tiltakskode, fra_dato, til_dato from tiltaksgjennomforing where tiltakskode::text = ?
         """.trimIndent()
-        val queryResult = queryOf(query, tiltakskode.name).map { DatabaseUtils.toTiltaksgjennomforing(it) }.asList
+        val queryResult = queryOf(query, tiltakskode.name).map { DatabaseMapper.toTiltaksgjennomforing(it) }.asList
         return db.session.run(queryResult)
     }
 
@@ -22,7 +21,7 @@ class TiltaksgjennomforingService(private val db: Database, private val logger: 
         val query = """
             select id, tittel, beskrivelse, tiltaksnummer, tiltakskode, fra_dato, til_dato from tiltaksgjennomforing where id = ?
         """.trimIndent()
-        val queryResult = queryOf(query, id).map { DatabaseUtils.toTiltaksgjennomforing(it) }.asSingle
+        val queryResult = queryOf(query, id).map { DatabaseMapper.toTiltaksgjennomforing(it) }.asSingle
         return db.session.run(queryResult)
     }
 
@@ -30,7 +29,7 @@ class TiltaksgjennomforingService(private val db: Database, private val logger: 
         val query = """
             select id, tittel, beskrivelse, tiltaksnummer, tiltakskode, fra_dato, til_dato from tiltaksgjennomforing
         """.trimIndent()
-        val queryResult = queryOf(query).map { DatabaseUtils.toTiltaksgjennomforing(it) }.asList
+        val queryResult = queryOf(query).map { DatabaseMapper.toTiltaksgjennomforing(it) }.asList
         return db.session.run(queryResult)
     }
 
@@ -49,7 +48,7 @@ class TiltaksgjennomforingService(private val db: Database, private val logger: 
             tiltaksgjennomforing.fraDato,
             tiltaksgjennomforing.tilDato,
             tiltaksgjennomforing.sakId
-        ).asExecute.query.map { DatabaseUtils.toTiltaksgjennomforing(it) }.asSingle
+        ).asExecute.query.map { DatabaseMapper.toTiltaksgjennomforing(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 
@@ -66,7 +65,7 @@ class TiltaksgjennomforingService(private val db: Database, private val logger: 
             tiltaksgjennomforing.fraDato,
             tiltaksgjennomforing.tilDato,
             arenaId
-        ).asExecute.query.map { DatabaseUtils.toTiltaksgjennomforing(it) }.asSingle
+        ).asExecute.query.map { DatabaseMapper.toTiltaksgjennomforing(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
@@ -1,9 +1,8 @@
 package no.nav.mulighetsrommet.api.services
 
-import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.database.Database
-import no.nav.mulighetsrommet.api.utils.DatabaseUtils
+import no.nav.mulighetsrommet.api.utils.DatabaseMapper
 import no.nav.mulighetsrommet.domain.Tiltakskode
 import no.nav.mulighetsrommet.domain.Tiltakstype
 import org.slf4j.Logger
@@ -14,7 +13,7 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
         val query = """
             select id, navn, innsatsgruppe_id, sanity_id, tiltakskode, fra_dato, til_dato from tiltakstype where tiltakskode::text = ?
         """.trimIndent()
-        val queryResult = queryOf(query, tiltakskode.name).map { DatabaseUtils.toTiltakstype(it) }.asSingle
+        val queryResult = queryOf(query, tiltakskode.name).map { DatabaseMapper.toTiltakstype(it) }.asSingle
         return db.session.run(queryResult)
     }
 
@@ -30,7 +29,7 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
             tiltakstype.tiltakskode.name,
             tiltakstype.fraDato,
             tiltakstype.tilDato
-        ).asExecute.query.map { DatabaseUtils.toTiltakstype(it) }.asSingle
+        ).asExecute.query.map { DatabaseMapper.toTiltakstype(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 
@@ -46,7 +45,7 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
             tiltakstype.fraDato,
             tiltakstype.tilDato,
             tiltakskode.name
-        ).asExecute.query.map { DatabaseUtils.toTiltakstype(it) }.asSingle
+        ).asExecute.query.map { DatabaseMapper.toTiltakstype(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 
@@ -58,7 +57,7 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
             .andWhere(searchQuery, "(lower(navn) like lower(:navn))")
             .trimIndent()
         val queryResult = queryOf(query, mapOf("innsatsgruppe_id" to innsatsgruppe, "navn" to "%$searchQuery%")).map {
-            DatabaseUtils.toTiltakstype(it)
+            DatabaseMapper.toTiltakstype(it)
         }.asList
         return db.session.run(queryResult)
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
@@ -3,6 +3,7 @@ package no.nav.mulighetsrommet.api.services
 import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.database.Database
+import no.nav.mulighetsrommet.api.utils.DatabaseUtils
 import no.nav.mulighetsrommet.domain.Tiltakskode
 import no.nav.mulighetsrommet.domain.Tiltakstype
 import org.slf4j.Logger
@@ -13,7 +14,7 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
         val query = """
             select id, navn, innsatsgruppe_id, sanity_id, tiltakskode, fra_dato, til_dato from tiltakstype where tiltakskode::text = ?
         """.trimIndent()
-        val queryResult = queryOf(query, tiltakskode.name).map { toTiltakstype(it) }.asSingle
+        val queryResult = queryOf(query, tiltakskode.name).map { DatabaseUtils.toTiltakstype(it) }.asSingle
         return db.session.run(queryResult)
     }
 
@@ -29,7 +30,7 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
             tiltakstype.tiltakskode.name,
             tiltakstype.fraDato,
             tiltakstype.tilDato
-        ).asExecute.query.map { toTiltakstype(it) }.asSingle
+        ).asExecute.query.map { DatabaseUtils.toTiltakstype(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 
@@ -45,7 +46,7 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
             tiltakstype.fraDato,
             tiltakstype.tilDato,
             tiltakskode.name
-        ).asExecute.query.map { toTiltakstype(it) }.asSingle
+        ).asExecute.query.map { DatabaseUtils.toTiltakstype(it) }.asSingle
         return db.session.run(queryResult)!!
     }
 
@@ -57,7 +58,7 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
             .andWhere(searchQuery, "(lower(navn) like lower(:navn))")
             .trimIndent()
         val queryResult = queryOf(query, mapOf("innsatsgruppe_id" to innsatsgruppe, "navn" to "%$searchQuery%")).map {
-            toTiltakstype(it)
+            DatabaseUtils.toTiltakstype(it)
         }.asList
         return db.session.run(queryResult)
     }
@@ -75,15 +76,4 @@ class TiltakstypeService(private val db: Database, private val logger: Logger) {
             }
         }
     }
-
-    private fun toTiltakstype(row: Row): Tiltakstype =
-        Tiltakstype(
-            id = row.int("id"),
-            navn = row.string("navn"),
-            innsatsgruppe = row.int("innsatsgruppe_id"),
-            sanityId = row.intOrNull("sanity_id"),
-            tiltakskode = Tiltakskode.valueOf(row.string("tiltakskode")),
-            fraDato = row.localDateTime("fra_dato"),
-            tilDato = row.localDateTime("til_dato"),
-        )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/DatabaseMapper.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/DatabaseMapper.kt
@@ -6,7 +6,7 @@ import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.Tiltakskode
 import no.nav.mulighetsrommet.domain.Tiltakstype
 
-object DatabaseUtils {
+object DatabaseMapper {
 
     fun toTiltakstype(row: Row): Tiltakstype =
         Tiltakstype(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/DatabaseUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/DatabaseUtils.kt
@@ -1,0 +1,41 @@
+package no.nav.mulighetsrommet.api.utils
+
+import kotliquery.Row
+import no.nav.mulighetsrommet.domain.Innsatsgruppe
+import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing
+import no.nav.mulighetsrommet.domain.Tiltakskode
+import no.nav.mulighetsrommet.domain.Tiltakstype
+
+object DatabaseUtils {
+
+    fun toTiltakstype(row: Row): Tiltakstype =
+        Tiltakstype(
+            id = row.int("id"),
+            navn = row.string("navn"),
+            innsatsgruppe = row.int("innsatsgruppe_id"),
+            sanityId = row.intOrNull("sanity_id"),
+            tiltakskode = Tiltakskode.valueOf(row.string("tiltakskode")),
+            fraDato = row.localDateTime("fra_dato"),
+            tilDato = row.localDateTime("til_dato"),
+        )
+
+    fun toTiltaksgjennomforing(row: Row): Tiltaksgjennomforing =
+        Tiltaksgjennomforing(
+            id = row.int("id"),
+            navn = row.string("navn"),
+            tiltaksnummer = row.int("tiltaksnummer"),
+            arrangorId = row.intOrNull("arrangor_id"),
+            tiltakskode = Tiltakskode.valueOf(row.string("tiltakskode")),
+            arenaId = row.int("arena_id"),
+            sanityId = row.intOrNull("sanity_id"),
+            fraDato = row.localDateTimeOrNull("fra_dato"),
+            tilDato = row.localDateTimeOrNull("til_dato"),
+            sakId = row.int("sak_id")
+        )
+
+    fun toInnsatsgruppe(row: Row): Innsatsgruppe = Innsatsgruppe(
+        id = row.int("id"),
+        tittel = row.string("tittel"),
+        beskrivelse = row.string("beskrivelse")
+    )
+}

--- a/mulighetsrommet-kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/consumers/TiltakEndretConsumer.kt
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory
 class TiltakEndretConsumer(private val client: MulighetsrommetApiClient) {
 
     private val logger = LoggerFactory.getLogger(TiltakEndretConsumer::class.java)
-    private var resourceUri = "/api/tiltakstyper"
+    private var resourceUri = "/api/arena/tiltakstyper"
 
     fun process(payload: JsonElement) {
         if (isInsertArenaOperation(payload.jsonObject)) handleInsert(payload.jsonObject) else handleUpdate(payload.jsonObject)

--- a/mulighetsrommet-kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory
 class TiltakgjennomforingEndretConsumer(private val client: MulighetsrommetApiClient) {
 
     private val logger = LoggerFactory.getLogger(TiltakgjennomforingEndretConsumer::class.java)
-    private var resourceUri = "/api/tiltaksgjennomforinger"
+    private var resourceUri = "/api/arena/tiltaksgjennomforinger"
 
     fun process(payload: JsonElement) {
         if (isInsertArenaOperation(payload.jsonObject)) handleInsert(payload.jsonObject) else handleUpdate(payload.jsonObject)


### PR DESCRIPTION
Separerer endepunktene i en egen arena route handler og service så det blir enklere å skille arena-spesifikke quirks fra vårt eget API.