### PR TITLE
Refactor/restructure topic consumers

### DIFF
--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Application.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Application.kt
@@ -27,17 +27,16 @@ fun main() {
 
     val kafkaPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties(app.kafka.consumerGroupId)
 
+    val db = Database(app.database)
+
     val consumers = listOf(
-        TiltakEndretConsumer(app.kafka.getTopic("tiltakendret"), api),
-        TiltakgjennomforingEndretConsumer(app.kafka.getTopic("tiltakgjennomforingendret"), api),
-        TiltakdeltakerEndretConsumer(app.kafka.getTopic("tiltakdeltakerendret"), api),
-        SakEndretConsumer(app.kafka.getTopic("sakendret"), api)
+        TiltakEndretConsumer(db, app.kafka.getTopic("tiltakendret"), api),
+        TiltakgjennomforingEndretConsumer(db, app.kafka.getTopic("tiltakgjennomforingendret"), api),
+        TiltakdeltakerEndretConsumer(db, app.kafka.getTopic("tiltakdeltakerendret"), api),
+        SakEndretConsumer(db, app.kafka.getTopic("sakendret"), api)
     )
 
-    val kafka = KafkaConsumerOrchestrator(
-        kafkaPreset, Database(app.database),
-        consumers as List<TopicConsumer<out Any, in Any>>
-    )
+    val kafka = KafkaConsumerOrchestrator(kafkaPreset, db, consumers)
 
     initializeServer(server) {
         configure(app, kafka)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Application.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Application.kt
@@ -8,6 +8,7 @@ import io.ktor.server.routing.*
 import no.nav.common.kafka.util.KafkaPropertiesPreset
 import no.nav.common.token_client.builder.AzureAdTokenClientBuilder
 import no.nav.mulighetsrommet.arena.adapter.consumers.*
+import no.nav.mulighetsrommet.arena.adapter.kafka.KafkaConsumerOrchestrator
 import no.nav.mulighetsrommet.arena.adapter.plugins.configureHTTP
 import no.nav.mulighetsrommet.arena.adapter.plugins.configureMonitoring
 import no.nav.mulighetsrommet.arena.adapter.plugins.configureSerialization

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Database.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Database.kt
@@ -3,10 +3,8 @@ package no.nav.mulighetsrommet.arena.adapter
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import kotliquery.Session
-import kotliquery.queryOf
 import kotliquery.sessionOf
 import org.flywaydb.core.Flyway
-import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 
 class Database(databaseConfig: DatabaseConfig) {
@@ -34,18 +32,5 @@ class Database(databaseConfig: DatabaseConfig) {
         logger.debug("Start flyway migrations")
         flyway = Flyway.configure().dataSource(jdbcUrl, databaseConfig.user, databaseConfig.password.value).load()
         flyway.migrate()
-    }
-
-    fun persistKafkaEvent(topic: String, key: String, payload: String) {
-        @Language("PostgreSQL")
-        val query = """
-            insert into events(topic, key, payload)
-            values (?, ?, ?::jsonb)
-            on conflict (topic, key)
-            do update set
-                payload = excluded.payload
-        """.trimIndent()
-        session.run(queryOf(query, topic, key, payload).asUpdate)
-        logger.debug("Persisted kafka event: $topic:$key")
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/KafkaConsumerOrchestrator.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/KafkaConsumerOrchestrator.kt
@@ -15,8 +15,8 @@ import java.util.function.Consumer
 
 class KafkaConsumerOrchestrator(
     consumerPreset: Properties,
-    private val db: Database,
-    private val consumers: List<TopicConsumer<out Any, in Any>>
+    db: Database,
+    private val consumers: List<TopicConsumer<*>>
 ) {
 
     private val logger = LoggerFactory.getLogger(KafkaConsumerOrchestrator::class.java)
@@ -73,17 +73,7 @@ class KafkaConsumerOrchestrator(
                     stringDeserializer(),
                     stringDeserializer(),
                     Consumer<ConsumerRecord<String, String>> { event ->
-                        val payload = consumer.toDomain(event.value())
-                        val key = consumer.resolveKey(payload)
-                        if (consumer.shouldProcessEvent(payload)) {
-                            db.persistKafkaEvent(
-                                event.topic(),
-                                key,
-                                event.value()
-                            )
-
-                            consumer.processEvent(payload)
-                        }
+                        consumer.processEvent(event)
                     }
                 )
         }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
@@ -9,6 +9,7 @@ import no.nav.mulighetsrommet.arena.adapter.Database
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
 import no.nav.mulighetsrommet.domain.arena.ArenaSak
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class SakEndretConsumer(
@@ -17,7 +18,7 @@ class SakEndretConsumer(
     private val client: MulighetsrommetApiClient
 ) : TopicConsumer<ArenaSak>(db) {
 
-    private val logger = LoggerFactory.getLogger(SakEndretConsumer::class.java)
+    override val logger: Logger = LoggerFactory.getLogger(SakEndretConsumer::class.java)
 
     override fun toDomain(payload: JsonElement): ArenaSak {
         return Json.decodeFromJsonElement(payload.jsonObject["after"]!!)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
@@ -1,21 +1,26 @@
 package no.nav.mulighetsrommet.arena.adapter.consumers
 
 import io.ktor.http.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import no.nav.mulighetsrommet.arena.adapter.Database
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
 import no.nav.mulighetsrommet.domain.arena.ArenaSak
 import org.slf4j.LoggerFactory
 
 class SakEndretConsumer(
+    db: Database,
     override val topic: String,
     private val client: MulighetsrommetApiClient
-) : TopicConsumer<ArenaSak, ArenaSak>() {
+) : TopicConsumer<ArenaSak>(db) {
 
     private val logger = LoggerFactory.getLogger(SakEndretConsumer::class.java)
 
-    override fun toDomain(payload: String): ArenaSak {
-        return Json.decodeFromJsonElement(Json.parseToJsonElement(payload).jsonObject["after"]!!)
+    override fun toDomain(payload: JsonElement): ArenaSak {
+        return Json.decodeFromJsonElement(payload.jsonObject["after"]!!)
     }
 
     override fun shouldProcessEvent(payload: ArenaSak): Boolean {
@@ -26,7 +31,7 @@ class SakEndretConsumer(
         return payload.SAK_ID.toString()
     }
 
-    override fun processEvent(payload: ArenaSak) {
+    override fun handleEvent(payload: ArenaSak) {
         client.sendRequest(HttpMethod.Put, "/api/v1/arena/sak", payload.toAdapterSak())
         logger.debug("processed sak endret event")
     }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import no.nav.mulighetsrommet.arena.adapter.Database
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
+import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
 import no.nav.mulighetsrommet.domain.arena.ArenaSak
 import org.slf4j.Logger

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import no.nav.mulighetsrommet.arena.adapter.Database
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
+import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
 import no.nav.mulighetsrommet.domain.arena.ArenaTiltak

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -10,6 +10,7 @@ import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
 import no.nav.mulighetsrommet.domain.arena.ArenaTiltak
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class TiltakEndretConsumer(
@@ -18,7 +19,7 @@ class TiltakEndretConsumer(
     private val client: MulighetsrommetApiClient
 ) : TopicConsumer<ArenaTiltak>(db) {
 
-    private val logger = LoggerFactory.getLogger(TiltakEndretConsumer::class.java)
+    override val logger: Logger = LoggerFactory.getLogger(TiltakEndretConsumer::class.java)
 
     override fun toDomain(payload: JsonElement): ArenaTiltak {
         return Json.decodeFromJsonElement(payload.jsonObject["after"]!!)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
@@ -10,6 +10,7 @@ import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
 import no.nav.mulighetsrommet.domain.arena.ArenaTiltakdeltaker
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class TiltakdeltakerEndretConsumer(
@@ -18,7 +19,7 @@ class TiltakdeltakerEndretConsumer(
     private val client: MulighetsrommetApiClient
 ) : TopicConsumer<ArenaTiltakdeltaker>(db) {
 
-    private val logger = LoggerFactory.getLogger(TiltakdeltakerEndretConsumer::class.java)
+    override val logger: Logger = LoggerFactory.getLogger(TiltakdeltakerEndretConsumer::class.java)
 
     override fun toDomain(payload: JsonElement): ArenaTiltakdeltaker {
         return Json.decodeFromJsonElement(payload.jsonObject["after"]!!)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import no.nav.mulighetsrommet.arena.adapter.Database
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
+import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
 import no.nav.mulighetsrommet.domain.arena.ArenaTiltakdeltaker

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
@@ -2,8 +2,10 @@ package no.nav.mulighetsrommet.arena.adapter.consumers
 
 import io.ktor.http.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
+import no.nav.mulighetsrommet.arena.adapter.Database
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
@@ -11,21 +13,22 @@ import no.nav.mulighetsrommet.domain.arena.ArenaTiltakdeltaker
 import org.slf4j.LoggerFactory
 
 class TiltakdeltakerEndretConsumer(
+    db: Database,
     override val topic: String,
     private val client: MulighetsrommetApiClient
-) : TopicConsumer<ArenaTiltakdeltaker, ArenaTiltakdeltaker>() {
+) : TopicConsumer<ArenaTiltakdeltaker>(db) {
 
     private val logger = LoggerFactory.getLogger(TiltakdeltakerEndretConsumer::class.java)
 
-    override fun toDomain(payload: String): ArenaTiltakdeltaker {
-        return Json.decodeFromJsonElement(Json.parseToJsonElement(payload).jsonObject["after"]!!)
+    override fun toDomain(payload: JsonElement): ArenaTiltakdeltaker {
+        return Json.decodeFromJsonElement(payload.jsonObject["after"]!!)
     }
 
     override fun resolveKey(payload: ArenaTiltakdeltaker): String {
         return payload.TILTAKDELTAKER_ID.toString()
     }
 
-    override fun processEvent(payload: ArenaTiltakdeltaker) {
+    override fun handleEvent(payload: ArenaTiltakdeltaker) {
         client.sendRequest(HttpMethod.Put, "/api/v1/arena/deltakere", payload.toAdapterTiltakdeltaker())
         logger.debug("processed tiltak endret event")
     }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -2,8 +2,10 @@ package no.nav.mulighetsrommet.arena.adapter.consumers
 
 import io.ktor.http.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
+import no.nav.mulighetsrommet.arena.adapter.Database
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
@@ -11,22 +13,27 @@ import no.nav.mulighetsrommet.domain.arena.ArenaTiltaksgjennomforing
 import org.slf4j.LoggerFactory
 
 class TiltakgjennomforingEndretConsumer(
+    db: Database,
     override val topic: String,
     private val client: MulighetsrommetApiClient
-) : TopicConsumer<ArenaTiltaksgjennomforing, ArenaTiltaksgjennomforing>() {
+) : TopicConsumer<ArenaTiltaksgjennomforing>(db) {
 
     private val logger = LoggerFactory.getLogger(TiltakgjennomforingEndretConsumer::class.java)
 
-    override fun toDomain(payload: String): ArenaTiltaksgjennomforing {
-        return Json.decodeFromJsonElement(Json.parseToJsonElement(payload).jsonObject["after"]!!)
+    override fun toDomain(payload: JsonElement): ArenaTiltaksgjennomforing {
+        return Json.decodeFromJsonElement(payload.jsonObject["after"]!!)
     }
 
     override fun resolveKey(payload: ArenaTiltaksgjennomforing): String {
         return payload.TILTAKGJENNOMFORING_ID.toString()
     }
 
-    override fun processEvent(payload: ArenaTiltaksgjennomforing) {
-        client.sendRequest(HttpMethod.Put, "/api/v1/arena/tiltaksgjennomforinger", payload.toAdapterTiltaksgjennomforing())
+    override fun handleEvent(payload: ArenaTiltaksgjennomforing) {
+        client.sendRequest(
+            HttpMethod.Put,
+            "/api/v1/arena/tiltaksgjennomforinger",
+            payload.toAdapterTiltaksgjennomforing()
+        )
         logger.debug("processed tiltakgjennomforing endret event")
     }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -10,6 +10,7 @@ import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.arena.ArenaTiltaksgjennomforing
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class TiltakgjennomforingEndretConsumer(
@@ -18,7 +19,7 @@ class TiltakgjennomforingEndretConsumer(
     private val client: MulighetsrommetApiClient
 ) : TopicConsumer<ArenaTiltaksgjennomforing>(db) {
 
-    private val logger = LoggerFactory.getLogger(TiltakgjennomforingEndretConsumer::class.java)
+    override val logger: Logger = LoggerFactory.getLogger(TiltakgjennomforingEndretConsumer::class.java)
 
     override fun toDomain(payload: JsonElement): ArenaTiltaksgjennomforing {
         return Json.decodeFromJsonElement(payload.jsonObject["after"]!!)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import no.nav.mulighetsrommet.arena.adapter.Database
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
+import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.arena.ArenaTiltaksgjennomforing

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TopicConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TopicConsumer.kt
@@ -2,10 +2,14 @@ package no.nav.mulighetsrommet.arena.adapter.consumers
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotliquery.queryOf
 import no.nav.mulighetsrommet.arena.adapter.Database
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.intellij.lang.annotations.Language
+import org.slf4j.Logger
 
 abstract class TopicConsumer<T>(private val db: Database) {
+    abstract val logger: Logger
     abstract val topic: String
 
     fun processEvent(event: ConsumerRecord<String, String>) {
@@ -13,12 +17,15 @@ abstract class TopicConsumer<T>(private val db: Database) {
         val decodedPayload = toDomain(eventPayload)
         if (shouldProcessEvent(decodedPayload)) {
             val key = resolveKey(decodedPayload)
-            db.persistKafkaEvent(
+
+            logger.debug("Persisting event: topic=$topic, key=$key")
+            persistEvent(
                 event.topic(),
                 key,
                 event.value()
             )
 
+            logger.debug("Handling event: topic=$topic, key=$key")
             handleEvent(decodedPayload)
         }
     }
@@ -30,4 +37,17 @@ abstract class TopicConsumer<T>(private val db: Database) {
     protected abstract fun resolveKey(payload: T): String
 
     protected abstract fun handleEvent(payload: T)
+
+    private fun persistEvent(topic: String, key: String, payload: String) {
+        @Language("PostgreSQL")
+        val query = """
+            insert into events(topic, key, payload)
+            values (?, ?, ?::jsonb)
+            on conflict (topic, key)
+            do update set
+                payload = excluded.payload
+        """.trimIndent()
+
+        db.session.run(queryOf(query, topic, key, payload).asUpdate)
+    }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/JsonElementDeserializer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/JsonElementDeserializer.kt
@@ -1,0 +1,18 @@
+package no.nav.mulighetsrommet.arena.adapter.kafka
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import org.apache.kafka.common.serialization.Deserializer
+import java.nio.charset.StandardCharsets
+
+class JsonElementDeserializer : Deserializer<JsonElement> {
+    override fun deserialize(topic: String, data: ByteArray?): JsonElement {
+        if (data == null) {
+            return JsonNull
+        }
+
+        val value = String(data, StandardCharsets.UTF_8)
+        return Json.parseToJsonElement(value)
+    }
+}

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/KafkaConsumerOrchestrator.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/KafkaConsumerOrchestrator.kt
@@ -1,4 +1,4 @@
-package no.nav.mulighetsrommet.arena.adapter
+package no.nav.mulighetsrommet.arena.adapter.kafka
 
 import net.javacrumbs.shedlock.provider.jdbc.JdbcLockProvider
 import no.nav.common.kafka.consumer.KafkaConsumerClient
@@ -7,7 +7,7 @@ import no.nav.common.kafka.consumer.feilhandtering.util.KafkaConsumerRecordProce
 import no.nav.common.kafka.consumer.util.ConsumerUtils.findConsumerConfigsWithStoreOnFailure
 import no.nav.common.kafka.consumer.util.KafkaConsumerClientBuilder
 import no.nav.common.kafka.consumer.util.deserializer.Deserializers.stringDeserializer
-import no.nav.mulighetsrommet.arena.adapter.consumers.TopicConsumer
+import no.nav.mulighetsrommet.arena.adapter.Database
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import java.util.*

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/KafkaConsumerOrchestrator.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/KafkaConsumerOrchestrator.kt
@@ -1,5 +1,6 @@
 package no.nav.mulighetsrommet.arena.adapter.kafka
 
+import kotlinx.serialization.json.JsonElement
 import net.javacrumbs.shedlock.provider.jdbc.JdbcLockProvider
 import no.nav.common.kafka.consumer.KafkaConsumerClient
 import no.nav.common.kafka.consumer.feilhandtering.KafkaConsumerRecordProcessor
@@ -8,7 +9,6 @@ import no.nav.common.kafka.consumer.util.ConsumerUtils.findConsumerConfigsWithSt
 import no.nav.common.kafka.consumer.util.KafkaConsumerClientBuilder
 import no.nav.common.kafka.consumer.util.deserializer.Deserializers.stringDeserializer
 import no.nav.mulighetsrommet.arena.adapter.Database
-import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.function.Consumer
@@ -63,16 +63,16 @@ class KafkaConsumerOrchestrator(
         logger.debug("Stopped kafka processors")
     }
 
-    private fun configureConsumersTopics(repository: KafkaConsumerRepository): List<KafkaConsumerClientBuilder.TopicConfig<String, String>> {
+    private fun configureConsumersTopics(repository: KafkaConsumerRepository): List<KafkaConsumerClientBuilder.TopicConfig<String, JsonElement>> {
         return consumers.map { consumer ->
-            KafkaConsumerClientBuilder.TopicConfig<String, String>()
+            KafkaConsumerClientBuilder.TopicConfig<String, JsonElement>()
                 .withStoreOnFailure(repository)
                 .withLogging()
                 .withConsumerConfig(
                     consumer.topic,
                     stringDeserializer(),
-                    stringDeserializer(),
-                    Consumer<ConsumerRecord<String, String>> { event ->
+                    JsonElementDeserializer(),
+                    Consumer { event ->
                         consumer.processEvent(event)
                     }
                 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/KafkaConsumerRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/KafkaConsumerRepository.kt
@@ -1,9 +1,10 @@
-package no.nav.mulighetsrommet.arena.adapter
+package no.nav.mulighetsrommet.arena.adapter.kafka
 
 import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.common.kafka.consumer.feilhandtering.KafkaConsumerRepository
 import no.nav.common.kafka.consumer.feilhandtering.StoredConsumerRecord
+import no.nav.mulighetsrommet.arena.adapter.Database
 import org.apache.kafka.common.TopicPartition
 import org.intellij.lang.annotations.Language
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
@@ -1,6 +1,5 @@
 package no.nav.mulighetsrommet.arena.adapter.kafka
 
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.arena.adapter.Database
@@ -12,21 +11,17 @@ abstract class TopicConsumer<T>(private val db: Database) {
     abstract val logger: Logger
     abstract val topic: String
 
-    fun processEvent(event: ConsumerRecord<String, String>) {
-        val eventPayload = Json.parseToJsonElement(event.value())
-        val decodedPayload = toDomain(eventPayload)
-        if (shouldProcessEvent(decodedPayload)) {
-            val key = resolveKey(decodedPayload)
+    fun processEvent(event: ConsumerRecord<String, JsonElement>) {
+        val payload = event.value()
+        val parsedPayload = toDomain(payload)
+        if (shouldProcessEvent(parsedPayload)) {
+            val key = resolveKey(parsedPayload)
 
             logger.debug("Persisting event: topic=$topic, key=$key")
-            persistEvent(
-                event.topic(),
-                key,
-                event.value()
-            )
+            persistEvent(topic, key, payload.toString())
 
             logger.debug("Handling event: topic=$topic, key=$key")
-            handleEvent(decodedPayload)
+            handleEvent(parsedPayload)
         }
     }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
@@ -1,4 +1,4 @@
-package no.nav.mulighetsrommet.arena.adapter.consumers
+package no.nav.mulighetsrommet.arena.adapter.kafka
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/DevApplication.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/DevApplication.kt
@@ -6,6 +6,7 @@ import com.sksamuel.hoplite.ConfigLoader
 import no.nav.common.kafka.util.KafkaPropertiesBuilder
 import no.nav.common.token_client.builder.AzureAdTokenClientBuilder
 import no.nav.mulighetsrommet.arena.adapter.consumers.*
+import no.nav.mulighetsrommet.arena.adapter.kafka.KafkaConsumerOrchestrator
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPrivateKey

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/DevApplication.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/DevApplication.kt
@@ -34,17 +34,16 @@ fun main() {
         .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
         .build()
 
+    val db = Database(app.database)
+
     val consumers = listOf(
-        TiltakEndretConsumer(app.kafka.getTopic("tiltakendret"), api),
-        TiltakgjennomforingEndretConsumer(app.kafka.getTopic("tiltakgjennomforingendret"), api),
-        TiltakdeltakerEndretConsumer(app.kafka.getTopic("tiltakdeltakerendret"), api),
-        SakEndretConsumer(app.kafka.getTopic("sakendret"), api)
+        TiltakEndretConsumer(db, app.kafka.getTopic("tiltakendret"), api),
+        TiltakgjennomforingEndretConsumer(db, app.kafka.getTopic("tiltakgjennomforingendret"), api),
+        TiltakdeltakerEndretConsumer(db, app.kafka.getTopic("tiltakdeltakerendret"), api),
+        SakEndretConsumer(db, app.kafka.getTopic("sakendret"), api)
     )
 
-    val kafka = KafkaConsumerOrchestrator(
-        preset, Database(app.database),
-        consumers as List<TopicConsumer<out Any, in Any>>
-    )
+    val kafka = KafkaConsumerOrchestrator(preset, db, consumers)
 
     initializeServer(server) {
         configure(app, kafka)


### PR DESCRIPTION
Har refaktorert kafka-modulen og flyttet event-prosesseringen fra KafkaConsumerOrchestrator til TopicConsumer, dette gjør at vi unngår en unchecked cast i main-funksjonen samt at vi får forenklet generics i TopicConsumer.
Flyttet også event-persistering fra Database-klassen til TopicConsumer, da denne var litt malplassert.
