### PR TITLE
Registrerer releases til Sentry

### DIFF
--- a/.github/workflows/mulighetsrommet-api.yaml
+++ b/.github/workflows/mulighetsrommet-api.yaml
@@ -64,6 +64,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Lag deployment i Sentry
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.gc.nav.no
+          SENTRY_ORG: nav
+          SENTRY_PROJECT: mulighetsrommet-api
+        with:
+          environment: dev
+          version: ${{ github.sha }}
+          set_commits: skip
       - name: Deploy
         uses: nais/deploy/actions/deploy@v1
         env:
@@ -82,6 +93,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Lag deployment i Sentry
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.gc.nav.no
+          SENTRY_ORG: nav
+          SENTRY_PROJECT: mulighetsrommet-api
+        with:
+          environment: production
+          version: ${{ github.sha }}
+          set_commits: skip
       - name: Deploy
         uses: nais/deploy/actions/deploy@v1
         env:

--- a/.github/workflows/mulighetsrommet-arena-adapter.yaml
+++ b/.github/workflows/mulighetsrommet-arena-adapter.yaml
@@ -63,6 +63,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Lag deployment i Sentry
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.gc.nav.no
+          SENTRY_ORG: nav
+          SENTRY_PROJECT: mulighetsrommet-arena-adapter
+        with:
+          environment: dev
+          version: ${{ github.sha }}
+          set_commits: skip
       - name: Deploy
         uses: nais/deploy/actions/deploy@v1
         env:

--- a/.github/workflows/mulighetsrommet-veileder-flate.yaml
+++ b/.github/workflows/mulighetsrommet-veileder-flate.yaml
@@ -74,6 +74,17 @@ jobs:
     if: github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v3
+      - name: Lag deployment i Sentry
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.gc.nav.no
+          SENTRY_ORG: nav
+          SENTRY_PROJECT: mulighetsrommet-veileder-flate
+        with:
+          environment: dev
+          version: ${{ github.sha }}
+          set_commits: skip
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -124,6 +135,8 @@ jobs:
           docker build -t ${IMAGE} .
           docker push ${IMAGE}
 
+
+
   deploy-prod:
     name: Deploy (prod)
     runs-on: ubuntu-latest
@@ -131,6 +144,17 @@ jobs:
     if: github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev_and_prod'
     steps:
       - uses: actions/checkout@v3
+      - name: Lag deployment i Sentry
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.gc.nav.no
+          SENTRY_ORG: nav
+          SENTRY_PROJECT: mulighetsrommet-veileder-flate
+        with:
+          environment: production
+          version: ${{ github.sha }}
+          set_commits: skip
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -138,3 +162,4 @@ jobs:
           RESOURCE: frontend/mulighetsrommet-veileder-flate/.nais/nais.yaml
           VAR: image=${{ env.IMAGE }}
           VARS: frontend/mulighetsrommet-veileder-flate/.nais/prod-gcp.yaml
+


### PR DESCRIPTION
Ved å registrere releases til Sentry så kan vi enklere gruppere feil mellom releases. Jeg venter på opprettelse av auth-token for Sentry som må legges til her på Github som en secret.