### PR TITLE
Filtrer på brukers oppfølgingsenhet

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useSanity.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useSanity.ts
@@ -5,6 +5,7 @@ import useDebounce from '../../hooks/useDebounce';
 
 export function useSanity<T>(query: string) {
   const debouncedQuery = useDebounce(query, 300);
+  console.log(query)
   return useQuery(
     [QueryKeys.SanityQuery, debouncedQuery],
     () => MulighetsrommetService.sanityQuery({ query: debouncedQuery }) as Promise<T>

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
@@ -8,8 +8,8 @@ export default function useTiltaksgjennomforing() {
   return useSanity<Tiltaksgjennomforing[]>(`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
   ${byggInnsatsgruppeFilter(filter.innsatsgrupper)} 
   ${byggTiltakstypeFilter(filter.tiltakstyper)}
-  ${byggSokefilter(filter.search)}
-  
+  ${byggSokefilter(filter.search)} 
+  %ENHET%
   ]
   {
     _id,
@@ -40,7 +40,3 @@ function byggSokefilter(search: string | undefined) {
     ? `&& [tiltaksgjennomforingNavn, string(tiltaksnummer), tiltakstype->tiltakstypeNavn, lokasjon, kontaktinfoArrangor->selskapsnavn, oppstartsdato] match "*${search}*"`
     : '';
 }
-
-//function
-
-//"0600" == fylke->nummer.current 0231

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/handlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/handlers.ts
@@ -15,7 +15,7 @@ export const handlers: RestHandler[] = [
       innsatsgruppe: 'Situasjonsbestemt innsats',
       oppfolgingsenhet: {
         navn: 'NAV Fredrikstad',
-        enhetId: '0106',
+        enhetId: '0231',
         fylkeId: '0400',
       },
     });
@@ -30,7 +30,9 @@ export const handlers: RestHandler[] = [
 
     const client = getSanityClient();
 
-    const result = await client.fetch(query);
+    const newQuery = query.replace("%ENHET%", "")
+
+    const result = await client.fetch(newQuery);
     return ok(result);
   }),
 ];

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.api.routes.v1
 
 import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.mulighetsrommet.api.services.SanityService

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -40,7 +40,7 @@ class SanityService(sanity: SanityConfig) {
     suspend fun executeQuery(query: String): JsonElement? {
         client.get {
             url {
-                parameters.append("query", query)
+                parameters.append("query", query.replace("%ENHET%", ""))
             }
         }.let {
             val response = it.body<JsonObject>()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -10,6 +10,7 @@ import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import no.nav.mulighetsrommet.api.SanityConfig
+import no.nav.mulighetsrommet.api.utils.replaceEnhetInQuery
 import org.slf4j.LoggerFactory
 import java.text.SimpleDateFormat
 import java.util.*
@@ -40,7 +41,7 @@ class SanityService(sanity: SanityConfig) {
     suspend fun executeQuery(query: String): JsonElement? {
         client.get {
             url {
-                parameters.append("query", query.replace("%ENHET%", ""))
+                parameters.append("query", replaceEnhetInQuery(query, "0231", "0400"))
             }
         }.let {
             val response = it.body<JsonObject>()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtil.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtil.kt
@@ -3,5 +3,6 @@ package no.nav.mulighetsrommet.api.utils
 fun replaceEnhetInQuery(query: String, enhetsId: String, fylkeId: String): String {
     return query.replace(
         oldValue = "%ENHET%",
-        newValue = "&& ((\"${enhetsId}\" in enheter[]->nummer.current) || (enheter[0] == null && \"${fylkeId}\" == fylke->nummer.current))")
+        newValue = "&& ((\"${enhetsId}\" in enheter[]->nummer.current) || (enheter[0] == null && \"${fylkeId}\" == fylke->nummer.current))"
+    )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtil.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtil.kt
@@ -1,0 +1,7 @@
+package no.nav.mulighetsrommet.api.utils
+
+fun replaceEnhetInQuery(query: String, enhetsId: String, fylkeId: String): String {
+    return query.replace(
+        oldValue = "%ENHET%",
+        newValue = "&& ((\"${enhetsId}\" in enheter[]->nummer.current) || (enheter[0] == null && \"${fylkeId}\" == fylke->nummer.current))")
+}

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtilKtTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtilKtTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 
 internal class SanityUtilKtTest : FunSpec({
 
-    test("should get tiltaksgjennomføring by id") {
+    test("should replace token with enhet and fylke ID") {
         val originalQuery =
             """*[_type == \"tiltaksgjennomforing\" && !(_id in path(\"drafts.**\"))
                  && tiltakstype->innsatsgruppe->tittel in [\"Situasjonsbestemt innsats\", \"Spesielt tilpasset innsats\"]

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtilKtTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtilKtTest.kt
@@ -5,48 +5,45 @@ import io.kotest.matchers.shouldBe
 
 internal class SanityUtilKtTest : FunSpec({
 
-                                              test("should get tiltaksgjennomføring by id") {
-                                                  val originalQuery =
-                                                      """*[_type == \"tiltaksgjennomforing\" && !(_id in path(\"drafts.**\"))
-                                                         && tiltakstype->innsatsgruppe->tittel in [\"Situasjonsbestemt innsats\", \"Spesielt tilpasset innsats\"]
-                                                         && tiltakstype->_id in [\"3526de0d-ad4c-4b81-b072-a13b3a4b4ed3\"]
-                                                         %ENHET%
-                                                         ]
-                                                         {
-                                                           _id,
-                                                           tiltaksgjennomforingNavn,
-                                                           lokasjon,
-                                                           oppstart
-                                                           oppstartsdato
-                                                           tiltaksnummer
-                                                           kontaktinfoArrangor->
-                                                           tiltakstype->
-                                                         }
-                                                      """
-                                                  val expectedQuery =
-                                                      """*[_type == \"tiltaksgjennomforing\" && !(_id in path(\"drafts.**\"))
-                                                         && tiltakstype->innsatsgruppe->tittel in [\"Situasjonsbestemt innsats\", \"Spesielt tilpasset innsats\"]
-                                                         && tiltakstype->_id in [\"3526de0d-ad4c-4b81-b072-a13b3a4b4ed3\"]
-                                                         && (("0219" in enheter[]->nummer.current) || (enheter[0] == null && "0600" == fylke->nummer.current))
-                                                         ]
-                                                         {
-                                                           _id,
-                                                           tiltaksgjennomforingNavn,
-                                                           lokasjon,
-                                                           oppstart
-                                                           oppstartsdato
-                                                           tiltaksnummer
-                                                           kontaktinfoArrangor->
-                                                           tiltakstype->
-                                                         }
-                                                      """
-                                                  replaceEnhetInQuery(
-                                                      query = originalQuery,
-                                                      "0219",
-                                                      "0600"
-                                                  ) shouldBe expectedQuery
-                                              }
-
-                                          })
-
-
+    test("should get tiltaksgjennomføring by id") {
+        val originalQuery =
+            """*[_type == \"tiltaksgjennomforing\" && !(_id in path(\"drafts.**\"))
+                 && tiltakstype->innsatsgruppe->tittel in [\"Situasjonsbestemt innsats\", \"Spesielt tilpasset innsats\"]
+                 && tiltakstype->_id in [\"3526de0d-ad4c-4b81-b072-a13b3a4b4ed3\"]
+                 %ENHET%
+                 ]
+                 {
+                   _id,
+                   tiltaksgjennomforingNavn,
+                   lokasjon,
+                   oppstart
+                   oppstartsdato
+                   tiltaksnummer
+                   kontaktinfoArrangor->
+                   tiltakstype->
+                 }
+              """
+        val expectedQuery =
+            """*[_type == \"tiltaksgjennomforing\" && !(_id in path(\"drafts.**\"))
+                 && tiltakstype->innsatsgruppe->tittel in [\"Situasjonsbestemt innsats\", \"Spesielt tilpasset innsats\"]
+                 && tiltakstype->_id in [\"3526de0d-ad4c-4b81-b072-a13b3a4b4ed3\"]
+                 && (("0219" in enheter[]->nummer.current) || (enheter[0] == null && "0600" == fylke->nummer.current))
+                 ]
+                 {
+                   _id,
+                   tiltaksgjennomforingNavn,
+                   lokasjon,
+                   oppstart
+                   oppstartsdato
+                   tiltaksnummer
+                   kontaktinfoArrangor->
+                   tiltakstype->
+                 }
+              """
+        replaceEnhetInQuery(
+            query = originalQuery,
+            "0219",
+            "0600"
+        ) shouldBe expectedQuery
+    }
+})

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtilKtTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtilKtTest.kt
@@ -1,0 +1,52 @@
+package no.nav.mulighetsrommet.api.utils
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+internal class SanityUtilKtTest : FunSpec({
+
+                                              test("should get tiltaksgjennomføring by id") {
+                                                  val originalQuery =
+                                                      """*[_type == \"tiltaksgjennomforing\" && !(_id in path(\"drafts.**\"))
+                                                         && tiltakstype->innsatsgruppe->tittel in [\"Situasjonsbestemt innsats\", \"Spesielt tilpasset innsats\"]
+                                                         && tiltakstype->_id in [\"3526de0d-ad4c-4b81-b072-a13b3a4b4ed3\"]
+                                                         %ENHET%
+                                                         ]
+                                                         {
+                                                           _id,
+                                                           tiltaksgjennomforingNavn,
+                                                           lokasjon,
+                                                           oppstart
+                                                           oppstartsdato
+                                                           tiltaksnummer
+                                                           kontaktinfoArrangor->
+                                                           tiltakstype->
+                                                         }
+                                                      """
+                                                  val expectedQuery =
+                                                      """*[_type == \"tiltaksgjennomforing\" && !(_id in path(\"drafts.**\"))
+                                                         && tiltakstype->innsatsgruppe->tittel in [\"Situasjonsbestemt innsats\", \"Spesielt tilpasset innsats\"]
+                                                         && tiltakstype->_id in [\"3526de0d-ad4c-4b81-b072-a13b3a4b4ed3\"]
+                                                         && (("0219" in enheter[]->nummer.current) || (enheter[0] == null && "0600" == fylke->nummer.current))
+                                                         ]
+                                                         {
+                                                           _id,
+                                                           tiltaksgjennomforingNavn,
+                                                           lokasjon,
+                                                           oppstart
+                                                           oppstartsdato
+                                                           tiltaksnummer
+                                                           kontaktinfoArrangor->
+                                                           tiltakstype->
+                                                         }
+                                                      """
+                                                  replaceEnhetInQuery(
+                                                      query = originalQuery,
+                                                      "0219",
+                                                      "0600"
+                                                  ) shouldBe expectedQuery
+                                              }
+
+                                          })
+
+


### PR DESCRIPTION
Denne PRen kobler data fra `BrukerService` med filter i Sanity slik at vi filtrer tiltaksgjennomføringer på brukers oppfølgingsenhet.