### PR TITLE
Skrur av videoopptak i Cypress.json

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress.json
+++ b/frontend/mulighetsrommet-veileder-flate/cypress.json
@@ -11,5 +11,6 @@
     "componentFolder": "src",
     "testFiles": ".*/__tests__/.*spec.tsx"
   },
+  "video": false,
   "videoUploadOnPasses": false
 }


### PR DESCRIPTION
Siden vi ikke får 4k HDR-opptak med Dolby Atmos-lyd velger vi å skru av video-opptak fra Cypress. Skrur det på igjen når vi får Cypress-testene i 3d-format.