### PR TITLE
Setter opp Unleash

### DIFF
--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
 
     val navCommonModules = "2.2022.07.01_07.12-6a0864fa6938"
     implementation("no.nav.common:token-client:$navCommonModules")
+    implementation("no.nav.common:feature-toggle:$navCommonModules")
 
     // Test
     val kotestVersion = "5.4.1"

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -21,7 +21,8 @@ data class AppConfig(
     val veilarbpersonConfig: VeilarbpersonConfig,
     val veilarbdialogConfig: VeilarbdialogConfig,
     val veilarbveilederConfig: VeilarbveilederConfig,
-    val swagger: SwaggerConfig? = null
+    val swagger: SwaggerConfig? = null,
+    val unleashConfig: UnleashConfig
 )
 
 data class AuthConfig(
@@ -73,4 +74,8 @@ data class VeilarbveilederConfig(
 
 data class SwaggerConfig(
     val enable: Boolean
+)
+
+data class UnleashConfig(
+    val baseUrl: String
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -3,9 +3,12 @@ package no.nav.mulighetsrommet.api.plugins
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
 import io.ktor.server.application.*
+import no.nav.common.featuretoggle.UnleashClient
+import no.nav.common.featuretoggle.UnleashClientImpl
 import no.nav.common.token_client.builder.AzureAdTokenClientBuilder
 import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient
 import no.nav.mulighetsrommet.api.AppConfig
+import no.nav.mulighetsrommet.api.UnleashConfig
 import no.nav.mulighetsrommet.api.clients.dialog.VeilarbdialogClient
 import no.nav.mulighetsrommet.api.clients.dialog.VeilarbdialogClientImpl
 import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClient
@@ -33,6 +36,7 @@ fun Application.configureDependencyInjection(appConfig: AppConfig) {
         SLF4JLogger()
         modules(
             db(appConfig.database),
+            unleash(appConfig.unleashConfig),
             services(
                 appConfig,
                 veilarbvedsstotte(appConfig),
@@ -48,6 +52,12 @@ fun Application.configureDependencyInjection(appConfig: AppConfig) {
 private fun db(databaseConfig: DatabaseConfig): Module {
     return module(createdAtStart = true) {
         single<Database> { FlywayDatabaseAdapter(databaseConfig) }
+    }
+}
+
+private fun unleash(unleashConfig: UnleashConfig): Module {
+    return module(createdAtStart = true) {
+        single<UnleashClient> { UnleashClientImpl(unleashConfig.baseUrl, "mulighetsrommet-api") }
     }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
@@ -9,7 +9,7 @@ import no.nav.mulighetsrommet.api.utils.getAccessToken
 import org.koin.ktor.ext.inject
 
 fun Route.brukerRoutes() {
-    val brukerService: BrukerService by inject()
+    val brukerService by inject<BrukerService>()
 
     route("/api/v1/bruker") {
         get {

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -48,3 +48,6 @@ app:
 
   swagger:
     enable: true
+
+  unleashConfig:
+    baseUrl: https://unleash.nais.io/api/

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -45,3 +45,6 @@ app:
 
   swagger:
     enable: true
+
+  unleashConfig:
+    baseUrl: https://unleash.nais.io/api/

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -45,3 +45,6 @@ app:
 
   sentry:
     dsn: https://658d2a7841654209b04b77e2c179d224@sentry.gc.nav.no/134
+
+  unleashConfig:
+    baseUrl: https://unleash.nais.io/api/

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
@@ -27,6 +27,7 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     veilarbpersonConfig = createVeilarbpersonConfig(),
     veilarbveilederConfig = createVeilarbveilederConfig(),
     veilarbdialogConfig = createVeilarbdialogConfig(),
+    unleashConfig = createUnleashConfig()
 )
 
 fun createVeilarboppfolgingConfig(): VeilarboppfolgingConfig {
@@ -97,5 +98,11 @@ fun createSanityConfig(): SanityConfig {
         projectId = "",
         authToken = "",
         dataset = ""
+    )
+}
+
+fun createUnleashConfig(): UnleashConfig {
+    return UnleashConfig(
+        baseUrl = "https://unleash.nais.io/api/"
     )
 }


### PR DESCRIPTION
Setter opp Unleash for mulighetsrommet-api slik at vi kan benytte oss av feature toggles i backend-koden.

Brukes ved å hente klienten via 
```kt
val unleash by inject<UnleashClient>()

val minToggleVerdi = unleash.isEnabled("<navn-på-toggle>")
```