### PR TITLE
Map riktig innsatsgruppe for innkommende events

### DIFF
--- a/mulighetsrommet-api/src/main/resources/db/migration/manual/update_innsatsgrupper_for_tiltakstyper.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/manual/update_innsatsgrupper_for_tiltakstyper.sql
@@ -1,0 +1,24 @@
+-- Tiltakstyper som ikke er kartlagt enda settes bare til standard innsats by default.
+
+-- Standard innsats
+update tiltakstype set innsatsgruppe_id = 1 where tiltakskode like 'DIGIOPPARB';
+update tiltakstype set innsatsgruppe_id = 1 where tiltakskode like 'JOBBK';
+
+-- Situasjonsbestemt innsats
+update tiltakstype set innsatsgruppe_id = 2 where tiltakskode like 'ARBTREN';
+update tiltakstype set innsatsgruppe_id = 2 where tiltakskode like 'AVKLARAG';
+update tiltakstype set innsatsgruppe_id = 2 where tiltakskode like 'ENKELAMO';
+update tiltakstype set innsatsgruppe_id = 2 where tiltakskode like 'ENKFAGYRKE';
+update tiltakstype set innsatsgruppe_id = 2 where tiltakskode like 'INDOPPFAG';
+update tiltakstype set innsatsgruppe_id = 2 where tiltakskode like 'INKLUTILS';
+update tiltakstype set innsatsgruppe_id = 2 where tiltakskode like 'MENTOR';
+update tiltakstype set innsatsgruppe_id = 2 where tiltakskode like 'MIDLONTIL';
+
+-- Spesiell tilpasset innsats
+update tiltakstype set innsatsgruppe_id = 3 where tiltakskode like 'ARBFORB';
+update tiltakstype set innsatsgruppe_id = 3 where tiltakskode like 'HOYEREUTD';
+
+-- Varig tilpasset innsats
+update tiltakstype set innsatsgruppe_id = 4 where tiltakskode like 'VARLONTIL';
+update tiltakstype set innsatsgruppe_id = 4 where tiltakskode like 'VASV';
+update tiltakstype set innsatsgruppe_id = 4 where tiltakskode like 'VATIAROR';

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -29,7 +29,7 @@ class TiltakEndretConsumer(
 
     private fun JsonObject.toTiltakstype() = Tiltakstype(
         navn = this["TILTAKSNAVN"]!!.jsonPrimitive.content,
-        innsatsgruppe = 1,
+        innsatsgruppe = ProcessingUtils.toInnsatsgruppe(this["TILTAKSKODE"]!!.jsonPrimitive.content),
         tiltakskode = this["TILTAKSKODE"]!!.jsonPrimitive.content,
         fraDato = ProcessingUtils.getArenaDateFromTo(this["DATO_FRA"]!!.jsonPrimitive.content),
         tilDato = ProcessingUtils.getArenaDateFromTo(this["DATO_TIL"]!!.jsonPrimitive.content)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ProcessingUtils.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ProcessingUtils.kt
@@ -28,14 +28,6 @@ object ProcessingUtils {
         }
     }
 
-    fun getArenaOperationType(json: JsonObject) = ArenaEventOperationType[json["op_type"]!!.jsonPrimitive.content]
-
-    fun isInsertArenaOperation(json: JsonObject) =
-        ArenaEventOperationType[json["op_type"]!!.jsonPrimitive.content] == ArenaEventOperationType.INSERT
-
-    fun isUpdateArenaOperation(json: JsonObject) =
-        ArenaEventOperationType[json["op_type"]!!.jsonPrimitive.content] == ArenaEventOperationType.UPDATE
-
     fun toDeltakerstatus(arenaStatus: String): Deltakerstatus = when (arenaStatus) {
         "AVSLAG", "IKKAKTUELL", "NEITAKK" -> Deltakerstatus.IKKE_AKTUELL
         "TILBUD", "JATAKK", "INFOMOETE", "AKTUELL", "VENTELISTE" -> Deltakerstatus.VENTER

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ProcessingUtils.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ProcessingUtils.kt
@@ -28,6 +28,21 @@ object ProcessingUtils {
         }
     }
 
+    /**
+     * 1 - Standard innsats
+     * 2 - Situasjonsbestemt innsats
+     * 3 - Spesiell tilpasset innsats
+     * 4 - Varig tilpasset innsats
+     * Inntil videre setter vi alle andre tiltakstyper vi ikke har kartlagt til standard innsats
+     */
+    fun toInnsatsgruppe(tiltakskode: String): Int = when (tiltakskode) {
+        "JOBBK", "DIGIOPPARB" -> 1
+        "AVKLARAG", "ARBTREN", "MIDLONTIL", "MENTOR", "INDOPPFAG", "INKLUTILS", "ENKFAGYRKE", "ENKELAMO" -> 2
+        "HOYEREUTD", "ARBFORB" -> 3
+        "VASV", "VATIAROR", "VARLONTIL" -> 4
+        else -> 1
+    }
+
     fun toDeltakerstatus(arenaStatus: String): Deltakerstatus = when (arenaStatus) {
         "AVSLAG", "IKKAKTUELL", "NEITAKK" -> Deltakerstatus.IKKE_AKTUELL
         "TILBUD", "JATAKK", "INFOMOETE", "AKTUELL", "VENTELISTE" -> Deltakerstatus.VENTER

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ProcessingUtils.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ProcessingUtils.kt
@@ -1,7 +1,5 @@
 package no.nav.mulighetsrommet.arena.adapter.utils
 
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import no.nav.mulighetsrommet.domain.Deltakerstatus
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter


### PR DESCRIPTION
Har ikke så mye å si for piloten sin del men har lagt ved map-funksjonalitet for innsatsgrupper på tiltakstyper som kommer inn via Arena kafka. La også til et manuelt script som vi kan kjøre når vi trenger å oppdatere eksisterende data på et senere tidspunkt.