### PR TITLE
Feature/support delete events

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
@@ -19,7 +19,7 @@ fun Route.arenaRoutes() {
     val arenaService: ArenaService by inject()
 
     route("/api/v1/arena/") {
-        put("tiltakstyper") {
+        put("tiltakstype") {
             runCatching {
                 val tiltakstype = call.receive<AdapterTiltak>()
                 arenaService.upsertTiltakstype(tiltakstype)
@@ -31,7 +31,17 @@ fun Route.arenaRoutes() {
             }
         }
 
-        put("tiltaksgjennomforinger") {
+        delete("tiltakstype") {
+            runCatching {
+                val tiltakstype = call.receive<AdapterTiltak>()
+                arenaService.deleteTiltakstype(tiltakstype)
+            }.onFailure {
+                logger.error("${this.context.request.path()} ${it.stackTraceToString()}")
+                call.respondText("Kunne ikke slette tiltakstype", status = HttpStatusCode.InternalServerError)
+            }
+        }
+
+        put("tiltaksgjennomforing") {
             runCatching {
                 val tiltaksgjennomforing = call.receive<AdapterTiltaksgjennomforing>()
                 arenaService.upsertTiltaksgjennomforing(tiltaksgjennomforing)
@@ -43,7 +53,17 @@ fun Route.arenaRoutes() {
             }
         }
 
-        put("deltakere") {
+        delete("tiltaksgjennomforing") {
+            runCatching {
+                val tiltaksgjennomforing = call.receive<AdapterTiltaksgjennomforing>()
+                arenaService.deleteTiltaksgjennomforing(tiltaksgjennomforing)
+            }.onFailure {
+                logger.error("${this.context.request.path()} ${it.stackTraceToString()}")
+                call.respondText("Kunne ikke slette tiltak", status = HttpStatusCode.InternalServerError)
+            }
+        }
+
+        put("deltaker") {
             runCatching {
                 val deltaker = call.receive<AdapterTiltakdeltaker>()
                 arenaService.upsertDeltaker(deltaker)
@@ -55,10 +75,33 @@ fun Route.arenaRoutes() {
             }
         }
 
+        delete("deltaker") {
+            runCatching {
+                val deltaker = call.receive<AdapterTiltakdeltaker>()
+                arenaService.deleteDeltaker(deltaker)
+            }.onFailure {
+                logger.error("${this.context.request.path()} ${it.stackTraceToString()}")
+                call.respondText("Kunne ikke slette deltaker", status = HttpStatusCode.InternalServerError)
+            }
+        }
+
         put("sak") {
             runCatching {
                 val sak = call.receive<AdapterSak>()
                 arenaService.updateTiltaksgjennomforingWithSak(sak)
+            }.onSuccess {
+                val response = it ?: HttpStatusCode.NotFound
+                call.respond(response)
+            }.onFailure {
+                logger.error("${this.context.request.path()} ${it.stackTraceToString()}")
+                call.respondText("Kunne ikke oppdatere tiltak med sak", status = HttpStatusCode.InternalServerError)
+            }
+        }
+
+        delete("sak") {
+            runCatching {
+                val sak = call.receive<AdapterSak>()
+                arenaService.unsetSakOnTiltaksgjennomforing(sak)
             }.onSuccess {
                 val response = it ?: HttpStatusCode.NotFound
                 call.respond(response)

--- a/mulighetsrommet-api/src/main/resources/db/migration/V3__cascading_delete_deltaker.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V3__cascading_delete_deltaker.sql
@@ -1,0 +1,6 @@
+alter table deltaker
+    drop constraint fk_tiltaksgjennomforing,
+    add constraint fk_tiltaksgjennomforing foreign key (tiltaksgjennomforing_id)
+        references tiltaksgjennomforing (arena_id)
+        on delete cascade
+        on update cascade;

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
@@ -104,7 +104,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
         }
 
         test("should get tiltak by id") {
-            service.getTiltaksgjennomforingById(1) shouldBe Tiltaksgjennomforing(
+            service.getTiltaksgjennomforingById(tiltak1.id) shouldBe Tiltaksgjennomforing(
                 id = 1,
                 navn = "Oppfølging",
                 tiltakskode = "INDOPPFOLG",
@@ -190,6 +190,12 @@ class TiltaksgjennomforingServiceTest : FunSpec({
                     service.getTiltaksgjennomforingById(1)?.tilgjengelighet shouldBe Tilgjengelighetsstatus.Ledig
                 }
             }
+        }
+
+        test("should delete tiltak") {
+            arenaService.deleteTiltaksgjennomforing(tiltak1)
+
+            service.getTiltaksgjennomforingById(tiltak1.id) shouldBe null
         }
     }
 })

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
@@ -20,7 +20,7 @@ class SakEndretConsumer(
 
     override val logger: Logger = LoggerFactory.getLogger(SakEndretConsumer::class.java)
 
-    override fun toDomain(payload: JsonElement): ArenaSak = ArenaEventHelpers.decodeAfter(payload)
+    override fun decodeEvent(payload: JsonElement): ArenaSak = ArenaEventHelpers.decodeAfter(payload)
 
     override fun shouldProcessEvent(payload: ArenaSak): Boolean {
         return sakIsRelatedToTiltaksgjennomforing(payload)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
@@ -20,7 +20,7 @@ class SakEndretConsumer(
 
     override val logger: Logger = LoggerFactory.getLogger(SakEndretConsumer::class.java)
 
-    override fun decodeEvent(payload: JsonElement): ArenaSak = ArenaEventHelpers.decodeAfter(payload)
+    override fun decodeEvent(payload: JsonElement): ArenaSak = ArenaEventHelpers.decodeEvent<ArenaSak>(payload).data
 
     override fun shouldProcessEvent(payload: ArenaSak): Boolean {
         return sakIsRelatedToTiltaksgjennomforing(payload)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -4,7 +4,9 @@ import io.ktor.http.*
 import kotlinx.serialization.json.JsonElement
 import no.nav.mulighetsrommet.arena.adapter.ConsumerConfig
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
+import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaEventHelpers
+import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaOperation
 import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
@@ -17,20 +19,19 @@ class TiltakEndretConsumer(
     override val consumerConfig: ConsumerConfig,
     override val events: EventRepository,
     private val client: MulighetsrommetApiClient
-) : TopicConsumer<ArenaTiltak>() {
+) : TopicConsumer<ArenaEvent<ArenaTiltak>>() {
 
-    override val logger: Logger = LoggerFactory.getLogger(TiltakEndretConsumer::class.java)
+    override val logger: Logger = LoggerFactory.getLogger(javaClass)
 
-    override fun decodeEvent(payload: JsonElement): ArenaTiltak =
-        ArenaEventHelpers.decodeEvent<ArenaTiltak>(payload).data
+    override fun decodeEvent(payload: JsonElement): ArenaEvent<ArenaTiltak> = ArenaEventHelpers.decodeEvent(payload)
 
-    override fun resolveKey(payload: ArenaTiltak): String {
-        return payload.TILTAKSKODE
+    override fun resolveKey(event: ArenaEvent<ArenaTiltak>): String {
+        return event.data.TILTAKSKODE
     }
 
-    override suspend fun handleEvent(payload: ArenaTiltak) {
-        client.sendRequest(HttpMethod.Put, "/api/v1/arena/tiltakstyper", payload.toAdapterTiltak())
-        logger.debug("processed tiltak endret event")
+    override suspend fun handleEvent(event: ArenaEvent<ArenaTiltak>) {
+        val method = if (event.operation == ArenaOperation.Delete) HttpMethod.Delete else HttpMethod.Put
+        client.sendRequest(method, "/api/v1/arena/tiltakstype", event.data.toAdapterTiltak())
     }
 
     private fun ArenaTiltak.toAdapterTiltak() = AdapterTiltak(

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -21,7 +21,8 @@ class TiltakEndretConsumer(
 
     override val logger: Logger = LoggerFactory.getLogger(TiltakEndretConsumer::class.java)
 
-    override fun decodeEvent(payload: JsonElement): ArenaTiltak = ArenaEventHelpers.decodeAfter(payload)
+    override fun decodeEvent(payload: JsonElement): ArenaTiltak =
+        ArenaEventHelpers.decodeEvent<ArenaTiltak>(payload).data
 
     override fun resolveKey(payload: ArenaTiltak): String {
         return payload.TILTAKSKODE

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -21,7 +21,7 @@ class TiltakEndretConsumer(
 
     override val logger: Logger = LoggerFactory.getLogger(TiltakEndretConsumer::class.java)
 
-    override fun toDomain(payload: JsonElement): ArenaTiltak = ArenaEventHelpers.decodeAfter(payload)
+    override fun decodeEvent(payload: JsonElement): ArenaTiltak = ArenaEventHelpers.decodeAfter(payload)
 
     override fun resolveKey(payload: ArenaTiltak): String {
         return payload.TILTAKSKODE

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
@@ -21,7 +21,7 @@ class TiltakdeltakerEndretConsumer(
 
     override val logger: Logger = LoggerFactory.getLogger(TiltakdeltakerEndretConsumer::class.java)
 
-    override fun toDomain(payload: JsonElement): ArenaTiltakdeltaker = ArenaEventHelpers.decodeAfter(payload)
+    override fun decodeEvent(payload: JsonElement): ArenaTiltakdeltaker = ArenaEventHelpers.decodeAfter(payload)
 
     override fun resolveKey(payload: ArenaTiltakdeltaker): String {
         return payload.TILTAKDELTAKER_ID.toString()

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
@@ -4,7 +4,9 @@ import io.ktor.http.*
 import kotlinx.serialization.json.JsonElement
 import no.nav.mulighetsrommet.arena.adapter.ConsumerConfig
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
+import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaEventHelpers
+import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaOperation
 import no.nav.mulighetsrommet.arena.adapter.kafka.TopicConsumer
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
 import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
@@ -17,20 +19,20 @@ class TiltakdeltakerEndretConsumer(
     override val consumerConfig: ConsumerConfig,
     override val events: EventRepository,
     private val client: MulighetsrommetApiClient
-) : TopicConsumer<ArenaTiltakdeltaker>() {
+) : TopicConsumer<ArenaEvent<ArenaTiltakdeltaker>>() {
 
-    override val logger: Logger = LoggerFactory.getLogger(TiltakdeltakerEndretConsumer::class.java)
+    override val logger: Logger = LoggerFactory.getLogger(javaClass)
 
-    override fun decodeEvent(payload: JsonElement): ArenaTiltakdeltaker =
-        ArenaEventHelpers.decodeEvent<ArenaTiltakdeltaker>(payload).data
+    override fun decodeEvent(payload: JsonElement): ArenaEvent<ArenaTiltakdeltaker> =
+        ArenaEventHelpers.decodeEvent(payload)
 
-    override fun resolveKey(payload: ArenaTiltakdeltaker): String {
-        return payload.TILTAKDELTAKER_ID.toString()
+    override fun resolveKey(event: ArenaEvent<ArenaTiltakdeltaker>): String {
+        return event.data.TILTAKDELTAKER_ID.toString()
     }
 
-    override suspend fun handleEvent(payload: ArenaTiltakdeltaker) {
-        client.sendRequest(HttpMethod.Put, "/api/v1/arena/deltakere", payload.toAdapterTiltakdeltaker())
-        logger.debug("processed tiltak endret event")
+    override suspend fun handleEvent(event: ArenaEvent<ArenaTiltakdeltaker>) {
+        val method = if (event.operation == ArenaOperation.Delete) HttpMethod.Delete else HttpMethod.Put
+        client.sendRequest(method, "/api/v1/arena/deltaker", event.data.toAdapterTiltakdeltaker())
     }
 
     private fun ArenaTiltakdeltaker.toAdapterTiltakdeltaker() = AdapterTiltakdeltaker(

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
@@ -21,7 +21,8 @@ class TiltakdeltakerEndretConsumer(
 
     override val logger: Logger = LoggerFactory.getLogger(TiltakdeltakerEndretConsumer::class.java)
 
-    override fun decodeEvent(payload: JsonElement): ArenaTiltakdeltaker = ArenaEventHelpers.decodeAfter(payload)
+    override fun decodeEvent(payload: JsonElement): ArenaTiltakdeltaker =
+        ArenaEventHelpers.decodeEvent<ArenaTiltakdeltaker>(payload).data
 
     override fun resolveKey(payload: ArenaTiltakdeltaker): String {
         return payload.TILTAKDELTAKER_ID.toString()

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -22,7 +22,7 @@ class TiltakgjennomforingEndretConsumer(
 
     override val logger: Logger = LoggerFactory.getLogger(TiltakgjennomforingEndretConsumer::class.java)
 
-    override fun toDomain(payload: JsonElement): ArenaTiltaksgjennomforing = ArenaEventHelpers.decodeAfter(payload)
+    override fun decodeEvent(payload: JsonElement): ArenaTiltaksgjennomforing = ArenaEventHelpers.decodeAfter(payload)
 
     override fun resolveKey(payload: ArenaTiltaksgjennomforing): String {
         return payload.TILTAKGJENNOMFORING_ID.toString()

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -22,7 +22,8 @@ class TiltakgjennomforingEndretConsumer(
 
     override val logger: Logger = LoggerFactory.getLogger(TiltakgjennomforingEndretConsumer::class.java)
 
-    override fun decodeEvent(payload: JsonElement): ArenaTiltaksgjennomforing = ArenaEventHelpers.decodeAfter(payload)
+    override fun decodeEvent(payload: JsonElement): ArenaTiltaksgjennomforing =
+        ArenaEventHelpers.decodeEvent<ArenaTiltaksgjennomforing>(payload).data
 
     override fun resolveKey(payload: ArenaTiltaksgjennomforing): String {
         return payload.TILTAKGJENNOMFORING_ID.toString()

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/helpers/ArenaEventHelpers.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/helpers/ArenaEventHelpers.kt
@@ -1,9 +1,8 @@
 package no.nav.mulighetsrommet.arena.adapter.consumers.helpers
 
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
 
 object ArenaEventHelpers {
     val json = Json { ignoreUnknownKeys = true }
@@ -11,7 +10,30 @@ object ArenaEventHelpers {
     /**
      * Attempts to decode the given JSON [event] payload's `after` property into a value of type [T].
      */
-    inline fun <reified T> decodeAfter(event: JsonElement): T {
-        return json.decodeFromJsonElement(event.jsonObject["after"]!!)
+    inline fun <reified T> decodeEvent(event: JsonElement): ArenaEvent<T> {
+        val operation = json.decodeFromJsonElement<ArenaOperation>(event.jsonObject["op_type"]!!)
+        val data = json.decodeFromJsonElement<T>(event.jsonObject["after"]!!)
+        return ArenaEvent(
+            operation = operation,
+            data = data,
+        )
     }
+}
+
+data class ArenaEvent<T>(
+    val operation: ArenaOperation,
+    val data: T
+)
+
+@Serializable
+enum class ArenaOperation {
+
+    @SerialName("I")
+    Insert,
+
+    @SerialName("U")
+    Update,
+
+    @SerialName("D")
+    Delete,
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/helpers/ArenaEventHelpers.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/helpers/ArenaEventHelpers.kt
@@ -8,15 +8,18 @@ object ArenaEventHelpers {
     val json = Json { ignoreUnknownKeys = true }
 
     /**
-     * Attempts to decode the given JSON [event] payload's `after` property into a value of type [T].
+     * Attempts to decode the given JSON [event] payload's `after` property into a value of type [T] when the
+     * op_type is Insert or Update, or the `before` property into a value of type [T] when the op_type
+     * is Delete
      */
     inline fun <reified T> decodeEvent(event: JsonElement): ArenaEvent<T> {
         val operation = json.decodeFromJsonElement<ArenaOperation>(event.jsonObject["op_type"]!!)
-        val data = json.decodeFromJsonElement<T>(event.jsonObject["after"]!!)
-        return ArenaEvent(
-            operation = operation,
-            data = data,
-        )
+        val data: T = if (operation == ArenaOperation.Delete) {
+            json.decodeFromJsonElement(event.jsonObject["before"]!!)
+        } else {
+            json.decodeFromJsonElement(event.jsonObject["after"]!!)
+        }
+        return ArenaEvent(operation = operation, data = data)
     }
 }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
@@ -11,7 +11,7 @@ abstract class TopicConsumer<T>() {
     abstract val events: EventRepository
 
     suspend fun processEvent(payload: JsonElement) {
-        val parsedPayload = toDomain(payload)
+        val parsedPayload = decodeEvent(payload)
         if (shouldProcessEvent(parsedPayload)) {
             val key = resolveKey(parsedPayload)
 
@@ -24,7 +24,7 @@ abstract class TopicConsumer<T>() {
     }
 
     suspend fun replayEvent(payload: JsonElement) {
-        val parsedEvent = toDomain(payload)
+        val parsedEvent = decodeEvent(payload)
         if (shouldProcessEvent(parsedEvent)) {
             val key = resolveKey(parsedEvent)
 
@@ -33,7 +33,7 @@ abstract class TopicConsumer<T>() {
         }
     }
 
-    protected abstract fun toDomain(payload: JsonElement): T
+    protected abstract fun decodeEvent(payload: JsonElement): T
 
     protected open fun shouldProcessEvent(payload: T): Boolean = true
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
@@ -15,10 +15,10 @@ abstract class TopicConsumer<T>() {
         if (shouldProcessEvent(parsedPayload)) {
             val key = resolveKey(parsedPayload)
 
-            logger.debug("Persisting event: topic=${consumerConfig.topic}, key=$key")
+            logger.info("Persisting event: topic=${consumerConfig.topic}, key=$key")
             events.saveEvent(consumerConfig.topic, key, payload.toString())
 
-            logger.debug("Handling event: topic=${consumerConfig.topic}, key=$key")
+            logger.info("Handling event: topic=${consumerConfig.topic}, key=$key")
             handleEvent(parsedPayload)
         }
     }
@@ -28,16 +28,16 @@ abstract class TopicConsumer<T>() {
         if (shouldProcessEvent(parsedEvent)) {
             val key = resolveKey(parsedEvent)
 
-            logger.debug("Replaying event: topic=${consumerConfig.topic}, key=$key")
+            logger.info("Replaying event: topic=${consumerConfig.topic}, key=$key")
             handleEvent(parsedEvent)
         }
     }
 
     protected abstract fun decodeEvent(payload: JsonElement): T
 
-    protected open fun shouldProcessEvent(payload: T): Boolean = true
+    protected open fun shouldProcessEvent(event: T): Boolean = true
 
-    protected abstract fun resolveKey(payload: T): String
+    protected abstract fun resolveKey(event: T): String
 
-    protected abstract suspend fun handleEvent(payload: T)
+    protected abstract suspend fun handleEvent(event: T)
 }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/helpers/ArenaEventHelpersTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/helpers/ArenaEventHelpersTest.kt
@@ -1,0 +1,31 @@
+package no.nav.mulighetsrommet.arena.adapter.no.nav.mulighetsrommet.arena.adapter.consumers.helpers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaEventHelpers
+import org.intellij.lang.annotations.Language
+
+class ArenaEventHelpersTest : FunSpec({
+
+    @Serializable
+    data class Foo(val name: String)
+
+    context("decodeAfter") {
+        test("should decode 'after' block to specified type") {
+            @Language("JSON")
+            val data = """
+            {
+                "after": {
+                    "name": "Bar"
+                }
+            }
+            """.trimIndent()
+
+            val decoded = ArenaEventHelpers.decodeAfter<Foo>(Json.parseToJsonElement(data))
+
+            decoded shouldBe Foo(name = "Bar")
+        }
+    }
+})

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/helpers/ArenaEventHelpersTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/helpers/ArenaEventHelpersTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaEventHelpers
+import no.nav.mulighetsrommet.arena.adapter.consumers.helpers.ArenaOperation
 import org.intellij.lang.annotations.Language
 
 class ArenaEventHelpersTest : FunSpec({
@@ -12,20 +13,37 @@ class ArenaEventHelpersTest : FunSpec({
     @Serializable
     data class Foo(val name: String)
 
-    context("decodeAfter") {
-        test("should decode 'after' block to specified type") {
+    context("decodeEvent") {
+        test("should decode arena operation") {
             @Language("JSON")
             val data = """
             {
+                "op_type": "I",
                 "after": {
                     "name": "Bar"
                 }
             }
             """.trimIndent()
 
-            val decoded = ArenaEventHelpers.decodeAfter<Foo>(Json.parseToJsonElement(data))
+            val decoded = ArenaEventHelpers.decodeEvent<Foo>(Json.parseToJsonElement(data))
 
-            decoded shouldBe Foo(name = "Bar")
+            decoded.operation shouldBe ArenaOperation.Insert
+        }
+
+        test("should decode 'after' block to specified type") {
+            @Language("JSON")
+            val data = """
+            {
+                "op_type": "I",
+                "after": {
+                    "name": "Bar"
+                }
+            }
+            """.trimIndent()
+
+            val decoded = ArenaEventHelpers.decodeEvent<Foo>(Json.parseToJsonElement(data))
+
+            decoded.data shouldBe Foo(name = "Bar")
         }
     }
 })


### PR DESCRIPTION
Implementert støtte for Delete-events på arena topics.
Delete av tiltaksgjennomføring fører til cascading delete av deltaker.
Delete av sak fører til at vi setter tiltakskode og år til null på tiltaksgjennomføringer.