### PR TITLE
Henter ikke tiltak før vi har brukerdata

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -53,8 +53,9 @@ describe('Tiltaksgjennomføringstabell', () => {
   });
 
   it('Filtrer på søkefelt', () => {
-    cy.getByTestId('filter_sokefelt').type('Digitalt');
-    cy.getByTestId('filtertags').children().should('have.length', 3);
+    cy.fjernFilter('situasjonsbestemt-innsats');
+    cy.getByTestId('filter_sokefelt').type('AFT');
+    cy.getByTestId('filtertags').children().should('have.length', 2);
 
     cy.wait(1000)
       .getByTestId('antall-tiltak')
@@ -70,6 +71,13 @@ describe('Tiltaksgjennomføringstabell', () => {
     cy.sortering('tabellheader_tiltaksnummer');
     cy.sortering('tabellheader_oppstartsdato');
     cy.sortering('tabellheader_status');
+  });
+
+  it('Skal vise tilbakestill filter-knapp når filter utenfor normalen', () => {
+    cy.velgFilter('situasjonsbestemt-innsats');
+    cy.getByTestId('knapp_tilbakestill-filter').should('not.exist');
+    cy.fjernFilter('situasjonsbestemt-innsats');
+    cy.getByTestId('knapp_tilbakestill-filter').should('exist');
   });
 });
 

--- a/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
@@ -64,6 +64,11 @@ Cypress.Commands.add('velgFilter', filternavn => {
   cy.getByTestId(`filtertag_${filternavn}`).should('exist');
 });
 
+Cypress.Commands.add('fjernFilter', filternavn => {
+  cy.getByTestId(`filter_checkbox_${filternavn}`).should('be.checked').click().should('not.be.checked');
+  cy.getByTestId(`filtertag_${filternavn}`).should('not.exist');
+});
+
 Cypress.Commands.add('apneLukketFilterAccordion', (filternavn, apne) => {
   if (apne) {
     cy.getByTestId(`filter_accordionheader_${filternavn}`).click();

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useSanity.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useSanity.ts
@@ -4,11 +4,14 @@ import { MulighetsrommetService } from 'mulighetsrommet-api-client';
 import useDebounce from '../../hooks/useDebounce';
 import { useHentFnrFraUrl } from '../../hooks/useHentFnrFraUrl';
 
-export function useSanity<T>(query: string) {
+export function useSanity<T>(query: string, enabled: boolean = true) {
   const debouncedQuery = useDebounce(query, 300);
   const fnr = useHentFnrFraUrl();
   return useQuery(
     [QueryKeys.SanityQuery, debouncedQuery, fnr],
-    () => MulighetsrommetService.sanityQuery({ query: debouncedQuery, fnr }) as Promise<T>
+    () => MulighetsrommetService.sanityQuery({ query: debouncedQuery, fnr }) as Promise<T>,
+    {
+      enabled: !!enabled,
+    }
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
@@ -24,7 +24,7 @@ export default function useTiltaksgjennomforing() {
     kontaktinfoArrangor->,
     tiltakstype->
   }`,
-    brukerdata?.data
+    !!brukerdata?.data
   );
 }
 

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
@@ -1,11 +1,14 @@
 import { useAtom } from 'jotai';
 import { tiltaksgjennomforingsfilter, Tiltaksgjennomforingsfiltergruppe } from '../../core/atoms/atoms';
 import { Tiltaksgjennomforing } from '../models';
+import { useHentBrukerdata } from './useHentBrukerdata';
 import { useSanity } from './useSanity';
 
 export default function useTiltaksgjennomforing() {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
-  return useSanity<Tiltaksgjennomforing[]>(`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
+  const brukerdata = useHentBrukerdata();
+  return useSanity<Tiltaksgjennomforing[]>(
+    `*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
   ${byggInnsatsgruppeFilter(filter.innsatsgrupper)} 
   ${byggTiltakstypeFilter(filter.tiltakstyper)}
   ${byggSokefilter(filter.search)} 
@@ -20,7 +23,9 @@ export default function useTiltaksgjennomforing() {
     tiltaksnummer,
     kontaktinfoArrangor->,
     tiltakstype->
-  }`);
+  }`,
+    brukerdata?.data
+  );
 }
 
 function byggInnsatsgruppeFilter(innsatsgrupper: Tiltaksgjennomforingsfiltergruppe[]): string {

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -177,11 +177,13 @@ const TiltaksgjennomforingsTabell = () => {
         </Table.Header>
         <Table.Body>
           {tiltaksgjennomforinger.length === 0 ? (
-            <Table.DataCell colSpan={5}>
-              <Alert variant="info" className="tabell__alert">
-                Det finnes ingen tiltakstyper med dette søket.
-              </Alert>
-            </Table.DataCell>
+            <Table.Row>
+              <Table.DataCell colSpan={5}>
+                <Alert variant="info" className="tabell__alert">
+                  Det finnes ingen tiltakstyper med dette søket.
+                </Alert>
+              </Table.DataCell>
+            </Table.Row>
           ) : (
             gjennomforingerForSide.map(
               ({


### PR DESCRIPTION
Denne PRen legger til støtte for å deaktivere en spørring mot Sanity basert på en boolsk verdi. I dette tilfelle vil vi ikke gjøre fetching av tiltaksgjennomføringer dersom vi ikke har brukerdata fordi uten brukerdata har vi heller ikke noen oppfølgingsenhet. Ved å vente på brukerdata før vi henter tiltaksgjennomføringer så slipper vi en ekstra lasteindikator som blinker noen millisekund før vi henter data på nytt basert på brukerdata hentet.

Fikser også en html-feil der vi viser feilmelding i tabell uten `Table.Row`.