### PR TITLE
Filtrer tiltak fra Sanity basert på en liste med innsatsgrupper

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -1,4 +1,8 @@
 describe('Tiltaksgjennomføringstabell', () => {
+  beforeEach(() => {
+    cy.resetSide();
+  });
+
   let antallTiltak;
   it('Sjekk at det er tiltaksgjennomføringer i tabellen', () => {
     cy.getByTestId('tabell_tiltaksgjennomforing').should('have.length.greaterThan', 1);
@@ -17,16 +21,16 @@ describe('Tiltaksgjennomføringstabell', () => {
   it('Filtrer på Innsatsgrupper', () => {
     cy.velgFilter('standardinnsats');
 
-    cy.getByTestId('filtertags').children().should('have.length', 4);
+    cy.getByTestId('filtertags').children().should('have.length', 3);
     cy.getByTestId('knapp_tilbakestill-filter').should('exist');
 
-    cy.wait(1000);
     cy.getByTestId('antall-tiltak').then($navn => {
       expect(antallTiltak).not.to.eq($navn.text());
     });
 
     cy.getByTestId('filtertag_lukkeknapp_standardinnsats').click();
     cy.getByTestId('filtertags').children().should('have.length', 2);
+    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
   });
 
   it('Filtrer på Tiltakstyper', () => {
@@ -36,11 +40,9 @@ describe('Tiltaksgjennomføringstabell', () => {
 
     cy.getByTestId('filtertags').children().should('have.length', 5);
 
-    cy.wait(1000)
-      .getByTestId('antall-tiltak')
-      .then($navn => {
-        expect(antallTiltak).not.to.eq($navn.text());
-      });
+    cy.getByTestId('antall-tiltak').then($navn => {
+      expect(antallTiltak).not.to.eq($navn.text());
+    });
 
     cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
 
@@ -56,11 +58,9 @@ describe('Tiltaksgjennomføringstabell', () => {
     cy.getByTestId('filter_sokefelt').type('AFT');
     cy.getByTestId('filtertags').children().should('have.length', 3);
 
-    cy.wait(1000)
-      .getByTestId('antall-tiltak')
-      .then($navn => {
-        expect(antallTiltak).not.to.eq($navn.text());
-      });
+    cy.getByTestId('antall-tiltak').then($navn => {
+      expect(antallTiltak).not.to.eq($navn.text());
+    });
     cy.getByTestId('filter_sokefelt').clear();
     cy.getByTestId('filtertags').children().should('have.length', 2);
   });
@@ -116,7 +116,6 @@ describe('Tiltaksgjennomføringsdetaljer', () => {
 
   it('Skal ha ferdig utfylt brukers innsatsgruppe', () => {
     // Situasjonsbestemt innsats er innsatsgruppe som returneres når testene kjører med mock-data
-    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
     cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
     cy.getByTestId('filtertags').children().should('have.length', 2);
     cy.getByTestId('knapp_tilbakestill-filter').should('not.exist');
@@ -128,12 +127,11 @@ describe('Tiltaksgjennomføringsdetaljer', () => {
 
   it('Skal huske filtervalg mellom detaljvisning og listevisning', () => {
     cy.getByTestId('filter_checkbox_standardinnsats').click();
-    cy.getByTestId('filtertags').children().should('have.length', 4);
+    cy.getByTestId('filtertags').children().should('have.length', 3);
     cy.getByTestId('tabell_tiltaksgjennomforing').first().click();
     cy.tilbakeTilListevisning();
-    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
     cy.getByTestId('filter_checkbox_standardinnsats').should('be.checked');
-    cy.getByTestId('filtertags').children().should('have.length', 4);
+    cy.getByTestId('filtertags').children().should('have.length', 3);
   });
 
   it('Skal vise korrekt feilmelding dersom ingen tiltaksgjennomføringer blir funnet', () => {

--- a/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
@@ -43,6 +43,19 @@ import 'cypress-axe';
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+// https://github.com/cypress-io/cypress/issues/7362#issuecomment-944273204
+// Hide fetch/XHR requests
+const app = window.top;
+
+if (!app.document.head.querySelector('[data-hide-command-log-request]')) {
+  const style = app.document.createElement('style');
+  style.innerHTML = '.command-name-request, .command-name-xhr { display: none }';
+  style.setAttribute('data-hide-command-log-request', '');
+
+  app.document.head.appendChild(style);
+}
+
 before('Start server', () => {
   cy.server();
   cy.visit('/');
@@ -55,17 +68,22 @@ before('Start server', () => {
   cy.getByTestId('tiltakstype-oversikt').children().should('have.length.greaterThan', 1);
 });
 
+Cypress.Commands.add('resetSide', () => {
+  cy.visit('/');
+});
+
 Cypress.Commands.add('getByTestId', (selector, ...args) => {
   return cy.get(`[data-testid=${selector}]`, ...args);
 });
 
 Cypress.Commands.add('velgFilter', filternavn => {
-  cy.getByTestId(`filter_checkbox_${filternavn}`).should('not.be.checked').click().should('be.checked');
+  cy.getByTestId(`filter_checkbox_${filternavn}`).click();
+  cy.getByTestId(`filter_checkbox_${filternavn}`).should('be.checked');
   cy.getByTestId(`filtertag_${filternavn}`).should('exist');
 });
 
 Cypress.Commands.add('fjernFilter', filternavn => {
-  cy.getByTestId(`filter_checkbox_${filternavn}`).should('be.checked').click().should('not.be.checked');
+  cy.getByTestId(`filtertag_lukkeknapp_${filternavn}`).click();
   cy.getByTestId(`filtertag_${filternavn}`).should('not.exist');
 });
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
@@ -25,12 +25,24 @@ const Filtermeny = () => {
       <Searchfield sokefilter={filter.search!} setSokefilter={(search: string) => setFilter({ ...filter, search })} />
       <InnsatsgruppeFilter
         accordionNavn="Innsatsgruppe"
-        option={filter.innsatsgruppe!}
-        key={filter.innsatsgruppe}
-        setOption={innsatsgruppe => setFilter({ ...filter, innsatsgruppe })}
+        option={filter.innsatsgruppe?.nokkel}
+        key={filter.innsatsgruppe?.nokkel}
+        setOption={innsatsgruppe => {
+          const foundInnsatsgruppe = innsatsgrupper.data?.find(gruppe => gruppe.nokkel === innsatsgruppe);
+          if (foundInnsatsgruppe) {
+            setFilter({
+              ...filter,
+              innsatsgruppe: {
+                id: foundInnsatsgruppe?._id,
+                tittel: foundInnsatsgruppe?.tittel,
+                nokkel: foundInnsatsgruppe?.nokkel,
+              },
+            });
+          }
+        }}
         data={
           innsatsgrupper.data?.map(innsatsgruppe => {
-            return innsatsgruppe.tittel;
+            return { id: innsatsgruppe._id, tittel: innsatsgruppe.tittel, nokkel: innsatsgruppe.nokkel };
           }) ?? []
         }
         isLoading={innsatsgrupper.isLoading}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
@@ -8,6 +8,7 @@ import CheckboxFilter from './CheckboxFilter';
 import { useInnsatsgrupper } from '../../core/api/queries/useInnsatsgrupper';
 import { useTiltakstyper } from '../../core/api/queries/useTiltakstyper';
 import { usePrepopulerFilter } from '../../hooks/usePrepopulerFilter';
+import InnsatsgruppeFilter from './InnsatsgruppeFilter';
 
 const Filtermeny = () => {
   const [filter, setFilter] = useAtom(tiltaksgjennomforingsfilter);
@@ -22,17 +23,14 @@ const Filtermeny = () => {
         Filter
       </Heading>
       <Searchfield sokefilter={filter.search!} setSokefilter={(search: string) => setFilter({ ...filter, search })} />
-      <CheckboxFilter
-        accordionNavn="Innsatsgrupper"
-        options={filter.innsatsgrupper!}
-        setOptions={innsatsgrupper => setFilter({ ...filter, innsatsgrupper })}
+      <InnsatsgruppeFilter
+        accordionNavn="Innsatsgruppe"
+        option={filter.innsatsgruppe!}
+        key={filter.innsatsgruppe}
+        setOption={innsatsgruppe => setFilter({ ...filter, innsatsgruppe })}
         data={
           innsatsgrupper.data?.map(innsatsgruppe => {
-            return {
-              id: innsatsgruppe._id,
-              tittel: innsatsgruppe.tittel,
-              nokkel: innsatsgruppe.nokkel,
-            };
+            return innsatsgruppe.tittel;
           }) ?? []
         }
         isLoading={innsatsgrupper.isLoading}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/InnsatsgruppeFilter.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/InnsatsgruppeFilter.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Accordion, Alert, Loader, Radio, RadioGroup } from '@navikt/ds-react';
+import './Filtermeny.less';
+import { kebabCase } from '../../utils/Utils';
+import { InnsatsgruppeNokler } from '../../core/api/models';
+
+interface InnsatsgruppeFilterProps {
+  accordionNavn: string;
+  option: InnsatsgruppeNokler;
+  setOption: (type: InnsatsgruppeNokler) => void;
+  data: string[];
+  isLoading: boolean;
+  isError: boolean;
+  defaultOpen?: boolean;
+}
+
+const InnsatsgruppeFilter = ({
+  accordionNavn,
+  option,
+  setOption,
+  data,
+  isLoading,
+  isError,
+  defaultOpen = false,
+}: InnsatsgruppeFilterProps) => {
+  const radiobox = (filtertype: InnsatsgruppeNokler) => {
+    return (
+      <Radio value={filtertype} key={`${filtertype}`} data-testid={`filter_checkbox_${kebabCase(filtertype)}`}>
+        {filtertype}
+      </Radio>
+    );
+  };
+
+  return (
+    <Accordion role="menu">
+      <Accordion.Item defaultOpen={defaultOpen}>
+        <Accordion.Header data-testid={`filter_accordionheader_${kebabCase(accordionNavn)}`}>
+          {accordionNavn}
+        </Accordion.Header>
+        <Accordion.Content role="menuitem" data-testid={`filter_accordioncontent_${kebabCase(accordionNavn)}`}>
+          {isLoading && <Loader className="filter-loader" size="xlarge" />}
+          {data && (
+            <RadioGroup
+              legend=""
+              hideLegend
+              size="small"
+              onChange={(e: InnsatsgruppeNokler) => {
+                setOption(e);
+              }}
+              value={option}
+            >
+              {data.map(radiobox)}
+            </RadioGroup>
+          )}
+          {isError && <Alert variant="error">Det har skjedd en feil</Alert>}
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+};
+
+export default InnsatsgruppeFilter;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/InnsatsgruppeFilter.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/InnsatsgruppeFilter.tsx
@@ -1,20 +1,19 @@
-import React from 'react';
 import { Accordion, Alert, Loader, Radio, RadioGroup } from '@navikt/ds-react';
-import './Filtermeny.less';
-import { kebabCase } from '../../utils/Utils';
 import { InnsatsgruppeNokler } from '../../core/api/models';
+import { kebabCase } from '../../utils/Utils';
+import './Filtermeny.less';
 
-interface InnsatsgruppeFilterProps {
+interface InnsatsgruppeFilterProps<T extends { id: string; tittel: string; nokkel?: InnsatsgruppeNokler }> {
   accordionNavn: string;
-  option: InnsatsgruppeNokler;
+  option?: InnsatsgruppeNokler;
   setOption: (type: InnsatsgruppeNokler) => void;
-  data: string[];
+  data: T[];
   isLoading: boolean;
   isError: boolean;
   defaultOpen?: boolean;
 }
 
-const InnsatsgruppeFilter = ({
+const InnsatsgruppeFilter = <T extends { id: string; tittel: string; nokkel?: InnsatsgruppeNokler }>({
   accordionNavn,
   option,
   setOption,
@@ -22,11 +21,15 @@ const InnsatsgruppeFilter = ({
   isLoading,
   isError,
   defaultOpen = false,
-}: InnsatsgruppeFilterProps) => {
-  const radiobox = (filtertype: InnsatsgruppeNokler) => {
+}: InnsatsgruppeFilterProps<T>) => {
+  const radiobox = (option: T) => {
     return (
-      <Radio value={filtertype} key={`${filtertype}`} data-testid={`filter_checkbox_${kebabCase(filtertype)}`}>
-        {filtertype}
+      <Radio
+        value={option.nokkel}
+        key={`${option.id}`}
+        data-testid={`filter_checkbox_${kebabCase(option?.tittel ?? '')}`}
+      >
+        {option.tittel}
       </Radio>
     );
   };

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tags/Filtertags.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tags/Filtertags.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { Tag } from '@navikt/ds-react';
 import { Close } from '@navikt/ds-icons';
+import { Tag } from '@navikt/ds-react';
+import { kebabCase } from '../../utils/Utils';
 import Ikonknapp from '../knapper/Ikonknapp';
 import './Filtertags.less';
-import { kebabCase } from '../../utils/Utils';
 
 interface FilterTagsProps {
   options: { id: string; tittel: string }[];

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
@@ -93,7 +93,7 @@ export interface Innsatsgruppe {
   _id: string;
   beskrivelse: string;
   tittel: Innsatsgrupper;
-  nokkel: string;
+  nokkel: InnsatsgruppeNokler;
 }
 
 export interface RegelverkFil {
@@ -129,3 +129,9 @@ export interface StatistikkFraCsvFil {
   Tiltakstype: string;
   Ukjent: string;
 }
+
+export type InnsatsgruppeNokler =
+  | 'STANDARD_INNSATS'
+  | 'SITUASJONSBESTEMT_INNSATS'
+  | 'SPESIELT_TILPASSET_INNSATS'
+  | 'VARIG_TILPASSET_INNSATS';

--- a/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
@@ -3,14 +3,14 @@ import { InnsatsgruppeNokler } from '../api/models';
 
 export interface Tiltaksgjennomforingsfilter {
   search?: string;
-  innsatsgruppe?: InnsatsgruppeNokler;
-  tiltakstyper: Tiltaksgjennomforingsfiltergruppe[];
+  innsatsgruppe?: Tiltaksgjennomforingsfiltergruppe<InnsatsgruppeNokler>;
+  tiltakstyper: Tiltaksgjennomforingsfiltergruppe<string>[];
 }
 
-export interface Tiltaksgjennomforingsfiltergruppe {
+export interface Tiltaksgjennomforingsfiltergruppe<T> {
   id: string;
   tittel: string;
-  nokkel?: string;
+  nokkel?: T;
 }
 
 export const initialTiltaksgjennomforingsfilter = {

--- a/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
@@ -1,8 +1,9 @@
 import { atomWithHash } from 'jotai/utils';
+import { InnsatsgruppeNokler } from '../api/models';
 
 export interface Tiltaksgjennomforingsfilter {
   search?: string;
-  innsatsgrupper: Tiltaksgjennomforingsfiltergruppe[];
+  innsatsgruppe?: InnsatsgruppeNokler;
   tiltakstyper: Tiltaksgjennomforingsfiltergruppe[];
 }
 
@@ -14,7 +15,7 @@ export interface Tiltaksgjennomforingsfiltergruppe {
 
 export const initialTiltaksgjennomforingsfilter = {
   search: '',
-  innsatsgrupper: [],
+  innsatsgruppe: undefined,
   tiltakstyper: [],
 };
 

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
@@ -15,7 +15,9 @@ export function usePrepopulerFilter() {
     if (matchedInnsatsgruppe) {
       const tiltakstyper = resetFilterTilUtgangspunkt ? [] : filter.tiltakstyper;
       const search = resetFilterTilUtgangspunkt ? '' : filter.search;
-      const innsatsgruppe = resetFilterTilUtgangspunkt ? matchedInnsatsgruppe.nokkel : filter.innsatsgruppe;
+      const innsatsgruppe = resetFilterTilUtgangspunkt
+        ? { id: matchedInnsatsgruppe._id, nokkel: matchedInnsatsgruppe.nokkel, tittel: matchedInnsatsgruppe.tittel }
+        : filter.innsatsgruppe;
       setFilter({
         search,
         tiltakstyper,

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
@@ -15,13 +15,11 @@ export function usePrepopulerFilter() {
     if (matchedInnsatsgruppe) {
       const tiltakstyper = resetFilterTilUtgangspunkt ? [] : filter.tiltakstyper;
       const search = resetFilterTilUtgangspunkt ? '' : filter.search;
-      const innsatsgrupper = resetFilterTilUtgangspunkt
-        ? [{ id: matchedInnsatsgruppe._id, ...matchedInnsatsgruppe }]
-        : [...filter.innsatsgrupper.filter(gruppe => gruppe.id !== matchedInnsatsgruppe._id)];
+      const innsatsgruppe = resetFilterTilUtgangspunkt ? matchedInnsatsgruppe.nokkel : filter.innsatsgruppe;
       setFilter({
         search,
         tiltakstyper,
-        innsatsgrupper,
+        innsatsgruppe,
       });
     }
   }

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -6,7 +6,7 @@ import Filtermeny from '../../components/filtrering/Filtermeny';
 import TiltaksgjennomforingsTabell from '../../components/tabell/TiltaksgjennomforingsTabell';
 import FilterTags from '../../components/tags/Filtertags';
 import SearchFieldTag from '../../components/tags/SearchFieldTag';
-import { tiltaksgjennomforingsfilter, Tiltaksgjennomforingsfiltergruppe } from '../../core/atoms/atoms';
+import { tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
 import '../../layouts/TiltaksgjennomforingsHeader.less';
 import Show from '../../utils/Show';
 import './ViewTiltakstypeOversikt.less';
@@ -15,6 +15,7 @@ import { useHentBrukerdata } from '../../core/api/queries/useHentBrukerdata';
 import { kebabCase } from '../../utils/Utils';
 import { useErrorHandler } from 'react-error-boundary';
 import { useInnsatsgrupper } from '../../core/api/queries/useInnsatsgrupper';
+import { InnsatsgruppeNokler } from '../../core/api/models';
 
 function BrukersOppfolgingsenhet() {
   const brukerdata = useHentBrukerdata();
@@ -50,8 +51,9 @@ const ViewTiltakstypeOversikt = () => {
 
   useErrorHandler(brukerdata?.error);
 
-  const brukersInnsatsgruppeErIkkeValgt = (gruppe: Tiltaksgjennomforingsfiltergruppe) =>
-    gruppe.nokkel !== brukerdata?.data?.innsatsgruppe;
+  const brukersInnsatsgruppeErIkkeValgt = (innsatsgruppe?: InnsatsgruppeNokler) => {
+    return innsatsgruppe !== brukerdata?.data?.innsatsgruppe;
+  };
 
   return (
     <div className="tiltakstype-oversikt" id="tiltakstype-oversikt" data-testid="tiltakstype-oversikt">
@@ -59,15 +61,22 @@ const ViewTiltakstypeOversikt = () => {
       <div className="filtercontainer">
         <div className="filtertags" data-testid="filtertags">
           <BrukersOppfolgingsenhet />
-          <FilterTags
-            options={filter.innsatsgrupper!}
-            handleClick={(id: string) => {
-              setFilter({
-                ...filter,
-                innsatsgrupper: [...filter.innsatsgrupper?.filter(innsatsgruppe => innsatsgruppe.id !== id)],
-              });
-            }}
-          />
+          {filter.innsatsgruppe && (
+            <FilterTags
+              options={[
+                {
+                  id: filter.innsatsgruppe,
+                  tittel: filter.innsatsgruppe,
+                },
+              ]}
+              handleClick={() => {
+                setFilter({
+                  ...filter,
+                  innsatsgruppe: undefined,
+                });
+              }}
+            />
+          )}
           <FilterTags
             options={filter.tiltakstyper!}
             handleClick={(id: string) =>
@@ -81,8 +90,8 @@ const ViewTiltakstypeOversikt = () => {
           <Show
             if={
               !innsatsgrupper.isLoading &&
-              (filter.innsatsgrupper.length === 0 ||
-                filter.innsatsgrupper.some(brukersInnsatsgruppeErIkkeValgt) ||
+              (filter.innsatsgruppe! === undefined ||
+                brukersInnsatsgruppeErIkkeValgt(filter.innsatsgruppe) ||
                 filter.search !== '' ||
                 filter.tiltakstyper.length > 0)
             }

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -63,12 +63,7 @@ const ViewTiltakstypeOversikt = () => {
           <BrukersOppfolgingsenhet />
           {filter.innsatsgruppe && (
             <FilterTags
-              options={[
-                {
-                  id: filter.innsatsgruppe,
-                  tittel: filter.innsatsgruppe,
-                },
-              ]}
+              options={[filter.innsatsgruppe]}
               handleClick={() => {
                 setFilter({
                   ...filter,
@@ -91,7 +86,7 @@ const ViewTiltakstypeOversikt = () => {
             if={
               !innsatsgrupper.isLoading &&
               (filter.innsatsgruppe! === undefined ||
-                brukersInnsatsgruppeErIkkeValgt(filter.innsatsgruppe) ||
+                brukersInnsatsgruppeErIkkeValgt(filter.innsatsgruppe.nokkel) ||
                 filter.search !== '' ||
                 filter.tiltakstyper.length > 0)
             }


### PR DESCRIPTION
Når en veileder velger en innsatsgruppe, så skal vi nå vise alle tiltaksgjennomføringer som brukeren har rett på, gitt innsatsgruppen.

Feks. 
Bruker tilhører `Situasjonsbestemt innsats`. Da skal veileder få opp både `Standard innsats og Situasjonsbestemte innsats` sine tiltak. 

```js
switch (innsatsgruppe) {
    case 'STANDARD_INNSATS':
      return ['STANDARD_INNSATS'];
    case 'SITUASJONSBESTEMT_INNSATS':
      return ['STANDARD_INNSATS', 'SITUASJONSBESTEMT_INNSATS'];
    case 'SPESIELT_TILPASSET_INNSATS':
      return ['STANDARD_INNSATS', 'SITUASJONSBESTEMT_INNSATS', 'SPESIELT_TILPASSET_INNSATS'];
    case 'VARIG_TILPASSET_INNSATS':
      return ['STANDARD_INNSATS', 'SITUASJONSBESTEMT_INNSATS', 'SPESIELT_TILPASSET_INNSATS', 'VARIG_TILPASSET_INNSATS'];
  }
```