### PR TITLE
Ikke hent draft documents fra Sanity

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -20,7 +20,7 @@ describe('Tiltaksgjennomføringstabell', () => {
     cy.getByTestId('filtertags').children().should('have.length', 2);
     cy.getByTestId('knapp_tilbakestill-filter').should('exist');
 
-    cy.w(1000)
+    cy.wait(1000)
       .getByTestId('antall-tiltak')
       .then($navn => {
         expect(antallTiltak).not.to.eq($navn.text());

--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -20,7 +20,7 @@ describe('Tiltaksgjennomføringstabell', () => {
     cy.getByTestId('filtertags').children().should('have.length', 2);
     cy.getByTestId('knapp_tilbakestill-filter').should('exist');
 
-    cy.wait(1000)
+    cy.w(1000)
       .getByTestId('antall-tiltak')
       .then($navn => {
         expect(antallTiltak).not.to.eq($navn.text());

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useInnsatsgrupper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useInnsatsgrupper.ts
@@ -2,5 +2,5 @@ import { Innsatsgruppe } from '../models';
 import { useSanity } from './useSanity';
 
 export function useInnsatsgrupper() {
-  return useSanity<Innsatsgruppe[]>('*[_type == "innsatsgruppe"] | order(order asc)');
+  return useSanity<Innsatsgruppe[]>('*[_type == "innsatsgruppe" && !(_id in path("drafts.**"))] | order(order asc) ');
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
@@ -5,7 +5,7 @@ import { useSanity } from './useSanity';
 
 export default function useTiltaksgjennomforing() {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
-  return useSanity<Tiltaksgjennomforing[]>(`*[_type == "tiltaksgjennomforing" 
+  return useSanity<Tiltaksgjennomforing[]>(`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
   ${byggInnsatsgruppeFilter(filter.innsatsgrupper)} 
   ${byggTiltakstypeFilter(filter.tiltakstyper)}
   ${byggSokefilter(filter.search)}

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingByTiltaksnummer.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingByTiltaksnummer.ts
@@ -4,7 +4,7 @@ import { useSanity } from './useSanity';
 
 export default function useTiltaksgjennomforingByTiltaksnummer() {
   const tiltaksnummer = useGetTiltaksnummerFraUrl();
-  return useSanity<Tiltaksgjennomforing>(`*[_type == "tiltaksgjennomforing" && tiltaksnummer == ${tiltaksnummer}] {
+  return useSanity<Tiltaksgjennomforing>(`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) && tiltaksnummer == ${tiltaksnummer}] {
     _id,
     tiltaksgjennomforingNavn,
     beskrivelse,

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltakstyper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltakstyper.ts
@@ -2,5 +2,5 @@ import { useSanity } from './useSanity';
 import { Tiltakstype } from '../models';
 
 export function useTiltakstyper() {
-  return useSanity<Tiltakstype[]>(`*[_type == "tiltakstype"]`);
+  return useSanity<Tiltakstype[]>(`*[_type == "tiltakstype" && !(_id in path("drafts.**"))]`);
 }


### PR DESCRIPTION
Når man starter å redigere et dokument i Sanity så opprettes det et såkalt `draft document`. Dette blir tilgjengelig for autentisert klient, dvs. at når vi starter en redigering og _noen_ henter data fra Sanity så kan de få draft-dokumentet i tillegg til original. 

Denne PRen fikser det problemet, slik at vi ikke henter draft-dokumenter.

Les mer hos Sanity her https://www.sanity.io/docs/drafts

Fra Sanity sine docs om drafs

> Drafts are not available to the public API, but can be accessed using an authenticated client or using an access token. Sometimes you therefore might need to filter drafts from your queries. You can do this by adding the following filter:
> `*[!(_id in path('drafts.**'))] // _id matches anything that is *not* in the drafts-path`