### PR TITLE
Fiks filter for innsatsgruppe

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -116,6 +116,7 @@ describe('Tiltaksgjennomføringsdetaljer', () => {
 
   it('Skal ha ferdig utfylt brukers innsatsgruppe', () => {
     // Situasjonsbestemt innsats er innsatsgruppe som returneres når testene kjører med mock-data
+    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
     cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
     cy.getByTestId('filtertags').children().should('have.length', 2);
     cy.getByTestId('knapp_tilbakestill-filter').should('not.exist');
@@ -123,6 +124,16 @@ describe('Tiltaksgjennomføringsdetaljer', () => {
     cy.getByTestId('filtertag_situasjonsbestemt-innsats').then($value => {
       expect($value.text()).to.eq('Situasjonsbestemt innsats');
     });
+  });
+
+  it('Skal huske filtervalg mellom detaljvisning og listevisning', () => {
+    cy.getByTestId('filter_checkbox_standardinnsats').click();
+    cy.getByTestId('filtertags').children().should('have.length', 4);
+    cy.getByTestId('tabell_tiltaksgjennomforing').first().click();
+    cy.tilbakeTilListevisning();
+    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
+    cy.getByTestId('filter_checkbox_standardinnsats').should('be.checked');
+    cy.getByTestId('filtertags').children().should('have.length', 4);
   });
 
   it('Skal vise korrekt feilmelding dersom ingen tiltaksgjennomføringer blir funnet', () => {

--- a/frontend/mulighetsrommet-veileder-flate/src/App.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/App.tsx
@@ -1,15 +1,15 @@
-import {Modal} from '@navikt/ds-react';
-import {ErrorBoundary} from 'react-error-boundary';
-import {QueryClient, QueryClientProvider} from 'react-query';
-import {ReactQueryDevtools} from 'react-query/devtools';
-import {BrowserRouter as Router} from 'react-router-dom';
-import {ToastContainer} from 'react-toastify';
+import { Modal } from '@navikt/ds-react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import './App.less';
 import Feedback from './components/feedback/Feedback';
-import {APPLICATION_NAME, MODAL_ACCESSIBILITY_WRAPPER} from './constants';
+import { APPLICATION_NAME, MODAL_ACCESSIBILITY_WRAPPER } from './constants';
 import RoutesConfig from './RoutesConfig';
-import {ErrorFallback} from './utils/ErrorFallback';
+import { ErrorFallback } from './utils/ErrorFallback';
 
 // Trengs for at tab og fokus ikke skal gå utenfor modal når den er åpen.
 Modal.setAppElement?.(`#${MODAL_ACCESSIBILITY_WRAPPER}`);

--- a/frontend/mulighetsrommet-veileder-flate/src/RoutesConfig.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/RoutesConfig.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
-import { useHentFnrFraUrl } from './hooks/useHentFnrFraUrl';
-import ViewTiltakstypeDetaljer from './views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer';
-import ViewTiltakstypeOversikt from './views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt';
 import FakeDoor from './components/fakedoor/FakeDoor';
 import { ENABLE_ARBEIDSFLATE, useFeatureToggles } from './core/api/feature-toggles';
+import { useHentFnrFraUrl } from './hooks/useHentFnrFraUrl';
+import { useInitialBrukerfilter } from './hooks/useInitialBrukerfilter';
+import ViewTiltakstypeDetaljer from './views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer';
+import ViewTiltakstypeOversikt from './views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt';
 
 const RoutesConfig = () => {
   const fnr = useHentFnrFraUrl();
   const features = useFeatureToggles();
+  useInitialBrukerfilter();
+
   const enableArbeidsflate = features.isSuccess && features.data[ENABLE_ARBEIDSFLATE];
 
   if (features.isLoading) {

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentBrukerdata.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentBrukerdata.ts
@@ -5,9 +5,6 @@ import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
 
 export function useHentBrukerdata() {
   const fnr = useHentFnrFraUrl();
-  if (!fnr) return undefined;
 
-  return useQuery<Bruker, Error>([QueryKeys.Brukerdata, fnr], () => MulighetsrommetService.getBrukerdata({ fnr }), {
-    enabled: !!fnr, // Ikke kjør spørringen hvis vi ikke har et fnr
-  });
+  return useQuery<Bruker, Error>([QueryKeys.Brukerdata, fnr], () => MulighetsrommetService.getBrukerdata({ fnr }));
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/useHentFnrFraUrl.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/useHentFnrFraUrl.ts
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 
 export function useHentFnrFraUrl() {
-  const { fnr } = useParams();
+  const { fnr = 'undefined' } = useParams();
   return fnr;
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/useInitialBrukerfilter.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/useInitialBrukerfilter.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useErrorHandler } from 'react-error-boundary';
+import { useHentBrukerdata } from '../core/api/queries/useHentBrukerdata';
+import { useInnsatsgrupper } from '../core/api/queries/useInnsatsgrupper';
+import { usePrepopulerFilter } from './usePrepopulerFilter';
+
+export function useInitialBrukerfilter() {
+  const brukerdata = useHentBrukerdata();
+  const { forcePrepopulerFilter } = usePrepopulerFilter();
+  useErrorHandler(brukerdata?.error);
+  const { data: innsatsgrupper } = useInnsatsgrupper();
+  const data = brukerdata?.data;
+
+  useEffect(() => {
+    if (data && innsatsgrupper) {
+      forcePrepopulerFilter(true);
+    }
+  }, [data, innsatsgrupper]);
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
@@ -1,5 +1,4 @@
 import { useAtom } from 'jotai';
-import { useEffect } from 'react';
 import { useErrorHandler } from 'react-error-boundary';
 import { useHentBrukerdata } from '../core/api/queries/useHentBrukerdata';
 import { useInnsatsgrupper } from '../core/api/queries/useInnsatsgrupper';
@@ -8,15 +7,8 @@ import { tiltaksgjennomforingsfilter } from '../core/atoms/atoms';
 export function usePrepopulerFilter() {
   const [filter, setFilter] = useAtom(tiltaksgjennomforingsfilter);
   const brukerdata = useHentBrukerdata();
-  useErrorHandler(brukerdata?.error);
   const { data: innsatsgrupper } = useInnsatsgrupper();
-  const data = brukerdata?.data;
-
-  useEffect(() => {
-    if (data && innsatsgrupper) {
-      forcePrepopulerFilter(false);
-    }
-  }, [data, innsatsgrupper]);
+  useErrorHandler(brukerdata?.error);
 
   function forcePrepopulerFilter(resetFilterTilUtgangspunkt: boolean) {
     const matchedInnsatsgruppe = innsatsgrupper?.find(gruppe => gruppe.nokkel === brukerdata?.data?.innsatsgruppe);
@@ -25,10 +17,7 @@ export function usePrepopulerFilter() {
       const search = resetFilterTilUtgangspunkt ? '' : filter.search;
       const innsatsgrupper = resetFilterTilUtgangspunkt
         ? [{ id: matchedInnsatsgruppe._id, ...matchedInnsatsgruppe }]
-        : [
-            ...filter.innsatsgrupper.filter(gruppe => gruppe.id !== matchedInnsatsgruppe._id),
-            { id: matchedInnsatsgruppe._id, ...matchedInnsatsgruppe },
-          ];
+        : [...filter.innsatsgrupper.filter(gruppe => gruppe.id !== matchedInnsatsgruppe._id)];
       setFilter({
         search,
         tiltakstyper,


### PR DESCRIPTION
Fikser visning av brukers innsatsgruppe når man går mellom liste og detaljvisning. Legger også til en Cypress-test for å teste at vi ikke får regresjoner.