### PR TITLE
Hent status om manuel oppfølging for bruker

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -78,10 +78,39 @@ describe('Tiltaksgjennomføringstabell', () => {
     cy.getByTestId('paginering').children().children().eq(2).click();
     cy.getByTestId('paginering').children().children().children().eq(2).should('have.attr', 'aria-current');
   });
+
+  it('Skal ha ferdig utfylt brukers innsatsgruppe', () => {
+    // Situasjonsbestemt innsats er innsatsgruppe som returneres når testene kjører med mock-data
+    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
+    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
+    cy.getByTestId('filtertags').children().should('have.length', 2);
+    cy.getByTestId('knapp_tilbakestill-filter').should('not.exist');
+
+    cy.getByTestId('filtertag_situasjonsbestemt-innsats').then($value => {
+      expect($value.text()).to.eq('Situasjonsbestemt innsats');
+    });
+  });
+
+  it('Skal huske filtervalg mellom detaljvisning og listevisning', () => {
+    cy.getByTestId('filter_checkbox_standardinnsats').click();
+    cy.getByTestId('filtertags').children().should('have.length', 4);
+    cy.getByTestId('tabell_tiltaksgjennomforing').first().click();
+    cy.tilbakeTilListevisning();
+    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
+    cy.getByTestId('filter_checkbox_standardinnsats').should('be.checked');
+    cy.getByTestId('filtertags').children().should('have.length', 4);
+  });
+
+  it('Skal vise korrekt feilmelding dersom ingen tiltaksgjennomføringer blir funnet', () => {
+    cy.getByTestId('filter_sokefelt').type('blablablablabla');
+    cy.getByTestId('feilmelding-container').should('be.visible');
+    cy.getByTestId('feilmelding-container').should('have.attr', 'aria-live');
+  });
 });
 
 describe('Tiltaksgjennomføringsdetaljer', () => {
   it('Gå til en tiltaksgjennomføring', () => {
+    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
     cy.getByTestId('tabell_tiltaksgjennomforing').first().click();
   });
 
@@ -114,31 +143,8 @@ describe('Tiltaksgjennomføringsdetaljer', () => {
     cy.getByTestId('tabell_tiltakstyper').children().children().should('have.length.greaterThan', 1);
   });
 
-  it('Skal ha ferdig utfylt brukers innsatsgruppe', () => {
-    // Situasjonsbestemt innsats er innsatsgruppe som returneres når testene kjører med mock-data
-    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
-    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
-    cy.getByTestId('filtertags').children().should('have.length', 2);
-    cy.getByTestId('knapp_tilbakestill-filter').should('not.exist');
-
-    cy.getByTestId('filtertag_situasjonsbestemt-innsats').then($value => {
-      expect($value.text()).to.eq('Situasjonsbestemt innsats');
-    });
-  });
-
-  it('Skal huske filtervalg mellom detaljvisning og listevisning', () => {
-    cy.getByTestId('filter_checkbox_standardinnsats').click();
-    cy.getByTestId('filtertags').children().should('have.length', 4);
+  it("Sjekk 'Del med bruker'", () => {
     cy.getByTestId('tabell_tiltaksgjennomforing').first().click();
-    cy.tilbakeTilListevisning();
-    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
-    cy.getByTestId('filter_checkbox_standardinnsats').should('be.checked');
-    cy.getByTestId('filtertags').children().should('have.length', 4);
-  });
-
-  it('Skal vise korrekt feilmelding dersom ingen tiltaksgjennomføringer blir funnet', () => {
-    cy.getByTestId('filter_sokefelt').type('blablablablabla');
-    cy.getByTestId('feilmelding-container').should('be.visible');
-    cy.getByTestId('feilmelding-container').should('have.attr', 'aria-live');
+    cy.getByTestId('del-med-bruker-button').should('be.visible').click();
   });
 });

--- a/frontend/mulighetsrommet-veileder-flate/src/components/knapper/Deleknapp.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/knapper/Deleknapp.tsx
@@ -10,9 +10,10 @@ interface DeleknappProps {
   handleClick: () => void;
   ariaLabel: string;
   dataTestId?: string;
+  disabled?: boolean;
 }
 
-const Deleknapp = ({ children, ariaLabel, className, handleClick, dataTestId }: DeleknappProps) => {
+const Deleknapp = ({ children, ariaLabel, className, handleClick, dataTestId, disabled = false }: DeleknappProps) => {
   const features = useFeatureToggles();
   const visDeleknapp = features.isSuccess && features.data[DELING_MED_BRUKER];
 
@@ -25,6 +26,7 @@ const Deleknapp = ({ children, ariaLabel, className, handleClick, dataTestId }: 
           className={classNames('deleknapp', className)}
           aria-label={ariaLabel}
           data-testid={dataTestId}
+          disabled={disabled}
         >
           {children}
         </Button>

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -19,6 +19,13 @@ export const apiHandlers: RestHandler[] = [
         enhetId: '0106',
       },
       fornavn: 'Iherdig',
+      manuellStatus: {
+        erUnderManuellOppfolging: false,
+        krrStatus: {
+          kanVarsles: true,
+          erReservert: false,
+        },
+      },
     });
   }),
 

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/worker.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/worker.ts
@@ -14,4 +14,3 @@ export function initializeMockWorker() {
     worker.start();
   }
 }
-

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
@@ -6,7 +6,7 @@ import Nokkelinfo from '../../components/nokkelinfo/Nokkelinfo';
 import SidemenyDetaljer from '../../components/sidemeny/SidemenyDetaljer';
 import TiltaksdetaljerFane from '../../components/tabs/TiltaksdetaljerFane';
 import useTiltaksgjennomforingByTiltaksnummer from '../../core/api/queries/useTiltaksgjennomforingByTiltaksnummer';
-import { Alert, Loader } from '@navikt/ds-react';
+import { Alert, HelpText, Loader, ReadMore } from '@navikt/ds-react';
 import { useGetTiltaksnummerFraUrl } from '../../core/api/queries/useGetTiltaksnummerFraUrl';
 import { useHentFnrFraUrl } from '../../hooks/useHentFnrFraUrl';
 import Deleknapp from '../../components/knapper/Deleknapp';
@@ -40,6 +40,12 @@ const ViewTiltakstypeDetaljer = () => {
       <Alert variant="warning">{`Det finnes ingen tiltaksgjennomføringer med tiltaksnummer "${tiltaksnummer}"`}</Alert>
     );
   }
+
+  const kanDeleMedBruker =
+    !brukerdata.data?.manuellStatus?.erUnderManuellOppfolging &&
+    !brukerdata.data?.manuellStatus?.krrStatus?.erReservert &&
+    brukerdata?.data?.manuellStatus?.krrStatus?.kanVarsles;
+
   return (
     <div className="tiltakstype-detaljer">
       <div className="tiltakstype-detaljer__info">
@@ -51,8 +57,19 @@ const ViewTiltakstypeDetaljer = () => {
       </div>
       <div>
         <SidemenyDetaljer />
-        <Deleknapp ariaLabel={'Dele'} handleClick={handleClickApneModal}>
-          Del med bruker
+        <Deleknapp
+          dataTestId="del-med-bruker-button"
+          ariaLabel={'Dele'}
+          handleClick={handleClickApneModal}
+          disabled={!kanDeleMedBruker}
+        >
+          {kanDeleMedBruker ? (
+            'Del med bruker'
+          ) : (
+            <span title="Bruker er under manuell oppfølging, finnes i Kontakt- og reservasjonsregisteret eller har ikke vært innlogget på NAV.no siste 18 mnd. Brukeren kan dermed ikke kontaktes digitalt.">
+              Kan ikke dele med bruker
+            </span>
+          )}
         </Deleknapp>
       </div>
       <TiltaksdetaljerFane />

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClient.kt
@@ -1,7 +1,9 @@
 package no.nav.mulighetsrommet.api.clients.oppfolging
 
+import no.nav.mulighetsrommet.api.domain.ManuellStatusDTO
 import no.nav.mulighetsrommet.api.domain.Oppfolgingsstatus
 
 interface VeilarboppfolgingClient {
     suspend fun hentOppfolgingsstatus(fnr: String, accessToken: String?): Oppfolgingsstatus?
+    suspend fun hentManuellStatus(fnr: String, accessToken: String?): ManuellStatusDTO?
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
@@ -66,7 +66,7 @@ class VeilarboppfolgingClientImpl(
             val body = response.body<ManuellStatusDTO>()
             body
         } catch (exe: Exception) {
-            log.error("Klarte ikke hente manuell status: {}", exe.message)
+            log.error("Klarte ikke hente manuell status")
             null
         }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
@@ -6,6 +6,7 @@ import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient
+import no.nav.mulighetsrommet.api.domain.ManuellStatusDTO
 import no.nav.mulighetsrommet.api.domain.Oppfolgingsstatus
 import no.nav.mulighetsrommet.api.setup.http.baseClient
 import org.slf4j.LoggerFactory
@@ -41,6 +42,31 @@ class VeilarboppfolgingClientImpl(
             response.body<Oppfolgingsstatus>()
         } catch (exe: Exception) {
             log.error("Klarte ikke hente oppfølgingsstatus: {}", exe.message)
+            null
+        }
+    }
+
+    override suspend fun hentManuellStatus(fnr: String, accessToken: String?): ManuellStatusDTO? {
+        return try {
+            val response = client.get("$baseUrl/v2/manuell/status?fnr=$fnr") {
+                bearerAuth(
+                    veilarboppfolgingTokenProvider.exchangeOnBehalfOfToken(
+                        scope,
+                        accessToken
+                    )
+                )
+                header("Nav-Consumer-Id", "mulighetsrommet-api")
+            }
+
+            if (response.status == HttpStatusCode.NotFound || response.status == HttpStatusCode.NoContent) {
+                log.info("Fant ikke manuell status for bruker.")
+                return null
+            }
+
+            val body = response.body<ManuellStatusDTO>()
+            body
+        } catch (exe: Exception) {
+            log.error("Klarte ikke hente manuell status: {}", exe.message)
             null
         }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/ManuellStatusDTO.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/ManuellStatusDTO.kt
@@ -1,0 +1,15 @@
+package no.nav.mulighetsrommet.api.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ManuellStatusDTO(
+    val erUnderManuellOppfolging: Boolean,
+    val krrStatus: KrrStatus
+)
+
+@Serializable
+data class KrrStatus(
+    val kanVarsles: Boolean,
+    val erReservert: Boolean,
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
@@ -5,16 +5,18 @@ import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClient
 import no.nav.mulighetsrommet.api.clients.person.VeilarbpersonClient
 import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClient
 import no.nav.mulighetsrommet.api.domain.Innsatsgruppe
+import no.nav.mulighetsrommet.api.domain.ManuellStatusDTO
 import no.nav.mulighetsrommet.api.domain.Oppfolgingsenhet
 
 class BrukerService(
     private val veilarboppfolgingClient: VeilarboppfolgingClient,
     private val veilarbvedtaksstotteClient: VeilarbvedtaksstotteClient,
-    private val veilarbpersonClient: VeilarbpersonClient,
+    private val veilarbpersonClient: VeilarbpersonClient
 ) {
 
     suspend fun hentBrukerdata(fnr: String, accessToken: String?): Brukerdata {
         val oppfolgingsenhet = veilarboppfolgingClient.hentOppfolgingsstatus(fnr, accessToken)
+        val manuellStatus = veilarboppfolgingClient.hentManuellStatus(fnr, accessToken)
         val sisteVedtak = veilarbvedtaksstotteClient.hentSiste14AVedtak(fnr, accessToken)
         val personInfo = veilarbpersonClient.hentPersonInfo(fnr, accessToken)
 
@@ -22,7 +24,8 @@ class BrukerService(
             fnr = fnr,
             oppfolgingsenhet = oppfolgingsenhet?.oppfolgingsenhet,
             innsatsgruppe = sisteVedtak?.innsatsgruppe,
-            fornavn = personInfo?.fornavn
+            fornavn = personInfo?.fornavn,
+            manuellStatus = manuellStatus
         )
     }
 }
@@ -33,4 +36,5 @@ data class Brukerdata(
     val innsatsgruppe: Innsatsgruppe?,
     val oppfolgingsenhet: Oppfolgingsenhet?,
     val fornavn: String?,
+    val manuellStatus: ManuellStatusDTO?
 )

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yml
@@ -256,6 +256,22 @@ components:
         type: string
 
   schemas:
+    ManuellStatus:
+      type: object
+      properties:
+        erUnderManuellOppfolging:
+          type: boolean
+          nullable: true
+        krrStatus:
+          type: object
+          properties:
+            kanVarsles:
+              type: boolean
+              nullable: true
+            erReservert:
+              type: boolean
+              nullable: true
+
     Tiltakstype:
       type: object
       required:
@@ -420,6 +436,8 @@ components:
           type: "#/components/schemas/Oppfolgingsenhet"
         fornavn:
           type: string
+        manuellStatus:
+          $ref: "#/components/schemas/ManuellStatus"
       required:
         - fnr
         - oppfolgingsenhet

--- a/mulighetsrommet-api/wiremock/mappings/mr-manuellstatus.json
+++ b/mulighetsrommet-api/wiremock/mappings/mr-manuellstatus.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/v2/manuell/status",
+    "queryParameters": {
+      "fnr": {
+        "matches": "[\\d\\D]*"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "erUnderManuellOppfolging": false,
+      "krrStatus": {
+        "kanVarsles": true,
+        "erReservert": false
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
Henter status om manuell oppfølging via `veilarboppfolging` sitt api. Returnerer det som en del av brukerdata-pakken til frontend slik at vi kan skjule "Del med bruker"-knapp for de brukerne vi ikke skal kunne kontakte.