### PR TITLE
Ikke hent tiltaksgjennomføringer vi har brukerdata

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -1,21 +1,20 @@
-import React, { useEffect, useState } from 'react';
 import { Alert, BodyShort, Button, Heading, Ingress, Loader, Pagination, Table } from '@navikt/ds-react';
-import './Tabell.less';
 import { useAtom } from 'jotai';
-import Lenke from '../lenke/Lenke';
-import Kopiknapp from '../kopiknapp/Kopiknapp';
+import { RESET } from 'jotai/utils';
+import { useEffect, useState } from 'react';
+import { logEvent } from '../../core/api/logger';
+import { Oppstart, Tilgjengelighetsstatus, Tiltaksgjennomforing } from '../../core/api/models';
+import { useHentBrukerdata } from '../../core/api/queries/useHentBrukerdata';
+import useTiltaksgjennomforing from '../../core/api/queries/useTiltaksgjennomforing';
+import { paginationAtom, tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
+import { usePrepopulerFilter } from '../../hooks/usePrepopulerFilter';
 import StatusGronn from '../../ikoner/Sirkel-gronn.png';
 import StatusGul from '../../ikoner/Sirkel-gul.png';
 import StatusRod from '../../ikoner/Sirkel-rod.png';
-import useTiltaksgjennomforing from '../../core/api/queries/useTiltaksgjennomforing';
-import { logEvent } from '../../core/api/logger';
-import { Oppstart, Tilgjengelighetsstatus, Tiltaksgjennomforing } from '../../core/api/models';
-import { paginationAtom, tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
-import { RESET } from 'jotai/utils';
 import { Feilmelding } from '../feilmelding/Feilmelding';
-import { usePrepopulerFilter } from '../../hooks/usePrepopulerFilter';
-import Body from '@navikt/ds-react/esm/table/Body';
-import { useHentBrukerdata } from '../../core/api/queries/useHentBrukerdata';
+import Kopiknapp from '../kopiknapp/Kopiknapp';
+import Lenke from '../lenke/Lenke';
+import './Tabell.less';
 
 const TiltaksgjennomforingsTabell = () => {
   const [sort, setSort] = useState<any>();

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforing.ts
@@ -2,10 +2,12 @@ import groq from 'groq';
 import { useAtom } from 'jotai';
 import { tiltaksgjennomforingsfilter, Tiltaksgjennomforingsfiltergruppe } from '../../atoms/atoms';
 import { Tiltaksgjennomforing } from '../models';
+import { useHentBrukerdata } from './useHentBrukerdata';
 import { useSanity } from './useSanity';
 
 export default function useTiltaksgjennomforing() {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
+  const brukerData = useHentBrukerdata();
   return useSanity<Tiltaksgjennomforing[]>(
     groq`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
   ${byggInnsatsgruppeFilter(filter.innsatsgrupper)} 
@@ -23,7 +25,10 @@ export default function useTiltaksgjennomforing() {
     kontaktinfoArrangor->,
     tiltakstype->,
     tilgjengelighetsstatus
-  }`
+  }`,
+    {
+      enabled: !!brukerData.data?.oppfolgingsenhet,
+    }
   );
 }
 


### PR DESCRIPTION
Vi venter med å hente tiltaksgjennomføringer til vi har brukerdata, slik at vi ikke flasher data før vi gjør en ny filtrering basert på brukers oppfølgingsenhet og innsatsgruppe.