### PR TITLE
Endrer fra Apent til Ledig for tilgjengelighetstatus

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -152,10 +152,13 @@ export default {
     {
       name: "tilgjengelighetsstatus",
       title: "Tilgjengelighetsstatus",
+      description:
+        "Tilgjengelighetsstatus utledes fra data i Arena og kan ikke overskrives her i Sanity.",
+      readOnly: true,
       type: "string",
       options: {
         list: [
-          { title: "Åpent", value: "Apent" },
+          { title: "Åpent", value: "Ledig" },
           { title: "Venteliste", value: "Venteliste" },
           { title: "Stengt", value: "Stengt" },
         ],

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -44,7 +44,7 @@ const TiltaksgjennomforingsTabell = () => {
       );
     }
 
-    if (status === 'Apent' || !status) {
+    if (status === 'Ledig' || !status) {
       return (
         <div className="tabell__tilgjengelighetsstatus">
           <img src={StatusGronn} alt="Grønt sirkelikon" />

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
@@ -14,7 +14,7 @@ type Innsatsgrupper =
   | 'Spesielt tilpasset innsats'
   | 'Varig tilpasset innsats';
 
-export type Tilgjengelighetsstatus = 'Apent' | 'Venteliste' | 'Stengt';
+export type Tilgjengelighetsstatus = 'Ledig' | 'Venteliste' | 'Stengt';
 export type Oppstart = 'dato' | 'lopende' | 'midlertidig_stengt';
 
 export interface Tiltakstype {


### PR DESCRIPTION
Verdien fra cron-jobb som setter tilgjengelighetsstatus operer med verdien `Ledig` istedenfor `Apent` så den blir endret i denne PRen. I tillegg legger jeg på readOnly og en beskrivelse av hvor dataene blir utledet fra. 
![image](https://user-images.githubusercontent.com/9053627/186851192-090efb25-96ab-4829-9eda-991b20168db2.png)
