### PR TITLE
Setter maks-bredde for innhold i fanene til 75ch

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.less
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.less
@@ -7,10 +7,9 @@
     &__liste {
       display: flex;
       flex-direction: row;
-      border-bottom: 1px solid var(--navds-semantic-color-border-muted);
-      margin-bottom: 2rem;
       gap: 5%;
       justify-content: start;
+      width: 100%;
 
       .navds-label {
         font-weight: normal;
@@ -42,9 +41,16 @@
   }
 
   .navds-tabs__tabpanel {
-    .tiltaksdetaljer__alert {
-      margin-bottom: 1rem;
+    .tiltaksdetaljer {
+      &__alert {
+        margin-bottom: 1rem;
+      }
+  
+      &__maksbredde {
+        max-width: 75ch;
+      }
     }
+    
   }
 
   @media (max-width: 1200px) {

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/detaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/detaljerFane.tsx
@@ -17,7 +17,7 @@ const DetaljerFane = ({
   tiltakstype,
 }: DetaljerFaneProps) => {
   return (
-    <div>
+    <div className="tiltaksdetaljer__maksbredde">
       {tiltakstypeAlert && (
         <Alert variant="info" className="tiltaksdetaljer__alert">
           {tiltakstypeAlert}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.less
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.less
@@ -1,6 +1,7 @@
 .mulighetsrommet-veileder-flate {
   .kontaktinfo {
     display: grid;
+    margin: 18px 0px;
     grid-template-columns: auto auto;
     gap: 2rem;
     &__header {


### PR DESCRIPTION
Strammer stylingen for detaljfanene en liten smule. Fjerner noe unødvendig padding for tabs, og setter en maks-bredde for innhold til 75ch for bedre lesbarhet.

**Før**
![image](https://user-images.githubusercontent.com/9053627/176658476-4ba02a77-a2ae-41b1-bae3-4a2abb697699.png)


**Etter**
![image](https://user-images.githubusercontent.com/9053627/176658296-4ee2d6c3-4b35-4115-840a-8858bd53215f.png)
