### PR TITLE
Tar høyde for null-verdier

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
@@ -12,7 +12,7 @@ interface TiltaksdetaljerFaneProps {
   tiltaksgjennomforingTiltaksansvarlig: Tiltaksansvarlig;
   tiltaksgjennomforingArrangorinfo: Arrangor;
   tiltakstype: Tiltakstype;
-  tiltaksgjennomforing: any;
+  tiltaksgjennomforing: any; // TODO Type opp denne
 }
 
 const TiltaksdetaljerFane = ({
@@ -38,25 +38,25 @@ const TiltaksdetaljerFane = ({
       </Tabs.List>
       <Tabs.Panel value="tab1">
         <DetaljerFane
-          tiltaksgjennomforingAlert={tiltaksgjennomforing.forHvemInfoboks}
+          tiltaksgjennomforingAlert={tiltaksgjennomforing?.forHvemInfoboks}
           tiltakstypeAlert={tiltakstype.faneinnhold!.forHvemInfoboks}
-          tiltaksgjennomforing={tiltaksgjennomforing.forHvem}
+          tiltaksgjennomforing={tiltaksgjennomforing?.forHvem}
           tiltakstype={tiltakstype.faneinnhold!.forHvem}
         />
       </Tabs.Panel>
       <Tabs.Panel value="tab2">
         <DetaljerFane
-          tiltaksgjennomforingAlert={tiltaksgjennomforing.detaljerOgInnholdInfoboks}
+          tiltaksgjennomforingAlert={tiltaksgjennomforing?.detaljerOgInnholdInfoboks}
           tiltakstypeAlert={tiltakstype.faneinnhold!.detaljerOgInnholdInfoboks}
-          tiltaksgjennomforing={tiltaksgjennomforing.detaljerOgInnhold}
+          tiltaksgjennomforing={tiltaksgjennomforing?.detaljerOgInnhold}
           tiltakstype={tiltakstype.faneinnhold!.detaljerOgInnhold}
         />
       </Tabs.Panel>
       <Tabs.Panel value="tab3">
         <DetaljerFane
-          tiltaksgjennomforingAlert={tiltaksgjennomforing.pameldingOgVarighetInfoboks}
+          tiltaksgjennomforingAlert={tiltaksgjennomforing?.pameldingOgVarighetInfoboks}
           tiltakstypeAlert={tiltakstype.faneinnhold!.pameldingOgVarighetInfoboks}
-          tiltaksgjennomforing={tiltaksgjennomforing.pameldingOgVarighet}
+          tiltaksgjennomforing={tiltaksgjennomforing?.pameldingOgVarighet}
           tiltakstype={tiltakstype.faneinnhold!.pameldingOgVarighet}
         />
       </Tabs.Panel>

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
@@ -12,6 +12,7 @@ import { Alert, Loader } from '@navikt/ds-react';
 const ViewTiltakstypeDetaljer = () => {
   const { tiltaksnummer } = useParams();
   const { data, isLoading, isError } = useTiltaksgjennomforingById(parseInt(tiltaksnummer!));
+
   return (
     <>
       {isLoading && <Loader className="filter-loader" size="xlarge" />}


### PR DESCRIPTION
Dersom en tiltaksgjennomføring i sanity ikke har noe data/tekst under feks. innhold faner 
<img width="706" alt="image" src="https://user-images.githubusercontent.com/9053627/173058008-f16154f3-0ff9-485d-84e5-ce2e42ee3ab5.png">

så vil frontend krasje.  Denne PRen fikser det.