### PR TITLE
Legger til støtte for oppstart = 'Midlertidig stengt'

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -118,6 +118,7 @@ export default {
         list: [
           { title: "Dato", value: "dato" },
           { title: "Løpende", value: "lopende" },
+          { title: "Midlertidig stengt", value: "midlertidig_stengt" },
         ],
       },
       validation: (Rule: Rule) => Rule.required(),
@@ -158,7 +159,7 @@ export default {
           { title: "Venteliste", value: "Venteliste" },
           { title: "Stengt", value: "Stengt" },
         ],
-      }
+      },
     },
   ],
   preview: {

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -53,6 +53,8 @@ const SidemenyDetaljer = () => {
 };
 
 function resolveOppstart({ oppstart, oppstartsdato }: Tiltaksgjennomforing) {
+  if (oppstart === 'midlertidig_stengt') return 'Midlertidig stengt';
+
   return oppstart === 'dato' && oppstartsdato ? new Intl.DateTimeFormat().format(new Date(oppstartsdato)) : 'Løpende';
 }
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -9,7 +9,7 @@ import StatusGul from '../../ikoner/Sirkel-gul.png';
 import StatusRod from '../../ikoner/Sirkel-rod.png';
 import useTiltaksgjennomforing from '../../core/api/queries/useTiltaksgjennomforing';
 import { logEvent } from '../../core/api/logger';
-import { Tilgjengelighetsstatus, Tiltaksgjennomforing } from '../../core/api/models';
+import { Oppstart, Tilgjengelighetsstatus, Tiltaksgjennomforing } from '../../core/api/models';
 import { paginationAtom, tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
 import { RESET } from 'jotai/utils';
 import { Feilmelding } from '../feilmelding/Feilmelding';
@@ -34,7 +34,16 @@ const TiltaksgjennomforingsTabell = () => {
     }
   }, [tiltaksgjennomforinger]);
 
-  const visStatus = (status?: Tilgjengelighetsstatus) => {
+  const visStatus = (oppstart: Oppstart, status?: Tilgjengelighetsstatus) => {
+    if (oppstart === 'midlertidig_stengt') {
+      return (
+        <div className="tabell__tilgjengelighetsstatus">
+          <img src={StatusRod} alt="Rødt sirkelikon" />
+          <div>Midlertidig stengt</div>
+        </div>
+      );
+    }
+
     if (status === 'Apent' || !status) {
       return (
         <div className="tabell__tilgjengelighetsstatus">
@@ -56,6 +65,21 @@ const TiltaksgjennomforingsTabell = () => {
           <div>Venteliste</div>
         </div>
       );
+    }
+  };
+
+  const visOppstartsdato = (oppstart: Oppstart, oppstartsdato?: string) => {
+    switch (oppstart) {
+      case 'dato':
+        return new Date(oppstartsdato!).toLocaleString('no-NO', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        });
+      case 'lopende':
+        return 'Løpende';
+      case 'midlertidig_stengt':
+        return 'Midlertidig stengt';
     }
   };
 
@@ -231,16 +255,8 @@ const TiltaksgjennomforingsTabell = () => {
                 </Table.DataCell>
                 <Table.DataCell>{tiltakstype.tiltakstypeNavn}</Table.DataCell>
                 <Table.DataCell>{lokasjon}</Table.DataCell>
-                <Table.DataCell>
-                  {oppstart === 'dato'
-                    ? new Date(oppstartsdato!).toLocaleString('no-NO', {
-                        year: 'numeric',
-                        month: '2-digit',
-                        day: '2-digit',
-                      })
-                    : 'Løpende'}
-                </Table.DataCell>
-                <Table.DataCell>{visStatus(tilgjengelighetsstatus)}</Table.DataCell>
+                <Table.DataCell>{visOppstartsdato(oppstart, oppstartsdato)}</Table.DataCell>
+                <Table.DataCell>{visStatus(oppstart, tilgjengelighetsstatus)} </Table.DataCell>
               </Table.Row>
             )
           )}

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
@@ -15,6 +15,7 @@ type Innsatsgrupper =
   | 'Varig tilpasset innsats';
 
 export type Tilgjengelighetsstatus = 'Apent' | 'Venteliste' | 'Stengt';
+export type Oppstart = 'dato' | 'lopende' | 'midlertidig_stengt';
 
 export interface Tiltakstype {
   _id: string;
@@ -57,7 +58,7 @@ export interface Tiltaksgjennomforing {
   tiltaksnummer: number;
   kontaktinfoArrangor: Arrangor;
   lokasjon: string;
-  oppstart: string;
+  oppstart: Oppstart;
   oppstartsdato?: string;
   faneinnhold?: {
     forHvemInfoboks?: string;


### PR DESCRIPTION
Trøndelag har et tiltak de ikke ønsker slettet, men det er midlertidig stengt for øyeblikket. De ønsker fortsatt at det skal kunne vises i løsningen, så denne PRen er forslag på løsning. 

* Legger til støtte for verdien `midlertidig_stengt` i oppstart-feltet i Sanity for en tiltaksgjennomføring.
* Fikser frontend til å ta høyde for at det kan finnes midlertidig stengt-verdier.

![image](https://user-images.githubusercontent.com/9053627/186643644-8f1ff97c-11b5-4579-8de2-7720ca26202d.png)

![image](https://user-images.githubusercontent.com/9053627/186643671-3f99c87c-e852-42e8-afbe-83bb9f2e0624.png)

![image](https://user-images.githubusercontent.com/9053627/186643714-ac725839-7609-445b-b650-600a0219f4c0.png)
