### PR TITLE
Fix tilbakestill filter når ingen innsatsgruppe

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/oppfolgingsenhet/BrukerOppfolgingsenhet.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/oppfolgingsenhet/BrukerOppfolgingsenhet.tsx
@@ -1,0 +1,35 @@
+import { Tag, Alert } from '@navikt/ds-react';
+import { useHentBrukerdata } from '../../core/api/queries/useHentBrukerdata';
+import { kebabCase } from '../../utils/Utils';
+
+export function BrukersOppfolgingsenhet() {
+  const brukerdata = useHentBrukerdata();
+  const brukersOppfolgingsenhet = brukerdata?.data?.oppfolgingsenhet?.navn;
+
+  if (brukerdata?.isLoading) {
+    return null;
+  }
+
+  return brukersOppfolgingsenhet ? (
+    <Tag
+      className={'nav-enhet-tag'}
+      key={'navenhet'}
+      variant={brukersOppfolgingsenhet ? 'info' : 'error'}
+      size="small"
+      data-testid={`${kebabCase('filtertag_navenhet')}`}
+      title="Brukers oppfølgingsenhet"
+    >
+      {brukersOppfolgingsenhet}
+    </Tag>
+  ) : (
+    <Alert
+      title="Kontroller om brukeren er under oppfølging og finnes i Arena"
+      key="alert-navenhet"
+      data-testid="alert-navenhet"
+      size="small"
+      variant="error"
+    >
+      Fant ingen oppfølgingsenhet
+    </Alert>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -14,6 +14,8 @@ import { paginationAtom, tiltaksgjennomforingsfilter } from '../../core/atoms/at
 import { RESET } from 'jotai/utils';
 import { Feilmelding } from '../feilmelding/Feilmelding';
 import { usePrepopulerFilter } from '../../hooks/usePrepopulerFilter';
+import Body from '@navikt/ds-react/esm/table/Body';
+import { useHentBrukerdata } from '../../core/api/queries/useHentBrukerdata';
 
 const TiltaksgjennomforingsTabell = () => {
   const [sort, setSort] = useState<any>();
@@ -24,6 +26,7 @@ const TiltaksgjennomforingsTabell = () => {
     return Math.ceil(tiltaksgjennomforing.length / rowsPerPage);
   };
   const [filter, setFilter] = useAtom(tiltaksgjennomforingsfilter);
+  const brukerdata = useHentBrukerdata();
 
   const { data: tiltaksgjennomforinger = [], isLoading, isError, isFetching } = useTiltaksgjennomforing();
 
@@ -124,7 +127,19 @@ const TiltaksgjennomforingsTabell = () => {
     })
     .slice((page - 1) * rowsPerPage, page * rowsPerPage);
 
-  if (tiltaksgjennomforinger.length === 0) {
+  if (!brukerdata?.data?.oppfolgingsenhet) {
+    return (
+      <Feilmelding ikonvariant="warning">
+        <Ingress>Kunne ikke hente brukers oppfølgingsenhet</Ingress>
+        <BodyShort>
+          Vi kunne ikke hente oppfølgingsenhet for brukeren. Kontroller at brukeren er under oppfølging og finnes i
+          Arena.
+        </BodyShort>
+      </Feilmelding>
+    );
+  }
+
+  if (tiltaksgjennomforinger.length == 0) {
     return (
       <Feilmelding ikonvariant="warning">
         <>


### PR DESCRIPTION
Denne PRen fikser en bug hvor vi viser `Tilbakestill filter`-knappen dersom vi ikke har klart å hente innsatsgruppe for bruker.

I tillegg legger den på en feilmelding til bruker med hint om å sjekke Arena dersom vi ikke klarer å hente brukers oppfølgingsenhet.

![Skjermbilde 2022-08-30 kl  08 30 56](https://user-images.githubusercontent.com/9053627/187366328-5784b0ef-a780-4d88-86da-839872728f51.png)
