### PR TITLE
Hent brukerdata i backend for filtrering mot Sanity

### DIFF
--- a/frontend/mulighetsrommet-api-client/src/services/MulighetsrommetService.ts
+++ b/frontend/mulighetsrommet-api-client/src/services/MulighetsrommetService.ts
@@ -18,15 +18,19 @@ export class MulighetsrommetService {
      */
     public static sanityQuery({
         query,
+        fnr,
     }: {
         /** Sanity query as a Groq-string. See https://www.sanity.io/docs/groq for more information. **/
-        query?: string,
+        query: string,
+        /** SSN for the user which will be used to filter based on the users 'oppfølgingsenhet' **/
+        fnr?: string,
     }): CancelablePromise<any> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/sanity',
             query: {
                 'query': query,
+                'fnr': fnr,
             },
         });
     }

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useSanity.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useSanity.ts
@@ -2,11 +2,13 @@ import { useQuery } from 'react-query';
 import { QueryKeys } from '../../core/api/QueryKeys';
 import { MulighetsrommetService } from 'mulighetsrommet-api-client';
 import useDebounce from '../../hooks/useDebounce';
+import { useHentFnrFraUrl } from '../../hooks/useHentFnrFraUrl';
 
 export function useSanity<T>(query: string) {
   const debouncedQuery = useDebounce(query, 300);
+  const fnr = useHentFnrFraUrl();
   return useQuery(
-    [QueryKeys.SanityQuery, debouncedQuery],
-    () => MulighetsrommetService.sanityQuery({ query: debouncedQuery }) as Promise<T>
+    [QueryKeys.SanityQuery, debouncedQuery, fnr],
+    () => MulighetsrommetService.sanityQuery({ query: debouncedQuery, fnr }) as Promise<T>
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -43,7 +43,7 @@ const ViewTiltakstypeOversikt = () => {
                   size="small"
                   data-testid={`${kebabCase('filtertag_navenhet')}`}
                 >
-                  {brukerdata?.data?.oppfolgingsenhet.navn}
+                  {brukerdata?.data?.oppfolgingsenhet?.navn}
                 </Tag>
               )}
               <FilterTags

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -1,26 +1,16 @@
 package no.nav.mulighetsrommet.api
 
-import com.nimbusds.jose.jwk.KeyUse
-import com.nimbusds.jose.jwk.RSAKey
 import com.sksamuel.hoplite.ConfigLoader
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.routing.*
-import no.nav.common.token_client.builder.AzureAdTokenClientBuilder
-import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClientImpl
-import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClientImpl
 import no.nav.mulighetsrommet.api.plugins.*
 import no.nav.mulighetsrommet.api.routes.internalRoutes
 import no.nav.mulighetsrommet.api.routes.swaggerRoutes
 import no.nav.mulighetsrommet.api.routes.v1.*
-import no.nav.mulighetsrommet.api.services.BrukerService
-import no.nav.mulighetsrommet.api.setup.http.baseClient
 import org.slf4j.LoggerFactory
-import java.security.KeyPairGenerator
-import java.security.interfaces.RSAPrivateKey
-import java.security.interfaces.RSAPublicKey
 
 fun main() {
     val config = ConfigLoader().loadConfigOrThrow<Config>("/application.yaml")
@@ -47,31 +37,6 @@ fun initializeServer(config: Config) {
 }
 
 fun Application.configure(config: AppConfig) {
-    val tokenClient = when (erLokalUtvikling()) {
-        true -> AzureAdTokenClientBuilder.builder()
-            .withClientId(config.auth.azure.audience)
-            .withPrivateJwk(createRSAKeyForLokalUtvikling("azure").toJSONString())
-            .withTokenEndpointUrl(config.auth.azure.tokenEndpointUrl)
-            .buildOnBehalfOfTokenClient()
-        false -> AzureAdTokenClientBuilder.builder().withNaisDefaults().buildOnBehalfOfTokenClient()
-    }
-
-    val veilarboppfolgingClientImpl = VeilarboppfolgingClientImpl(
-        baseUrl = config.veilarboppfolgingConfig.url,
-        tokenClient,
-        config.veilarboppfolgingConfig.scope,
-        client = baseClient
-    )
-
-    val veilarbvedtaksstotteClientImpl = VeilarbvedtaksstotteClientImpl(
-        baseUrl = config.veilarbvedtaksstotteConfig.url,
-        tokenClient,
-        config.veilarbvedtaksstotteConfig.scope,
-        client = baseClient
-    )
-
-    val brukerService = BrukerService(veilarboppfolgingClientImpl, veilarbvedtaksstotteClientImpl)
-
     configureDependencyInjection(config)
     configureAuthentication(config.auth)
     configureRouting()
@@ -91,23 +56,7 @@ fun Application.configure(config: AppConfig) {
             innsatsgruppeRoutes()
             arenaRoutes()
             sanityRoutes()
-            brukerRoutes(brukerService = brukerService)
+            brukerRoutes()
         }
     }
 }
-
-fun erLokalUtvikling(): Boolean {
-    return System.getenv("NAIS_CLUSTER_NAME") == null
-}
-
-fun createRSAKeyForLokalUtvikling(keyID: String): RSAKey = KeyPairGenerator
-    .getInstance("RSA").let {
-        it.initialize(2048)
-        it.generateKeyPair()
-    }.let {
-        RSAKey.Builder(it.public as RSAPublicKey)
-            .privateKey(it.private as RSAPrivateKey)
-            .keyUse(KeyUse.SIGNATURE)
-            .keyID(keyID)
-            .build()
-    }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -1,8 +1,16 @@
 package no.nav.mulighetsrommet.api.plugins
 
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.RSAKey
 import io.ktor.server.application.*
+import no.nav.common.token_client.builder.AzureAdTokenClientBuilder
+import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient
 import no.nav.mulighetsrommet.api.AppConfig
 import no.nav.mulighetsrommet.api.DatabaseConfig
+import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClient
+import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClientImpl
+import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClient
+import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClientImpl
 import no.nav.mulighetsrommet.api.database.Database
 import no.nav.mulighetsrommet.api.services.*
 import org.koin.core.module.Module
@@ -10,11 +18,17 @@ import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
 import org.koin.logger.SLF4JLogger
 import org.slf4j.Logger
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
 
 fun Application.configureDependencyInjection(appConfig: AppConfig) {
     install(Koin) {
         SLF4JLogger()
-        modules(db(appConfig.database), services(log, appConfig))
+        modules(
+            db(appConfig.database),
+            services(log, appConfig, veilarbvedsstotte(appConfig), veilarboppfolging(appConfig))
+        )
     }
 }
 
@@ -24,10 +38,66 @@ private fun db(databaseConfig: DatabaseConfig): Module {
     }
 }
 
-private fun services(logger: Logger, appConfig: AppConfig) = module {
+private fun veilarbvedsstotte(config: AppConfig): VeilarbvedtaksstotteClient {
+    return VeilarbvedtaksstotteClientImpl(
+        config.veilarbvedtaksstotteConfig.url,
+        tokenClientProvider(config),
+        config.veilarbvedtaksstotteConfig.scope,
+        config.veilarbvedtaksstotteConfig.httpClient
+    )
+}
+
+private fun veilarboppfolging(config: AppConfig): VeilarboppfolgingClient {
+    return VeilarboppfolgingClientImpl(
+        config.veilarboppfolgingConfig.url,
+        tokenClientProvider(config),
+        config.veilarboppfolgingConfig.scope,
+        config.veilarboppfolgingConfig.httpClient
+    )
+}
+
+private fun tokenClientProvider(config: AppConfig): AzureAdOnBehalfOfTokenClient {
+    return when (erLokalUtvikling()) {
+        true -> AzureAdTokenClientBuilder.builder()
+            .withClientId(config.auth.azure.audience)
+            .withPrivateJwk(createRSAKeyForLokalUtvikling("azure").toJSONString())
+            .withTokenEndpointUrl(config.auth.azure.tokenEndpointUrl)
+            .buildOnBehalfOfTokenClient()
+        false -> AzureAdTokenClientBuilder.builder().withNaisDefaults().buildOnBehalfOfTokenClient()
+    }
+}
+
+private fun services(
+    logger: Logger,
+    appConfig: AppConfig,
+    veilarbvedsstotte: VeilarbvedtaksstotteClient,
+    veilarboppfolging: VeilarboppfolgingClient
+) = module {
     single { ArenaService(get(), logger) }
     single { TiltaksgjennomforingService(get(), logger) }
     single { TiltakstypeService(get(), logger) }
     single { InnsatsgruppeService(get(), logger) }
-    single { SanityService(appConfig.sanity) }
+    single { SanityService(appConfig.sanity, get()) }
+    single {
+        BrukerService(
+            veilarboppfolgingClient = veilarboppfolging,
+            veilarbvedtaksstotteClient = veilarbvedsstotte
+        )
+    }
 }
+
+private fun erLokalUtvikling(): Boolean {
+    return System.getenv("NAIS_CLUSTER_NAME") == null
+}
+
+private fun createRSAKeyForLokalUtvikling(keyID: String): RSAKey = KeyPairGenerator
+    .getInstance("RSA").let {
+        it.initialize(2048)
+        it.generateKeyPair()
+    }.let {
+        RSAKey.Builder(it.public as RSAPublicKey)
+            .privateKey(it.private as RSAPrivateKey)
+            .keyUse(KeyUse.SIGNATURE)
+            .keyID(keyID)
+            .build()
+    }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
@@ -6,8 +6,11 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.mulighetsrommet.api.services.BrukerService
 import no.nav.mulighetsrommet.api.utils.getAccessToken
+import org.koin.ktor.ext.inject
 
-fun Route.brukerRoutes(brukerService: BrukerService) {
+fun Route.brukerRoutes() {
+    val brukerService: BrukerService by inject()
+
     route("/api/v1/bruker") {
         get("{fnr}") {
             val fnr = call.parameters["fnr"] ?: return@get call.respondText(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/InnsatsgruppeRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/InnsatsgruppeRoutes.kt
@@ -7,7 +7,6 @@ import no.nav.mulighetsrommet.api.services.InnsatsgruppeService
 import org.koin.ktor.ext.inject
 
 fun Route.innsatsgruppeRoutes() {
-
     val innsatsgruppeService: InnsatsgruppeService by inject()
 
     route("/api/v1/innsatsgrupper") {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
@@ -2,10 +2,10 @@ package no.nav.mulighetsrommet.api.routes.v1
 
 import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.mulighetsrommet.api.services.SanityService
+import no.nav.mulighetsrommet.api.utils.getAccessToken
 import org.koin.ktor.ext.inject
 import org.slf4j.LoggerFactory
 
@@ -18,8 +18,10 @@ fun Route.sanityRoutes() {
             val query = call.request.queryParameters["query"]
                 ?: return@get call.respondText("No query parameter with value '?query' present. Cannot execute query against Sanity")
             log.debug("Query sanity with value: $query")
+            val fnr = call.request.queryParameters["fnr"]
+            val accessToken = call.getAccessToken()
 
-            val result = sanityService.executeQuery(query)
+            val result = sanityService.executeQuery(query, fnr, accessToken)
             call.respondText(result.toString(), ContentType.Application.Json)
         }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
@@ -1,6 +1,5 @@
 package no.nav.mulighetsrommet.api.services
 
-import io.ktor.server.plugins.*
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClient
 import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClient
@@ -16,13 +15,9 @@ class BrukerService(
         val oppfolgingsenhet = veilarboppfolgingClient.hentOppfolgingsstatus(fnr, accessToken)
         val sisteVedtak = veilarbvedtaksstotteClient.hentSiste14AVedtak(fnr, accessToken)
 
-        if (oppfolgingsenhet?.oppfolgingsenhet == null) {
-            throw NotFoundException("Fant ikke oppfølgingsenhet")
-        }
-
         return Brukerdata(
             fnr = fnr,
-            oppfolgingsenhet = oppfolgingsenhet.oppfolgingsenhet,
+            oppfolgingsenhet = oppfolgingsenhet?.oppfolgingsenhet,
             innsatsgruppe = sisteVedtak?.innsatsgruppe
         )
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory
 import java.text.SimpleDateFormat
 import java.util.*
 
+private val log = LoggerFactory.getLogger(SanityService::class.java)
+
 class SanityService(sanityConfig: SanityConfig, brukerService: BrukerService) {
     private val logger = LoggerFactory.getLogger(SanityService::class.java)
     private val client: HttpClient
@@ -38,7 +40,17 @@ class SanityService(sanityConfig: SanityConfig, brukerService: BrukerService) {
         }
     }
 
-    suspend fun executeQuery(query: String): JsonElement? {
+    suspend fun executeQuery(query: String, fnr: String?, accessToken: String?): JsonElement? {
+        var brukerData: Brukerdata?
+        if (fnr !== null) {
+            // TODO Bruk brukerData til å filtrere - Kommer via Signes branch senere
+            brukerData = brukerService.hentBrukerdata(fnr, accessToken)
+            log.info(
+                "Hentet brukerdata som trengs for videre filtrering mot Sanity.\nInnsatsgruppe: {}\nOppfølgingsstatus: {}",
+                brukerData.innsatsgruppe,
+                brukerData.oppfolgingsenhet
+            )
+        }
         client.get {
             url {
                 parameters.append("query", query)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -45,11 +45,6 @@ class SanityService(sanityConfig: SanityConfig, brukerService: BrukerService) {
         if (fnr !== null) {
             // TODO Bruk brukerData til å filtrere - Kommer via Signes branch senere
             brukerData = brukerService.hentBrukerdata(fnr, accessToken)
-            log.info(
-                "Hentet brukerdata som trengs for videre filtrering mot Sanity.\nInnsatsgruppe: {}\nOppfølgingsstatus: {}",
-                brukerData.innsatsgruppe,
-                brukerData.oppfolgingsenhet
-            )
         }
         client.get {
             url {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -14,14 +14,15 @@ import org.slf4j.LoggerFactory
 import java.text.SimpleDateFormat
 import java.util.*
 
-class SanityService(sanity: SanityConfig) {
+class SanityService(sanityConfig: SanityConfig, brukerService: BrukerService) {
     private val logger = LoggerFactory.getLogger(SanityService::class.java)
     private val client: HttpClient
-    private val sanityToken = sanity.authToken
-    private val projectId = sanity.projectId
-    private val dataset = sanity.dataset
+    private val sanityToken = sanityConfig.authToken
+    private val projectId = sanityConfig.projectId
+    private val dataset = sanityConfig.dataset
     private val apiVersion = SimpleDateFormat("yyyy-MM-dd").format(Date())
     private val sanityBaseUrl = "https://$projectId.apicdn.sanity.io/v$apiVersion/data/query/$dataset"
+    private val brukerService = brukerService
 
     init {
         logger.debug("Init SanityHttpClient")

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yml
@@ -31,6 +31,12 @@ paths:
           schema:
             type: string
           description: Sanity query as a Groq-string. See https://www.sanity.io/docs/groq for more information.
+          required: true
+        - in: query
+          name: fnr
+          schema:
+            type: string
+          description: SSN for the user which will be used to filter based on the users 'oppfølgingsenhet'  
       responses:
         200:
           description: Sanity query result


### PR DESCRIPTION
Denne PRen gjør følgende:

* Endrer hvordan vi får koblet opp `BrukerService`. Gjør all oppkobling i DependencyInjection-filen.
* Legger til argumentet `fnr` i openapi-yaml for Sanity-endepunktet slik at vi kan sende med fnr for de spørringene hvor det trengs mer kontekst rundt bruker i backend.
* Henter ut brukerdata dersom vi sender med fnr, men vi bruker ikke dataene til noe enda. Venter på Signes branch `enhet-sanity-query` før vi kobler alt sammen.