### PR TITLE
Feature/paginate events based on

### DIFF
--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/ConsumerGroup.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/ConsumerGroup.kt
@@ -1,5 +1,5 @@
 package no.nav.mulighetsrommet.arena.adapter.kafka
 
-class ConsumerSetup(
+data class ConsumerGroup(
     val consumers: List<TopicConsumer<out Any>>
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/ConsumerSetup.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/ConsumerSetup.kt
@@ -1,19 +1,5 @@
 package no.nav.mulighetsrommet.arena.adapter.kafka
 
-import no.nav.mulighetsrommet.arena.adapter.KafkaConfig
-import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
-import no.nav.mulighetsrommet.arena.adapter.consumers.SakEndretConsumer
-import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakEndretConsumer
-import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakdeltakerEndretConsumer
-import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakgjennomforingEndretConsumer
-import no.nav.mulighetsrommet.arena.adapter.getTopic
-import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
-
-class ConsumerSetup(kafkaConfig: KafkaConfig, eventRepository: EventRepository, apiClient: MulighetsrommetApiClient) {
-    val consumers = listOf(
-        TiltakEndretConsumer(kafkaConfig.getTopic("tiltakendret"), eventRepository, apiClient),
-        TiltakgjennomforingEndretConsumer(kafkaConfig.getTopic("tiltakgjennomforingendret"), eventRepository, apiClient),
-        TiltakdeltakerEndretConsumer(kafkaConfig.getTopic("tiltakdeltakerendret"), eventRepository, apiClient),
-        SakEndretConsumer(kafkaConfig.getTopic("sakendret"), eventRepository, apiClient),
-    )
-}
+class ConsumerSetup(
+    val consumers: List<TopicConsumer<out Any>>
+)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/KafkaConsumerOrchestrator.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/KafkaConsumerOrchestrator.kt
@@ -19,7 +19,7 @@ import java.util.function.Consumer
 class KafkaConsumerOrchestrator(
     consumerPreset: Properties,
     db: Database,
-    private val consumerSetup: ConsumerSetup,
+    private val group: ConsumerGroup,
     private val topicRepository: TopicRepository,
     pollDelay: Long
 ) {
@@ -32,7 +32,7 @@ class KafkaConsumerOrchestrator(
     init {
         logger.debug("Initializing Kafka")
 
-        updateTopics(consumerSetup.consumers)
+        updateTopics(group.consumers)
 
         val kafkaConsumerRepository = KafkaConsumerRepository(db)
         val consumerTopicsConfig = configureConsumersTopics(kafkaConsumerRepository)
@@ -110,7 +110,7 @@ class KafkaConsumerOrchestrator(
         updated.filter { x -> current.any { y -> y.id == x.id && y.running != x.running } }
 
     private fun configureConsumersTopics(repository: KafkaConsumerRepository): List<KafkaConsumerClientBuilder.TopicConfig<String, JsonElement>> {
-        return consumerSetup.consumers.map { consumer ->
+        return group.consumers.map { consumer ->
             KafkaConsumerClientBuilder.TopicConfig<String, JsonElement>()
                 .withStoreOnFailure(repository)
                 .withLogging()

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
@@ -7,7 +7,7 @@ import no.nav.mulighetsrommet.arena.adapter.consumers.SakEndretConsumer
 import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakEndretConsumer
 import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakdeltakerEndretConsumer
 import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakgjennomforingEndretConsumer
-import no.nav.mulighetsrommet.arena.adapter.kafka.ConsumerSetup
+import no.nav.mulighetsrommet.arena.adapter.kafka.ConsumerGroup
 import no.nav.mulighetsrommet.arena.adapter.kafka.KafkaConsumerOrchestrator
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
 import no.nav.mulighetsrommet.arena.adapter.repositories.TopicRepository
@@ -17,7 +17,7 @@ import no.nav.mulighetsrommet.database.DatabaseConfig
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
 import org.koin.logger.SLF4JLogger
-import java.util.Properties
+import java.util.*
 
 fun Application.configureDependencyInjection(
     appConfig: AppConfig,
@@ -46,7 +46,7 @@ private fun consumers(kafkaConfig: KafkaConfig) = module {
             TiltakdeltakerEndretConsumer(kafkaConfig.getTopic("tiltakdeltakerendret"), get(), get()),
             SakEndretConsumer(kafkaConfig.getTopic("sakendret"), get(), get()),
         )
-        ConsumerSetup(consumers)
+        ConsumerGroup(consumers)
     }
 }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/EventRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/EventRepository.kt
@@ -6,15 +6,9 @@ import no.nav.mulighetsrommet.database.Database
 import org.intellij.lang.annotations.Language
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.LocalDate
-import java.time.LocalDateTime
 
 class EventRepository(private val db: Database) {
     private val logger: Logger = LoggerFactory.getLogger(EventRepository::class.java)
-
-    companion object {
-        val MINIMUM_EVENT_CREATION_DATE: LocalDate = LocalDate.parse("1900-01-01")
-    }
 
     fun saveEvent(topic: String, key: String, payload: String) {
         @Language("PostgreSQL")
@@ -31,16 +25,16 @@ class EventRepository(private val db: Database) {
             .let { db.run(it) }
     }
 
-    fun getEvents(topic: String, limit: Int, createdAfter: LocalDateTime? = null): List<Event> {
-        logger.info("Getting events topic=$topic, amount=$limit, createdAfter=$createdAfter")
+    fun getEvents(topic: String, limit: Int, id: Int? = null): List<Event> {
+        logger.info("Getting events topic=$topic, amount=$limit, id=$id")
 
         @Language("PostgreSQL")
         val query = """
-            select id, payload, created_at
+            select id, payload
             from events
             where topic = :topic
-            and created_at > :created_after
-            order by created_at
+              and id > :id
+            order by id
             limit :limit
         """.trimIndent()
 
@@ -49,7 +43,7 @@ class EventRepository(private val db: Database) {
             mapOf(
                 "topic" to topic,
                 "limit" to limit,
-                "created_after" to (createdAfter ?: MINIMUM_EVENT_CREATION_DATE)
+                "id" to (id ?: 0),
             )
         )
             .map { it.toEvent() }
@@ -62,12 +56,10 @@ private fun Row.toEvent(): Event {
     return Event(
         id = int("id"),
         payload = string("payload"),
-        createdAt = localDateTime("created_at")
     )
 }
 
 data class Event(
     val id: Int,
     val payload: String,
-    val createdAt: LocalDateTime
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/routes/ApiRoutes.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/routes/ApiRoutes.kt
@@ -8,9 +8,7 @@ import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.arena.adapter.jobs.JobRunners
 import no.nav.mulighetsrommet.arena.adapter.services.TopicService
-import no.nav.mulighetsrommet.domain.DateSerializer
 import org.koin.ktor.ext.inject
-import java.time.LocalDateTime
 
 fun Route.apiRoutes() {
     val topicService: TopicService by inject()
@@ -18,7 +16,7 @@ fun Route.apiRoutes() {
         val request = call.receive<ReplayTopicEventsRequest>()
 
         JobRunners.executeBackgroundJob {
-            topicService.replayEvents(topic = request.topic, createdAfter = request.createdAfter)
+            topicService.replayEvents(topic = request.topic, id = request.id)
         }
 
         call.respond(HttpStatusCode.Created)
@@ -28,6 +26,5 @@ fun Route.apiRoutes() {
 @Serializable
 data class ReplayTopicEventsRequest(
     val topic: String,
-    @Serializable(DateSerializer::class)
-    val createdAfter: LocalDateTime? = null,
+    val id: Int? = null,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicService.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicService.kt
@@ -4,13 +4,13 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.produce
 import kotlinx.serialization.json.Json
-import no.nav.mulighetsrommet.arena.adapter.kafka.ConsumerSetup
+import no.nav.mulighetsrommet.arena.adapter.kafka.ConsumerGroup
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
 import org.slf4j.LoggerFactory
 
 class TopicService(
     private val events: EventRepository,
-    private val consumerSetup: ConsumerSetup,
+    private val group: ConsumerGroup,
     private val channelCapacity: Int = 200,
     private val numChannelConsumers: Int = 20
 ) {
@@ -33,7 +33,7 @@ class TopicService(
             close()
         }
 
-        val relevantConsumers = consumerSetup.consumers.filter { it.consumerConfig.topic == topic }
+        val relevantConsumers = group.consumers.filter { it.consumerConfig.topic == topic }
 
         // Create `numConsumers` coroutines to process the events simultaneously
         (0..numChannelConsumers)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicService.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicService.kt
@@ -4,12 +4,9 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.produce
 import kotlinx.serialization.json.Json
-import kotliquery.Row
 import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
-import no.nav.mulighetsrommet.arena.adapter.repositories.Event
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
 import org.slf4j.LoggerFactory
-import java.time.LocalDateTime
 
 class TopicService(
     private val events: EventRepository,
@@ -20,17 +17,17 @@ class TopicService(
     private val logger = LoggerFactory.getLogger(TopicService::class.java)
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    suspend fun replayEvents(topic: String, createdAfter: LocalDateTime? = null) = coroutineScope {
+    suspend fun replayEvents(topic: String, id: Int? = null) = coroutineScope {
         logger.info("Replaying events from topic '{}'", topic)
 
         // Produce events in a separate coroutine
         val events = produce(capacity = channelCapacity) {
-            var prevEventTime: LocalDateTime? = createdAfter
+            var prevEventId: Int? = id
             do {
-                events.getEvents(topic, limit = channelCapacity, createdAfter = prevEventTime)
-                    .also { prevEventTime = it.lastOrNull()?.createdAt }
+                events.getEvents(topic, limit = channelCapacity, id = prevEventId)
+                    .also { prevEventId = it.lastOrNull()?.id }
                     .forEach { send(it) }
-            } while (isActive && prevEventTime != null)
+            } while (isActive && prevEventId != null)
 
             logger.info("All events produced, closing channel...")
             close()
@@ -57,16 +54,4 @@ class TopicService(
             }
             .awaitAll()
     }
-}
-
-private fun Row.toTopic(): String {
-    return string("topic")
-}
-
-private fun Row.toEvent(): Event {
-    return Event(
-        id = int("id"),
-        payload = string("payload"),
-        createdAt = localDateTime("created_at")
-    )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicService.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicService.kt
@@ -4,13 +4,13 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.produce
 import kotlinx.serialization.json.Json
-import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
+import no.nav.mulighetsrommet.arena.adapter.kafka.ConsumerSetup
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
 import org.slf4j.LoggerFactory
 
 class TopicService(
     private val events: EventRepository,
-    private val consumers: List<TopicConsumer<*>>,
+    private val consumerSetup: ConsumerSetup,
     private val channelCapacity: Int = 200,
     private val numChannelConsumers: Int = 20
 ) {
@@ -33,7 +33,7 @@ class TopicService(
             close()
         }
 
-        val relevantConsumers = consumers.filter { it.consumerConfig.topic == topic }
+        val relevantConsumers = consumerSetup.consumers.filter { it.consumerConfig.topic == topic }
 
         // Create `numConsumers` coroutines to process the events simultaneously
         (0..numChannelConsumers)

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicServiceTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicServiceTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.mockk.*
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import no.nav.mulighetsrommet.arena.adapter.kafka.ConsumerSetup
 import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.arena.adapter.repositories.Event
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
@@ -19,7 +20,7 @@ class TopicServiceTest : FunSpec({
         val events = mockk<EventRepository>()
         val consumer = mockk<TopicConsumer<Any>>()
 
-        val service = TopicService(events, listOf(consumer))
+        val service = TopicService(events, ConsumerSetup(listOf(consumer)))
 
         beforeEach {
             every { consumer.consumerConfig.topic } answers { topic }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicServiceTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicServiceTest.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.mockk.*
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import no.nav.mulighetsrommet.arena.adapter.kafka.ConsumerSetup
+import no.nav.mulighetsrommet.arena.adapter.kafka.ConsumerGroup
 import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.arena.adapter.repositories.Event
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
@@ -20,7 +20,7 @@ class TopicServiceTest : FunSpec({
         val events = mockk<EventRepository>()
         val consumer = mockk<TopicConsumer<Any>>()
 
-        val service = TopicService(events, ConsumerSetup(listOf(consumer)))
+        val service = TopicService(events, ConsumerGroup(listOf(consumer)))
 
         beforeEach {
             every { consumer.consumerConfig.topic } answers { topic }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicServiceTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/TopicServiceTest.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.json.JsonPrimitive
 import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.arena.adapter.repositories.Event
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
-import java.time.LocalDateTime
 
 class TopicServiceTest : FunSpec({
 
@@ -45,11 +44,7 @@ class TopicServiceTest : FunSpec({
             every {
                 events.getEvents(topic, any(), any())
             } returns listOf(
-                Event(
-                    id = 1,
-                    payload = fooEventPayload.toString(),
-                    createdAt = LocalDateTime.parse("2022-06-01T00:00:00")
-                )
+                Event(id = 1, payload = fooEventPayload.toString())
             ) andThen listOf()
 
             service.replayEvents(topic)
@@ -59,22 +54,20 @@ class TopicServiceTest : FunSpec({
             }
         }
 
-        test("should replay all events in the order of their creation date") {
-            val firstEventCreatedAt = LocalDateTime.parse("2022-06-01T00:00:00")
+        test("should replay all events in the order of their id") {
             every {
                 events.getEvents(topic, any(), null)
             } returns listOf(
-                Event(id = 1, payload = fooEventPayload.toString(), createdAt = firstEventCreatedAt)
+                Event(id = 1, payload = fooEventPayload.toString())
             )
 
-            val secondEventCreatedAt = LocalDateTime.parse("2022-06-02T00:00:00")
             every {
-                events.getEvents(topic, any(), firstEventCreatedAt)
+                events.getEvents(topic, any(), 1)
             } returns listOf(
-                Event(id = 2, payload = barEventPayload.toString(), createdAt = secondEventCreatedAt)
+                Event(id = 2, payload = barEventPayload.toString())
             )
 
-            every { events.getEvents(topic, any(), secondEventCreatedAt) } returns listOf()
+            every { events.getEvents(topic, any(), 2) } returns listOf()
 
             service.replayEvents(topic)
 
@@ -84,24 +77,22 @@ class TopicServiceTest : FunSpec({
             }
         }
 
-        test("should only replay events created after the specified creation date") {
-            val firstEventCreatedAt = LocalDateTime.parse("2022-06-01T00:00:00")
+        test("should only replay events after the specified id") {
             every {
                 events.getEvents(topic, any(), null)
             } returns listOf(
-                Event(id = 1, payload = fooEventPayload.toString(), createdAt = firstEventCreatedAt)
+                Event(id = 1, payload = fooEventPayload.toString())
             )
 
-            val secondEventCreatedAt = LocalDateTime.parse("2022-06-02T00:00:00")
             every {
-                events.getEvents(topic, any(), firstEventCreatedAt)
+                events.getEvents(topic, any(), 1)
             } returns listOf(
-                Event(id = 2, payload = barEventPayload.toString(), createdAt = secondEventCreatedAt)
+                Event(id = 2, payload = barEventPayload.toString())
             )
 
-            every { events.getEvents(topic, any(), secondEventCreatedAt) } returns listOf()
+            every { events.getEvents(topic, any(), 2) } returns listOf()
 
-            service.replayEvents(topic, firstEventCreatedAt)
+            service.replayEvents(topic, 1)
 
             coVerify(exactly = 0) {
                 consumer.replayEvent(fooEventPayload)


### PR DESCRIPTION
Endrer event-pagineringen til å bli basert på id i stedet for opprettelsesdato.
Fikser samtidig en bug i oppsett av DI, der TopicService ikke ble riktig initialisert.
For å gjøre TopicService ytterligere testbar blir TopicConsumers deklarert som del av DI, slik at ConsumerGroup blir hakket mer generell.