### PR TITLE
Øker min-replicas til 2 for å ikke ha nedetid ved cluster-oppgraderinger

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/.nais/nais.yaml
+++ b/frontend/mulighetsrommet-veileder-flate/.nais/nais.yaml
@@ -25,8 +25,8 @@ spec:
     path: /
     initialDelay: 10
   replicas:
-    min: 1
-    max: 2
+    min: 2
+    max: 3
     cpuThresholdPercentage: 75
   resources:
     limits:

--- a/mulighetsrommet-api/.nais/nais-prod.yaml
+++ b/mulighetsrommet-api/.nais/nais-prod.yaml
@@ -20,8 +20,8 @@ spec:
     path: /internal/liveness
     initialDelay: 20
   replicas:
-    min: 1
-    max: 2
+    min: 2
+    max: 3
     cpuThresholdPercentage: 75
   resources:
     limits:

--- a/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
@@ -20,8 +20,8 @@ spec:
     path: /internal/liveness
     initialDelay: 20
   replicas:
-    min: 1
-    max: 2
+    min: 2
+    max: 3
     cpuThresholdPercentage: 75
   resources:
     limits:

--- a/mulighetsrommet-arena-ords-proxy/.nais/nais.yaml
+++ b/mulighetsrommet-arena-ords-proxy/.nais/nais.yaml
@@ -20,8 +20,8 @@ spec:
     path: /internal/liveness
     initialDelay: 20
   replicas:
-    min: 1
-    max: 2
+    min: 2
+    max: 3
     cpuThresholdPercentage: 75
   resources:
     limits:


### PR DESCRIPTION
Ref: https://nav-it.slack.com/archives/C5KUST8N6/p1658925402670759?thread_ts=1658921088.207689&cid=C5KUST8N6 så bør vi sette `replicas.min: 2` for å ikke ha nedetid når det er cluster-oppgraderinger i prod-gcp.