### PR TITLE
Legger til korrekt sortering for innsatsgrupper

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/innsatsgruppe.ts
+++ b/frontend/mulighetsrommet-cms/schemas/innsatsgruppe.ts
@@ -17,10 +17,23 @@ export default {
       type: "string",
       validation: (Rule: Rule) => Rule.required(),
     },
+    {
+      name: "order",
+      title: "Rekkefølge",
+      type: "number",
+    },
   ],
   preview: {
     select: {
       title: "tittel",
+      order: "order",
+    },
+    prepare: (selection) => {
+      const { title, order } = selection;
+      return {
+        title,
+        subtitle: `Sorteringsrekkefølge = ${order}`,
+      };
     },
   },
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useInnsatsgrupper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useInnsatsgrupper.ts
@@ -2,5 +2,5 @@ import { Innsatsgruppe } from '../models';
 import { useSanity } from './useSanity';
 
 export function useInnsatsgrupper() {
-  return useSanity<Innsatsgruppe[]>('*[_type == "innsatsgruppe"]');
+  return useSanity<Innsatsgruppe[]>('*[_type == "innsatsgruppe"] | order(order asc)');
 }


### PR DESCRIPTION
Legger til feltet `order` for innsatsgrupper, slik at vi kan sette korrekt sortering i Sanity slik vi ønsker at sorteringen skal være i frontend. Sorteringen er nå som følger:

![image](https://user-images.githubusercontent.com/9053627/175254024-0d6ebc4a-fb12-4dda-8588-eb23ef9c095a.png)

Og så kan man manuelt endre i Sanity dersom vi ønsker en annen sortering på et senere tidspunkt

![image](https://user-images.githubusercontent.com/9053627/175254124-09ffeee4-b439-4207-9314-ce04f25b5c87.png)
