### PR TITLE
FRONTEND - Vis historikk mock

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -21,7 +21,7 @@ describe('Tiltaksgjennomføringstabell', () => {
   it('Filtrer på Innsatsgrupper', () => {
     cy.velgFilter('standardinnsats');
 
-    cy.getByTestId('filtertags').children().should('have.length', 3);
+    cy.forventetAntallFiltertags(2);
     cy.getByTestId('knapp_tilbakestill-filter').should('exist');
 
     cy.wait(1000);
@@ -30,7 +30,7 @@ describe('Tiltaksgjennomføringstabell', () => {
     });
 
     cy.getByTestId('filtertag_lukkeknapp_standardinnsats').click();
-    cy.getByTestId('filtertags').children().should('have.length', 2);
+    cy.forventetAntallFiltertags(1);
     cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
   });
 
@@ -39,7 +39,7 @@ describe('Tiltaksgjennomføringstabell', () => {
     cy.velgFilter('avklaring');
     cy.velgFilter('oppfolging');
 
-    cy.getByTestId('filtertags').children().should('have.length', 5);
+    cy.forventetAntallFiltertags(4);
 
     cy.wait(1000);
     cy.getByTestId('antall-tiltak').then($navn => {
@@ -51,21 +51,23 @@ describe('Tiltaksgjennomføringstabell', () => {
     cy.getByTestId('filter_checkbox_avklaring').should('not.be.checked');
     cy.getByTestId('filter_checkbox_oppfolging').should('not.be.checked');
 
-    cy.getByTestId('filtertags').children().should('have.length', 2);
+    cy.forventetAntallFiltertags(2);
     cy.apneLukketFilterAccordion('tiltakstyper', false);
   });
 
   it('Filtrer på søkefelt', () => {
     cy.fjernFilter('situasjonsbestemt-innsats');
     cy.getByTestId('filter_sokefelt').type('AFT');
-    cy.getByTestId('filtertags').children().should('have.length', 3);
+    // cy.getByTestId('filtertags').children().should('have.length', 3);
+    cy.forventetAntallFiltertags(2);
 
     cy.wait(1000);
     cy.getByTestId('antall-tiltak').then($navn => {
       expect(antallTiltak).not.to.eq($navn.text());
     });
     cy.getByTestId('filter_sokefelt').clear();
-    cy.getByTestId('filtertags').children().should('have.length', 2);
+    // cy.getByTestId('filtertags').children().should('have.length', 2);
+    cy.forventetAntallFiltertags(1);
   });
 
   it('Skal vise tilbakestill filter-knapp når filter utenfor normalen', () => {
@@ -85,7 +87,7 @@ describe('Tiltaksgjennomføringstabell', () => {
   it('Skal ha ferdig utfylt brukers innsatsgruppe', () => {
     // Situasjonsbestemt innsats er innsatsgruppe som returneres når testene kjører med mock-data
     cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
-    cy.getByTestId('filtertags').children().should('have.length', 2);
+    cy.forventetAntallFiltertags(2);
     cy.getByTestId('knapp_tilbakestill-filter').should('not.exist');
 
     cy.getByTestId('filtertag_situasjonsbestemt-innsats').then($value => {
@@ -95,11 +97,13 @@ describe('Tiltaksgjennomføringstabell', () => {
 
   it('Skal huske filtervalg mellom detaljvisning og listevisning', () => {
     cy.getByTestId('filter_checkbox_standardinnsats').click();
-    cy.getByTestId('filtertags').children().should('have.length', 3);
+    // cy.getByTestId('filtertags').children().should('have.length', 3);
+    cy.forventetAntallFiltertags(2);
     cy.getByTestId('tabell_tiltaksgjennomforing').first().click();
     cy.tilbakeTilListevisning();
     cy.getByTestId('filter_checkbox_standardinnsats').should('be.checked');
-    cy.getByTestId('filtertags').children().should('have.length', 3);
+    // cy.getByTestId('filtertags').children().should('have.length', 3);
+    cy.forventetAntallFiltertags(2);
   });
 
   it('Skal vise korrekt feilmelding dersom ingen tiltaksgjennomføringer blir funnet', () => {

--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -58,7 +58,6 @@ describe('Tiltaksgjennomføringstabell', () => {
   it('Filtrer på søkefelt', () => {
     cy.fjernFilter('situasjonsbestemt-innsats');
     cy.getByTestId('filter_sokefelt').type('AFT');
-    // cy.getByTestId('filtertags').children().should('have.length', 3);
     cy.forventetAntallFiltertags(2);
 
     cy.wait(1000);
@@ -66,7 +65,6 @@ describe('Tiltaksgjennomføringstabell', () => {
       expect(antallTiltak).not.to.eq($navn.text());
     });
     cy.getByTestId('filter_sokefelt').clear();
-    // cy.getByTestId('filtertags').children().should('have.length', 2);
     cy.forventetAntallFiltertags(1);
   });
 
@@ -97,12 +95,10 @@ describe('Tiltaksgjennomføringstabell', () => {
 
   it('Skal huske filtervalg mellom detaljvisning og listevisning', () => {
     cy.getByTestId('filter_checkbox_standardinnsats').click();
-    // cy.getByTestId('filtertags').children().should('have.length', 3);
     cy.forventetAntallFiltertags(2);
     cy.getByTestId('tabell_tiltaksgjennomforing').first().click();
     cy.tilbakeTilListevisning();
     cy.getByTestId('filter_checkbox_standardinnsats').should('be.checked');
-    // cy.getByTestId('filtertags').children().should('have.length', 3);
     cy.forventetAntallFiltertags(2);
   });
 

--- a/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
@@ -87,6 +87,10 @@ Cypress.Commands.add('fjernFilter', filternavn => {
   cy.getByTestId(`filtertag_${filternavn}`).should('not.exist');
 });
 
+Cypress.Commands.add('forventetAntallFiltertags', antallForventet => {
+  cy.get('.cypress-tag').should('have.length', antallForventet);
+});
+
 Cypress.Commands.add('apneLukketFilterAccordion', (filternavn, apne) => {
   if (apne) {
     cy.getByTestId(`filter_accordionheader_${filternavn}`).click();

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.tsx
@@ -7,7 +7,7 @@ import { HistorikkForBruker } from './HistorikkForBruker';
 import './HistorikkForBruker.less';
 
 export function HistorikkButton() {
-  const [apneModal, setApneModal] = useState(true);
+  const [apneModal, setApneModal] = useState(false);
   const features = useFeatureToggles();
   const toggleModal = () => setApneModal(!apneModal);
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.tsx
@@ -7,7 +7,7 @@ import { HistorikkForBruker } from './HistorikkForBruker';
 import './HistorikkForBruker.less';
 
 export function HistorikkButton() {
-  const [apneModal, setApneModal] = useState(false);
+  const [apneModal, setApneModal] = useState(true);
   const features = useFeatureToggles();
   const toggleModal = () => setApneModal(!apneModal);
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@navikt/ds-react';
+import { useState } from 'react';
+import { useFeatureToggles, VIS_HISTORIKK } from '../../core/api/feature-toggles';
+import { useHentHistorikk } from '../../core/api/queries/useHentHistorikk';
+import StandardModal from '../modal/StandardModal';
+import { HistorikkForBruker } from './HistorikkForBruker';
+import './HistorikkForBruker.less';
+
+export function HistorikkButton() {
+  const [apneModal, setApneModal] = useState(false);
+  const features = useFeatureToggles();
+  const toggleModal = () => setApneModal(!apneModal);
+
+  const visHistorikkKnapp = features.isSuccess && features.data[VIS_HISTORIKK];
+  useHentHistorikk(visHistorikkKnapp);
+
+  if (!visHistorikkKnapp) return null;
+
+  return (
+    <>
+      <Button onClick={toggleModal}>Historikk</Button>
+      <StandardModal
+        className="historikk-modal"
+        hideButtons
+        modalOpen={apneModal}
+        setModalOpen={toggleModal}
+        heading="Aktivitet"
+        handleForm={() => {}}
+      >
+        <HistorikkForBruker />
+      </StandardModal>
+    </>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.less
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.less
@@ -2,6 +2,10 @@
     color: var(--navds-global-color-semantic-text);
     padding-bottom: 10rem;
 
+    .historikk-text-content {
+        margin: 0;
+    }
+
     .historikk-for-bruker-liste {
         list-style: none;
         padding: 0;
@@ -30,7 +34,6 @@
     }
 
     .historikk-for-bruker-statusbadge {
-        
         display: inline-block;
         text-align: center;
         border-radius: 5%;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.less
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.less
@@ -1,0 +1,71 @@
+.historikk-for-bruker {
+    color: var(--navds-global-color-semantic-text);
+    padding-bottom: 10rem;
+
+    .historikk-for-bruker-liste {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+    
+    .historikk-for-bruker-heading {
+        margin: 1rem 0rem 0rem 0rem;
+    }
+    
+    .historikk-for-bruker-element {
+        border-bottom: 2px solid var(--navds-semantic-color-border-inverted);
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+    }
+
+    .historikk-for-bruker-metadata {
+        color: var(--navds-semantic-color-text-muted);
+        min-width: 150px;
+        display: grid;
+        grid-gap: 2rem;
+        grid-template-columns: repeat(2, 1fr);
+        margin-bottom: 1rem;
+        margin-top: 0.2rem;
+    }
+
+    .historikk-for-bruker-statusbadge {
+        
+        display: inline-block;
+        text-align: center;
+        border-radius: 5%;
+        padding: 0.2rem;
+        font-size: 0.8rem;
+    }
+    
+    .historikk-for-bruker-statusbadgde-farge {
+        &-AVSLUTTET {
+            background: var(--navds-global-color-gray-100);
+            color: var(--navds-global-color-gray-800);
+            
+        }
+        
+        &-DELTAR {
+            background: var(--navds-global-color-green-100);
+            color: var(--navds-global-color-green-800);
+            
+        }
+        
+        &-IKKE_AKTUELL {
+            background: var(--navds-global-color-red-100);
+            color: var(--navds-global-color-red-900);
+            
+        }
+        
+        &-VENTER {
+            background: var(--navds-global-color-lightblue-100);
+            color: var(--navds-global-color-lightblue-800);
+            
+        }
+    }
+}
+
+.historikk-modal {
+    width: calc(100% - 20rem);
+    max-width: 70%;
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.tsx
@@ -39,7 +39,7 @@ export function HistorikkForBruker() {
         {data?.map(historikk => {
           return (
             <li key={historikk.id} className="historikk-for-bruker-element">
-              <section>
+              <div>
                 <h1 className="historikk-for-bruker-heading navds-heading navds-heading--small">
                   {historikk.tiltaksnavn}
                 </h1>
@@ -50,7 +50,7 @@ export function HistorikkForBruker() {
                 <p className="historikk-text-content">
                   {formaterDato(historikk.fra_dato)} - {formaterDato(historikk.til_dato)}
                 </p>
-              </section>
+              </div>
               <aside>
                 <StatusBadge status={historikk.status} />
               </aside>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.tsx
@@ -39,19 +39,21 @@ export function HistorikkForBruker() {
         {data?.map(historikk => {
           return (
             <li key={historikk.id} className="historikk-for-bruker-element">
-              <div>
-                <h3 className="historikk-for-bruker-heading">{historikk.tiltaksnavn}</h3>
+              <section>
+                <h1 className="historikk-for-bruker-heading navds-heading navds-heading--small">
+                  {historikk.tiltaksnavn}
+                </h1>
                 <div className="historikk-for-bruker-metadata">
-                  <span>{historikk.tiltakstype}</span>
-                  <span>{historikk.arrangor}</span>
+                  <p className="historikk-text-content">{historikk.tiltakstype}</p>
+                  <p className="historikk-text-content">{historikk.arrangor}</p>
                 </div>
-                <span>
+                <p className="historikk-text-content">
                   {formaterDato(historikk.fra_dato)} - {formaterDato(historikk.til_dato)}
-                </span>
-              </div>
-              <div>
+                </p>
+              </section>
+              <aside>
                 <StatusBadge status={historikk.status} />
-              </div>
+              </aside>
             </li>
           );
         })}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkForBruker.tsx
@@ -1,0 +1,61 @@
+import { Alert, Loader } from '@navikt/ds-react';
+import classNames from 'classnames';
+import { Deltakerstatus, useHentHistorikk } from '../../core/api/queries/useHentHistorikk';
+import { formaterDato } from '../../utils/Utils';
+import './HistorikkForBruker.less';
+
+function StatusBadge({ status }: { status: Deltakerstatus }) {
+  return (
+    <div
+      className={classNames('historikk-for-bruker-statusbadge', `historikk-for-bruker-statusbadgde-farge-${status}`)}
+    >
+      {statustekst(status)}
+    </div>
+  );
+}
+
+function statustekst(status: Deltakerstatus): string {
+  switch (status) {
+    case 'AVSLUTTET':
+      return 'Fullført';
+    case 'DELTAR':
+      return 'Deltar';
+    case 'IKKE_AKTUELL':
+      return 'Ikke aktuell';
+    case 'VENTER':
+      return 'Venter på oppstart';
+  }
+}
+
+export function HistorikkForBruker() {
+  const { data, isLoading, isError } = useHentHistorikk();
+  if (isLoading) return <Loader />;
+
+  if (isError) return <Alert variant="error">Klarte ikke hente historikk for bruker</Alert>;
+
+  return (
+    <div className="historikk-for-bruker">
+      <ul className="historikk-for-bruker-liste">
+        {data?.map(historikk => {
+          return (
+            <li key={historikk.id} className="historikk-for-bruker-element">
+              <div>
+                <h3 className="historikk-for-bruker-heading">{historikk.tiltaksnavn}</h3>
+                <div className="historikk-for-bruker-metadata">
+                  <span>{historikk.tiltakstype}</span>
+                  <span>{historikk.arrangor}</span>
+                </div>
+                <span>
+                  {formaterDato(historikk.fra_dato)} - {formaterDato(historikk.til_dato)}
+                </span>
+              </div>
+              <div>
+                <StatusBadge status={historikk.status} />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/StandardModal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/StandardModal.tsx
@@ -13,6 +13,7 @@ interface StandardModalModalProps {
   btnText?: string;
   children: React.ReactNode;
   shouldCloseOnOverlayClick?: boolean;
+  hideButtons?: boolean;
 }
 
 const StandardModal = ({
@@ -25,6 +26,7 @@ const StandardModal = ({
   btnText,
   children,
   shouldCloseOnOverlayClick,
+  hideButtons = false,
 }: StandardModalModalProps) => {
   const clickSend = () => {
     setModalOpen();
@@ -50,14 +52,16 @@ const StandardModal = ({
           {heading}
         </Heading>
         {children}
-        <div className="modal_btngroup">
-          <Button onClick={clickSend} data-testid="modal_btn-send">
-            {btnText || 'Send'}
-          </Button>
-          <Button variant="tertiary" onClick={clickCancel} data-testid="modal_btn-cancel">
-            Avbryt
-          </Button>
-        </div>
+        {!hideButtons ? (
+          <div className="modal_btngroup">
+            <Button onClick={clickSend} data-testid="modal_btn-send">
+              {btnText || 'Send'}
+            </Button>
+            <Button variant="tertiary" onClick={clickCancel} data-testid="modal_btn-cancel">
+              Avbryt
+            </Button>
+          </div>
+        ) : null}
       </Modal.Content>
     </Modal>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/components/oppfolgingsenhet/BrukerOppfolgingsenhet.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/oppfolgingsenhet/BrukerOppfolgingsenhet.tsx
@@ -12,7 +12,7 @@ export function BrukersOppfolgingsenhet() {
 
   return brukersOppfolgingsenhet ? (
     <Tag
-      className={'nav-enhet-tag'}
+      className="nav-enhet-tag cypress-tag"
       key={'navenhet'}
       variant={brukersOppfolgingsenhet ? 'info' : 'error'}
       size="small"

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tags/Filtertags.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tags/Filtertags.tsx
@@ -15,6 +15,7 @@ const FilterTags = ({ options, handleClick }: FilterTagsProps) => {
       {options.map(filtertype => {
         return (
           <Tag
+            className="cypress-tag"
             key={filtertype.id}
             variant="info"
             size="small"

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tags/SearchFieldTag.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tags/SearchFieldTag.tsx
@@ -17,7 +17,7 @@ const SearchFieldTag = () => {
   return (
     <>
       {filter.search && (
-        <Tag variant="info" size="small">
+        <Tag className="cypress-tag" variant="info" size="small">
           {`'${filter.search}'`}
           <Ikonknapp handleClick={handleClickFjernFilter} ariaLabel="Lukkeknapp">
             <Close className="filtertags__ikon" aria-label="Lukkeknapp" />

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/feature-toggles.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/feature-toggles.ts
@@ -4,19 +4,22 @@ import { useQuery } from 'react-query';
 export const ENABLE_ARBEIDSFLATE = 'mulighetsrommet.enable-arbeidsflate';
 export const FEEDBACK = 'mulighetsrommet.feedback';
 export const DELING_MED_BRUKER = 'mulighetsrommet.deling-med-bruker';
+export const VIS_HISTORIKK = 'mulighetsrommet.vis-historikk';
 
-export const ALL_TOGGLES = [ENABLE_ARBEIDSFLATE, FEEDBACK, DELING_MED_BRUKER];
+export const ALL_TOGGLES = [ENABLE_ARBEIDSFLATE, FEEDBACK, DELING_MED_BRUKER, VIS_HISTORIKK];
 
 export interface Features {
   [ENABLE_ARBEIDSFLATE]: boolean;
   [FEEDBACK]: boolean;
   [DELING_MED_BRUKER]: boolean;
+  [VIS_HISTORIKK]: boolean;
 }
 
 export const initialFeatures: Features = {
   [ENABLE_ARBEIDSFLATE]: false,
   [DELING_MED_BRUKER]: false,
   [FEEDBACK]: false,
+  [VIS_HISTORIKK]: false,
 };
 
 const toggles = ALL_TOGGLES.map(element => 'feature=' + element).join('&');

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentHistorikk.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentHistorikk.ts
@@ -1,0 +1,28 @@
+import { useQuery } from 'react-query';
+import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
+import { mulighetsrommetClient } from '../clients';
+import { QueryKeys } from '../query-keys';
+
+interface Historikk {
+  id: string;
+  fnr: string;
+  fra_dato: Date;
+  til_dato: Date;
+  status: Deltakerstatus;
+  tiltaksnummer: string;
+  tiltaksnavn: string;
+  tiltakstype: string;
+  arrangor: string;
+}
+
+export type Deltakerstatus = 'VENTER' | 'AVSLUTTET' | 'DELTAR' | 'IKKE_AKTUELL';
+
+// TODO Type opp retur-verdi for hook
+export function useHentHistorikk(prefetch: boolean = true) {
+  const fnr = useHentFnrFraUrl();
+  return useQuery<Historikk[], any>(
+    [QueryKeys.Historikk, fnr],
+    () => mulighetsrommetClient.historikk.hentHistorikkForBruker({ fnr }),
+    { enabled: prefetch }
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/query-keys.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/query-keys.ts
@@ -2,4 +2,5 @@ export const enum QueryKeys {
   SanityQuery = 'sanityQuery',
   Brukerdata = 'brukerdata',
   Veilederdata = 'veilederdata',
+  Historikk = 'historikk',
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -2,6 +2,7 @@ import SanityClient from '@sanity/client';
 import { rest, RestHandler } from 'msw';
 import { badReq, ok } from './responses';
 import { mockFeatures } from './features';
+import { historikk } from '../fixtures/historikk';
 
 export const apiHandlers: RestHandler[] = [
   rest.get('*/api/v1/bruker', (req, res, ctx) => {
@@ -49,6 +50,16 @@ export const apiHandlers: RestHandler[] = [
 
     const result = await client.fetch(query, { enhetsId: 'enhet.lokal.0106', fylkeId: 'enhet.fylke.5700' });
     return ok(result);
+  }),
+
+  rest.get('*/api/v1/historikk', async req => {
+    const fnr = req.url.searchParams.get('fnr');
+
+    if (!(typeof fnr === 'string')) {
+      return badReq("'fnr' must be specified");
+    }
+
+    return ok(historikk);
   }),
 ];
 

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
@@ -1,7 +1,14 @@
-import { Features, ENABLE_ARBEIDSFLATE, FEEDBACK, DELING_MED_BRUKER } from '../../core/api/feature-toggles';
+import {
+  Features,
+  ENABLE_ARBEIDSFLATE,
+  FEEDBACK,
+  DELING_MED_BRUKER,
+  VIS_HISTORIKK,
+} from '../../core/api/feature-toggles';
 
 export const mockFeatures: Features = {
   [ENABLE_ARBEIDSFLATE]: true,
   [FEEDBACK]: true,
   [DELING_MED_BRUKER]: true,
+  [VIS_HISTORIKK]: true,
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/historikk.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/historikk.ts
@@ -1,0 +1,47 @@
+// TODO Type opp historikk basert på modell fra openapi.yaml
+import { faker } from '@faker-js/faker';
+
+interface Historikk {
+  id: string;
+  fnr: string;
+  fra_dato: Date;
+  til_dato: Date;
+  status: Deltakerstatus;
+  tiltaksnummer: string;
+  tiltaksnavn: string;
+  tiltakstype: string;
+  arrangor: string;
+}
+
+type Deltakerstatus = 'VENTER' | 'AVSLUTTET' | 'DELTAR' | 'IKKE_AKTUELL';
+
+export const historikk: Historikk[] = genererHistorikk(7);
+
+function genererHistorikk(antallRader: number): Historikk[] {
+  const data = [...Array(antallRader)].map(i => ({
+    id: faker.git.shortSha(),
+    fnr: '12345678910',
+    fra_dato: faker.date.recent(10),
+    til_dato: faker.date.soon(10),
+    status: faker.helpers.arrayElement(['VENTER', 'AVSLUTTET', 'DELTAR', 'IKKE_AKTUELL']),
+    tiltaksnummer: faker.random.numeric(6),
+    tiltaksnavn: faker.company.catchPhrase(),
+    tiltakstype: faker.helpers.arrayElement([
+      'Lønnstilskudd',
+      'Mentor',
+      'Midlertidig lønnstilskudd',
+      'Nettbasert arbeidsmarkedsopplæring (AMO)',
+      'Nettkurs',
+      '2-årig opplæringstiltak',
+      'Arbeidspraksis i skjermet virksomhet',
+      'Arbeidspraksis i ordinær virksomhet',
+      'Produksjonsverksted (PV)',
+      'Resultatbasert finansiering av oppfølging',
+      'Spa prosjekter',
+      'Lærlinger i statlige etater',
+    ]),
+    arrangor: faker.helpers.arrayElement(['AS3', 'Adecco', 'Jobbklubben', 'Kom i Arbeid AS']),
+  }));
+
+  return data as Historikk[];
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
@@ -9,6 +9,15 @@ export const inneholderUrl = (string: string) => {
 export function specialChar(string: string | { label: string }) {
   return string.toString().toLowerCase().split('æ').join('ae').split('ø').join('o').split('å').join('a');
 }
+
 export function kebabCase(string: string | { label: string }) {
   return specialChar(string).replace(/\s+/g, '-');
+}
+
+export function formaterDato(dato: string | Date) {
+  return new Date(dato).toLocaleString('no-NO', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -3,6 +3,7 @@ import { useAtom } from 'jotai';
 import { RESET } from 'jotai/utils';
 import { useErrorHandler } from 'react-error-boundary';
 import Filtermeny from '../../components/filtrering/Filtermeny';
+import { HistorikkButton } from '../../components/historikk/HistorikkButton';
 import { BrukersOppfolgingsenhet } from '../../components/oppfolgingsenhet/BrukerOppfolgingsenhet';
 import TiltaksgjennomforingsTabell from '../../components/tabell/TiltaksgjennomforingsTabell';
 import FilterTags from '../../components/tags/Filtertags';
@@ -61,6 +62,7 @@ const ViewTiltakstypeOversikt = () => {
             }
           />
           <SearchFieldTag />
+          <HistorikkButton />
           <Show if={!innsatsgrupper.isLoading && skalResetteFilter}>
             <Button
               size="small"

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yml
@@ -244,6 +244,25 @@ paths:
               schema:
                 type: string
 
+  /api/v1/historikk:
+    get:
+      tags:
+        - Historikk
+      operationId: hentHistorikkForBruker
+      parameters:
+      - in: query
+        name: fnr
+        schema:
+          type: string
+        description: SSN for the user which will be used to fetch 'historikk' for user
+      responses: # TODO type opp korrekt data fra backend for historikk-endepunktet
+        200:
+          description: Historical data about the user
+          content:
+            application/json:
+              schema: { }
+      
+
 
 components:
   securitySchemes:


### PR DESCRIPTION
Foreløpig utkast til gui for "Historikk for bruker". 

* Setter opp mock-data fra msw
* Funksjonaliteten er bak toggle `mulighetsrommet.vis-historikk` som kun er på for mock, og av for alle andre miljøer.



Gjenstår:
* Å hente data fra backend (inkludert ords og andre baksystemer for å hente korrekt informasjon)
* Se på statustekster. Det er litt mismatch mellom skisser og statusene fra databasen / Arena


Knappen her er ikke slik den skal være, men avventer korrekt ikon fra Tom Stian
![image](https://user-images.githubusercontent.com/9053627/188420236-e5456f0f-1dd8-4689-b814-40fe36cf350c.png)

![image](https://user-images.githubusercontent.com/9053627/188420271-863478c2-8645-445e-94c1-20cf34a4bf4f.png)
