### PR TITLE
Persisterer filter og paginering i url

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Heading, Loader, Pagination, Table } from '@navikt/ds-react';
 import './Tabell.less';
+import { useAtom } from 'jotai';
 import Lenke from '../lenke/Lenke';
 import Kopiknapp from '../kopiknapp/Kopiknapp';
 import StatusGronn from '../../ikoner/Sirkel-gronn.png';
@@ -9,10 +10,11 @@ import StatusRod from '../../ikoner/Sirkel-rod.png';
 import useTiltaksgjennomforing from '../../api/queries/useTiltaksgjennomforing';
 import { logEvent } from '../../api/logger';
 import { Tiltaksgjennomforing } from '../../api/models';
+import { paginationAtom } from '../../core/atoms/atoms';
 
 const TiltaksgjennomforingsTabell = () => {
   const [sort, setSort] = useState<any>();
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useAtom(paginationAtom);
   const rowsPerPage = 15;
   const pagination = (tiltaksgjennomforing: Tiltaksgjennomforing[]) => {
     return Math.ceil(tiltaksgjennomforing.length / rowsPerPage);
@@ -21,11 +23,11 @@ const TiltaksgjennomforingsTabell = () => {
   const { data: tiltaksgjennomforinger = [], isLoading, isError, isFetching } = useTiltaksgjennomforing();
 
   useEffect(() => {
-    if (isFetching) {
+    if (tiltaksgjennomforinger.length <= rowsPerPage && !isFetching) {
       // Reset state
       setPage(1);
     }
-  }, [isFetching]);
+  }, [tiltaksgjennomforinger]);
 
   const tilgjengelighetsstatus = (status: string) => {
     //TODO endre denne når vi får inn data fra Arena

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tags/SearchFieldTag.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tags/SearchFieldTag.tsx
@@ -20,7 +20,7 @@ const SearchFieldTag = () => {
     <>
       {filter.search && (
         <Tag variant="info" size="small">
-          Søk på tittel
+          {filter.search}
           <Ikonknapp handleClick={handleClickFjernFilter} ariaLabel="Lukkeknapp">
             <Close className="filtertags__ikon" aria-label="Lukkeknapp" />
           </Ikonknapp>

--- a/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai';
+import { atomWithHash } from 'jotai/utils';
 
 export interface Tiltaksgjennomforingsfilter {
   search?: string;
@@ -11,8 +11,15 @@ export interface Tiltaksgjenomforingsfiltergruppe {
   tittel: string;
 }
 
-export const tiltaksgjennomforingsfilter = atom<Tiltaksgjennomforingsfilter>({
+export const initialTiltaksgjennomforingsfilter = {
   search: '',
   innsatsgrupper: [],
   tiltakstyper: [],
-});
+};
+
+export const tiltaksgjennomforingsfilter = atomWithHash<Tiltaksgjennomforingsfilter>(
+  'filter',
+  initialTiltaksgjennomforingsfilter
+);
+
+export const paginationAtom = atomWithHash('page', 1);

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect } from 'react';
 import { Button } from '@navikt/ds-react';
 import { useAtom } from 'jotai';
+import { RESET } from 'jotai/utils';
 import { FAKE_DOOR, useFeatureToggles } from '../../api/feature-toggles';
 import Filtermeny from '../../components/filtrering/Filtermeny';
 import TiltaksgjennomforingsTabell from '../../components/tabell/TiltaksgjennomforingsTabell';
 import FilterTags from '../../components/tags/Filtertags';
 import SearchFieldTag from '../../components/tags/SearchFieldTag';
-import { tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
+import { initialTiltaksgjennomforingsfilter, tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
 import '../../layouts/TiltaksgjennomforingsHeader.less';
 import Show from '../../utils/Show';
 import './ViewTiltakstypeOversikt.less';
@@ -20,10 +21,10 @@ const ViewTiltakstypeOversikt = () => {
 
   //TODO fiks denne når vi får inn prefiltrering
   useEffect(() => {
-    if (filter.tiltakstyper?.length === 0 && filter.innsatsgrupper?.length === 0) {
-      setFilter(tiltaksgjennomforingsfilter.init);
+    if (filter === initialTiltaksgjennomforingsfilter) {
+      setFilter(RESET);
     }
-  }, [filter.tiltakstyper, filter.innsatsgrupper]);
+  }, [filter]);
 
   return (
     <>
@@ -54,12 +55,12 @@ const ViewTiltakstypeOversikt = () => {
               />
               <SearchFieldTag />
             </div>
-            <Show if={filter !== tiltaksgjennomforingsfilter.init}>
+            <Show if={filter !== initialTiltaksgjennomforingsfilter}>
               <div className="tilbakestill-filter-knapp">
                 <Button
                   size="small"
                   variant="secondary"
-                  onClick={() => setFilter(tiltaksgjennomforingsfilter.init)}
+                  onClick={() => setFilter(RESET)}
                   data-testid="knapp_tilbakestill-filter"
                 >
                   Tilbakestill filter


### PR DESCRIPTION
Bruker Jotai sin `atomWithHash` for å persistere filter og paginering via url https://jotai.org/docs/utils/atom-with-hash

Dermed kan bruker refreshe så mye de orker, og filterne blir værende.


https://user-images.githubusercontent.com/9053627/175935420-918dd46e-ec56-4040-98ed-b469ee59dbd5.mov

