### PR TITLE
Legger til innsatsgrupper som eget dokument

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/innsatsgruppe.ts
+++ b/frontend/mulighetsrommet-cms/schemas/innsatsgruppe.ts
@@ -1,0 +1,26 @@
+import { Rule } from "@sanity/types";
+
+export default {
+  name: "innsatsgruppe",
+  title: "Innsatsgruppe",
+  type: "document",
+  fields: [
+    {
+      name: "tittel",
+      title: "Tittel",
+      type: "string",
+      validation: (Rule: Rule) => Rule.required(),
+    },
+    {
+      name: "beskrivelse",
+      title: "Beskrivelse",
+      type: "string",
+      validation: (Rule: Rule) => Rule.required(),
+    },
+  ],
+  preview: {
+    select: {
+      title: "tittel",
+    },
+  },
+};

--- a/frontend/mulighetsrommet-cms/schemas/schema.js
+++ b/frontend/mulighetsrommet-cms/schemas/schema.js
@@ -7,6 +7,7 @@ import tiltaksgjennomforing from "./tiltaksgjennomforing";
 import arrangor from "./arrangor";
 import kontaktperson from "./kontaktperson";
 import enhet from "./enhet";
+import innsatsgruppe from "./innsatsgruppe";
 
 export default createSchema({
   name: "default",
@@ -18,6 +19,7 @@ export default createSchema({
     arrangor,
     kontaktperson,
     enhet,
+    innsatsgruppe,
 
     // When added to this list, object types can be used as
     // { type: 'typename' } in other document schemas

--- a/frontend/mulighetsrommet-cms/schemas/tiltakstype.js
+++ b/frontend/mulighetsrommet-cms/schemas/tiltakstype.js
@@ -26,25 +26,11 @@ export default {
     {
       name: "innsatsgruppe",
       title: "Innsatsgruppe",
-      type: "string",
+      type: "reference",
       options: {
-        layout: "dropdown",
-        list: [
-          { title: "Standardinnsats", value: "Standardinnsats" },
-          {
-            title: "Situasjonsbestemt innsats",
-            value: "Situasjonsbestemt innsats",
-          },
-          {
-            title: "Spesielt tilpasset innsats",
-            value: "Spesielt tilpasset innsats",
-          },
-          {
-            title: "Varig tilpasset innsats",
-            value: "Varig tilpasset innsats",
-          },
-        ],
+        disableNew: true,
       },
+      to: [{ type: "innsatsgruppe" }],
     },
     {
       name: "varighet",
@@ -144,6 +130,7 @@ export default {
   preview: {
     select: {
       title: "tiltakstypeNavn",
+      subtitle: "innsatsgruppe.tittel",
     },
   },
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/models.ts
@@ -2,7 +2,7 @@ export interface Tiltakstype {
   _id: number;
   tiltakstypeNavn: string;
   beskrivelse?: string;
-  innsatsgruppe: string;
+  innsatsgruppe: Innsatsgruppe;
   varighet?: string;
   regelverkFil?: string; //skal være fil
   regelverkFilNavn?: string;
@@ -53,4 +53,10 @@ export interface Tiltaksansvarlig {
   enhet: string;
   telefonnummer: string;
   epost: string;
+}
+
+export interface Innsatsgruppe {
+  _id: string;
+  beskrivelse: string;
+  tittel: string;
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useInnsatsgrupper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useInnsatsgrupper.ts
@@ -1,7 +1,6 @@
-import { useQuery } from 'react-query';
-import { Innsatsgruppe, MulighetsrommetService } from 'mulighetsrommet-api-client';
-import { QueryKeys } from '../../core/api/QueryKeys';
+import { Innsatsgruppe } from '../models';
+import { useSanity } from './useSanity';
 
 export function useInnsatsgrupper() {
-  return useQuery<Innsatsgruppe[]>(QueryKeys.Innsatsgrupper, MulighetsrommetService.getInnsatsgrupper);
+  return useSanity<Innsatsgruppe[]>('*[_type == "innsatsgruppe"]');
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingById.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingById.ts
@@ -20,6 +20,6 @@ export default function useTiltaksgjennomforingById(id: number) {
     },
     kontaktinfoArrangor->,
     kontaktinfoTiltaksansvarlige[]->,
-    tiltakstype->
+    tiltakstype->{..., innsatsgruppe->}
   }[0]`);
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
@@ -28,8 +28,8 @@ const Filtermeny = () => {
         data={
           innsatsgrupper.data?.map(innsatsgruppe => {
             return {
-              id: innsatsgruppe.id,
-              tittel: innsatsgruppe.navn,
+              id: innsatsgruppe._id,
+              tittel: innsatsgruppe.tittel,
             };
           }) ?? []
         }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -34,7 +34,7 @@ const SidemenyDetaljer = ({ tiltaksgjennomforing }: SidemenyDetaljerProps) => {
 
         <div className="tiltakstype-detaljer__rad">
           <strong>Innsatsgruppe</strong>
-          <span>{tiltakstype.innsatsgruppe} </span>
+          <span>{tiltakstype.innsatsgruppe.beskrivelse} </span>
         </div>
 
         <div className="tiltakstype-detaljer__rad">

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/entities/tiltakstype.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/entities/tiltakstype.ts
@@ -7,7 +7,11 @@ export type TiltakstypeEntity = Entity<DatabaseDictionary, 'tiltakstype'>;
 export function toTiltakstype(entity: TiltakstypeEntity): Tiltakstype {
   return {
     _id: entity.id,
-    innsatsgruppe: entity.innsatsgruppe!!,
+    innsatsgruppe: {
+      beskrivelse: entity.innsatsgruppe!!,
+      _id: '',
+      tittel: '',
+    },
     tiltakstypeNavn: entity.tiltakstypeNavn,
   };
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
@@ -10,7 +10,11 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltaksnummer: faker.datatype.number({ min: 100000, max: 999999 }),
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      innsatsgruppe: '',
+      innsatsgruppe: {
+        _id: '',
+        beskrivelse: '',
+        tittel: '',
+      },
       tiltakstypeNavn: '',
     },
     kontaktinfoArrangor: {
@@ -40,7 +44,11 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltaksnummer: faker.datatype.number({ min: 100000, max: 999999 }),
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      innsatsgruppe: '',
+      innsatsgruppe: {
+        _id: '',
+        beskrivelse: '',
+        tittel: '',
+      },
       tiltakstypeNavn: '',
     },
     kontaktinfoArrangor: {
@@ -70,7 +78,11 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltaksnummer: faker.datatype.number({ min: 100000, max: 999999 }),
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      innsatsgruppe: '',
+      innsatsgruppe: {
+        _id: '',
+        beskrivelse: '',
+        tittel: '',
+      },
       tiltakstypeNavn: '',
     },
     kontaktinfoArrangor: {
@@ -100,7 +112,11 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltaksnummer: faker.datatype.number({ min: 100000, max: 999999 }),
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      innsatsgruppe: '',
+      innsatsgruppe: {
+        _id: '',
+        beskrivelse: '',
+        tittel: '',
+      },
       tiltakstypeNavn: '',
     },
     kontaktinfoArrangor: {
@@ -130,7 +146,11 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltaksnummer: faker.datatype.number({ min: 100000, max: 999999 }),
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }),
-      innsatsgruppe: '',
+      innsatsgruppe: {
+        _id: '',
+        beskrivelse: '',
+        tittel: '',
+      },
       tiltakstypeNavn: '',
     },
     kontaktinfoArrangor: {

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltakstyper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltakstyper.ts
@@ -4,112 +4,200 @@ import { Tiltakstype } from '../../api/models';
 export const tiltakstyper: Tiltakstype[] = [
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '1',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Opplæring',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '1',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Funksjonsassistanse',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '1',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Utvidet oppfølging',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '1',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Avklaring',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '1',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Arbeidsmarkedsopplæring (AMO)',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '1',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Ekspertbistand',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '1',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Jobbklubb',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '2',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Oppfølging',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '2',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Digital jobbklubb',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '2',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Fag- og yrkesopplæring',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '2',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Arbeidstrening',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '2',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Arbeidsforberedende trening',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '2',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Midlertidig lønnstilskudd',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '2',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Varig lønnstilskudd',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '3',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Varig tilrettelagt arbeid i skjermet virksomhet',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '3',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Varig tilrettelagt arbeid i ordinær virksomhet',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '3',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Inkluderingstilskudd',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '3',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Funksjonsassistanse i arbeidslivet',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '3',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Mentor',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '3',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Arbeidsrettet rehabilitering',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '3',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Individuell jobbstøtte',
   },
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }),
-    innsatsgruppe: '4',
+    innsatsgruppe: {
+      _id: '',
+      beskrivelse: '',
+      tittel: '',
+    },
     tiltakstypeNavn: 'Tilskudd til sommerjobb',
   },
 ];


### PR DESCRIPTION
Flytter innsatsgrupper til Sanity som en egen type. Oppdaterer tiltakstype-skjema til å ta en reference til en innsatsgruppe istedenfor en tekststreng. Oppdaterer frontend til å ta i mot korrekte data. 