### PR TITLE
bugfix/send fnr as a query param instead of path param

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/setup/http/RestClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/setup/http/RestClient.kt
@@ -3,16 +3,11 @@ package no.nav.mulighetsrommet.api.setup.http
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 
 internal val baseClient = HttpClient(CIO) {
     expectSuccess = false
-    install(Logging) {
-        logger = Logger.DEFAULT
-        level = LogLevel.INFO
-    }
     install(ContentNegotiation) {
         json(
             Json {


### PR DESCRIPTION
- send fnr as query param instead of path param
- turn of http logging in baseClient
