### PR TITLE
Fikser feil ved filtrering og paginering

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
@@ -1,11 +1,13 @@
 import { useAtom } from 'jotai';
-import {Tiltaksgjennomforingsfilter, tiltaksgjennomforingsfilter, Tiltaksgjenomforingsfiltergruppe} from '../../core/atoms/atoms';
+import { tiltaksgjennomforingsfilter, Tiltaksgjenomforingsfiltergruppe } from '../../core/atoms/atoms';
 import { Tiltaksgjennomforing } from '../models';
 import { useSanity } from './useSanity';
 
 export default function useTiltaksgjennomforing() {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
-  return useSanity<Tiltaksgjennomforing[]>(`*[_type == "tiltaksgjennomforing" ${byggInnsatsgruppeFilter(filter.innsatsgrupper)} ${byggTiltakstypeFilter(filter.tiltakstyper)}]{
+  return useSanity<Tiltaksgjennomforing[]>(`*[_type == "tiltaksgjennomforing" ${byggInnsatsgruppeFilter(
+    filter.innsatsgrupper
+  )} ${byggTiltakstypeFilter(filter.tiltakstyper)}]{
     _id,
     tiltaksgjennomforingNavn,
     lokasjon,
@@ -19,14 +21,12 @@ export default function useTiltaksgjennomforing() {
 
 function byggInnsatsgruppeFilter(innsatsgrupper: Tiltaksgjenomforingsfiltergruppe[]): string {
   return innsatsgrupper.length > 0
-      ? `&& tiltakstype->innsatsgruppe->tittel in [${innsatsgrupper
-          .map(gruppe => `"${gruppe.tittel}"`)
-          .join(', ')}]`
-      : '';
+    ? `&& tiltakstype->innsatsgruppe->tittel in [${innsatsgrupper.map(gruppe => `"${gruppe.tittel}"`).join(', ')}]`
+    : '';
 }
 
 function byggTiltakstypeFilter(tiltakstyper: Tiltaksgjenomforingsfiltergruppe[]): string {
   return tiltakstyper.length > 0
-      ? `&& tiltakstype->_id in [${tiltakstyper.map(type => `"${type.id}"`).join(', ')}]`
-      : '';
+    ? `&& tiltakstype->_id in [${tiltakstyper.map(type => `"${type.id}"`).join(', ')}]`
+    : '';
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
@@ -1,6 +1,4 @@
 import { atom } from 'jotai';
-import { Innsatsgruppe } from 'mulighetsrommet-api-client';
-import { Tiltakstype } from '../../api/models';
 
 export interface Tiltaksgjennomforingsfilter {
   search?: string;
@@ -9,8 +7,8 @@ export interface Tiltaksgjennomforingsfilter {
 }
 
 export interface Tiltaksgjenomforingsfiltergruppe {
-  id: string,
-  tittel: string
+  id: string;
+  tittel: string;
 }
 
 export const tiltaksgjennomforingsfilter = atom<Tiltaksgjennomforingsfilter>({


### PR DESCRIPTION
Dersom man sto på en side > 1 i pagineringen av tiltaksgjennomføringene og så valgte å filtrere på en tiltakstype eller innsatsgruppe så fikk man ikke opp noen treff. Denne PRen fikser det ved å resette siden man står på til 1 når man gjør en filtrering slik at man får opp resultater.