### PR TITLE
Oppsett for auth mellom arena-adapter og arena-ords-proxy

### DIFF
--- a/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
@@ -50,3 +50,4 @@ spec:
     outbound:
       rules:
         - application: mulighetsrommet-api
+        - application: mulighetsrommet-arena-ords-proxy

--- a/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
@@ -52,3 +52,4 @@ spec:
     outbound:
       rules:
         - application: mulighetsrommet-api
+        - application: mulighetsrommet-arena-ords-proxy

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
@@ -21,6 +21,7 @@ data class AppConfig(
 data class ServiceConfig(
     val mulighetsrommetApi: AuthenticatedService,
     val topicService: TopicService.Config,
+    val arenaOrdsApi: AuthenticatedService
 )
 
 data class AuthenticatedService(

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
@@ -7,6 +7,9 @@ app:
     mulighetsrommetApi:
       url: http://mulighetsrommet-api
       scope: api://dev-gcp.team-mulighetsrommet.mulighetsrommet-api/.default
+    arenaOrdsApi:
+      url: http://mulighetsrommet-arena-ords-proxy
+      scope: api://dev-gcp.team-mulighetsrommet.mulighetsrommet-arena-ords-proxy/.default
     topicService:
       channelCapacity: 500
       numChannelConsumers: 50

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
@@ -7,6 +7,9 @@ app:
     mulighetsrommetApi:
       url: http://localhost:8080
       scope: default
+    arenaOrdsApi:
+      url: http://localhost:8086
+      scope: default
     topicService:
       channelCapacity: 10
       numChannelConsumers: 1

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
@@ -7,6 +7,9 @@ app:
     mulighetsrommetApi:
       url: http://mulighetsrommet-api
       scope: api://prod-gcp.team-mulighetsrommet.mulighetsrommet-api/.default
+    arenaOrdsApi:
+      url: http://mulighetsrommet-arena-ords-proxy
+      scope: api://prod-gcp.team-mulighetsrommet.mulighetsrommet-arena-ords-proxy/.default
     topicService:
       channelCapacity: 500
       numChannelConsumers: 50

--- a/mulighetsrommet-arena-ords-proxy/.nais/nais.yaml
+++ b/mulighetsrommet-arena-ords-proxy/.nais/nais.yaml
@@ -35,3 +35,7 @@ spec:
   azure:
     application:
       enabled: true
+  accessPolicy:
+    inbound:
+      rules:
+        - application: mulighetsrommet-arena-adapter


### PR DESCRIPTION
Boilerplate for oppsett av autentisering mellom mulighetsrommet-arena-adapter og mulighetsrommet-arena-ords-proxy.
Jeg har ikke satt opp noe client enda for å kommunisere mot ords-proxy. Jeg tenker det kan være en oppgave man tar når vi skal i gang med å kalle ords.