### PR TITLE
Filtrer ut 406 (saker som feiler)

### DIFF
--- a/mulighetsrommet-api/alerts-api.yaml
+++ b/mulighetsrommet-api/alerts-api.yaml
@@ -7,12 +7,11 @@ metadata:
   namespace: team-mulighetsrommet
   labels:
     team: team-mulighetsrommet
+    app: mulighetsrommet-api
 spec:
   receivers:
     slack:
       channel: "#team-valp-feil"
-      # <!here> results in a @here message in Slack
-      prependText: " | "
   alerts:
     - alert: applikasjon nede
       # Change <appname> to the name of the app you want to monitor
@@ -30,15 +29,15 @@ spec:
       expr: selftests_aggregate_result_status{app="mulighetsrommet-api"} > 0
       for: 1m
       action: "Sjekk app {{ $labels.app }} i namespace {{ $labels.kubernetes_namespace }} sine selftest for å se hva som er galt"
-    - alert: Høy andel HTTP serverfeil (5xx responser)
+    - alert: Høy andel HTTP serverfeil (5xx responser) [${{ $labels.app }}]
       severity: danger
       # Change <appname> to the name of the app you want to monitor and <namespace> to the namespace of the app
       expr: (100 * (sum by (backend) (rate(response_total{status_code=~"^5\\d\\d", namespace="team-mulighetsrommet", app="mulighetsrommet-api"}[3m])) / sum by (backend) (rate(response_total{namespace="team-mulighetsrommet", app="mulighetsrommet-api"}[3m])))) > 10
       for: 3m
-      action: "Sjekk loggene for å se hvorfor {{ $labels.app }} returnerer HTTP feilresponser"
-    - alert: Høy andel HTTP klientfeil (4xx responser)
+      action: "Sjekk loggene for å se hvorfor returnerer HTTP feilresponser"
+    - alert: Høy andel HTTP klientfeil (4xx responser) [${{ $labels.app }}]
       severity: warning
       # Change <appname> to the name of the app you want to monitor and <namespace> to the namespace of the app
       expr: (100 * (sum by (backend) (rate(response_total{status_code=~"^4(?!(?:09)$)\\d\\d", namespace="team-mulighetsrommet", app="mulighetsrommet-api"}[3m])) / sum by (backend) (rate(response_total{namespace="team-mulighetsrommet", app="mulighetsrommet-api"}[3m])))) > 10
       for: 3m
-      action: "Sjekk loggene for å se hvorfor {{ $labels.app }} returnerer HTTP feilresponser"
+      action: "Sjekk loggene for å se hvorfor returnerer HTTP feilresponser"

--- a/mulighetsrommet-api/alerts-api.yaml
+++ b/mulighetsrommet-api/alerts-api.yaml
@@ -39,6 +39,6 @@ spec:
     - alert: Høy andel HTTP klientfeil (4xx responser)
       severity: warning
       # Change <appname> to the name of the app you want to monitor and <namespace> to the namespace of the app
-      expr: (100 * (sum by (backend) (rate(response_total{status_code=~"^4\\d\\d", namespace="team-mulighetsrommet", app="mulighetsrommet-api"}[3m])) / sum by (backend) (rate(response_total{namespace="team-mulighetsrommet", app="mulighetsrommet-api"}[3m])))) > 10
+      expr: (100 * (sum by (backend) (rate(response_total{status_code=~"^4(?!(?:09)$)\\d\\d", namespace="team-mulighetsrommet", app="mulighetsrommet-api"}[3m])) / sum by (backend) (rate(response_total{namespace="team-mulighetsrommet", app="mulighetsrommet-api"}[3m])))) > 10
       for: 3m
       action: "Sjekk loggene for å se hvorfor {{ $labels.app }} returnerer HTTP feilresponser"

--- a/mulighetsrommet-arena-adapter/alerts-arena-adapter.yaml
+++ b/mulighetsrommet-arena-adapter/alerts-arena-adapter.yaml
@@ -7,12 +7,11 @@ metadata:
   namespace: team-mulighetsrommet
   labels:
     team: team-mulighetsrommet
+    app: mulighetsrommet-api
 spec:
   receivers:
     slack:
       channel: "#team-valp-feil"
-      # <!here> results in a @here message in Slack
-      prependText: " | "
   alerts:
     - alert: applikasjon nede
       # Change <appname> to the name of the app you want to monitor
@@ -30,15 +29,15 @@ spec:
       expr: selftests_aggregate_result_status{app="mulighetsrommet-arena-adapter"} > 0
       for: 1m
       action: "Sjekk app {{ $labels.app }} i namespace {{ $labels.kubernetes_namespace }} sine selftest for å se hva som er galt"
-    - alert: Høy andel HTTP serverfeil (5xx responser)
+    - alert: Høy andel HTTP serverfeil (5xx responser) [${{ $labels.app }}]
       severity: danger
       # Change <appname> to the name of the app you want to monitor and <namespace> to the namespace of the app
       expr: (100 * (sum by (backend) (rate(response_total{status_code=~"^5\\d\\d", namespace="team-mulighetsrommet", app="mulighetsrommet-arena-adapter"}[3m])) / sum by (backend) (rate(response_total{namespace="team-mulighetsrommet", app="mulighetsrommet-arena-adapter"}[3m])))) > 10
       for: 3m
-      action: "Sjekk loggene for for å se hvorfor {{ $labels.app }} returnerer HTTP feilresponser"
-    - alert: Høy andel HTTP klientfeil (4xx responser)
+      action: "Sjekk loggene for for å se hvorfor returnerer HTTP feilresponser"
+    - alert: Høy andel HTTP klientfeil (4xx responser) [${{ $labels.app }}]
       severity: warning
       # Change <appname> to the name of the app you want to monitor and <namespace> to the namespace of the app
       expr: (100 * (sum by (backend) (rate(response_total{status_code=~"^4\\d\\d", namespace="team-mulighetsrommet", app="mulighetsrommet-arena-adapter"}[3m])) / sum by (backend) (rate(response_total{namespace="team-mulighetsrommet", app="mulighetsrommet-arena-adapter"}[3m])))) > 10
       for: 3m
-      action: "Sjekk loggene for å se hvorfor {{ $labels.app }} returnerer HTTP feilresponser"
+      action: "Sjekk loggene for å se hvorfor returnerer HTTP feilresponser"

--- a/mulighetsrommet-arena-adapter/alerts-arena-adapter.yaml
+++ b/mulighetsrommet-arena-adapter/alerts-arena-adapter.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: team-mulighetsrommet
   labels:
     team: team-mulighetsrommet
-    app: mulighetsrommet-api
+    app: mulighetsrommet-arena-adapter
 spec:
   receivers:
     slack:


### PR DESCRIPTION
Filtrerer ut 409 conflicts på saker siden dette kan potensielt lage mye unødvendig støy i alerts. Fikset også manglende label.