### PR TITLE
Fikser skriveleif, og oppdaterer .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ gradle-app.setting
 
 # Cache of project
 .gradletasknamecache
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ Enn så lenge benytter vi følgende tooling for å kjøre tasks for henholdsvis 
 For å gjøre noen rutineoppgaver enklere er det mulig å installere følgende git hooks på eget initiativ (ikke en komplett liste, blir oppdatert etter hvert som behovet oppstår):
 
 - Installasjon av pre-commit hook for å kjøre `ktlintFormat` på endrede filer: Kjør kommando `./gradlew addKtlintFormatGitPreCommitHook`
-- Installasjon av pre-commit hook for å kjøre `ktlintCheck` på endrede filer: Kjør kommando `./gradlew waddKtlintCheckGitPreCommitHook`
+- Installasjon av pre-commit hook for å kjøre `ktlintCheck` på endrede filer: Kjør kommando `./gradlew addKtlintCheckGitPreCommitHook`
 

--- a/mulighetsrommet-api/README.md
+++ b/mulighetsrommet-api/README.md
@@ -39,7 +39,7 @@ bruke [sdkman](https://sdkman.io/install).
 
 ### Docker
 
-Vår database kjører i en docker container og da må `docker` og `docker-compose` være installert (Captian Obvious). For å
+Vår database kjører i en docker container og da må `docker` og `docker-compose` være installert (Captain Obvious). For å
 installere disse kan du følge oppskriften på [Dockers](https://www.docker.com/) offisielle side. For installering på Mac
 trykk [her](https://docs.docker.com/desktop/mac/install/) eller
 trykk [her](https://docs.docker.com/engine/install/ubuntu/) for Ubuntu.

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/AuthenticationTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/AuthenticationTest.kt
@@ -41,7 +41,7 @@ class AuthenticationTest : FunSpec({
             withMulighetsrommetApp(oauth) {
 
                 val response = client.get("/api/innsatsgrupper") {
-                    header(HttpHeaders.Authorization, "Bearer ${oauth.issueToken(issuerId = "skatteetaten").serialize()}") // TODO Skulle denne vært issuerId istedenfor audience? Tester vel ellers det samme som metoden over
+                    header(HttpHeaders.Authorization, "Bearer ${oauth.issueToken(issuerId = "skatteetaten").serialize()}")
                 }
                 response.status shouldBe HttpStatusCode.Unauthorized
             }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/AuthenticationTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/AuthenticationTest.kt
@@ -41,7 +41,7 @@ class AuthenticationTest : FunSpec({
             withMulighetsrommetApp(oauth) {
 
                 val response = client.get("/api/innsatsgrupper") {
-                    header(HttpHeaders.Authorization, "Bearer ${oauth.issueToken(audience = "skatteetaten").serialize()}")
+                    header(HttpHeaders.Authorization, "Bearer ${oauth.issueToken(issuerId = "skatteetaten").serialize()}") // TODO Skulle denne vært issuerId istedenfor audience? Tester vel ellers det samme som metoden over
                 }
                 response.status shouldBe HttpStatusCode.Unauthorized
             }


### PR DESCRIPTION
For å kjøre `docker-compose` på M1-mac måtte jeg legge til en `docker-compose.override.yml` som ser slik ut 

```yml
# Override-fil for M1-chip for nye Mac'er
services:
 zookeeper:
  platform: linux/amd64
 kafka:
  platform: linux/amd64
  ```
  
  Har valgt å legge den i .gitignore siden de som ikke har M1-mac'er ikke skal få overridet sine innstillinger. 
  
Fikser også kommando i readme for å legge til `addKtlintFormatGitPreCommitHook` som hadde en `w` foran seg, og som dermed ikke fungerte.
  
  Oppdaterer også en test jeg antar er litt "feil" da den er identisk med testen over, så vil tro det er litt copy-paste bare. 
  
  Fikser også en liten skriveleif fra Captian -> Captain