### PR TITLE
Ikke flash-vis løsning før toggle er hentet

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -45,11 +45,15 @@ const ViewTiltakstypeOversikt = () => {
   const [filter, setFilter] = useAtom(tiltaksgjennomforingsfilter);
   const { forcePrepopulerFilter } = usePrepopulerFilter();
   const brukerdata = useHentBrukerdata();
-
   const features = useFeatureToggles();
   const visFakeDoorFeature = features.isSuccess && features.data[FAKE_DOOR];
   const brukersInnsatsgruppeErIkkeValgt = (gruppe: Tiltaksgjennomforingsfiltergruppe) =>
     gruppe.nokkel !== brukerdata?.data?.innsatsgruppe;
+
+  if (features.isLoading) {
+    // Passer på at vi ikke flash-viser løsningen før vi har hentet toggle for fake-door
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
Ved å vente på verdi fra toggle så får vi ikke en flash-visning av selve arbeidsflaten før man viser fake-door-plakaten.