### PR TITLE
reference secrets managed through google secrets manager

### DIFF
--- a/.github/workflows/mulighetsrommet-api.yaml
+++ b/.github/workflows/mulighetsrommet-api.yaml
@@ -70,4 +70,3 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: mulighetsrommet-api/.nais/nais.yaml
           VAR: image=${{ env.IMAGE }}
-          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}

--- a/mulighetsrommet-api/.nais/nais.yaml
+++ b/mulighetsrommet-api/.nais/nais.yaml
@@ -48,10 +48,5 @@ spec:
           namespace: pto
           cluster: dev-fss
         - application: mulighetsrommet-arena-adapter
-  env:
-    - name: KTOR_LOCAL_DEV
-      value: "false"
-    - name: SANITY_DATASET
-      value: "production"
-    - name: SANITY_PROJECT_ID
-      value: "xegcworx"
+  envFrom:
+    - secret: mulighetsrommet-api


### PR DESCRIPTION
Har flyttet env vars til GCP i stedet, da applikasjonen har feilet med å starte pga. manglende sanity-token.