### PR TITLE
Oppretter en proxy for Sanity

### DIFF
--- a/.github/workflows/mulighetsrommet-api.yaml
+++ b/.github/workflows/mulighetsrommet-api.yaml
@@ -70,3 +70,5 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: mulighetsrommet-api/.nais/nais.yaml
           VAR: image=${{ env.IMAGE }}
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+          SANITY_PROJECTID: ${{ secrets.SANITY_PROJECTID }}

--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -48,6 +48,8 @@ dependencies {
     implementation("io.ktor:ktor-server-default-headers:$ktorVersion")
     implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
     implementation("io.ktor:ktor-server-auto-head-response:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
 
     val hopliteVersion = "1.4.16"

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -9,10 +9,7 @@ import io.ktor.server.routing.*
 import no.nav.mulighetsrommet.api.plugins.*
 import no.nav.mulighetsrommet.api.routes.internalRoutes
 import no.nav.mulighetsrommet.api.routes.swaggerRoutes
-import no.nav.mulighetsrommet.api.routes.v1.arenaRoutes
-import no.nav.mulighetsrommet.api.routes.v1.innsatsgruppeRoutes
-import no.nav.mulighetsrommet.api.routes.v1.tiltaksgjennomforingRoutes
-import no.nav.mulighetsrommet.api.routes.v1.tiltakstypeRoutes
+import no.nav.mulighetsrommet.api.routes.v1.*
 import org.slf4j.LoggerFactory
 
 fun main() {
@@ -58,6 +55,7 @@ fun Application.configure(config: AppConfig) {
             tiltaksgjennomforingRoutes()
             innsatsgruppeRoutes()
             arenaRoutes()
+            sanityRoutes()
         }
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -14,7 +14,8 @@ data class ServerConfig(
 
 data class AppConfig(
     val database: DatabaseConfig,
-    val auth: AuthConfig
+    val auth: AuthConfig,
+    val sanity: SanityConfig
 )
 
 data class DatabaseConfig(
@@ -28,6 +29,12 @@ data class DatabaseConfig(
 
 data class AuthConfig(
     val azure: AuthProvider
+)
+
+data class SanityConfig(
+    val projectId: String,
+    val authToken: String,
+    val dataset: String,
 )
 
 data class AuthProvider(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -4,10 +4,7 @@ import io.ktor.server.application.*
 import no.nav.mulighetsrommet.api.AppConfig
 import no.nav.mulighetsrommet.api.DatabaseConfig
 import no.nav.mulighetsrommet.api.database.Database
-import no.nav.mulighetsrommet.api.services.ArenaService
-import no.nav.mulighetsrommet.api.services.InnsatsgruppeService
-import no.nav.mulighetsrommet.api.services.TiltaksgjennomforingService
-import no.nav.mulighetsrommet.api.services.TiltakstypeService
+import no.nav.mulighetsrommet.api.services.*
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
@@ -17,7 +14,7 @@ import org.slf4j.Logger
 fun Application.configureDependencyInjection(appConfig: AppConfig) {
     install(Koin) {
         SLF4JLogger()
-        modules(db(appConfig.database), services(log))
+        modules(db(appConfig.database), services(log, appConfig))
     }
 }
 
@@ -27,9 +24,10 @@ private fun db(databaseConfig: DatabaseConfig): Module {
     }
 }
 
-private fun services(logger: Logger) = module {
+private fun services(logger: Logger, appConfig: AppConfig) = module {
     single { ArenaService(get(), logger) }
     single { TiltaksgjennomforingService(get(), logger) }
     single { TiltakstypeService(get(), logger) }
     single { InnsatsgruppeService(get(), logger) }
+    single { SanityService(appConfig) }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
@@ -1,0 +1,33 @@
+package no.nav.mulighetsrommet.api.routes.v1
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.plugins.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.mulighetsrommet.api.services.SanityService
+import org.koin.ktor.ext.inject
+
+fun Route.sanityRoutes() {
+
+    val sanityService: SanityService by inject()
+    val validDatasets = listOf("production", "test", "dev")
+
+    route("/api/v1/sanity") {
+        get {
+            val query = call.request.queryParameters["query"]
+                ?: return@get call.respondText("No query parameter with value '?query' present. Cannot execute query against Sanity")
+            val dataset = call.request.queryParameters["dataset"] ?: "production"
+
+            if (!validDatasets.contains(dataset)) throw BadRequestException(
+                "Dataset '$dataset' er ikke et gyldig datasett. Gyldige datasett er ${
+                validDatasets.joinToString(
+                    ", "
+                )
+                }"
+            )
+
+            call.respondText(sanityService.executeQuery(query, dataset), ContentType.Application.Json)
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -1,0 +1,52 @@
+package no.nav.mulighetsrommet.api.services
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import no.nav.mulighetsrommet.api.AppConfig
+import org.slf4j.LoggerFactory
+import java.text.SimpleDateFormat
+import java.util.*
+
+class SanityService(appConfig: AppConfig) {
+    private val logger = LoggerFactory.getLogger(SanityService::class.java)
+    private val client: HttpClient
+    private val sanityToken = appConfig.sanity.authToken
+    private val projectId = appConfig.sanity.projectId
+    private val apiVersion = SimpleDateFormat("yyyy-MM-dd").format(Date())
+    private val sanityBaseUrl = "https://$projectId.apicdn.sanity.io/v$apiVersion/data/query/"
+
+    init {
+        logger.debug("Init SanityHttpClient")
+        client = HttpClient(CIO) {
+            install(ContentNegotiation) {
+                json()
+            }
+            expectSuccess = true
+            defaultRequest {
+                bearerAuth(sanityToken)
+                url(sanityBaseUrl)
+            }
+        }
+    }
+
+    suspend fun executeQuery(query: String, dataset: String): String {
+        val response: HttpResponse = client.get("") {
+            url {
+                appendPathSegments(dataset, "/")
+                parameters.append("query", query)
+            }
+        }
+        if (response.status == HttpStatusCode.OK) {
+            return response.body()
+        }
+
+        return response.status.description
+    }
+}

--- a/mulighetsrommet-api/src/main/resources/application.yaml
+++ b/mulighetsrommet-api/src/main/resources/application.yaml
@@ -15,3 +15,8 @@ app:
       issuer: ${AZURE_OPENID_CONFIG_ISSUER:-http://localhost:8081/azure}
       jwksUri: ${AZURE_OPENID_CONFIG_JWKS_URI:-http://localhost:8081/azure/jwks}
       audience: ${AZURE_APP_CLIENT_ID:-mulighetsrommet-api}
+
+  sanity:
+    projectId: ${SANITY_PROJECTID}
+    authToken:  ${SANITY_AUTH_TOKEN}
+    dataset: ${SANITY_DATASET}

--- a/mulighetsrommet-api/src/main/resources/logback.xml
+++ b/mulighetsrommet-api/src/main/resources/logback.xml
@@ -1,4 +1,9 @@
 <configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
     <appender name="stdout_json" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <!-- https://doc.nais.io/observability/logs/examples/#issues-with-long-log-messages -->
@@ -13,10 +18,13 @@
             </throwableConverter>
         </encoder>
     </appender>
-    <root level="INFO">
-        <appender-ref ref="stdout_json" />
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="no.nav.mulighetsrommet" level="INFO" />
+    <root level="INFO">
+        <appender-ref ref="stdout_json"/>
+    </root>
+    <logger name="no.nav.mulighetsrommet" level="INFO"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
 </configuration>

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
@@ -20,6 +20,7 @@ fun <R> withMulighetsrommetApp(
 fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     database = createDatabaseConfig(),
     auth = createAuthConfig(oauth),
+    sanity = createSanityConfig()
 )
 
 fun createDatabaseConfig(
@@ -54,3 +55,11 @@ fun createAuthConfig(
         audience = audience
     )
 )
+
+fun createSanityConfig(): SanityConfig {
+    return SanityConfig(
+        projectId = "",
+        authToken = "",
+        dataset = ""
+    )
+}


### PR DESCRIPTION
Oppretter et endepunkt `/api/v1/sanity` som tar i mot query-parameterne `query` som er obligatorisk. Eks. `?query=<groq-spørring>`. Endepunktet støtter også `?dataset=<navn på dataset>` som godtar verdiene `dev, test eller production`. 

Om man ikke har med `dataset` så er det `production` som blir default.

Groq-spørringen må uriEncodes før man sender til backend.

Legger også til secrets i byggsteget for GH workflow.

Ved lokal utvikling må man legge til miljøvariablene `SANITY_PROJECTID` og `SANITY_AUTH_TOKEN`.

Jeg har opprettet et access token `mulighetsrommet-api` i Sanity. For lokal utvikling kan man lage seg et eget access token og gi det `developer`-tilgang.