### PR TITLE
Beholder filter-state ved transisjon mellom oversikt og gjennomføring

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -17,7 +17,7 @@ describe('Tiltaksgjennomføringstabell', () => {
   it('Filtrer på Innsatsgrupper', () => {
     cy.velgFilter('standardinnsats');
 
-    cy.getByTestId('filtertags').children().should('have.length', 3);
+    cy.getByTestId('filtertags').children().should('have.length', 2);
     cy.getByTestId('knapp_tilbakestill-filter').should('exist');
 
     cy.wait(1000);
@@ -26,7 +26,7 @@ describe('Tiltaksgjennomføringstabell', () => {
     });
 
     cy.getByTestId('filtertag_lukkeknapp_standardinnsats').click();
-    cy.getByTestId('filtertags').children().should('have.length', 2);
+    cy.getByTestId('filtertags').children().should('have.length', 1);
   });
 
   it('Filtrer på Tiltakstyper', () => {
@@ -34,7 +34,7 @@ describe('Tiltaksgjennomføringstabell', () => {
     cy.velgFilter('avklaring');
     cy.velgFilter('oppfolging');
 
-    cy.getByTestId('filtertags').children().should('have.length', 4);
+    cy.getByTestId('filtertags').children().should('have.length', 3);
 
     cy.wait(1000)
       .getByTestId('antall-tiltak')
@@ -82,8 +82,8 @@ describe('Tiltaksgjennomføringstabell', () => {
 
   it('Skal kunne navigere mellom sider via paginering', () => {
     cy.getByTestId('paginering').should('exist');
-    cy.getByTestId('paginering').children().children().eq(2).should('not.have.attr', 'aria-current');
-    cy.getByTestId('paginering').children().children().eq(3).click().children().should('have.attr', 'aria-current');
+    cy.getByTestId('paginering').children().children().eq(1).should('not.have.attr', 'aria-current');
+    cy.getByTestId('paginering').children().children().eq(2).click().children().should('have.attr', 'aria-current');
   });
 });
 
@@ -123,6 +123,7 @@ describe('Tiltaksgjennomføringsdetaljer', () => {
 
   it('Skal ha ferdig utfylt brukers innsatsgruppe', () => {
     // Situasjonsbestemt innsats er innsatsgruppe som returneres når testene kjører med mock-data
+    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
     cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
     cy.getByTestId('filtertags').children().should('have.length', 2);
     cy.getByTestId('knapp_tilbakestill-filter').should('not.exist');

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
@@ -54,6 +54,7 @@ const Filtermeny = () => {
         isLoading={tiltakstyper.isLoading}
         isError={tiltakstyper.isError}
         sortert
+        defaultOpen={filter.tiltakstyper.length > 0}
       />
     </div>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -10,7 +10,7 @@ import StatusRod from '../../ikoner/Sirkel-rod.png';
 import useTiltaksgjennomforing from '../../core/api/queries/useTiltaksgjennomforing';
 import { logEvent } from '../../core/api/logger';
 import { Tiltaksgjennomforing, Tilgjengelighetsstatus } from '../../core/api/models';
-import { paginationAtom } from '../../core/atoms/atoms';
+import { paginationAtom, tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
 
 const TiltaksgjennomforingsTabell = () => {
   const [sort, setSort] = useState<any>();
@@ -19,6 +19,7 @@ const TiltaksgjennomforingsTabell = () => {
   const pagination = (tiltaksgjennomforing: Tiltaksgjennomforing[]) => {
     return Math.ceil(tiltaksgjennomforing.length / rowsPerPage);
   };
+  const [filter] = useAtom(tiltaksgjennomforingsfilter);
 
   const { data: tiltaksgjennomforinger = [], isLoading, isError, isFetching } = useTiltaksgjennomforing();
 
@@ -198,7 +199,11 @@ const TiltaksgjennomforingsTabell = () => {
               }) => (
                 <Table.Row key={_id}>
                   <Table.DataCell className="tabell__tiltaksnavn">
-                    <Lenke to={`${tiltaksnummer}`} isInline data-testid="tabell_tiltaksgjennomforing">
+                    <Lenke
+                      to={`${tiltaksnummer}#filter=${encodeURIComponent(JSON.stringify(filter))}`}
+                      isInline
+                      data-testid="tabell_tiltaksgjennomforing"
+                    >
                       {tiltaksgjennomforingNavn}
                     </Lenke>
                     <div>{kontaktinfoArrangor.selskapsnavn}</div>

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
@@ -23,10 +23,7 @@ export function usePrepopulerFilter() {
       const search = resetFilterTilUtgangspunkt ? '' : filter.search;
       const innsatsgrupper = resetFilterTilUtgangspunkt
         ? [{ id: matchedInnsatsgruppe._id, ...matchedInnsatsgruppe }]
-        : [
-            ...filter.innsatsgrupper.filter(gruppe => gruppe.id !== matchedInnsatsgruppe._id),
-            { id: matchedInnsatsgruppe._id, ...matchedInnsatsgruppe },
-          ];
+        : [...filter.innsatsgrupper];
       setFilter({
         search,
         tiltakstyper,

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
@@ -9,9 +9,12 @@ import useTiltaksgjennomforingByTiltaksnummer from '../../core/api/queries/useTi
 import { Alert, Loader } from '@navikt/ds-react';
 import { useGetTiltaksnummerFraUrl } from '../../core/api/queries/useGetTiltaksnummerFraUrl';
 import { useHentFnrFraUrl } from '../../hooks/useHentFnrFraUrl';
+import { useAtom } from 'jotai';
+import { tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
 
 const ViewTiltakstypeDetaljer = () => {
   const tiltaksnummer = useGetTiltaksnummerFraUrl();
+  const [filter] = useAtom(tiltaksgjennomforingsfilter);
   const fnr = useHentFnrFraUrl();
   const { data: tiltaksgjennomforing, isLoading, isError } = useTiltaksgjennomforingByTiltaksnummer();
 
@@ -31,7 +34,7 @@ const ViewTiltakstypeDetaljer = () => {
   return (
     <div className="tiltakstype-detaljer">
       <div className="tiltakstype-detaljer__info">
-        <Tilbakeknapp tilbakelenke={`/${fnr}`} />
+        <Tilbakeknapp tilbakelenke={`/${fnr}/#filter=${encodeURIComponent(JSON.stringify(filter))}`} />
         <TiltaksgjennomforingsHeader />
         {tiltaksgjennomforing.tiltakstype.nokkelinfoKomponenter && (
           <Nokkelinfo nokkelinfoKomponenter={tiltaksgjennomforing.tiltakstype.nokkelinfoKomponenter} />

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -67,12 +67,12 @@ const ViewTiltakstypeOversikt = () => {
               <BrukersOppfolgingsenhet />
               <FilterTags
                 options={filter.innsatsgrupper!}
-                handleClick={(id: string) =>
+                handleClick={(id: string) => {
                   setFilter({
                     ...filter,
-                    innsatsgrupper: filter.innsatsgrupper?.filter(innsatsgruppe => innsatsgruppe.id !== id),
-                  })
-                }
+                    innsatsgrupper: [...filter.innsatsgrupper?.filter(innsatsgruppe => innsatsgruppe.id !== id)],
+                  });
+                }}
               />
               <FilterTags
                 options={filter.tiltakstyper!}


### PR DESCRIPTION
Denne PRen fikser det så vi beholder filter-state når man går mellom oversikten og inn på en tiltaksgjennomføring og tilbake igjen til oversikten.