### PR TITLE
set number of replicas to 10

### DIFF
--- a/mulighetsrommet-api/.nais/nais-prod.yaml
+++ b/mulighetsrommet-api/.nais/nais-prod.yaml
@@ -21,7 +21,7 @@ spec:
     initialDelay: 20
   replicas:
     min: 2
-    max: 3
+    max: 10
     cpuThresholdPercentage: 75
   resources:
     limits:

--- a/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
@@ -21,7 +21,7 @@ spec:
     initialDelay: 20
   replicas:
     min: 2
-    max: 3
+    max: 10
     cpuThresholdPercentage: 75
   resources:
     limits:


### PR DESCRIPTION
This is mostly a test to se how the stack behaves when (and if) many kafka
events are processed simultaneously
