### PR TITLE
Feature/treat sak with missing tiltak as success

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
@@ -98,7 +98,7 @@ fun Route.arenaRoutes() {
                 val sak = call.receive<AdapterSak>()
                 arenaService.updateTiltaksgjennomforingWithSak(sak)
             }.onSuccess {
-                val response = it ?: HttpStatusCode.NotFound
+                val response = it ?: HttpStatusCode.Conflict
                 call.respond(response)
             }.onFailure {
                 logError(logger, it)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumer.kt
@@ -34,7 +34,9 @@ class SakEndretConsumer(
 
     override suspend fun handleEvent(event: ArenaEvent<ArenaSak>) {
         val method = if (event.operation == ArenaOperation.Delete) HttpMethod.Delete else HttpMethod.Put
-        client.sendRequest(method, "/api/v1/arena/sak", event.data.toAdapterSak())
+        client.sendRequest(method, "/api/v1/arena/sak", event.data.toAdapterSak()) {
+            status.isSuccess() || status == HttpStatusCode.Conflict
+        }
     }
 
     private fun sakIsRelatedToTiltaksgjennomforing(payload: ArenaSak): Boolean = payload.SAKSKODE == "TILT"

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/kafka/TopicConsumer.kt
@@ -5,7 +5,7 @@ import no.nav.mulighetsrommet.arena.adapter.ConsumerConfig
 import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
 import org.slf4j.Logger
 
-abstract class TopicConsumer<T>() {
+abstract class TopicConsumer<T> {
     abstract val consumerConfig: ConsumerConfig
     abstract val logger: Logger
     abstract val events: EventRepository

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumerTest.kt
@@ -1,0 +1,169 @@
+package no.nav.mulighetsrommet.arena.adapter.no.nav.mulighetsrommet.arena.adapter.consumers
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.content.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import io.mockk.mockk
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import no.nav.mulighetsrommet.arena.adapter.ConsumerConfig
+import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
+import no.nav.mulighetsrommet.arena.adapter.consumers.SakEndretConsumer
+import no.nav.mulighetsrommet.arena.adapter.repositories.EventRepository
+import no.nav.mulighetsrommet.domain.adapter.AdapterSak
+
+class SakEndretConsumerTest : FunSpec({
+    context("when sakskode is not TILT") {
+        test("should not call api with mapped event payload") {
+            val engine = MockEngine {
+                respond(
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    status = HttpStatusCode.OK,
+                    content = ByteReadChannel("{}"),
+                )
+            }
+
+            val event = createInsertEvent(
+                """{
+                    "SAK_ID": 1,
+                    "SAKSKODE": "NOT_TILT",
+                    "AAR": 2022,
+                    "LOPENRSAK": 2
+                }"""
+            )
+
+            createSakEndretConsumer(engine).processEvent(event)
+
+            engine.requestHistory shouldHaveSize 0
+        }
+    }
+
+    context("when sakskode is TILT") {
+        test("should call api with mapped event payload") {
+            val engine = MockEngine {
+                respond(
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    status = HttpStatusCode.OK,
+                    content = ByteReadChannel("{}"),
+                )
+            }
+
+            val event = createInsertEvent(
+                """{
+                    "SAK_ID": 1,
+                    "SAKSKODE": "TILT",
+                    "AAR": 2022,
+                    "LOPENRSAK": 2
+                }"""
+            )
+
+            createSakEndretConsumer(engine).processEvent(event)
+
+            val request = engine.requestHistory.last()
+
+            request.method shouldBe HttpMethod.Put
+            decodeRequestBody<AdapterSak>(request) shouldBe AdapterSak(
+                id = 1,
+                aar = 2022,
+                lopenummer = 2,
+            )
+        }
+
+        context("when api returns 409") {
+            test("should treat the result as successful") {
+                val engine = MockEngine {
+                    respond(
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        status = HttpStatusCode.Conflict,
+                        content = ByteReadChannel("{}"),
+                    )
+                }
+
+                val consumer = createSakEndretConsumer(engine)
+
+                val event = createInsertEvent(
+                    """{
+                        "SAK_ID": 1,
+                        "SAKSKODE": "TILT",
+                        "AAR": 2022,
+                        "LOPENRSAK": 2
+                    }"""
+                )
+
+                consumer.processEvent(event)
+
+                val request = engine.requestHistory.last()
+
+                request.method shouldBe HttpMethod.Put
+                decodeRequestBody<AdapterSak>(request) shouldBe AdapterSak(
+                    id = 1,
+                    aar = 2022,
+                    lopenummer = 2,
+                )
+            }
+        }
+
+        context("when api returns 500") {
+            test("should treat the result as error") {
+                val engine = MockEngine {
+                    respond(
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        status = HttpStatusCode.InternalServerError,
+                        content = ByteReadChannel("{}"),
+                    )
+                }
+
+                val consumer = createSakEndretConsumer(engine)
+
+                val event = createInsertEvent(
+                    """{
+                        "SAK_ID": 1,
+                        "SAKSKODE": "TILT",
+                        "AAR": 2022,
+                        "LOPENRSAK": 2
+                    }"""
+                )
+
+                shouldThrow<ResponseException> {
+                    consumer.processEvent(event)
+                }
+            }
+        }
+    }
+})
+
+private fun createSakEndretConsumer(engine: HttpClientEngine): SakEndretConsumer {
+    val client = MulighetsrommetApiClient(engine, maxRetries = 1, baseUri = "api") {
+        "Bearer token"
+    }
+
+    val events = mockk<EventRepository>(relaxed = true)
+
+    return SakEndretConsumer(
+        ConsumerConfig("sakendret", "sakendret"),
+        events,
+        client
+    )
+}
+
+@OptIn(InternalSerializationApi::class)
+inline fun <reified T : Any> decodeRequestBody(request: HttpRequestData): T {
+    return Json.decodeFromString(T::class.serializer(), (request.body as TextContent).text)
+}
+
+private fun createInsertEvent(data: String) = Json.parseToJsonElement(
+    """{
+        "op_type": "I",
+        "after": $data
+    }
+    """
+)

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
@@ -95,7 +95,7 @@ private fun <T> decodeRequestBody(request: HttpRequestData, kSerializer: KSerial
     return Json.decodeFromString(kSerializer, (request.body as TextContent).text)
 }
 
-fun createInsertEvent(data: String) = Json.parseToJsonElement(
+private fun createInsertEvent(data: String) = Json.parseToJsonElement(
     """{
     "op_type": "I",
     "after": $data

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
@@ -1,15 +1,13 @@
 package no.nav.mulighetsrommet.arena.adapter.no.nav.mulighetsrommet.arena.adapter.consumers
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.*
 import io.ktor.client.engine.mock.*
-import io.ktor.client.request.*
-import io.ktor.content.*
+import io.ktor.client.plugins.*
 import io.ktor.http.*
-import io.ktor.utils.io.*
 import io.mockk.mockk
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.json.Json
 import no.nav.mulighetsrommet.arena.adapter.ConsumerConfig
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.arena.adapter.consumers.TiltakgjennomforingEndretConsumer
@@ -18,46 +16,15 @@ import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
 
 class TiltakgjennomforingEndretConsumerTest : FunSpec({
 
-    val engine = MockEngine {
-        respond(
-            headers = headersOf(HttpHeaders.ContentType, "application/json"),
-            status = HttpStatusCode.OK,
-            content = ByteReadChannel("{}"),
-        )
-    }
-    val client = MulighetsrommetApiClient(engine, baseUri = "api") {
-        "Bearer token"
-    }
-
-    val events = mockk<EventRepository>(relaxed = true)
-
-    val consumer = TiltakgjennomforingEndretConsumer(
-        ConsumerConfig("tiltakgjennomforing", "tiltakgjennomforing"),
-        events,
-        client
-    )
-
     test("should call api with mapped event payload") {
-        val event = createInsertEvent(
-            """{
-                "TILTAKGJENNOMFORING_ID": 3780431,
-                "LOKALTNAVN": "Testenavn",
-                "TILTAKSKODE": "INDOPPFAG",
-                "ARBGIV_ID_ARRANGOR": 49612,
-                "SAK_ID": 13572352,
-                "DATO_FRA": null,
-                "DATO_TIL": null,
-                "STATUS_TREVERDIKODE_INNSOKNING": "J",
-                "ANTALL_DELTAKERE": 5
-            }"""
-        )
+        val engine = MockEngine { respondOk() }
 
-        consumer.processEvent(event)
+        val event = createtiltaksgjennomforingEndretEvent(antallDeltakere = 5)
+        createTiltaksgjennomforingEndretConsumer(engine).processEvent(event)
 
         val request = engine.requestHistory.last()
-
         request.method shouldBe HttpMethod.Put
-        decodeRequestBody(request, AdapterTiltaksgjennomforing.serializer()) shouldBe AdapterTiltaksgjennomforing(
+        decodeRequestBody<AdapterTiltaksgjennomforing>(request) shouldBe AdapterTiltaksgjennomforing(
             id = 3780431,
             navn = "Testenavn",
             tiltakskode = "INDOPPFAG",
@@ -71,34 +38,51 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
     }
 
     test("should decode ANTALL_DELTAKERE as nearest integer") {
-        val event = createInsertEvent(
-            """{
-                "TILTAKGJENNOMFORING_ID": 3780431,
-                "LOKALTNAVN": "Testenavn",
-                "TILTAKSKODE": "INDOPPFAG",
-                "ARBGIV_ID_ARRANGOR": 49612,
-                "SAK_ID": 13572352,
-                "DATO_FRA": null,
-                "DATO_TIL": null,
-                "STATUS_TREVERDIKODE_INNSOKNING": "J",
-                "ANTALL_DELTAKERE": 5.5
-            }"""
-        )
+        val engine = MockEngine { respondOk() }
 
-        consumer.processEvent(event)
+        val event = createtiltaksgjennomforingEndretEvent(antallDeltakere = 5.5)
+        createTiltaksgjennomforingEndretConsumer(engine).processEvent(event)
 
-        decodeRequestBody(engine.requestHistory.last(), AdapterTiltaksgjennomforing.serializer()).antallPlasser shouldBe 6
+        decodeRequestBody<AdapterTiltaksgjennomforing>(engine.requestHistory.last()).antallPlasser shouldBe 6
+    }
+
+    context("when api returns 500") {
+        test("should treat the result as error") {
+            val consumer = createTiltaksgjennomforingEndretConsumer(
+                MockEngine { respondError(HttpStatusCode.InternalServerError) }
+            )
+
+            shouldThrow<ResponseException> {
+                consumer.processEvent(createtiltaksgjennomforingEndretEvent())
+            }
+        }
     }
 })
 
-private fun <T> decodeRequestBody(request: HttpRequestData, kSerializer: KSerializer<T>): T {
-    return Json.decodeFromString(kSerializer, (request.body as TextContent).text)
+fun createTiltaksgjennomforingEndretConsumer(engine: HttpClientEngine): TiltakgjennomforingEndretConsumer {
+    val client = MulighetsrommetApiClient(engine, maxRetries = 1, baseUri = "api") {
+        "Bearer token"
+    }
+
+    val events = mockk<EventRepository>(relaxed = true)
+
+    return TiltakgjennomforingEndretConsumer(
+        ConsumerConfig("tiltakgjennomforing", "tiltakgjennomforing"),
+        events,
+        client
+    )
 }
 
-private fun createInsertEvent(data: String) = Json.parseToJsonElement(
+private fun createtiltaksgjennomforingEndretEvent(antallDeltakere: Number = 5) = ArenaEvent.createInsertEvent(
     """{
-    "op_type": "I",
-    "after": $data
-}
-"""
+        "TILTAKGJENNOMFORING_ID": 3780431,
+        "LOKALTNAVN": "Testenavn",
+        "TILTAKSKODE": "INDOPPFAG",
+        "ARBGIV_ID_ARRANGOR": 49612,
+        "SAK_ID": 13572352,
+        "DATO_FRA": null,
+        "DATO_TIL": null,
+        "STATUS_TREVERDIKODE_INNSOKNING": "J",
+        "ANTALL_DELTAKERE": $antallDeltakere
+    }"""
 )

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TopicConsumerTestUtils.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TopicConsumerTestUtils.kt
@@ -1,0 +1,22 @@
+package no.nav.mulighetsrommet.arena.adapter.no.nav.mulighetsrommet.arena.adapter.consumers
+
+import io.ktor.client.request.*
+import io.ktor.http.content.*
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+
+@OptIn(InternalSerializationApi::class)
+inline fun <reified T : Any> decodeRequestBody(request: HttpRequestData): T {
+    return Json.decodeFromString(T::class.serializer(), (request.body as TextContent).text)
+}
+
+object ArenaEvent {
+    fun createInsertEvent(data: String) = Json.parseToJsonElement(
+        """{
+            "op_type": "I",
+            "after": $data
+        }
+        """
+    )
+}


### PR DESCRIPTION
- Endrer sak-endepunktet fra å returnere 409 i stedet for 404 når tiltaksgjennomføring ikke finnes (virker litt mer riktig).
- Forsøker 5 ganger å prøve på nytt om det returneres 409 (samt 5XX) fra api'et til arena-adapter
- Hvis sak-endepunktet returnerer 409 etter 5 forsøk vil eventet likevel håndteres som success, med antagelse om at dette er sak som eksisterer uten en tiltaksgjennomføring