### PR TITLE
use internal ingresses between services on gcp

### DIFF
--- a/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
@@ -44,3 +44,7 @@ spec:
   azure:
     application:
       enabled: true
+  accessPolicy:
+    outbound:
+      rules:
+        - application: mulighetsrommet-api

--- a/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
@@ -46,3 +46,7 @@ spec:
   azure:
     application:
       enabled: true
+  accessPolicy:
+    outbound:
+      rules:
+        - application: mulighetsrommet-api

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
@@ -5,7 +5,7 @@ server:
 app:
   services:
     mulighetsrommetApi:
-      url: https://mulighetsrommet-api.dev.intern.nav.no
+      url: http://mulighetsrommet-api
       scope: api://dev-gcp.team-mulighetsrommet.mulighetsrommet-api/.default
     topicService:
       channelCapacity: 500

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
@@ -5,7 +5,7 @@ server:
 app:
   services:
     mulighetsrommetApi:
-      url: https://mulighetsrommet-api.intern.nav.no
+      url: http://mulighetsrommet-api
       scope: api://prod-gcp.team-mulighetsrommet.mulighetsrommet-api/.default
     topicService:
       channelCapacity: 500


### PR DESCRIPTION
Det er bedre å benytte service-adressen mellom tjenester på gcp enn å gå via en ingress.
Er visst både mer stabilt, og totalt sett skaper det mindre trykk i infrastrukturen fordi requester ikke trenger å forlate clusteret (gitt at tjenestene er på samme cluster).

Formatet står forklart her: https://doc.nais.io/clusters/service-discovery/

Når vi benytter dette må vi også sette `outbound.rules` i `nais.yaml`, noe som ikke har vært nødvendig å gjøre når vi har brukt ingressene. 