### PR TITLE
Feature/add tilgjengelighetsstatus

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
   # The service is referenced as part of the authentication between applications as part of local development.
   mock-oauth2-server:
     image: ghcr.io/navikt/mock-oauth2-server:0.4.6
+    restart: "always"
     ports:
       - "8081:8081"
     profiles:

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
@@ -41,38 +41,44 @@ class ArenaService(private val db: Database) {
         return db.run(queryResult)!!
     }
 
-    fun upsertTiltaksgjennomforing(tiltaksgjennomforing: AdapterTiltaksgjennomforing): AdapterTiltaksgjennomforing {
-        logger.info(
-            "Lagrer tiltak tiltakskode={} sakId={}",
-            tiltaksgjennomforing.tiltakskode,
-            tiltaksgjennomforing.sakId
-        )
+    fun upsertTiltaksgjennomforing(tiltak: AdapterTiltaksgjennomforing): AdapterTiltaksgjennomforing {
+        logger.info("Lagrer tiltak tiltakskode=${tiltak.tiltakskode} sakId=${tiltak.sakId}")
 
         @Language("PostgreSQL")
         val query = """
-            insert into tiltaksgjennomforing (navn, arrangor_id, tiltakskode, arena_id, fra_dato, til_dato, sak_id)
-            values (?, ?, ?, ?, ?, ?, ?)
+            insert into tiltaksgjennomforing (navn,
+                                              arrangor_id,
+                                              tiltakskode,
+                                              arena_id,
+                                              fra_dato,
+                                              til_dato, sak_id,
+                                              apent_for_innsok,
+                                              antall_plasser)
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?)
             on conflict (arena_id)
-            do update set
-                navn = excluded.navn,
-                arrangor_id = excluded.arrangor_id,
-                tiltakskode = excluded.tiltakskode,
-                arena_id = excluded.arena_id,
-                fra_dato = excluded.fra_dato,
-                til_dato = excluded.til_dato,
-                sak_id = excluded.sak_id
+                do update set navn             = excluded.navn,
+                              arrangor_id      = excluded.arrangor_id,
+                              tiltakskode      = excluded.tiltakskode,
+                              arena_id         = excluded.arena_id,
+                              fra_dato         = excluded.fra_dato,
+                              til_dato         = excluded.til_dato,
+                              sak_id           = excluded.sak_id,
+                              apent_for_innsok = excluded.apent_for_innsok,
+                              antall_plasser   = excluded.antall_plasser
             returning *
         """.trimIndent()
 
         val queryResult = queryOf(
             query,
-            tiltaksgjennomforing.navn,
-            tiltaksgjennomforing.arrangorId,
-            tiltaksgjennomforing.tiltakskode,
-            tiltaksgjennomforing.id,
-            tiltaksgjennomforing.fraDato,
-            tiltaksgjennomforing.tilDato,
-            tiltaksgjennomforing.sakId
+            tiltak.navn,
+            tiltak.arrangorId,
+            tiltak.tiltakskode,
+            tiltak.id,
+            tiltak.fraDato,
+            tiltak.tilDato,
+            tiltak.sakId,
+            tiltak.apentForInnsok,
+            tiltak.antallPlasser,
         ).map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }.asSingle
         return db.run(queryResult)!!
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -4,12 +4,14 @@ import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.utils.DatabaseMapper
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing
+import org.intellij.lang.annotations.Language
 
 class TiltaksgjennomforingService(private val db: Database) {
 
     fun getTiltaksgjennomforingerByTiltakskode(tiltakskode: String): List<Tiltaksgjennomforing> {
+        @Language("PostgreSQL")
         val query = """
-            select id, navn, tiltaksnummer, tiltakskode, aar
+            select id, navn, tiltaksnummer, tiltakskode, aar, tilgjengelighet
             from tiltaksgjennomforing_valid
             where tiltakskode = ?
         """.trimIndent()
@@ -18,8 +20,9 @@ class TiltaksgjennomforingService(private val db: Database) {
     }
 
     fun getTiltaksgjennomforingById(id: Int): Tiltaksgjennomforing? {
+        @Language("PostgreSQL")
         val query = """
-            select id, navn, tiltaksnummer, tiltakskode, aar
+            select id, navn, tiltaksnummer, tiltakskode, aar, tilgjengelighet
             from tiltaksgjennomforing_valid
             where id = ?
         """.trimIndent()
@@ -28,8 +31,9 @@ class TiltaksgjennomforingService(private val db: Database) {
     }
 
     fun getTiltaksgjennomforinger(): List<Tiltaksgjennomforing> {
+        @Language("PostgreSQL")
         val query = """
-            select id, navn, tiltaksnummer, tiltakskode, aar
+            select id, navn, tiltaksnummer, tiltakskode, aar, tilgjengelighet
             from tiltaksgjennomforing_valid
         """.trimIndent()
         val queryResult = queryOf(query).map { DatabaseMapper.toTiltaksgjennomforing(it) }.asList

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/DatabaseMapper.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/DatabaseMapper.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.utils
 
 import kotliquery.Row
 import no.nav.mulighetsrommet.domain.*
+import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing.Tilgjengelighetsstatus
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
@@ -22,7 +23,10 @@ object DatabaseMapper {
             navn = row.string("navn"),
             tiltaksnummer = row.int("tiltaksnummer"),
             tiltakskode = row.string("tiltakskode"),
-            aar = row.int("aar")
+            aar = row.int("aar"),
+            tilgjengelighet = Tilgjengelighetsstatus.valueOf(
+                row.string("tilgjengelighet")
+            )
         )
 
     fun toInnsatsgruppe(row: Row): Innsatsgruppe = Innsatsgruppe(
@@ -53,7 +57,9 @@ object DatabaseMapper {
         fraDato = row.localDateTimeOrNull("fra_dato"),
         tilDato = row.localDateTimeOrNull("til_dato"),
         arrangorId = row.intOrNull("arrangor_id"),
-        sakId = row.int("sak_id")
+        sakId = row.int("sak_id"),
+        apentForInnsok = row.boolean("apent_for_innsok"),
+        antallPlasser = row.intOrNull("antall_plasser"),
     )
 
     fun toAdapterTiltakdeltaker(row: Row): AdapterTiltakdeltaker = AdapterTiltakdeltaker(

--- a/mulighetsrommet-api/src/main/resources/db/migration/V2__add_tilgjengelighetsstatus.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V2__add_tilgjengelighetsstatus.sql
@@ -1,0 +1,68 @@
+create type tilgjengelighetsstatus as enum ('Ledig', 'Venteliste', 'Stengt');
+
+alter table tiltaksgjennomforing
+    add apent_for_innsok boolean                not null default true,
+    add antall_plasser   int,
+    add tilgjengelighet  tilgjengelighetsstatus not null default 'Ledig';
+
+create or replace function update_tilgjengelighet()
+    returns trigger as
+$$
+begin
+    new.tilgjengelighet =
+            case
+                when new.apent_for_innsok = false then 'Stengt'
+                when new.antall_plasser is null then 'Ledig'
+                when (
+                         select count(*) as antall_deltakere
+                         from deltaker
+                         where tiltaksgjennomforing_id = new.arena_id
+                           and status = 'DELTAR'
+                     ) < new.antall_plasser then 'Ledig'
+                else 'Venteliste'
+                end::tilgjengelighetsstatus;
+    return new;
+end
+$$ language plpgsql;
+
+create trigger update_tilgjengelighet
+    before insert or update of apent_for_innsok, antall_plasser
+    on tiltaksgjennomforing
+    for each row
+execute procedure update_tilgjengelighet();
+
+create or replace function update_tilgjengelighet_after_deltakelse()
+    returns trigger as
+$$
+begin
+    update tiltaksgjennomforing t
+    set tilgjengelighet =
+            case
+                when t.apent_for_innsok = false then 'Stengt'
+                when t.antall_plasser is null then 'Ledig'
+                when (
+                         select count(*) as antall_deltakere
+                         from deltaker
+                         where tiltaksgjennomforing_id = new.tiltaksgjennomforing_id
+                           and status = 'DELTAR'
+                     ) < t.antall_plasser then 'Ledig'
+                else 'Venteliste'
+                end::tilgjengelighetsstatus
+    where t.arena_id = new.tiltaksgjennomforing_id;
+
+    return new;
+end
+$$ language plpgsql;
+
+create trigger update_tilgjengelighet_after_deltakelse
+    after insert or update
+    on deltaker
+    for each row
+execute procedure update_tilgjengelighet_after_deltakelse();
+
+create or replace view tiltaksgjennomforing_valid(id, navn, tiltaksnummer, tiltakskode, aar, tilgjengelighet) as
+select id, navn, tiltaksnummer, tiltakskode, aar, tilgjengelighet
+from tiltaksgjennomforing
+where tiltaksnummer is not null
+  and aar is not null
+

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yml
@@ -290,12 +290,19 @@ components:
           type: integer
         aar:
           type: integer
+        tilgjenglighet:
+          type: string
+          enum:
+            - ApentForInnsok
+            - Venteliste
+            - Stengt
       required:
         - _id
         - navn
         - tiltakskode
         - tiltaksnummer
         - aar
+        - tilgjengelighet
 
     Tiltakskode:
       type: string

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTest.kt
@@ -4,17 +4,14 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.*
 import io.ktor.http.*
-import no.nav.security.mock.oauth2.withMockOAuth2Server
 
 class ApplicationTest : FunSpec({
     context("liveness") {
         test("should respond with 200 OK") {
-            withMockOAuth2Server {
-                withMulighetsrommetApp {
-                    val response = client.get("/internal/liveness")
+            withMulighetsrommetApp {
+                val response = client.get("/internal/liveness")
 
-                    response.status shouldBe HttpStatusCode.OK
-                }
+                response.status shouldBe HttpStatusCode.OK
             }
         }
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
@@ -19,7 +19,7 @@ fun <R> withMulighetsrommetApp(
 }
 
 fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
-    database = createDatabaseConfig(),
+    database = createDatabaseConfigWithRandomSchema(),
     auth = createAuthConfig(oauth),
     sanity = createSanityConfig(),
     veilarboppfolgingConfig = createVeilarboppfolgingConfig(),
@@ -39,15 +39,6 @@ fun createVeilarbvedsstotteConfig(): VeilarbvedtaksstotteConfig {
         scope = ""
     )
 }
-
-fun createDatabaseConfig(
-    host: String = "localhost",
-    port: Int = 5442,
-    name: String = "mulighetsrommet-api-db",
-    user: String = "valp",
-    password: Password = Password("valp"),
-    maximumPoolSize: Int = 1,
-) = DatabaseConfig(host, port, name, null, user, password, maximumPoolSize)
 
 fun createDatabaseConfigWithRandomSchema(
     host: String = "localhost",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
@@ -6,9 +6,12 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.createDatabaseConfigWithRandomSchema
 import no.nav.mulighetsrommet.database.kotest.extensions.DatabaseListener
+import no.nav.mulighetsrommet.domain.Deltakerstatus
 import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing
+import no.nav.mulighetsrommet.domain.Tiltaksgjennomforing.Tilgjengelighetsstatus
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
+import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
 import java.time.LocalDateTime
 
@@ -20,34 +23,40 @@ class TiltaksgjennomforingServiceTest : FunSpec({
 
     register(listener)
 
-    beforeSpec {
+    context("CRUD") {
         val arenaService = ArenaService(listener.db)
 
-        val tiltakstype = AdapterTiltak(
-            navn = "Arbeidstrening",
-            innsatsgruppe = 1,
-            tiltakskode = "ARBTREN",
-            fraDato = LocalDateTime.now(),
-            tilDato = LocalDateTime.now().plusYears(1)
-        )
+        val service = TiltaksgjennomforingService(listener.db)
 
-        val tiltakstype2 = AdapterTiltak(
-            navn = "Oppfølging",
-            innsatsgruppe = 2,
-            tiltakskode = "INDOPPFOLG",
-            fraDato = LocalDateTime.now(),
-            tilDato = LocalDateTime.now().plusYears(1)
-        )
+        beforeAny {
+            arenaService.upsertTiltakstype(
+                AdapterTiltak(
+                    navn = "Arbeidstrening",
+                    innsatsgruppe = 1,
+                    tiltakskode = "ARBTREN",
+                    fraDato = LocalDateTime.now(),
+                    tilDato = LocalDateTime.now().plusYears(1)
+                )
+            )
+            arenaService.upsertTiltakstype(
+                AdapterTiltak(
+                    navn = "Oppfølging",
+                    innsatsgruppe = 2,
+                    tiltakskode = "INDOPPFOLG",
+                    fraDato = LocalDateTime.now(),
+                    tilDato = LocalDateTime.now().plusYears(1)
+                )
+            )
+        }
 
-        val tiltaksgjennomforing = AdapterTiltaksgjennomforing(
+        val tiltak1 = AdapterTiltaksgjennomforing(
             navn = "Oppfølging",
             arrangorId = 1,
             tiltakskode = "INDOPPFOLG",
             id = 1,
             sakId = 1,
         )
-
-        val tiltaksgjennomforing2 = AdapterTiltaksgjennomforing(
+        val tiltak2 = AdapterTiltaksgjennomforing(
             navn = "Trening",
             arrangorId = 1,
             tiltakskode = "ARBTREN",
@@ -55,39 +64,132 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             sakId = 2,
         )
 
-        arenaService.upsertTiltakstype(tiltakstype)
-        arenaService.upsertTiltakstype(tiltakstype2)
-        arenaService.upsertTiltaksgjennomforing(tiltaksgjennomforing)
-        arenaService.upsertTiltaksgjennomforing(tiltaksgjennomforing2)
-        arenaService.updateTiltaksgjennomforingWithSak(
-            AdapterSak(id = 1, lopenummer = 11, aar = 2022)
-        )
-        arenaService.updateTiltaksgjennomforingWithSak(
-            AdapterSak(id = 2, lopenummer = 22, aar = 2022)
-        )
-    }
+        test("should return empty result when there are no created tiltak") {
+            service.getTiltaksgjennomforinger() shouldBe listOf()
+        }
 
-    context("CRUD") {
-        val service = TiltaksgjennomforingService(listener.db)
+        test("should return empty result when tiltak are missing tiltaksnummer") {
+            arenaService.upsertTiltaksgjennomforing(tiltak1)
+            arenaService.upsertTiltaksgjennomforing(tiltak2)
 
-        test("should get tiltaksgjennomføring by id") {
-            val tiltaksgjennomforing = service.getTiltaksgjennomforingById(1)
+            service.getTiltaksgjennomforinger() shouldBe listOf()
+        }
 
-            tiltaksgjennomforing shouldBe Tiltaksgjennomforing(
+        test("should get tiltak when they have been assigned tiltaksnummer") {
+            arenaService.updateTiltaksgjennomforingWithSak(
+                AdapterSak(id = 1, lopenummer = 11, aar = 2022)
+            )
+            arenaService.updateTiltaksgjennomforingWithSak(
+                AdapterSak(id = 2, lopenummer = 22, aar = 2022)
+            )
+
+            service.getTiltaksgjennomforinger() shouldBe listOf(
+                Tiltaksgjennomforing(
+                    id = 1,
+                    navn = "Oppfølging",
+                    tiltakskode = "INDOPPFOLG",
+                    tiltaksnummer = 11,
+                    aar = 2022,
+                    tilgjengelighet = Tilgjengelighetsstatus.Ledig
+                ),
+                Tiltaksgjennomforing(
+                    id = 2,
+                    navn = "Trening",
+                    tiltakskode = "ARBTREN",
+                    tiltaksnummer = 22,
+                    aar = 2022,
+                    tilgjengelighet = Tilgjengelighetsstatus.Ledig
+                ),
+            )
+        }
+
+        test("should get tiltak by id") {
+            service.getTiltaksgjennomforingById(1) shouldBe Tiltaksgjennomforing(
                 id = 1,
                 navn = "Oppfølging",
                 tiltakskode = "INDOPPFOLG",
                 tiltaksnummer = 11,
-                aar = 2022
+                aar = 2022,
+                tilgjengelighet = Tilgjengelighetsstatus.Ledig
             )
-        }
-
-        test("should get tiltaksgjennomføringer") {
-            service.getTiltaksgjennomforinger() shouldHaveSize 2
         }
 
         test("should get tiltaksgjennomføringer by tiltakskode") {
             service.getTiltaksgjennomforingerByTiltakskode("ARBTREN") shouldHaveSize 1
+        }
+
+        context("tilgjengelighetsstatus") {
+            context("when tiltak is closed for applications") {
+                beforeAny {
+                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(apentForInnsok = false))
+                }
+
+                afterAny {
+                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(apentForInnsok = true))
+                }
+
+                test("should have tilgjengelighet set to STENGT") {
+                    service.getTiltaksgjennomforingById(1)?.tilgjengelighet shouldBe Tilgjengelighetsstatus.Stengt
+                }
+            }
+
+            context("when there are no limits to available seats") {
+                beforeAny {
+                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = null))
+                }
+
+                test("should have tilgjengelighet set to APENT_FOR_INNSOK") {
+                    service.getTiltaksgjennomforingById(1)?.tilgjengelighet shouldBe Tilgjengelighetsstatus.Ledig
+                }
+            }
+
+            context("when there are no available seats") {
+                beforeAny {
+                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 0))
+                }
+
+                test("should have tilgjengelighet set to VENTELISTE") {
+                    service.getTiltaksgjennomforingById(1)?.tilgjengelighet shouldBe Tilgjengelighetsstatus.Venteliste
+                }
+            }
+
+            context("when all available seats are occupied by deltakelser with status DELTAR") {
+                beforeAny {
+                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 1))
+
+                    arenaService.upsertDeltaker(
+                        AdapterTiltakdeltaker(
+                            id = 1,
+                            tiltaksgjennomforingId = tiltak1.id,
+                            personId = 1,
+                            status = Deltakerstatus.DELTAR
+                        )
+                    )
+                }
+
+                test("should have tilgjengelighet set to VENTELISTE") {
+                    service.getTiltaksgjennomforingById(1)?.tilgjengelighet shouldBe Tilgjengelighetsstatus.Venteliste
+                }
+            }
+
+            context("when deltakelser are no longer DELTAR") {
+                beforeAny {
+                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 1))
+
+                    arenaService.upsertDeltaker(
+                        AdapterTiltakdeltaker(
+                            id = 1,
+                            tiltaksgjennomforingId = tiltak1.id,
+                            personId = 1,
+                            status = Deltakerstatus.AVSLUTTET
+                        )
+                    )
+                }
+
+                test("should have tilgjengelighet set to APENT_FOR_INNSOK") {
+                    service.getTiltaksgjennomforingById(1)?.tilgjengelighet shouldBe Tilgjengelighetsstatus.Ledig
+                }
+            }
         }
     }
 })

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -10,6 +10,7 @@ import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.arena.ArenaTiltaksgjennomforing
+import no.nav.mulighetsrommet.domain.arena.JaNeiStatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -44,5 +45,7 @@ class TiltakgjennomforingEndretConsumer(
         tilDato = ProcessingUtils.getArenaDateFromTo(this.DATO_TIL),
         arrangorId = this.ARBGIV_ID_ARRANGOR,
         sakId = this.SAK_ID,
+        apentForInnsok = this.STATUS_TREVERDIKODE_INNSOKNING != JaNeiStatus.Nei,
+        antallPlasser = this.ANTALL_DELTAKERE,
     )
 }

--- a/mulighetsrommet-domain/src/main/kotlin/no.nav.mulighetsrommet.domain/Tiltaksgjennomforing.kt
+++ b/mulighetsrommet-domain/src/main/kotlin/no.nav.mulighetsrommet.domain/Tiltaksgjennomforing.kt
@@ -9,4 +9,12 @@ data class Tiltaksgjennomforing(
     val tiltakskode: String,
     val tiltaksnummer: Int,
     val aar: Int,
-)
+    val tilgjengelighet: Tilgjengelighetsstatus,
+) {
+    enum class Tilgjengelighetsstatus {
+        Ledig,
+        Venteliste,
+        Stengt,
+    }
+}
+

--- a/mulighetsrommet-domain/src/main/kotlin/no/nav/mulighetsrommet/domain/adapter/AdapterTiltaksgjennomforing.kt
+++ b/mulighetsrommet-domain/src/main/kotlin/no/nav/mulighetsrommet/domain/adapter/AdapterTiltaksgjennomforing.kt
@@ -5,7 +5,7 @@ import no.nav.mulighetsrommet.domain.DateSerializer
 import java.time.LocalDateTime
 
 @Serializable
-data class AdapterTiltaksgjennomforing (
+data class AdapterTiltaksgjennomforing(
     val id: Int,
     val navn: String,
     val tiltakskode: String,
@@ -15,4 +15,6 @@ data class AdapterTiltaksgjennomforing (
     val fraDato: LocalDateTime? = null,
     @Serializable(with = DateSerializer::class)
     val tilDato: LocalDateTime? = null,
+    val apentForInnsok: Boolean = true,
+    val antallPlasser: Int? = null,
 )

--- a/mulighetsrommet-domain/src/main/kotlin/no/nav/mulighetsrommet/domain/arena/ArenaTiltaksgjennomforing.kt
+++ b/mulighetsrommet-domain/src/main/kotlin/no/nav/mulighetsrommet/domain/arena/ArenaTiltaksgjennomforing.kt
@@ -3,7 +3,7 @@ package no.nav.mulighetsrommet.domain.arena
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ArenaTiltaksgjennomforing (
+data class ArenaTiltaksgjennomforing(
     val TILTAKGJENNOMFORING_ID: Int,
     val SAK_ID: Int,
     val TILTAKSKODE: String,
@@ -11,4 +11,6 @@ data class ArenaTiltaksgjennomforing (
     val DATO_TIL: String?,
     val LOKALTNAVN: String,
     val ARBGIV_ID_ARRANGOR: Int?,
+    val STATUS_TREVERDIKODE_INNSOKNING: JaNeiStatus?,
+    val ANTALL_DELTAKERE: Int?
 )

--- a/mulighetsrommet-domain/src/main/kotlin/no/nav/mulighetsrommet/domain/arena/JaNeiStatus.kt
+++ b/mulighetsrommet-domain/src/main/kotlin/no/nav/mulighetsrommet/domain/arena/JaNeiStatus.kt
@@ -1,0 +1,15 @@
+package no.nav.mulighetsrommet.domain.arena
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class JaNeiStatus {
+
+    @SerialName("J")
+    Ja,
+
+    @SerialName("N")
+    Nei,
+
+}


### PR DESCRIPTION
Utleder tilgjengelighetsstatus for tiltaksgjennomføringer.
Det er implementert som en trigger ved endring på tiltaksgjennomføringer og en trigger ved endringer på tiltaksdeltakelser.
Begge triggere skriver ny tilgjengelighetsstatus på tiltaksgjennomføringen basert de to nye kolonnene  `apent_for_innsok` og `antall_deltakere`, samt hvor mange deltakere som har status `DELTAR` på gjeldende tiltak.