### PR TITLE
Ci

### DIFF
--- a/.github/workflows/mulighetsrommet-api.yaml
+++ b/.github/workflows/mulighetsrommet-api.yaml
@@ -64,6 +64,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Deploy
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: mulighetsrommet-api/.nais/nais-dev.yaml
+          VAR: image=${{ env.IMAGE }}
       - name: Lag deployment i Sentry
         uses: getsentry/action-release@v1
         env:
@@ -72,16 +79,9 @@ jobs:
           SENTRY_ORG: nav
           SENTRY_PROJECT: mulighetsrommet-api
         with:
-          environment: dev
+          environment: dev-gcp
           version: ${{ github.sha }}
           set_commits: skip
-      - name: Deploy
-        uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: mulighetsrommet-api/.nais/nais-dev.yaml
-          VAR: image=${{ env.IMAGE }}
 
   deploy-prod:
     name: Deploy (prod)
@@ -91,6 +91,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Deploy
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: mulighetsrommet-api/.nais/nais-prod.yaml
+          VAR: image=${{ env.IMAGE }}
       - name: Lag deployment i Sentry
         uses: getsentry/action-release@v1
         env:
@@ -99,13 +106,6 @@ jobs:
           SENTRY_ORG: nav
           SENTRY_PROJECT: mulighetsrommet-api
         with:
-          environment: production
+          environment: prod-gcp
           version: ${{ github.sha }}
           set_commits: skip
-      - name: Deploy
-        uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: mulighetsrommet-api/.nais/nais-prod.yaml
-          VAR: image=${{ env.IMAGE }}

--- a/.github/workflows/mulighetsrommet-api.yaml
+++ b/.github/workflows/mulighetsrommet-api.yaml
@@ -72,6 +72,7 @@ jobs:
           RESOURCE: mulighetsrommet-api/.nais/nais-dev.yaml
           VAR: image=${{ env.IMAGE }}
       - name: Lag deployment i Sentry
+        continue-on-error: true
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -99,6 +100,7 @@ jobs:
           RESOURCE: mulighetsrommet-api/.nais/nais-prod.yaml
           VAR: image=${{ env.IMAGE }}
       - name: Lag deployment i Sentry
+        continue-on-error: true
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/mulighetsrommet-arena-adapter.yaml
+++ b/.github/workflows/mulighetsrommet-arena-adapter.yaml
@@ -64,17 +64,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-#      - name: Lag deployment i Sentry
-#        uses: getsentry/action-release@v1
-#        env:
-#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#          SENTRY_URL: https://sentry.gc.nav.no
-#          SENTRY_ORG: nav
-#          SENTRY_PROJECT: mulighetsrommet-arena-adapter
-#        with:
-#          environment: dev
-#          version: ${{ github.sha }}
-#          set_commits: skip
       - name: Deploy
         uses: nais/deploy/actions/deploy@v1
         env:
@@ -82,6 +71,17 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
           VAR: image=${{ env.IMAGE }}
+      - name: Lag deployment i Sentry
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.gc.nav.no
+          SENTRY_ORG: nav
+          SENTRY_PROJECT: mulighetsrommet-arena-adapter
+        with:
+          environment: dev-gcp
+          version: ${{ github.sha }}
+          set_commits: skip
 
   deploy-prod:
     name: Deploy (prod)
@@ -98,3 +98,14 @@ jobs:
           CLUSTER: prod-gcp
           RESOURCE: mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
           VAR: image=${{ env.IMAGE }}
+      - name: Lag deployment i Sentry
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.gc.nav.no
+          SENTRY_ORG: nav
+          SENTRY_PROJECT: mulighetsrommet-arena-adapter
+        with:
+          environment: prod-gcp
+          version: ${{ github.sha }}
+          set_commits: skip

--- a/.github/workflows/mulighetsrommet-arena-adapter.yaml
+++ b/.github/workflows/mulighetsrommet-arena-adapter.yaml
@@ -72,6 +72,7 @@ jobs:
           RESOURCE: mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
           VAR: image=${{ env.IMAGE }}
       - name: Lag deployment i Sentry
+        continue-on-error: true
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -99,6 +100,7 @@ jobs:
           RESOURCE: mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
           VAR: image=${{ env.IMAGE }}
       - name: Lag deployment i Sentry
+        continue-on-error: true
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/mulighetsrommet-veileder-flate.yaml
+++ b/.github/workflows/mulighetsrommet-veileder-flate.yaml
@@ -150,6 +150,7 @@ jobs:
           VAR: image=${{ env.IMAGE }}
           VARS: frontend/mulighetsrommet-veileder-flate/.nais/prod-gcp.yaml
       - name: Lag deployment i Sentry
+        continue-on-error: true
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/mulighetsrommet-veileder-flate.yaml
+++ b/.github/workflows/mulighetsrommet-veileder-flate.yaml
@@ -74,6 +74,13 @@ jobs:
     if: github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v3
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: frontend/mulighetsrommet-veileder-flate/.nais/nais.yaml
+          VAR: image=${{ env.IMAGE }}
+          VARS: frontend/mulighetsrommet-veileder-flate/.nais/dev-gcp.yaml
       - name: Lag deployment i Sentry
         uses: getsentry/action-release@v1
         env:
@@ -85,13 +92,6 @@ jobs:
           environment: dev
           version: ${{ github.sha }}
           set_commits: skip
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: frontend/mulighetsrommet-veileder-flate/.nais/nais.yaml
-          VAR: image=${{ env.IMAGE }}
-          VARS: frontend/mulighetsrommet-veileder-flate/.nais/dev-gcp.yaml
 
   build-and-test:
     name: Build and test for production
@@ -135,8 +135,6 @@ jobs:
           docker build -t ${IMAGE} .
           docker push ${IMAGE}
 
-
-
   deploy-prod:
     name: Deploy (prod)
     runs-on: ubuntu-latest
@@ -144,6 +142,13 @@ jobs:
     if: github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev_and_prod'
     steps:
       - uses: actions/checkout@v3
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: frontend/mulighetsrommet-veileder-flate/.nais/nais.yaml
+          VAR: image=${{ env.IMAGE }}
+          VARS: frontend/mulighetsrommet-veileder-flate/.nais/prod-gcp.yaml
       - name: Lag deployment i Sentry
         uses: getsentry/action-release@v1
         env:
@@ -155,11 +160,3 @@ jobs:
           environment: production
           version: ${{ github.sha }}
           set_commits: skip
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: frontend/mulighetsrommet-veileder-flate/.nais/nais.yaml
-          VAR: image=${{ env.IMAGE }}
-          VARS: frontend/mulighetsrommet-veileder-flate/.nais/prod-gcp.yaml
-


### PR DESCRIPTION
- Lager Sentry-release etter deplyment i stedet for før deployment
- Har gjort Sentry-release optional ved å sette `continue-on-error: true`. NAV sin Sentry-instans virker ganske ustabil og da er det litt kjedelig at en deployment ikke blir vellykket når det kun er Sentry det står på (slik som nå). Det kan by på problemer der stacktraces i Sentry ikke stemmer med commit-hash'en, men jeg tror det er en trade off som er verdt det.