### PR TITLE
Fikser rar oppførsel ved lasting av tiltaksgjennomføringer

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/api/queries/useTiltaksgjennomforing.ts
@@ -2,12 +2,10 @@ import groq from 'groq';
 import { useAtom } from 'jotai';
 import { tiltaksgjennomforingsfilter, Tiltaksgjennomforingsfiltergruppe } from '../../core/atoms/atoms';
 import { Tiltaksgjennomforing } from '../models';
-import { useHentBrukerdata } from './useHentBrukerdata';
 import { useSanity } from './useSanity';
 
 export default function useTiltaksgjennomforing() {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
-  const brukerdata = useHentBrukerdata();
   return useSanity<Tiltaksgjennomforing[]>(
     groq`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
   ${byggInnsatsgruppeFilter(filter.innsatsgrupper)} 
@@ -24,8 +22,7 @@ export default function useTiltaksgjennomforing() {
     tiltaksnummer,
     kontaktinfoArrangor->,
     tiltakstype->
-  }`,
-    !!brukerdata?.data
+  }`
   );
 }
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -55,7 +55,7 @@ const TiltaksgjennomforingsTabell = () => {
     }
   };
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return <Loader className="filter-loader" size="xlarge" />;
   }
 


### PR DESCRIPTION
Ved å vente på brukerdata så ble visningen av av tiltaksgjennomføringstabellen litt rar mtp. at den viser at man har gjort et søk når man ikke har gjort noen ting. Ved å fjerne ventingen på brukerdata så får vi korrekt oppførsel på spinneren for tiltaksgjennomføringene.

**Før**
https://user-images.githubusercontent.com/9053627/182331798-50860df7-5c12-45ed-a6b3-61b3c1f37c33.mov

**Etter**
https://user-images.githubusercontent.com/9053627/182331837-0266f6ac-0a01-428d-8c75-d6794d99f6a3.mov


