### PR TITLE
Setter SANITY_DATASET til test for deploy-dev for api

### DIFF
--- a/.github/workflows/mulighetsrommet-api.yaml
+++ b/.github/workflows/mulighetsrommet-api.yaml
@@ -70,3 +70,4 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: mulighetsrommet-api/.nais/nais.yaml
           VAR: image=${{ env.IMAGE }}
+          SANITY_DATASET: test


### PR DESCRIPTION
Litt usikker på om SANITY_DATASET vil overstyre det som hentes fra Secret manager i gcp, men vi gjør et forsøk 🤞