### PR TITLE
Del opp mock handler til vårt api og veilarbpersonflate

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/package.json
+++ b/frontend/mulighetsrommet-veileder-flate/package.json
@@ -3,17 +3,17 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "backend": "cross-env VITE_MULIGHETSROMMET_API_BASE='http://localhost:8080' vite",
+    "backend": "cross-env VITE_MULIGHETSROMMET_API_BASE='http://localhost:8080' VITE_VEILARBPERSONFLATE_MOCK=true vite",
     "build": "eslint && tsc && VITE_ENVIRONMENT=production VITE_MULIGHETSROMMET_API_BASE='/mulighetsrommet-api' vite build --base=https://mulighetsrommet-veileder-flate.intern.nav.no/",
     "build:preprod": "eslint && tsc && VITE_ENVIRONMENT=dev VITE_MULIGHETSROMMET_API_BASE='/mulighetsrommet-api' vite build --base=https://mulighetsrommet-veileder-flate.dev.intern.nav.no/",
-    "build:mock": "eslint && tsc && cross-env VITE_MULIGHETSROMMET_API_MOCK=true vite build",
+    "build:mock": "eslint && tsc && cross-env VITE_MULIGHETSROMMET_API_MOCK=true VITE_VEILARBPERSONFLATE_MOCK=true vite build",
     "clean": "rimraf build",
     "cy:run": "npx cypress run --e2e",
     "cypress": "npx cypress open",
     "lint": "eslint src --ext .js,.ts,.tsx",
     "prettier": "prettier --write 'src/**/*.ts{,x}'",
     "serve": "vite preview",
-    "start": "cross-env VITE_ENVIRONMENT=localhost VITE_MULIGHETSROMMET_API_MOCK=true vite"
+    "start": "cross-env VITE_ENVIRONMENT=localhost VITE_MULIGHETSROMMET_API_MOCK=true VITE_VEILARBPERSONFLATE_MOCK=true vite"
   },
   "browserslist": [
     ">0.2%",

--- a/frontend/mulighetsrommet-veileder-flate/src/env.d.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_MULIGHETSROMMET_API_BASE?: string;
   readonly VITE_ENVIRONMENT?: 'localhost' | 'dev' | 'production';
   readonly VITE_MULIGHETSROMMET_API_MOCK?: 'true' | 'false';
+  readonly VITE_VEILARBPERSONFLATE_MOCK?: 'true' | 'false';
   readonly VITE_SANITY_PROJECT_ID?: string;
   readonly VITE_SANITY_DATASET?: string;
   readonly VITE_SANITY_ACCESS_TOKEN?: string;

--- a/frontend/mulighetsrommet-veileder-flate/src/index.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/index.tsx
@@ -5,15 +5,13 @@ import { createRoot } from 'react-dom/client';
 import { headers, toRecord } from './core/api/headers';
 import App from './App';
 import { APPLICATION_NAME } from './constants';
+import { initializeMockWorker } from "./mock/worker";
 
 OpenAPI.HEADERS = toRecord(headers);
 
 OpenAPI.BASE = String(import.meta.env.VITE_MULIGHETSROMMET_API_BASE ?? '');
 
-if (import.meta.env.VITE_MULIGHETSROMMET_API_MOCK === 'true') {
-  const worker = require('./mock/worker');
-  worker.start();
-}
+initializeMockWorker()
 
 Navspa.eksporter(APPLICATION_NAME, App);
 

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -3,11 +3,7 @@ import { rest, RestHandler } from 'msw';
 import { badReq, ok } from './responses';
 import { mockFeatures } from './features';
 
-export const handlers: RestHandler[] = [
-  rest.get('*/api/feature', (req, res, ctx) => {
-    return res(ctx.delay(500), ctx.json(mockFeatures));
-  }),
-
+export const apiHandlers: RestHandler[] = [
   rest.get('*/api/v1/bruker/:fnr', (req, res, ctx) => {
     const { fnr } = req.params;
     return ok({
@@ -17,6 +13,7 @@ export const handlers: RestHandler[] = [
         navn: 'NAV Fredrikstad',
         enhetId: '0106',
       },
+      fornavn: 'Iherdig',
     });
   }),
 

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/veilarbpersonflateHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/veilarbpersonflateHandlers.ts
@@ -1,0 +1,8 @@
+import { rest, RestHandler } from 'msw';
+import { mockFeatures } from './features';
+
+export const veilarbpersonflateHandlers: RestHandler[] = [
+  rest.get('*/api/feature', (req, res, ctx) => {
+    return res(ctx.delay(500), ctx.json(mockFeatures));
+  }),
+];

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/worker.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/worker.ts
@@ -1,6 +1,17 @@
 import { setupWorker } from 'msw';
-import { handlers } from './api/handlers';
+import { apiHandlers } from './api/apiHandlers';
+import { veilarbpersonflateHandlers } from './api/veilarbpersonflateHandlers';
 
 // This configures a Service Worker with the given request handlers.
-const worker = setupWorker(...handlers);
-export default worker;
+
+export function initializeMockWorker() {
+  const handlers = [
+    ...(import.meta.env.VITE_MULIGHETSROMMET_API_MOCK === 'true' ? apiHandlers : []),
+    ...(import.meta.env.VITE_VEILARBPERSONFLATE_MOCK === 'true' ? veilarbpersonflateHandlers : []),
+  ];
+  if (handlers.length !== 0) {
+    const worker = setupWorker(...handlers);
+    worker.start();
+  }
+}
+


### PR DESCRIPTION
* Del opp mocken sånn at ved npm start så mockes både vårt api og feature toggelsene som vanlig, mens ved npm run backend så vil ikke vårt api mockes men feature toggelsene vil det fortsatt