### PR TITLE
Feature/reduce duplication in events table

### DIFF
--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Application.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Application.kt
@@ -30,15 +30,14 @@ fun main() {
 
     val kafkaPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties(app.kafka.consumerGroupId)
 
-    val kafka = KafkaConsumerOrchestrator(
-        app.kafka,
-        kafkaPreset,
-        Database(app.database),
-        TiltakEndretConsumer(api),
-        TiltakgjennomforingEndretConsumer(api),
-        TiltakdeltakerEndretConsumer(api),
-        SakEndretConsumer(api)
+    val consumers = listOf(
+        TiltakEndretConsumer(app.kafka.getTopic("tiltakendret"), api),
+        TiltakgjennomforingEndretConsumer(app.kafka.getTopic("tiltakgjennomforingendret"), api),
+        TiltakdeltakerEndretConsumer(app.kafka.getTopic("tiltakdeltakerendret"), api),
+        SakEndretConsumer(app.kafka.getTopic("sakendret"), api)
     )
+
+    val kafka = KafkaConsumerOrchestrator(kafkaPreset, Database(app.database), consumers)
 
     initializeServer(server) {
         configure(app, kafka)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.arena.adapter
 
 import com.sksamuel.hoplite.Masked
+import java.lang.RuntimeException
 
 data class Config(
     val server: ServerConfig,
@@ -42,6 +43,12 @@ data class KafkaConfig(
     val consumerGroupId: String,
     val topics: TopicsConfig
 )
+
+fun KafkaConfig.getTopic(key: String): String {
+    return topics.consumer.getOrElse(key) {
+        throw RuntimeException("No topic configured for key '$key'")
+    }
+}
 
 data class TopicsConfig(
     val consumer: Map<String, String>

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Database.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Database.kt
@@ -36,12 +36,16 @@ class Database(databaseConfig: DatabaseConfig) {
         flyway.migrate()
     }
 
-    fun persistKafkaEvent(topic: String, key: String, partition: Int, offset: Long, payload: String) {
+    fun persistKafkaEvent(topic: String, key: String, payload: String) {
         @Language("PostgreSQL")
         val query = """
-            insert into events(topic, key, partition, record_offset, payload) values (?, ?, ?, ?, ?::jsonb) on conflict do nothing
+            insert into events(topic, key, payload)
+            values (?, ?, ?::jsonb)
+            on conflict (topic, key)
+            do update set
+                payload = excluded.payload
         """.trimIndent()
-        session.run(queryOf(query, topic, key, partition, offset, payload).asUpdate)
-        logger.debug("Persisted kafka event: $topic:$partition:$offset:$key")
+        session.run(queryOf(query, topic, key, payload).asUpdate)
+        logger.debug("Persisted kafka event: $topic:$key")
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Database.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Database.kt
@@ -6,6 +6,7 @@ import kotliquery.Session
 import kotliquery.queryOf
 import kotliquery.sessionOf
 import org.flywaydb.core.Flyway
+import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 
 class Database(databaseConfig: DatabaseConfig) {
@@ -36,8 +37,9 @@ class Database(databaseConfig: DatabaseConfig) {
     }
 
     fun persistKafkaEvent(topic: String, key: String, partition: Int, offset: Long, payload: String) {
+        @Language("PostgreSQL")
         val query = """
-            insert into events(topic, key, partition, record_offset, payload) values(?, ?, ?, ?, ? ::jsonb) on conflict do nothing
+            insert into events(topic, key, partition, record_offset, payload) values (?, ?, ?, ?, ?::jsonb) on conflict do nothing
         """.trimIndent()
         session.run(queryOf(query, topic, key, partition, offset, payload).asUpdate)
         logger.debug("Persisted kafka event: $topic:$partition:$offset:$key")

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/KafkaConsumerOrchestrator.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/KafkaConsumerOrchestrator.kt
@@ -8,29 +8,21 @@ import no.nav.common.kafka.consumer.feilhandtering.util.KafkaConsumerRecordProce
 import no.nav.common.kafka.consumer.util.ConsumerUtils.findConsumerConfigsWithStoreOnFailure
 import no.nav.common.kafka.consumer.util.KafkaConsumerClientBuilder
 import no.nav.common.kafka.consumer.util.deserializer.Deserializers.stringDeserializer
-import no.nav.mulighetsrommet.arena.adapter.consumers.SakEndretConsumer
-import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakEndretConsumer
-import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakdeltakerEndretConsumer
-import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakgjennomforingEndretConsumer
+import no.nav.mulighetsrommet.arena.adapter.consumers.TopicConsumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.function.Consumer
 
 class KafkaConsumerOrchestrator(
-    config: KafkaConfig,
     consumerPreset: Properties,
     private val db: Database,
-    private val tiltakEndretConsumer: TiltakEndretConsumer,
-    private val tiltakgjennomforingEndretConsumer: TiltakgjennomforingEndretConsumer,
-    private val tiltakdeltakerEndretConsumer: TiltakdeltakerEndretConsumer,
-    private val sakEndretConsumer: SakEndretConsumer
+    private val consumers: List<TopicConsumer>
 ) {
 
     private val logger = LoggerFactory.getLogger(KafkaConsumerOrchestrator::class.java)
     private val consumerClient: KafkaConsumerClient
     private val consumerRecordProcessor: KafkaConsumerRecordProcessor
-    private val consumerTopics: Map<String, String> = config.topics.consumer
 
     init {
         logger.debug("Initializing Kafka")
@@ -73,30 +65,30 @@ class KafkaConsumerOrchestrator(
     }
 
     private fun configureConsumersTopics(repository: KafkaConsumerRepository): List<KafkaConsumerClientBuilder.TopicConfig<String, String>> {
-        return consumerTopics.map { topic ->
+        return consumers.map { consumer ->
             KafkaConsumerClientBuilder.TopicConfig<String, String>()
                 .withStoreOnFailure(repository)
                 .withLogging()
                 .withConsumerConfig(
-                    topic.value,
+                    consumer.topic,
                     stringDeserializer(),
                     stringDeserializer(),
-                    Consumer<ConsumerRecord<String, String>> {
-                        db.persistKafkaEvent(it.topic(), it.key(), it.partition(), it.offset(), it.value())
-                        topicMapper(it.topic(), it.value())
+                    Consumer<ConsumerRecord<String, String>> { event ->
+                        val payload = Json.parseToJsonElement(event.value())
+                        val key = consumer.resolveKey(payload)
+                        if (consumer.shouldProcessEvent(payload)) {
+                            db.persistKafkaEvent(
+                                event.topic(),
+                                key,
+                                event.partition(),
+                                event.offset(),
+                                event.value()
+                            )
+
+                            consumer.processEvent(payload)
+                        }
                     }
                 )
-        }
-    }
-
-    private fun topicMapper(topic: String, value: String) {
-        val payload = Json.parseToJsonElement(value)
-        when (topic) {
-            consumerTopics["tiltakendret"] -> tiltakEndretConsumer.process(payload)
-            consumerTopics["tiltakgjennomforingendret"] -> tiltakgjennomforingEndretConsumer.process(payload)
-            consumerTopics["tiltakdeltakerendret"] -> tiltakdeltakerEndretConsumer.process(payload)
-            consumerTopics["sakendret"] -> sakEndretConsumer.process(payload)
-            else -> logger.info("Klarte ikke å mappe topic. Ukjent topic: $topic")
         }
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/KafkaConsumerOrchestrator.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/KafkaConsumerOrchestrator.kt
@@ -80,8 +80,6 @@ class KafkaConsumerOrchestrator(
                             db.persistKafkaEvent(
                                 event.topic(),
                                 key,
-                                event.partition(),
-                                event.offset(),
                                 event.value()
                             )
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/KafkaConsumerRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/KafkaConsumerRepository.kt
@@ -5,31 +5,30 @@ import kotliquery.queryOf
 import no.nav.common.kafka.consumer.feilhandtering.KafkaConsumerRepository
 import no.nav.common.kafka.consumer.feilhandtering.StoredConsumerRecord
 import org.apache.kafka.common.TopicPartition
+import org.intellij.lang.annotations.Language
 
-class KafkaConsumerRepository(private val db: Database) :
-    KafkaConsumerRepository {
+class KafkaConsumerRepository(private val db: Database) : KafkaConsumerRepository {
     override fun storeRecord(record: StoredConsumerRecord): Long {
-        return try {
-            val query = """
-                insert into failed_events (topic, partition, record_offset, key, value, headers_json, record_timestamp) values (?, ?, ?, ?, ?, ?, ?)
-            """.trimIndent()
-            val queryResult = queryOf(
-                query,
-                record.topic,
-                record.partition,
-                record.offset,
-                record.key,
-                record.value,
-                record.headersJson,
-                record.timestamp
-            ).asUpdateAndReturnGeneratedKey
-            db.session.run(queryResult)!!
-        } catch (e: Exception) {
-            -1
-        }
+        @Language("PostgreSQL")
+        val query = """
+            insert into failed_events (topic, partition, record_offset, key, value, headers_json, record_timestamp)
+            values (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+        val queryResult = queryOf(
+            query,
+            record.topic,
+            record.partition,
+            record.offset,
+            record.key,
+            record.value,
+            record.headersJson,
+            record.timestamp
+        ).asUpdateAndReturnGeneratedKey
+        return db.session.run(queryResult)!!
     }
 
     override fun deleteRecords(ids: MutableList<Long>) {
+        @Language("PostgreSQL")
         val query = """
             delete from failed_events where id = any(?)
         """.trimIndent()
@@ -42,18 +41,18 @@ class KafkaConsumerRepository(private val db: Database) :
     }
 
     override fun hasRecordWithKey(topic: String, partition: Int, key: ByteArray): Boolean {
-
+        @Language("PostgreSQL")
         val query = """
             select id from failed_events where topic = ? and partition = ? and key = ? limit 1
         """.trimIndent()
 
-        val queryResult = queryOf(query, topic, partition, key).map { it -> it.int("id") }.asSingle
+        val queryResult = queryOf(query, topic, partition, key).map { it.int("id") }.asSingle
 
         return db.session.run(queryResult) != null
     }
 
     override fun getRecords(topic: String, partition: Int, maxRecords: Int): MutableList<StoredConsumerRecord> {
-
+        @Language("PostgreSQL")
         val query = """
             select * from failed_events where topic = ? and partition = ? order by record_offset limit ?
         """.trimIndent()
@@ -64,7 +63,7 @@ class KafkaConsumerRepository(private val db: Database) :
     }
 
     override fun incrementRetries(id: Long) {
-
+        @Language("PostgreSQL")
         val query = """
             update failed_events set retries = retries + 1, last_retry = current_timestamp where id = ?
         """.trimIndent()
@@ -75,14 +74,16 @@ class KafkaConsumerRepository(private val db: Database) :
     }
 
     override fun getTopicPartitions(topics: MutableList<String>): MutableList<TopicPartition> {
-
+        @Language("PostgreSQL")
         val query = """
             select distinct topic, partition from failed_events where topic = any(?)
         """.trimIndent()
 
         val topicsArray = db.session.createArrayOf("varchar", topics)
 
-        val queryResult = queryOf(query, topicsArray).map { it -> TopicPartition(it.string("topic"), it.int("partition")) }.asList
+        val queryResult = queryOf(query, topicsArray)
+            .map { TopicPartition(it.string("topic"), it.int("partition")) }
+            .asList
 
         return db.session.run(queryResult).toMutableList()
     }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/MulighetsrommetApiClient.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/MulighetsrommetApiClient.kt
@@ -24,7 +24,9 @@ class MulighetsrommetApiClient(uriBase: String, private val getToken: () -> Stri
             install(ContentNegotiation) {
                 json()
             }
-            install(Logging)
+            install(Logging) {
+                level = LogLevel.INFO
+            }
             defaultRequest {
                 contentType(ContentType.Application.Json)
 
@@ -45,7 +47,7 @@ class MulighetsrommetApiClient(uriBase: String, private val getToken: () -> Stri
         }
 
         if (!response.status.isSuccess()) {
-            throw Exception("Request to mulighetsrommet-api failed")
+            throw Exception("Request to mulighetsrommet-api failed with ${response.status}")
         }
 
         logger.debug("sent request status ${response.status} (${response.request.url})")

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
@@ -1,27 +1,39 @@
 package no.nav.mulighetsrommet.arena.adapter.consumers
 
 import io.ktor.http.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.domain.arena.ArenaSak
 import org.slf4j.LoggerFactory
 
-class SakEndretConsumer(private val client: MulighetsrommetApiClient) {
+class SakEndretConsumer(
+    override val topic: String,
+    private val client: MulighetsrommetApiClient
+) : TopicConsumer() {
 
     private val logger = LoggerFactory.getLogger(SakEndretConsumer::class.java)
-    private var resourceUri = "/api/v1/arena/sak"
 
-    fun process(payload: JsonElement) {
-        val sak = payload.jsonObject["after"]!!.jsonObject.toSak()
-
-        if (sakIsRelatedToTiltaksgjennomforing(sak)) {
-            client.sendRequest(HttpMethod.Put, "/api/arena/sak", sak)
-            logger.debug("processed sak endret event")
-        }
+    override fun shouldProcessEvent(payload: JsonElement): Boolean {
+        return sakIsRelatedToTiltaksgjennomforing(payload)
     }
 
-    private fun sakIsRelatedToTiltaksgjennomforing(updatedSak: ArenaSak) =
-        updatedSak.sakskode == "TILT"
+    override fun resolveKey(payload: JsonElement): String {
+        return payload.jsonObject["after"]!!.jsonObject["SAK_ID"]!!.jsonPrimitive.content
+    }
+
+    override fun processEvent(payload: JsonElement) {
+        val sak = payload.jsonObject["after"]!!.jsonObject.toSak()
+        client.sendRequest(HttpMethod.Put, "/api/v1/arena/sak", sak)
+        logger.debug("processed sak endret event")
+    }
+
+    private fun sakIsRelatedToTiltaksgjennomforing(payload: JsonElement): Boolean {
+        val sakskode = payload.jsonObject["after"]!!.jsonObject["SAKSKODE"]!!.jsonPrimitive.content
+        return sakskode == "TILT"
+    }
 
     private fun JsonObject.toSak() = ArenaSak(
         sakId = this["SAK_ID"]!!.jsonPrimitive.content.toInt(),

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -10,14 +10,20 @@ import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.Tiltakstype
 import org.slf4j.LoggerFactory
 
-class TiltakEndretConsumer(private val client: MulighetsrommetApiClient) {
+class TiltakEndretConsumer(
+    override val topic: String,
+    private val client: MulighetsrommetApiClient
+) : TopicConsumer() {
 
     private val logger = LoggerFactory.getLogger(TiltakEndretConsumer::class.java)
-    private var resourceUri = "/api/v1/arena/tiltakstyper"
 
-    fun process(payload: JsonElement) {
+    override fun resolveKey(payload: JsonElement): String {
+        return payload.jsonObject["after"]!!.jsonObject["TILTAKSKODE"]!!.jsonPrimitive.content
+    }
+
+    override fun processEvent(payload: JsonElement) {
         val tiltakstype = payload.jsonObject["after"]!!.jsonObject.toTiltakstype()
-        client.sendRequest(HttpMethod.Put, "/api/arena/tiltakstyper", tiltakstype)
+        client.sendRequest(HttpMethod.Put, "/api/v1/arena/tiltakstyper", tiltakstype)
         logger.debug("processed tiltak endret event")
     }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
@@ -10,14 +10,20 @@ import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.Deltaker
 import org.slf4j.LoggerFactory
 
-class TiltakdeltakerEndretConsumer(private val client: MulighetsrommetApiClient) {
+class TiltakdeltakerEndretConsumer(
+    override val topic: String,
+    private val client: MulighetsrommetApiClient
+) : TopicConsumer() {
 
     private val logger = LoggerFactory.getLogger(TiltakdeltakerEndretConsumer::class.java)
-    private var resourceUri = "/api/v1/arena/deltakere"
 
-    fun process(payload: JsonElement) {
+    override fun resolveKey(payload: JsonElement): String {
+        return payload.jsonObject["after"]!!.jsonObject["TILTAKDELTAKER_ID"]!!.jsonPrimitive.content
+    }
+
+    override fun processEvent(payload: JsonElement) {
         val updatedDeltaker = payload.jsonObject["after"]!!.jsonObject.toDeltaker()
-        client.sendRequest(HttpMethod.Put, "/api/arena/deltakere", updatedDeltaker)
+        client.sendRequest(HttpMethod.Put, "/api/v1/arena/deltakere", updatedDeltaker)
         logger.debug("processed tiltak endret event")
     }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -10,14 +10,20 @@ import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing
 import org.slf4j.LoggerFactory
 
-class TiltakgjennomforingEndretConsumer(private val client: MulighetsrommetApiClient) {
+class TiltakgjennomforingEndretConsumer(
+    override val topic: String,
+    private val client: MulighetsrommetApiClient
+) : TopicConsumer() {
 
     private val logger = LoggerFactory.getLogger(TiltakgjennomforingEndretConsumer::class.java)
-    private var resourceUri = "/api/v1/arena/tiltaksgjennomforinger"
 
-    fun process(payload: JsonElement) {
+    override fun resolveKey(payload: JsonElement): String {
+        return payload.jsonObject["after"]!!.jsonObject["TILTAKGJENNOMFORING_ID"]!!.jsonPrimitive.content
+    }
+
+    override fun processEvent(payload: JsonElement) {
         val updateTiltaksgjennomforing = payload.jsonObject["after"]!!.jsonObject.toTiltaksgjennomforing()
-        client.sendRequest(HttpMethod.Put, "/api/arena/tiltaksgjennomforinger", updateTiltaksgjennomforing)
+        client.sendRequest(HttpMethod.Put, "/api/v1/arena/tiltaksgjennomforinger", updateTiltaksgjennomforing)
         logger.debug("processed tiltakgjennomforing endret event")
     }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TopicConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TopicConsumer.kt
@@ -1,0 +1,13 @@
+package no.nav.mulighetsrommet.arena.adapter.consumers
+
+import kotlinx.serialization.json.JsonElement
+
+abstract class TopicConsumer {
+    abstract val topic: String
+
+    open fun shouldProcessEvent(payload: JsonElement): Boolean = true
+
+    abstract fun resolveKey(payload: JsonElement): String
+
+    abstract fun processEvent(payload: JsonElement)
+}

--- a/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V4__make_events_unique_on_topic_and_key.sql
+++ b/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V4__make_events_unique_on_topic_and_key.sql
@@ -1,0 +1,9 @@
+alter table events
+    drop constraint events_unique;
+
+alter table events
+    drop column record_offset,
+    drop column partition;
+
+alter table events
+    add constraint events_unique unique (topic, key);

--- a/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V5__add_updated_at_to_events.sql
+++ b/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V5__add_updated_at_to_events.sql
@@ -1,0 +1,17 @@
+alter table events
+    add column updated_at timestamp default now() not null;
+
+create or replace function trigger_set_timestamp()
+    returns trigger as
+$$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger set_timestamp
+    before update
+    on events
+    for each row
+execute procedure trigger_set_timestamp();

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/DevApplication.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/DevApplication.kt
@@ -37,15 +37,14 @@ fun main() {
         .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
         .build()
 
-    val kafka = KafkaConsumerOrchestrator(
-        app.kafka,
-        preset,
-        Database(app.database),
-        TiltakEndretConsumer(api),
-        TiltakgjennomforingEndretConsumer(api),
-        TiltakdeltakerEndretConsumer(api),
-        SakEndretConsumer(api)
+    val consumers = listOf(
+        TiltakEndretConsumer(app.kafka.getTopic("tiltakendret"), api),
+        TiltakgjennomforingEndretConsumer(app.kafka.getTopic("tiltakgjennomforingendret"), api),
+        TiltakdeltakerEndretConsumer(app.kafka.getTopic("tiltakdeltakerendret"), api),
+        SakEndretConsumer(app.kafka.getTopic("sakendret"), api)
     )
+
+    val kafka = KafkaConsumerOrchestrator(preset, Database(app.database), consumers)
 
     initializeServer(server) {
         configure(app, kafka)


### PR DESCRIPTION
- Refaktorert arena-adapteret til å bli noe mer generisk og flyttet mapping-logikken ut i de forskjellige TopicConsumer'ene
- Endret events-tabellen til at vi kun persisterer det siste eventet på en gitt kombinasjon av topic+key
  - På sikt tenker vi at denne tabellen skal benyttes til å kunne gjenspille dataen på en topic uten at vi trenger å be om en initial load, samt at den kan brukes til ifm. feilsøking om det skulle bli nødvendig