### PR TITLE
Viser korrekt beskrivelse for gjennomføringer

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/models.ts
@@ -1,6 +1,16 @@
+type Tiltakstyper =
+  | 'Digital jobbklubb'
+  | 'AFT'
+  | 'Jobbklubb'
+  | 'ARR'
+  | 'Oppfølging'
+  | 'Avklaring'
+  | 'VTA'
+  | 'Opplæring (Gruppe AMO)';
+
 export interface Tiltakstype {
   _id: number;
-  tiltakstypeNavn: string;
+  tiltakstypeNavn: Tiltakstyper;
   beskrivelse?: string;
   innsatsgruppe: Innsatsgruppe;
   varighet?: string;

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useGetTiltaksnummerFraUrl.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useGetTiltaksnummerFraUrl.ts
@@ -1,0 +1,6 @@
+import { useParams } from 'react-router-dom';
+
+export function useGetTiltaksnummerFraUrl() {
+  const { tiltaksnummer = '' } = useParams();
+  return tiltaksnummer;
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingByTiltaksnummer.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingByTiltaksnummer.ts
@@ -1,8 +1,10 @@
-import { useSanity } from './useSanity';
 import { Tiltaksgjennomforing } from '../models';
+import { useGetTiltaksnummerFraUrl } from './useGetTiltaksnummerFraUrl';
+import { useSanity } from './useSanity';
 
-export default function useTiltaksgjennomforingById(id: number) {
-  return useSanity<Tiltaksgjennomforing>(`*[_type == "tiltaksgjennomforing" && tiltaksnummer == ${id}] {
+export default function useTiltaksgjennomforingByTiltaksnummer() {
+  const tiltaksnummer = useGetTiltaksnummerFraUrl();
+  return useSanity<Tiltaksgjennomforing>(`*[_type == "tiltaksgjennomforing" && tiltaksnummer == ${tiltaksnummer}] {
     _id,
     tiltaksgjennomforingNavn,
     beskrivelse,

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -3,14 +3,14 @@ import { Panel } from '@navikt/ds-react';
 import Kopiknapp from '../kopiknapp/Kopiknapp';
 import { Tiltaksgjennomforing } from '../../api/models';
 import Regelverksinfo from './Regelverksinfo';
+import useTiltaksgjennomforingByTiltaksnummer from '../../api/queries/useTiltaksgjennomforingByTiltaksnummer';
 
-interface SidemenyDetaljerProps {
-  tiltaksgjennomforing: Tiltaksgjennomforing;
-}
+const SidemenyDetaljer = () => {
+  const { data } = useTiltaksgjennomforingByTiltaksnummer();
+  if (!data) return null;
 
-const SidemenyDetaljer = ({ tiltaksgjennomforing }: SidemenyDetaljerProps) => {
-  const { tiltaksnummer, kontaktinfoArrangor, tiltakstype } = tiltaksgjennomforing;
-  const oppstart = resolveOppstart(tiltaksgjennomforing);
+  const { tiltaksnummer, kontaktinfoArrangor, tiltakstype } = data;
+  const oppstart = resolveOppstart(data);
 
   return (
     <>
@@ -34,7 +34,7 @@ const SidemenyDetaljer = ({ tiltaksgjennomforing }: SidemenyDetaljerProps) => {
 
         <div className="tiltakstype-detaljer__rad">
           <strong>Innsatsgruppe</strong>
-          <span>{tiltakstype.innsatsgruppe.beskrivelse} </span>
+          <span>{tiltakstype?.innsatsgruppe?.beskrivelse} </span>
         </div>
 
         <div className="tiltakstype-detaljer__rad">
@@ -44,9 +44,9 @@ const SidemenyDetaljer = ({ tiltaksgjennomforing }: SidemenyDetaljerProps) => {
         {(tiltakstype.regelverkFiler || tiltakstype.regelverkLenker) && (
           <div className="tiltakstype-detaljer__rad">
             <strong>Regelverk</strong>
-            <Regelverksinfo regelverkFiler={tiltakstype.regelverkFiler} regelverkLenker={tiltakstype.regelverkLenker}/>
-          </div>)
-        }
+            <Regelverksinfo regelverkFiler={tiltakstype.regelverkFiler} regelverkLenker={tiltakstype.regelverkLenker} />
+          </div>
+        )}
       </Panel>
     </>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
@@ -4,14 +4,13 @@ import { Tabs } from '@navikt/ds-react';
 import KontaktinfoFane from './kontaktinfofane/KontaktinfoFane';
 import DetaljerFane from './detaljerFane';
 import { logEvent } from '../../api/logger';
-import { Tiltaksgjennomforing } from '../../api/models';
+import useTiltaksgjennomforingByTiltaksnummer from '../../api/queries/useTiltaksgjennomforingByTiltaksnummer';
 
-interface TiltaksdetaljerFaneProps {
-  tiltaksgjennomforing: Tiltaksgjennomforing;
-}
+const TiltaksdetaljerFane = () => {
+  const { data } = useTiltaksgjennomforingByTiltaksnummer();
+  if (!data) return null;
 
-const TiltaksdetaljerFane = ({ tiltaksgjennomforing }: TiltaksdetaljerFaneProps) => {
-  const { tiltakstype, kontaktinfoTiltaksansvarlige, kontaktinfoArrangor } = tiltaksgjennomforing;
+  const { tiltakstype, kontaktinfoTiltaksansvarlige, kontaktinfoArrangor, faneinnhold } = data;
   const faneoverskrifter = ['For hvem', 'Detaljer og innhold', 'Påmelding og varighet', 'Kontaktinfo', 'Innsikt'];
 
   return (
@@ -29,25 +28,25 @@ const TiltaksdetaljerFane = ({ tiltaksgjennomforing }: TiltaksdetaljerFaneProps)
       </Tabs.List>
       <Tabs.Panel value="tab1">
         <DetaljerFane
-          tiltaksgjennomforingAlert={tiltaksgjennomforing.faneinnhold?.forHvemInfoboks}
+          tiltaksgjennomforingAlert={faneinnhold?.forHvemInfoboks}
           tiltakstypeAlert={tiltakstype.faneinnhold?.forHvemInfoboks}
-          tiltaksgjennomforing={tiltaksgjennomforing.faneinnhold?.forHvem}
+          tiltaksgjennomforing={faneinnhold?.forHvem}
           tiltakstype={tiltakstype.faneinnhold?.forHvem}
         />
       </Tabs.Panel>
       <Tabs.Panel value="tab2">
         <DetaljerFane
-          tiltaksgjennomforingAlert={tiltaksgjennomforing.faneinnhold?.detaljerOgInnholdInfoboks}
+          tiltaksgjennomforingAlert={faneinnhold?.detaljerOgInnholdInfoboks}
           tiltakstypeAlert={tiltakstype.faneinnhold?.detaljerOgInnholdInfoboks}
-          tiltaksgjennomforing={tiltaksgjennomforing.faneinnhold?.detaljerOgInnhold}
+          tiltaksgjennomforing={faneinnhold?.detaljerOgInnhold}
           tiltakstype={tiltakstype.faneinnhold?.detaljerOgInnhold}
         />
       </Tabs.Panel>
       <Tabs.Panel value="tab3">
         <DetaljerFane
-          tiltaksgjennomforingAlert={tiltaksgjennomforing.faneinnhold?.pameldingOgVarighetInfoboks}
+          tiltaksgjennomforingAlert={faneinnhold?.pameldingOgVarighetInfoboks}
           tiltakstypeAlert={tiltakstype.faneinnhold?.pameldingOgVarighetInfoboks}
-          tiltaksgjennomforing={tiltaksgjennomforing.faneinnhold?.pameldingOgVarighet}
+          tiltaksgjennomforing={faneinnhold?.pameldingOgVarighet}
           tiltakstype={tiltakstype.faneinnhold?.pameldingOgVarighet}
         />
       </Tabs.Panel>

--- a/frontend/mulighetsrommet-veileder-flate/src/layouts/TiltaksgjennomforingsHeader.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/layouts/TiltaksgjennomforingsHeader.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import './TiltaksgjennomforingsHeader.less';
 import { Heading } from '@navikt/ds-react';
 import { kebabCase } from '../utils/Utils';
-import { Tiltaksgjennomforing } from '../api/models';
+import useTiltaksgjennomforingByTiltaksnummer from '../api/queries/useTiltaksgjennomforingByTiltaksnummer';
 
-interface TiltaksgjennomforingsHeaderProps {
-  tiltaksgjennomforing: Tiltaksgjennomforing;
-}
+const TiltaksgjennomforingsHeader = () => {
+  const { data } = useTiltaksgjennomforingByTiltaksnummer();
+  if (!data) return null;
 
-const TiltaksgjennomforingsHeader = ({ tiltaksgjennomforing }: TiltaksgjennomforingsHeaderProps) => {
-  const { tiltaksgjennomforingNavn, beskrivelse, tiltakstype } = tiltaksgjennomforing;
+  const { tiltaksgjennomforingNavn, beskrivelse, tiltakstype } = data;
   return (
     <div className="tiltaksgjennomforing__title">
       <Heading
@@ -19,7 +18,10 @@ const TiltaksgjennomforingsHeader = ({ tiltaksgjennomforing }: Tiltaksgjennomfor
       >
         {tiltaksgjennomforingNavn}
       </Heading>
-      {beskrivelse && <div className="tiltaksgjennomforing__beskrivelse">{beskrivelse}</div>}
+      {tiltakstype?.tiltakstypeNavn === 'Opplæring (Gruppe AMO)'
+        ? beskrivelse && <div className="tiltaksgjennomforing__beskrivelse">{beskrivelse}</div>
+        : null}
+
       {tiltakstype.beskrivelse && <div className="tiltaksgjennomforing__beskrivelse">{tiltakstype.beskrivelse}</div>}
     </div>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
@@ -4,14 +4,14 @@ import Tilbakeknapp from '../../components/tilbakeknapp/Tilbakeknapp';
 import TiltaksgjennomforingsHeader from '../../layouts/TiltaksgjennomforingsHeader';
 import Statistikk from '../../components/statistikk/Statistikk';
 import SidemenyDetaljer from '../../components/sidemeny/SidemenyDetaljer';
-import { useParams } from 'react-router-dom';
 import TiltaksdetaljerFane from '../../components/tabs/TiltaksdetaljerFane';
-import useTiltaksgjennomforingById from '../../api/queries/useTiltaksgjennomforingById';
+import useTiltaksgjennomforingByTiltaksnummer from '../../api/queries/useTiltaksgjennomforingByTiltaksnummer';
 import { Alert, Loader } from '@navikt/ds-react';
+import { useGetTiltaksnummerFraUrl } from '../../api/queries/useGetTiltaksnummerFraUrl';
 
 const ViewTiltakstypeDetaljer = () => {
-  const { tiltaksnummer = '' } = useParams();
-  const { data: tiltaksgjennomforing, isLoading, isError } = useTiltaksgjennomforingById(parseInt(tiltaksnummer));
+  const tiltaksnummer = useGetTiltaksnummerFraUrl();
+  const { data: tiltaksgjennomforing, isLoading, isError } = useTiltaksgjennomforingByTiltaksnummer();
 
   if (isLoading) {
     return <Loader className="filter-loader" size="xlarge" />;
@@ -31,15 +31,15 @@ const ViewTiltakstypeDetaljer = () => {
     <div className="tiltakstype-detaljer">
       <div className="tiltakstype-detaljer__info">
         <Tilbakeknapp tilbakelenke="/" />
-        <TiltaksgjennomforingsHeader tiltaksgjennomforing={tiltaksgjennomforing} />
+        <TiltaksgjennomforingsHeader />
         <Statistikk
           tittel="Overgang til arbeid"
           hjelpetekst="Her skal det stå litt om hva denne statistikken viser oss"
           statistikktekst="69%"
         />
       </div>
-      <SidemenyDetaljer tiltaksgjennomforing={tiltaksgjennomforing} />
-      <TiltaksdetaljerFane tiltaksgjennomforing={tiltaksgjennomforing} />
+      <SidemenyDetaljer />
+      <TiltaksdetaljerFane />
     </div>
   );
 };


### PR DESCRIPTION
Gjør en endring slik at vi viser beskrivelsen for tiltaksgjennomføringene for de gjennomføringene som har tiltakstype = Gruppeopplæring (AMO). For alle andre gjennomføringer viser vi beskrivelsen som ligger på selve tiltakstypen.

Jeg har også refaktorert bort litt prop-drilling og tar heller og bruker react-query sin caching-strategy til å gjenbruke kall til hooks for å "hente" tiltaksgjennomføringsdata direkte i de komponentene som trenger det. Da blir koden mer lesbar og mye enklere å flytte rundt på komponentene uten å ta hensyn til hvor data blir sendt nedover i DOM-treet. 