### PR TITLE
Viser feilmelding dersom vi ikke klarer å hente brukers oppfølgingsenhet

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -116,3 +116,13 @@ describe('Tiltaksgjennomføringstabell', () => {
     });
   });
 });
+
+describe('Feilmelding når vi ikke kan hente brukers oppfølgingsenhet', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/v1/bruker/*', 'lol').as('getBrukerdata');
+    cy.visit('/');
+  });
+  it('Skal vise feilmelding dersom oppfølgingsenhet ikke kan vises', () => {
+    cy.getByTestId('alert-navenhet').should('be.visible');
+  });
+});

--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -119,7 +119,7 @@ describe('Tiltaksgjennomføringstabell', () => {
 
 describe('Feilmelding når vi ikke kan hente brukers oppfølgingsenhet', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/v1/bruker/*', 'lol').as('getBrukerdata');
+    cy.intercept('GET', '**/api/v1/bruker/*', {}).as('getBrukerdata');
     cy.visit('/');
   });
   it('Skal vise feilmelding dersom oppfølgingsenhet ikke kan vises', () => {

--- a/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
@@ -51,10 +51,7 @@ before('Start server', () => {
     console.log(err);
     return false;
   });
-  cy.route({
-    method: 'GET',
-    url: '/',
-  });
+
   cy.getByTestId('tiltakstype-oversikt').children().should('have.length.greaterThan', 1);
 });
 

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tag, Button } from '@navikt/ds-react';
+import { Tag, Button, Alert } from '@navikt/ds-react';
 import { useAtom } from 'jotai';
 import { RESET } from 'jotai/utils';
 import { FAKE_DOOR, useFeatureToggles } from '../../api/feature-toggles';
@@ -26,6 +26,7 @@ const ViewTiltakstypeOversikt = () => {
   const features = useFeatureToggles();
   const visFakeDoorFeature = features.isSuccess && features.data[FAKE_DOOR];
 
+  const brukersOppfolgingsenhet = brukerdata?.data?.oppfolgingsenhet?.navn;
   return (
     <>
       {visFakeDoorFeature ? (
@@ -35,16 +36,20 @@ const ViewTiltakstypeOversikt = () => {
           <Filtermeny />
           <div className="filtercontainer">
             <div className="filtertags" data-testid="filtertags">
-              {brukerdata?.data && (
+              {brukersOppfolgingsenhet ? (
                 <Tag
                   className={'nav-enhet-tag'}
                   key={'navenhet'}
-                  variant="info"
+                  variant={brukersOppfolgingsenhet ? 'info' : 'error'}
                   size="small"
                   data-testid={`${kebabCase('filtertag_navenhet')}`}
                 >
-                  {brukerdata?.data?.oppfolgingsenhet?.navn}
+                  {brukersOppfolgingsenhet}
                 </Tag>
+              ) : (
+                <Alert key="alert-navenhet" data-testid="alert-navenhet" size="small" variant="error">
+                  Klarte ikke hente brukers oppfølgingsenhet
+                </Alert>
               )}
               <FilterTags
                 options={filter.innsatsgrupper!}


### PR DESCRIPTION
Dersom vi ikke klarer å hente brukers oppfølgingsenhet så vises det nå en `<Alert />` der vi skulle ha vist oppfølgingsenheten.

Har også fikset en liten Cypress-test som sjekker at `<Alert />` vises når vi ikke får korrekt data returnert fra backend.

![image](https://user-images.githubusercontent.com/9053627/178205753-d9dc2346-539a-4e0f-bd62-d50428e2fabd.png)
