### PR TITLE
KAIZEN groq for syntax highlighting

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useInnsatsgrupper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useInnsatsgrupper.ts
@@ -1,6 +1,9 @@
+import groq from 'groq';
 import { Innsatsgruppe } from '../models';
 import { useSanity } from './useSanity';
 
 export function useInnsatsgrupper() {
-  return useSanity<Innsatsgruppe[]>('*[_type == "innsatsgruppe" && !(_id in path("drafts.**"))] | order(order asc) ');
+  return useSanity<Innsatsgruppe[]>(
+    groq`*[_type == "innsatsgruppe" && !(_id in path("drafts.**"))] | order(order asc)`
+  );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useSisteStatistikkFil.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useSisteStatistikkFil.ts
@@ -1,8 +1,9 @@
 import { useSanity } from './useSanity';
-import {StatistikkFil} from "../models";
+import { StatistikkFil } from '../models';
+import groq from 'groq';
 
 export default function useSisteStatistikkFil() {
-  return useSanity<StatistikkFil>(`*[_type == "statistikkfil"]| order(_createdAt desc) {
+  return useSanity<StatistikkFil>(groq`*[_type == "statistikkfil"]| order(_createdAt desc) {
         _id,
         "statistikkFilUrl": statistikkfilopplastning.asset->url,
 }[0]`);

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
@@ -1,3 +1,4 @@
+import groq from 'groq';
 import { useAtom } from 'jotai';
 import { tiltaksgjennomforingsfilter, Tiltaksgjennomforingsfiltergruppe } from '../../core/atoms/atoms';
 import { Tiltaksgjennomforing } from '../models';
@@ -8,7 +9,7 @@ export default function useTiltaksgjennomforing() {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
   const brukerdata = useHentBrukerdata();
   return useSanity<Tiltaksgjennomforing[]>(
-    `*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
+    groq`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
   ${byggInnsatsgruppeFilter(filter.innsatsgrupper)} 
   ${byggTiltakstypeFilter(filter.tiltakstyper)}
   ${byggSokefilter(filter.search)} 

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingByTiltaksnummer.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforingByTiltaksnummer.ts
@@ -1,10 +1,11 @@
+import groq from 'groq';
 import { Tiltaksgjennomforing } from '../models';
 import { useGetTiltaksnummerFraUrl } from './useGetTiltaksnummerFraUrl';
 import { useSanity } from './useSanity';
 
 export default function useTiltaksgjennomforingByTiltaksnummer() {
   const tiltaksnummer = useGetTiltaksnummerFraUrl();
-  return useSanity<Tiltaksgjennomforing>(`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) && tiltaksnummer == ${tiltaksnummer}] {
+  return useSanity<Tiltaksgjennomforing>(groq`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) && tiltaksnummer == ${tiltaksnummer}] {
     _id,
     tiltaksgjennomforingNavn,
     beskrivelse,

--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltakstyper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltakstyper.ts
@@ -1,6 +1,7 @@
 import { useSanity } from './useSanity';
 import { Tiltakstype } from '../models';
+import groq from 'groq';
 
 export function useTiltakstyper() {
-  return useSanity<Tiltakstype[]>(`*[_type == "tiltakstype" && !(_id in path("drafts.**"))]`);
+  return useSanity<Tiltakstype[]>(groq`*[_type == "tiltakstype" && !(_id in path("drafts.**"))]`);
 }


### PR DESCRIPTION
For Groq-spørringer så kan man legge til vscode-pluginen https://marketplace.visualstudio.com/items?itemName=sanity-io.vscode-sanity for å få syntax highlighting for groq-spørringer som er tagget med `groq`.

Med plugin installert og tagget med groq:
![image](https://user-images.githubusercontent.com/9053627/178691899-2b40b7b4-2aef-44cb-badd-8ae60c1ae6a2.png)

Uten plugin og/eller groq:
![image](https://user-images.githubusercontent.com/9053627/178691971-599dd74f-7145-4872-a89b-e993602d454e.png)
