### PR TITLE
Småfiks for uthenting av beskrivelse fra tiltakstyper

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
@@ -66,7 +66,7 @@ const TiltaksdetaljerFane = ({
           arrangorinfo={tiltaksgjennomforingArrangorinfo}
         />
       </Tabs.Panel>
-      <Tabs.Panel value="tab5">Innsikt</Tabs.Panel>
+      <Tabs.Panel value="tab5">Her kommer det grader og annet snacks - Innsikt</Tabs.Panel>
     </Tabs>
   );
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/detaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/detaljerFane.tsx
@@ -17,7 +17,7 @@ const DetaljerFane = ({
   tiltakstype,
 }: DetaljerFaneProps) => {
   return (
-    <>
+    <div style={{ maxWidth: '75ch' }}>
       {tiltakstypeAlert && (
         <Alert variant="info" className="tiltaksdetaljer__alert">
           {tiltakstypeAlert}
@@ -30,7 +30,7 @@ const DetaljerFane = ({
       )}
       <PortableText value={tiltakstype} />
       <PortableText value={tiltaksgjennomforing} />
-    </>
+    </div>
   );
 };
 

--- a/frontend/mulighetsrommet-veileder-flate/src/layouts/TiltaksgjennomforingsHeader.less
+++ b/frontend/mulighetsrommet-veileder-flate/src/layouts/TiltaksgjennomforingsHeader.less
@@ -5,6 +5,7 @@
     }
     &__beskrivelse {
       font-size: 22px;
+      max-width: 75ch;
     }
   }
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/layouts/TiltaksgjennomforingsHeader.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/layouts/TiltaksgjennomforingsHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import './TiltaksgjennomforingsHeader.less';
 import { Heading } from '@navikt/ds-react';
 import { kebabCase } from '../utils/Utils';
@@ -7,7 +7,7 @@ import { PortableText } from '@portabletext/react';
 interface TiltaksgjennomforingsHeaderProps {
   tiltaksgjennomforingsnavn: string;
   beskrivelseTiltaksgjennomforing?: string;
-  beskrivelseTiltakstype?: ReactNode;
+  beskrivelseTiltakstype?: any;
 }
 
 const TiltaksgjennomforingsHeader = ({

--- a/frontend/mulighetsrommet-veileder-flate/src/layouts/TiltaksgjennomforingsHeader.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/layouts/TiltaksgjennomforingsHeader.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import './TiltaksgjennomforingsHeader.less';
 import { Heading } from '@navikt/ds-react';
 import { kebabCase } from '../utils/Utils';
+import { PortableText } from '@portabletext/react';
 
 interface TiltaksgjennomforingsHeaderProps {
   tiltaksgjennomforingsnavn: string;
   beskrivelseTiltaksgjennomforing?: string;
-  beskrivelseTiltakstype?: string;
+  beskrivelseTiltakstype?: ReactNode;
 }
 
 const TiltaksgjennomforingsHeader = ({
@@ -26,7 +27,9 @@ const TiltaksgjennomforingsHeader = ({
       {beskrivelseTiltaksgjennomforing && (
         <div className="tiltaksgjennomforing__beskrivelse">{beskrivelseTiltaksgjennomforing}</div>
       )}
-      {beskrivelseTiltakstype && <div className="tiltaksgjennomforing__beskrivelse">{beskrivelseTiltakstype}</div>}
+      <div className="tiltaksgjennomforing__beskrivelse">
+        <PortableText value={beskrivelseTiltakstype} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Legger til `max-width: 75ch` etter avklaring med Tom Stian, da tekst i fanene ble veldig bred uten noe maksbredde. Dette gjør det litt enklere å lese mye tekst.

Bruker også `<PortableText.../>`-komponenten for å vise tiltakstype-beskrivelsen.