### PR TITLE
Kan velge flere tiltaksansvarlige

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.js
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.js
@@ -175,11 +175,11 @@ export default {
     },
     //TODO skal kunne legge til flere tiltaksansvarlige
     {
-      name: "kontaktinfoTiltaksansvarlig",
+      name: "kontaktinfoTiltaksansvarlige",
       title: "Tiltaksansvarlig",
-      type: "reference",
-      to: [{ type: "navKontaktperson" }],
-      validation: (Rule) => Rule.required(),
+      type: "array",
+      of: [{ type: "reference", to: [{ type: "navKontaktperson" }] }],
+      validation: (Rule) => Rule.required().min(1).unique(),
     },
     {
       name: "lenker",

--- a/frontend/mulighetsrommet-veileder-flate/src/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/models.ts
@@ -36,7 +36,7 @@ export interface Tiltaksgjennomforing {
     pameldingOgVarighetInfoboks?: string;
     pameldingOgVarighet?: object;
   };
-  kontaktinfoTiltaksansvarlig: Tiltaksansvarlig;
+  kontaktinfoTiltaksansvarlige: Tiltaksansvarlig[];
 }
 
 export interface Arrangor {

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingById.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingById.ts
@@ -19,7 +19,7 @@ export default function useTiltaksgjennomforingById(id: number) {
       pameldingOgVarighet,
     },
     kontaktinfoArrangor->,
-    kontaktinfoTiltaksansvarlig->,
+    kontaktinfoTiltaksansvarlige[]->,
     tiltakstype->
   }[0]`);
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
@@ -11,7 +11,7 @@ interface TiltaksdetaljerFaneProps {
 }
 
 const TiltaksdetaljerFane = ({ tiltaksgjennomforing }: TiltaksdetaljerFaneProps) => {
-  const { tiltakstype, kontaktinfoTiltaksansvarlig, kontaktinfoArrangor } = tiltaksgjennomforing;
+  const { tiltakstype, kontaktinfoTiltaksansvarlige, kontaktinfoArrangor } = tiltaksgjennomforing;
   const faneoverskrifter = ['For hvem', 'Detaljer og innhold', 'Påmelding og varighet', 'Kontaktinfo', 'Innsikt'];
 
   return (
@@ -52,7 +52,7 @@ const TiltaksdetaljerFane = ({ tiltaksgjennomforing }: TiltaksdetaljerFaneProps)
         />
       </Tabs.Panel>
       <Tabs.Panel value="tab4">
-        <KontaktinfoFane tiltaksansvarligInfo={kontaktinfoTiltaksansvarlig} arrangorinfo={kontaktinfoArrangor} />
+        <KontaktinfoFane tiltaksansvarlige={kontaktinfoTiltaksansvarlige} arrangorinfo={kontaktinfoArrangor} />
       </Tabs.Panel>
       <Tabs.Panel value="tab5">Her kommer det grader og annet snacks - Innsikt</Tabs.Panel>
     </Tabs>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
@@ -18,10 +18,6 @@ const ArrangorInfo = ({ arrangorinfo }: ArrangorProps) => {
           <BodyShort>{arrangorinfo.telefonnummer}</BodyShort>
         </div>
         <div className="kontaktinfo__rad">
-          <Label size="small">Epost</Label>
-          <BodyShort>{arrangorinfo.epost}</BodyShort>
-        </div>
-        <div className="kontaktinfo__rad">
           <Label size="small">Adresse</Label>
           <BodyShort>{arrangorinfo.adresse}</BodyShort>
         </div>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.tsx
@@ -6,11 +6,11 @@ import TiltaksansvarligInfo from './TiltaksansvarligInfo';
 import { Arrangor, Tiltaksansvarlig } from '../../../api/models';
 
 interface KontaktinfoFaneProps {
-  tiltaksansvarligInfo: Tiltaksansvarlig;
+  tiltaksansvarlige: Tiltaksansvarlig[];
   arrangorinfo: Arrangor;
 }
 
-const KontaktinfoFane = ({ tiltaksansvarligInfo, arrangorinfo }: KontaktinfoFaneProps) => {
+const KontaktinfoFane = ({ tiltaksansvarlige, arrangorinfo }: KontaktinfoFaneProps) => {
   return (
     <div className="kontaktinfo">
       <div>
@@ -23,7 +23,7 @@ const KontaktinfoFane = ({ tiltaksansvarligInfo, arrangorinfo }: KontaktinfoFane
         <Heading size="large" level="2" className="kontaktinfo__header">
           Tiltaksansvarlig
         </Heading>
-        <TiltaksansvarligInfo tiltaksansvarlig={tiltaksansvarligInfo} />
+        <TiltaksansvarligInfo tiltaksansvarlige={tiltaksansvarlige} />
       </div>
     </div>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/TiltaksansvarligInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/TiltaksansvarligInfo.tsx
@@ -4,13 +4,16 @@ import './KontaktinfoFane.less';
 import { Tiltaksansvarlig } from '../../../api/models';
 
 interface TiltaksansvarligProps {
-  tiltaksansvarlig: Tiltaksansvarlig;
+  tiltaksansvarlige: Tiltaksansvarlig[];
 }
 
-const TiltaksansvarligInfo = ({ tiltaksansvarlig }: TiltaksansvarligProps) => {
-  //TODO når det er mulig å ha flere tiltaksansvarlige i Sanity må det mappes her
+const TiltaksansvarligInfo = ({ tiltaksansvarlige }: TiltaksansvarligProps) => {
+  return <>{tiltaksansvarlige.map(tiltaksansvarligComponent)}</>;
+};
+
+function tiltaksansvarligComponent(tiltaksansvarlig: Tiltaksansvarlig) {
   return (
-    <>
+    <div className="kontaktinfo__header" key={tiltaksansvarlig._id}>
       <Heading size="small" level="3" className="kontaktinfo__navn">
         {tiltaksansvarlig.navn}
       </Heading>
@@ -21,14 +24,17 @@ const TiltaksansvarligInfo = ({ tiltaksansvarlig }: TiltaksansvarligProps) => {
         </div>
         <div className="kontaktinfo__rad">
           <Label size="small">Epost</Label>
-          <BodyShort>{tiltaksansvarlig.epost}</BodyShort>
+          <BodyShort>
+            <a href={`mailto:${tiltaksansvarlig.epost}`}>{tiltaksansvarlig.epost}</a>
+          </BodyShort>
         </div>
         <div className="kontaktinfo__rad">
           <Label size="small">Enhet</Label>
           <BodyShort>{tiltaksansvarlig.enhet}</BodyShort>
         </div>
       </div>
-    </>
+    </div>
   );
-};
+}
+
 export default TiltaksansvarligInfo;

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/entities/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/entities/tiltaksgjennomforing.ts
@@ -20,12 +20,14 @@ export function toTiltaksgjennomforing(entity: TiltaksgjennomforingEntity): Tilt
     tiltakstype: entity.tiltakstype as Tiltakstype,
     lokasjon: entity.lokasjon,
     oppstart: entity.oppstart,
-    kontaktinfoTiltaksansvarlig: {
-      _id: entity.kontaktinfoTiltaksansvarlig.id!,
-      enhet: entity.kontaktinfoTiltaksansvarlig.enhet!,
-      epost: entity.kontaktinfoTiltaksansvarlig.epost!,
-      telefonnummer: entity.kontaktinfoTiltaksansvarlig.telefonnummer!,
-      navn: entity.kontaktinfoTiltaksansvarlig.navn!,
-    },
+    kontaktinfoTiltaksansvarlige: [
+      {
+        _id: entity.kontaktinfoTiltaksansvarlig.id!,
+        enhet: entity.kontaktinfoTiltaksansvarlig.enhet!,
+        epost: entity.kontaktinfoTiltaksansvarlig.epost!,
+        telefonnummer: entity.kontaktinfoTiltaksansvarlig.telefonnummer!,
+        navn: entity.kontaktinfoTiltaksansvarlig.navn!,
+      },
+    ],
   };
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
@@ -52,13 +52,15 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     },
     lokasjon: '',
     oppstart: '',
-    kontaktinfoTiltaksansvarlige: {
-      _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      enhet: '',
-      epost: '',
-      navn: '',
-      telefonnummer: '',
-    },
+    kontaktinfoTiltaksansvarlige: [
+      {
+        _id: faker.datatype.number({ min: 100000, max: 999999 }),
+        enhet: '',
+        epost: '',
+        navn: '',
+        telefonnummer: '',
+      },
+    ],
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
@@ -80,13 +82,15 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     },
     lokasjon: '',
     oppstart: '',
-    kontaktinfoTiltaksansvarlige: {
-      _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      enhet: '',
-      epost: '',
-      navn: '',
-      telefonnummer: '',
-    },
+    kontaktinfoTiltaksansvarlige: [
+      {
+        _id: faker.datatype.number({ min: 100000, max: 999999 }),
+        enhet: '',
+        epost: '',
+        navn: '',
+        telefonnummer: '',
+      },
+    ],
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
@@ -108,13 +112,15 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     },
     lokasjon: '',
     oppstart: '',
-    kontaktinfoTiltaksansvarlige: {
-      _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      enhet: '',
-      epost: '',
-      navn: '',
-      telefonnummer: '',
-    },
+    kontaktinfoTiltaksansvarlige: [
+      {
+        _id: faker.datatype.number({ min: 100000, max: 999999 }),
+        enhet: '',
+        epost: '',
+        navn: '',
+        telefonnummer: '',
+      },
+    ],
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
@@ -136,12 +142,14 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     },
     lokasjon: '',
     oppstart: '',
-    kontaktinfoTiltaksansvarlige: {
-      _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      enhet: '',
-      epost: '',
-      navn: '',
-      telefonnummer: '',
-    },
+    kontaktinfoTiltaksansvarlige: [
+      {
+        _id: faker.datatype.number({ min: 100000, max: 999999 }),
+        enhet: '',
+        epost: '',
+        navn: '',
+        telefonnummer: '',
+      },
+    ],
   },
 ];

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
@@ -22,7 +22,37 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     },
     lokasjon: '',
     oppstart: '',
-    kontaktinfoTiltaksansvarlig: {
+    kontaktinfoTiltaksansvarlige: [
+      {
+        _id: faker.datatype.number({ min: 100000, max: 999999 }),
+        enhet: '',
+        epost: '',
+        navn: '',
+        telefonnummer: '',
+      },
+    ],
+  },
+  {
+    _id: faker.datatype.number({ min: 100000, max: 999999 }),
+    tiltaksgjennomforingNavn: 'Opplæring',
+    beskrivelse: faker.lorem.paragraph(3),
+
+    tiltaksnummer: faker.datatype.number({ min: 100000, max: 999999 }),
+    tiltakstype: {
+      _id: faker.datatype.number({ min: 100000, max: 999999 }),
+      innsatsgruppe: '',
+      tiltakstypeNavn: '',
+    },
+    kontaktinfoArrangor: {
+      _id: faker.datatype.number({ min: 100000, max: 999999 }),
+      adresse: '',
+      epost: '',
+      selskapsnavn: '',
+      telefonnummer: '',
+    },
+    lokasjon: '',
+    oppstart: '',
+    kontaktinfoTiltaksansvarlige: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
       enhet: '',
       epost: '',
@@ -50,7 +80,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     },
     lokasjon: '',
     oppstart: '',
-    kontaktinfoTiltaksansvarlig: {
+    kontaktinfoTiltaksansvarlige: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
       enhet: '',
       epost: '',
@@ -78,7 +108,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     },
     lokasjon: '',
     oppstart: '',
-    kontaktinfoTiltaksansvarlig: {
+    kontaktinfoTiltaksansvarlige: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
       enhet: '',
       epost: '',
@@ -106,35 +136,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     },
     lokasjon: '',
     oppstart: '',
-    kontaktinfoTiltaksansvarlig: {
-      _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      enhet: '',
-      epost: '',
-      navn: '',
-      telefonnummer: '',
-    },
-  },
-  {
-    _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    tiltaksgjennomforingNavn: 'Opplæring',
-    beskrivelse: faker.lorem.paragraph(3),
-
-    tiltaksnummer: faker.datatype.number({ min: 100000, max: 999999 }),
-    tiltakstype: {
-      _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      innsatsgruppe: '',
-      tiltakstypeNavn: '',
-    },
-    kontaktinfoArrangor: {
-      _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      adresse: '',
-      epost: '',
-      selskapsnavn: '',
-      telefonnummer: '',
-    },
-    lokasjon: '',
-    oppstart: '',
-    kontaktinfoTiltaksansvarlig: {
+    kontaktinfoTiltaksansvarlige: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
       enhet: '',
       epost: '',

--- a/scripts/upload-sanity/domain.ts
+++ b/scripts/upload-sanity/domain.ts
@@ -13,7 +13,7 @@ export interface SanityArrangor {
   _id: string;
   selskapsnavn: string;
   telefonnummer: string;
-  epost: string;
+  epost?: string;
   adresse: string;
 }
 
@@ -39,7 +39,7 @@ export interface SanityTiltaksgjennomforing {
     pameldingOgVarighetInfoboks: string;
     pameldingOgVarighet: Block[];
   };
-  kontaktinfoTiltaksansvarlig: Reference;
+  kontaktinfoTiltaksansvarlige: Reference[];
   lenker?: Lenke[];
 }
 
@@ -90,6 +90,7 @@ export type Tiltakstype =
 interface Reference {
   _ref: string;
   _type: "reference";
+  _key?: string;
 }
 
 export interface Block {

--- a/scripts/upload-sanity/upload.ts
+++ b/scripts/upload-sanity/upload.ts
@@ -142,7 +142,6 @@ function opprettArrangor(row: Row): SanityArrangor {
     _type: "arrangor",
     selskapsnavn: navn,
     telefonnummer: telefon,
-    epost: epost,
     adresse: postnr,
     _id: epost.replace("@", "_"), // Sanity liker ikke @ i id'ene sine
   };
@@ -213,10 +212,13 @@ function opprettTiltaksgjennomforing(
       pameldingOgVarighetInfoboks: "",
       pameldingOgVarighet: addBlockContent(pameldingOgVarighet),
     },
-    kontaktinfoTiltaksansvarlig: {
-      _type: "reference",
-      _ref: kontaktinfoPerson.ident,
-    },
+    kontaktinfoTiltaksansvarlige: [
+      {
+        _type: "reference",
+        _ref: kontaktinfoPerson.ident,
+        _key: short.generate(),
+      },
+    ],
     kontaktinfoArrangor: {
       _ref: arrangor._id,
       _type: "reference",


### PR DESCRIPTION
Endrer datamodellen for tiltaksgjennomføringer ved at jeg legger til mulighet for å velge flere enn én tiltaksansvarlig. Man må legge til minst 1. 

Oppdaterer også frontend til å hente korrekte data og vise disse på en god måte.

Legger også til mailto-lenke for epost slik at veileder enkelt kan trykke på lenke for å åpne default mail-klient og begynne å skrive e-post.

Fjerner epost for arrangør etter avtale med Marthe til pilot.

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/9053627/175000122-42bceacc-0437-48af-b58f-aa60c56a92f9.png">
