### PR TITLE
handle deltaker foreign key violations as conflict

### DIFF
--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     // Kotlin
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("com.michael-bull.kotlin-result:kotlin-result:1.1.16")
+    implementation("io.arrow-kt:arrow-core:1.1.2")
 
     val ktorVersion = "2.1.0"
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
@@ -80,6 +81,7 @@ dependencies {
     val kotestVersion = "5.4.1"
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testImplementation("io.kotest.extensions:kotest-assertions-arrow:1.2.5")
     testImplementation("org.assertj:assertj-db:2.0.2")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.6.10")

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
@@ -8,11 +8,13 @@ import io.ktor.server.routing.*
 import io.ktor.util.logging.*
 import io.ktor.util.pipeline.*
 import no.nav.mulighetsrommet.api.services.ArenaService
+import no.nav.mulighetsrommet.database.utils.DatabaseOperationError
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
 import org.koin.ktor.ext.inject
+import org.postgresql.util.PSQLException
 
 fun Route.arenaRoutes() {
 
@@ -22,105 +24,98 @@ fun Route.arenaRoutes() {
 
     route("/api/v1/arena/") {
         put("tiltakstype") {
-            runCatching {
-                val tiltakstype = call.receive<AdapterTiltak>()
-                arenaService.upsertTiltakstype(tiltakstype)
-            }.onSuccess { updatedTiltakstype ->
-                call.respond(updatedTiltakstype)
-            }.onFailure {
-                logError(logger, it)
-                call.respondText("Kunne ikke oppdatere tiltakstype", status = HttpStatusCode.InternalServerError)
-            }
+            val tiltakstype = call.receive<AdapterTiltak>()
+            arenaService.upsertTiltakstype(tiltakstype)
+                .map { call.respond(it) }
+                .mapLeft {
+                    logError(logger, it.error)
+                    call.respond(HttpStatusCode.InternalServerError, "Kunne ikke oppdatere tiltakstype")
+                }
         }
 
         delete("tiltakstype") {
-            runCatching {
-                val tiltakstype = call.receive<AdapterTiltak>()
-                arenaService.deleteTiltakstype(tiltakstype)
-            }.onSuccess {
-                call.response.status(HttpStatusCode.OK)
-            }.onFailure {
-                logError(logger, it)
-                call.respondText("Kunne ikke slette tiltakstype", status = HttpStatusCode.InternalServerError)
-            }
+            val tiltakstype = call.receive<AdapterTiltak>()
+            arenaService.deleteTiltakstype(tiltakstype)
+                .map { call.response.status(HttpStatusCode.OK) }
+                .mapLeft {
+                    logError(logger, it.error)
+                    call.respond(HttpStatusCode.InternalServerError, "Kunne ikke slette tiltakstype")
+                }
         }
 
         put("tiltaksgjennomforing") {
-            runCatching {
-                val tiltaksgjennomforing = call.receive<AdapterTiltaksgjennomforing>()
-                arenaService.upsertTiltaksgjennomforing(tiltaksgjennomforing)
-            }.onSuccess { createdTiltaksgjennomforing ->
-                call.respond(createdTiltaksgjennomforing)
-            }.onFailure {
-                logError(logger, it)
-                call.respondText("Kunne ikke opprette tiltak", status = HttpStatusCode.InternalServerError)
-            }
+            val tiltaksgjennomforing = call.receive<AdapterTiltaksgjennomforing>()
+            arenaService.upsertTiltaksgjennomforing(tiltaksgjennomforing)
+                .map { call.respond(it) }
+                .mapLeft {
+                    logError(logger, it.error)
+                    call.respond(HttpStatusCode.InternalServerError, "Kunne ikke opprette tiltak")
+                }
         }
 
         delete("tiltaksgjennomforing") {
-            runCatching {
-                val tiltaksgjennomforing = call.receive<AdapterTiltaksgjennomforing>()
-                arenaService.deleteTiltaksgjennomforing(tiltaksgjennomforing)
-            }.onSuccess {
-                call.response.status(HttpStatusCode.OK)
-            }.onFailure {
-                logError(logger, it)
-                call.respondText("Kunne ikke slette tiltak", status = HttpStatusCode.InternalServerError)
-            }
+            val tiltaksgjennomforing = call.receive<AdapterTiltaksgjennomforing>()
+            arenaService.deleteTiltaksgjennomforing(tiltaksgjennomforing)
+                .map { call.response.status(HttpStatusCode.OK) }
+                .mapLeft {
+                    logError(logger, it.error)
+                    call.respond(HttpStatusCode.InternalServerError, "Kunne ikke slette tiltak")
+                }
         }
 
         put("deltaker") {
-            runCatching {
-                val deltaker = call.receive<AdapterTiltakdeltaker>()
-                arenaService.upsertDeltaker(deltaker)
-            }.onSuccess { createdDeltaker ->
-                call.respond(createdDeltaker)
-            }.onFailure {
-                logError(logger, it)
-                call.respondText("Kunne ikke opprette deltaker", status = HttpStatusCode.InternalServerError)
-            }
+            val deltaker = call.receive<AdapterTiltakdeltaker>()
+            arenaService.upsertDeltaker(deltaker)
+                .map { call.respond(HttpStatusCode.OK, it) }
+                .mapLeft {
+                    when (it) {
+                        is DatabaseOperationError.ForeignKeyViolation -> {
+                            call.respond(HttpStatusCode.Conflict, "Kunne ikke opprette deltaker")
+                        }
+                        else -> {
+                            logError(logger, it.error)
+                            call.respond(HttpStatusCode.InternalServerError, "Kunne ikke opprette deltaker")
+                        }
+                    }
+                }
         }
 
         delete("deltaker") {
-            runCatching {
-                val deltaker = call.receive<AdapterTiltakdeltaker>()
-                arenaService.deleteDeltaker(deltaker)
-            }.onSuccess {
-                call.response.status(HttpStatusCode.OK)
-            }.onFailure {
-                logError(logger, it)
-                call.respondText("Kunne ikke slette deltaker", status = HttpStatusCode.InternalServerError)
-            }
+            val deltaker = call.receive<AdapterTiltakdeltaker>()
+            arenaService.deleteDeltaker(deltaker)
+                .map { call.response.status(HttpStatusCode.OK) }
+                .mapLeft {
+                    logError(logger, it.error)
+                    call.respond(HttpStatusCode.InternalServerError, "Kunne ikke slette deltaker")
+                }
         }
+    }
 
-        put("sak") {
-            runCatching {
-                val sak = call.receive<AdapterSak>()
-                arenaService.updateTiltaksgjennomforingWithSak(sak)
-            }.onSuccess {
+    put("sak") {
+        val sak = call.receive<AdapterSak>()
+        arenaService.updateTiltaksgjennomforingWithSak(sak)
+            .map {
                 val response = it ?: HttpStatusCode.Conflict
                 call.respond(response)
-            }.onFailure {
-                logError(logger, it)
-                call.respondText("Kunne ikke oppdatere tiltak med sak", status = HttpStatusCode.InternalServerError)
             }
-        }
+            .mapLeft {
+                logError(logger, it.error)
+                call.respond(HttpStatusCode.InternalServerError, "Kunne ikke oppdatere tiltak med sak")
+            }
+    }
 
-        delete("sak") {
-            runCatching {
-                val sak = call.receive<AdapterSak>()
-                arenaService.unsetSakOnTiltaksgjennomforing(sak)
-            }.onSuccess {
-                call.response.status(HttpStatusCode.OK)
-            }.onFailure {
-                logError(logger, it)
-                call.respondText("Kunne ikke oppdatere tiltak med sak", status = HttpStatusCode.InternalServerError)
+    delete("sak") {
+        val sak = call.receive<AdapterSak>()
+        arenaService.unsetSakOnTiltaksgjennomforing(sak)
+            .map { call.response.status(HttpStatusCode.OK) }
+            .mapLeft {
+                logError(logger, it.error)
+                call.respond(HttpStatusCode.InternalServerError, "Kunne ikke oppdatere tiltak med sak")
             }
-        }
     }
 }
 
-private fun PipelineContext<Unit, ApplicationCall>.logError(logger: Logger, error: Throwable) {
+private fun PipelineContext<Unit, ApplicationCall>.logError(logger: Logger, error: PSQLException) {
     logger.debug(
         "Error during at request handler method=${this.context.request.httpMethod.value} path=${this.context.request.path()}",
         error

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
@@ -3,6 +3,8 @@ package no.nav.mulighetsrommet.api.services
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.utils.DatabaseMapper
 import no.nav.mulighetsrommet.database.Database
+import no.nav.mulighetsrommet.database.utils.QueryResult
+import no.nav.mulighetsrommet.database.utils.query
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
@@ -11,9 +13,9 @@ import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 
 class ArenaService(private val db: Database) {
-    private val logger = LoggerFactory.getLogger(ArenaService::class.java)
+    private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun upsertTiltakstype(tiltakstype: AdapterTiltak): AdapterTiltak {
+    fun upsertTiltakstype(tiltakstype: AdapterTiltak): QueryResult<AdapterTiltak> = query {
         logger.info("Lagrer tiltakstype tiltakskode=${tiltakstype.tiltakskode}")
 
         @Language("PostgreSQL")
@@ -29,13 +31,13 @@ class ArenaService(private val db: Database) {
             returning *
         """.trimIndent()
 
-        return tiltakstype.run { queryOf(query, navn, innsatsgruppe, tiltakskode, fraDato, tilDato) }
+        tiltakstype.run { queryOf(query, navn, innsatsgruppe, tiltakskode, fraDato, tilDato) }
             .map { DatabaseMapper.toAdapterTiltak(it) }
             .asSingle
             .let { db.run(it)!! }
     }
 
-    fun deleteTiltakstype(tiltakstype: AdapterTiltak) {
+    fun deleteTiltakstype(tiltakstype: AdapterTiltak): QueryResult<Unit> = query {
         logger.info("Sletter tiltakstype tiltakskode=${tiltakstype.tiltakskode}")
 
         @Language("PostgreSQL")
@@ -49,7 +51,9 @@ class ArenaService(private val db: Database) {
             .let { db.run(it) }
     }
 
-    fun upsertTiltaksgjennomforing(tiltak: AdapterTiltaksgjennomforing): AdapterTiltaksgjennomforing {
+    fun upsertTiltaksgjennomforing(
+        tiltak: AdapterTiltaksgjennomforing
+    ): QueryResult<AdapterTiltaksgjennomforing> = query {
         logger.info("Lagrer tiltak id=${tiltak.id}, tiltakskode=${tiltak.tiltakskode}, sakId=${tiltak.sakId}")
 
         @Language("PostgreSQL")
@@ -76,7 +80,7 @@ class ArenaService(private val db: Database) {
             returning *
         """.trimIndent()
 
-        return tiltak
+        tiltak
             .run {
                 queryOf(
                     query,
@@ -96,7 +100,7 @@ class ArenaService(private val db: Database) {
             .let { db.run(it)!! }
     }
 
-    fun deleteTiltaksgjennomforing(tiltak: AdapterTiltaksgjennomforing) {
+    fun deleteTiltaksgjennomforing(tiltak: AdapterTiltaksgjennomforing): QueryResult<Unit> = query {
         logger.info("Sletter tiltak id=${tiltak.id}, tiltakskode=${tiltak.tiltakskode}, sakId=${tiltak.sakId}")
 
         @Language("PostgreSQL")
@@ -105,12 +109,14 @@ class ArenaService(private val db: Database) {
             where arena_id = ?
         """.trimIndent()
 
-        tiltak.run { queryOf(query, id) }
-            .asExecute
-            .let { db.run(it) }
+        query {
+            tiltak.run { queryOf(query, id) }
+                .asExecute
+                .let { db.run(it) }
+        }
     }
 
-    fun upsertDeltaker(deltaker: AdapterTiltakdeltaker): AdapterTiltakdeltaker {
+    fun upsertDeltaker(deltaker: AdapterTiltakdeltaker): QueryResult<AdapterTiltakdeltaker> = query {
         logger.info("Lagrer deltaker id=${deltaker.id}, tiltak=${deltaker.tiltaksgjennomforingId}")
 
         @Language("PostgreSQL")
@@ -128,13 +134,13 @@ class ArenaService(private val db: Database) {
             returning *
         """.trimIndent()
 
-        return deltaker.run { queryOf(query, id, tiltaksgjennomforingId, personId, fraDato, tilDato, status.name) }
+        deltaker.run { queryOf(query, id, tiltaksgjennomforingId, personId, fraDato, tilDato, status.name) }
             .map { DatabaseMapper.toAdapterTiltakdeltaker(it) }
             .asSingle
             .let { db.run(it)!! }
     }
 
-    fun deleteDeltaker(deltaker: AdapterTiltakdeltaker) {
+    fun deleteDeltaker(deltaker: AdapterTiltakdeltaker): QueryResult<Unit> = query {
         logger.info("Sletter deltaker id=${deltaker.id}, tiltak=${deltaker.tiltaksgjennomforingId}")
 
         @Language("PostgreSQL")
@@ -148,7 +154,7 @@ class ArenaService(private val db: Database) {
             .let { db.run(it) }
     }
 
-    fun updateTiltaksgjennomforingWithSak(sak: AdapterSak): AdapterTiltaksgjennomforing? {
+    fun updateTiltaksgjennomforingWithSak(sak: AdapterSak): QueryResult<AdapterTiltaksgjennomforing?> = query {
         logger.info("Oppdaterer tiltak med sak sakId=${sak.id} tiltaksnummer=${sak.lopenummer}")
 
         @Language("PostgreSQL")
@@ -158,13 +164,13 @@ class ArenaService(private val db: Database) {
             returning *
         """.trimIndent()
 
-        return sak.run { queryOf(query, lopenummer, aar, id) }
+        sak.run { queryOf(query, lopenummer, aar, id) }
             .map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }
             .asSingle
             .let { db.run(it) }
     }
 
-    fun unsetSakOnTiltaksgjennomforing(sak: AdapterSak): AdapterTiltaksgjennomforing? {
+    fun unsetSakOnTiltaksgjennomforing(sak: AdapterSak): QueryResult<AdapterTiltaksgjennomforing?> = query {
         logger.info("Fjerner referanse til sak for tiltak sakId=${sak.id} tiltaksnummer=${sak.lopenummer}")
 
         @Language("PostgreSQL")
@@ -174,7 +180,7 @@ class ArenaService(private val db: Database) {
             returning *
         """.trimIndent()
 
-        return sak.run { queryOf(query, id) }
+        sak.run { queryOf(query, id) }
             .map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }
             .asSingle
             .let { db.run(it) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/database/utils/QueryResult.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/database/utils/QueryResult.kt
@@ -1,0 +1,39 @@
+package no.nav.mulighetsrommet.database.utils
+
+import arrow.core.Either
+import org.postgresql.util.PSQLException
+
+typealias QueryResult<T> = Either<DatabaseOperationError, T>
+
+/**
+ * Runs the provided [queryRunner] and returns a [QueryResult] with the value [T] when it runs successfully,
+ * or a [DatabaseOperationError] resolved from the underlying [PSQLException].
+ */
+fun <T> query(queryRunner: () -> T): QueryResult<T> = try {
+    Either.Right(queryRunner.invoke())
+} catch (e: PSQLException) {
+    Either.Left(DatabaseOperationError.fromPSQLException(e))
+}
+
+/**
+ * The [DatabaseOperationError] can be used for more readable and explicit error handling of database operations
+ * that result in a [PSQLException].
+ *
+ * See the postgres documentation [0] for description of all error codes if more error variants are needed.
+ *
+ * [0]: https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+sealed class DatabaseOperationError(val error: PSQLException) {
+    class ForeignKeyViolation(error: PSQLException) : DatabaseOperationError(error)
+    class DatabaseError(error: PSQLException) : DatabaseOperationError(error)
+
+    companion object {
+        /**
+         * Resolves a [DatabaseOperationError] instance from the provided [PSQLException].
+         */
+        fun fromPSQLException(error: PSQLException) = when (error.sqlState) {
+            "23503" -> ForeignKeyViolation(error)
+            else -> DatabaseError(error)
+        }
+    }
+}

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
@@ -1,8 +1,8 @@
 package no.nav.mulighetsrommet.api.services
 
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCaseOrder
-import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.createDatabaseConfigWithRandomSchema
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseListener
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
@@ -110,8 +110,8 @@ class ArenaServiceTest : FunSpec({
             }
 
             test("should not do an update when the sak does not reference any tiltaksgjennomføring") {
-                service.updateTiltaksgjennomforingWithSak(sak.copy(id = 999)) shouldBe null
-                service.unsetSakOnTiltaksgjennomforing(sak.copy(id = 999)) shouldBe null
+                service.updateTiltaksgjennomforingWithSak(sak.copy(id = 999)) shouldBeRight null
+                service.unsetSakOnTiltaksgjennomforing(sak.copy(id = 999)) shouldBeRight null
             }
         }
     }


### PR DESCRIPTION
This is a quick fix to the deadlock of insert-events followed by delete-events of deltaker with relation to a tiltaksgjennomføring that has already been deleted.