### PR TITLE
Endrer kolonne 'navn' i tbl 'tiltakstype'

### DIFF
--- a/mulighetsrommet-api/src/main/resources/db/migration/V28__alter_tiltakstype_varchar_to_text.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V28__alter_tiltakstype_varchar_to_text.sql
@@ -1,0 +1,2 @@
+alter table tiltakstype
+alter column navn type text;


### PR DESCRIPTION
Endrer typen for kolonne `navn` fra `varchar(500` til `text`.

Kjørt migrering lokalt. Alt ok.