### PR TITLE
Nytt filter for individuelle eller gruppetiltak

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
+++ b/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
@@ -1,6 +1,6 @@
 import { blockContentValidation } from "../validation/blockContentValidation";
 
-const MAKS_LENGDE_INNHOLD = 1000;
+const MAKS_LENGDE_INNHOLD = 1500;
 
 export default {
   name: "faneinnhold",

--- a/frontend/mulighetsrommet-cms/schemas/tiltakstype.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltakstype.ts
@@ -20,6 +20,21 @@ export default {
       description: "Her kan du skrive en beskrivelse av tiltakstypen",
     },
     {
+      name: "typeTiltak",
+      title: "Individuelt eller gruppetiltak?",
+      description: "Er tiltaket et individuelt- eller et gruppetiltak?",
+      type: "string",
+      options: {
+        list: [
+          { title: "Individuelt tiltak", value: "individuelt" },
+          { title: "Gruppetiltak", value: "gruppe" },
+        ],
+      },
+      layout: "radio",
+      validation: (Rule) =>
+        Rule.required().error("Du må velge ett av alternativene"),
+    },
+    {
       name: "nokkelinfoKomponenter",
       title: "Nøkkelinfo",
       type: "array",

--- a/frontend/mulighetsrommet-cms/schemas/tiltakstype.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltakstype.ts
@@ -20,7 +20,7 @@ export default {
       description: "Her kan du skrive en beskrivelse av tiltakstypen",
     },
     {
-      name: "typeTiltak",
+      name: "tiltaksgruppe",
       title: "Individuelt eller gruppetiltak?",
       description: "Er tiltaket et individuelt- eller et gruppetiltak?",
       type: "string",

--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.js
@@ -1,4 +1,4 @@
-xdescribe('Tiltaksgjennomføringstabell', () => {
+describe('Tiltaksgjennomføringstabell', () => {
   let antallTiltak;
   it('Sjekk at det er tiltaksgjennomføringer i tabellen', () => {
     cy.getByTestId('tabell_tiltaksgjennomforing').should('have.length.greaterThan', 1);
@@ -49,6 +49,21 @@ xdescribe('Tiltaksgjennomføringstabell', () => {
 
     cy.forventetAntallFiltertags(2);
     cy.apneLukketFilterAccordion('tiltakstyper', false);
+  });
+
+  it('Filtrer på individuelle eller gruppetiltak', () => {
+    cy.apneLukketFilterAccordion('gruppe-eller-individuelle-tiltak', true);
+    cy.velgFilter('gruppetiltak');
+    cy.forventetAntallFiltertags(3);
+
+    cy.getByTestId('filter_checkbox_gruppetiltak').should('be.checked');
+    cy.getByTestId('filter_checkbox_individuelle-tiltak').should('not.be.checked');
+
+    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
+
+    cy.getByTestId('filter_checkbox_gruppetiltak').should('not.be.checked');
+    cy.getByTestId('filter_checkbox_individuelle-tiltak').should('not.be.checked');
+    cy.apneLukketFilterAccordion('gruppe-eller-individuelle-tiltak', false);
   });
 
   it('Filtrer på søkefelt', () => {

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/FilterForIndividueltEllerGruppetiltak.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/FilterForIndividueltEllerGruppetiltak.tsx
@@ -19,8 +19,8 @@ export function FilterForIndividueltEllerGruppetiltak() {
   return (
     <CheckboxFilter
       accordionNavn="Gruppe eller individuelle tiltak"
-      options={filter.tiltaksgruppe}
-      setOptions={tiltaksgruppe => setFilter({ ...filter, tiltaksgruppe })}
+      options={filter.typeTiltak}
+      setOptions={typeTiltak => setFilter({ ...filter, typeTiltak })}
       data={
         typer.map(({ id, tittel }) => {
           return {
@@ -32,7 +32,7 @@ export function FilterForIndividueltEllerGruppetiltak() {
       isLoading={false}
       isError={false}
       sortert
-      defaultOpen={filter.tiltaksgruppe.length > 0}
+      defaultOpen={filter.typeTiltak.length > 0}
     />
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/FilterForIndividueltEllerGruppetiltak.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/FilterForIndividueltEllerGruppetiltak.tsx
@@ -1,0 +1,38 @@
+import { useAtom } from 'jotai';
+import { tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
+import CheckboxFilter from './CheckboxFilter';
+
+const typer = [
+  {
+    id: 'individuelt',
+    tittel: 'Individuelle tiltak',
+  },
+  {
+    id: 'gruppe',
+    tittel: 'Gruppetiltak',
+  },
+];
+
+export function FilterForIndividueltEllerGruppetiltak() {
+  const [filter, setFilter] = useAtom(tiltaksgjennomforingsfilter);
+
+  return (
+    <CheckboxFilter
+      accordionNavn="Gruppe eller individuelle tiltak"
+      options={filter.tiltaksgruppe}
+      setOptions={tiltaksgruppe => setFilter({ ...filter, tiltaksgruppe })}
+      data={
+        typer.map(({ id, tittel }) => {
+          return {
+            id,
+            tittel,
+          };
+        }) ?? []
+      }
+      isLoading={false}
+      isError={false}
+      sortert
+      defaultOpen={filter.tiltaksgruppe.length > 0}
+    />
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/FilterForIndividueltEllerGruppetiltak.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/FilterForIndividueltEllerGruppetiltak.tsx
@@ -19,8 +19,8 @@ export function FilterForIndividueltEllerGruppetiltak() {
   return (
     <CheckboxFilter
       accordionNavn="Gruppe eller individuelle tiltak"
-      options={filter.typeTiltak}
-      setOptions={typeTiltak => setFilter({ ...filter, typeTiltak })}
+      options={filter.tiltaksgruppe}
+      setOptions={tiltaksgruppe => setFilter({ ...filter, tiltaksgruppe })}
       data={
         typer.map(({ id, tittel }) => {
           return {
@@ -32,7 +32,7 @@ export function FilterForIndividueltEllerGruppetiltak() {
       isLoading={false}
       isError={false}
       sortert
-      defaultOpen={filter.typeTiltak.length > 0}
+      defaultOpen={filter.tiltaksgruppe.length > 0}
     />
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
@@ -9,6 +9,7 @@ import { useInnsatsgrupper } from '../../core/api/queries/useInnsatsgrupper';
 import { useTiltakstyper } from '../../core/api/queries/useTiltakstyper';
 import { usePrepopulerFilter } from '../../hooks/usePrepopulerFilter';
 import InnsatsgruppeFilter from './InnsatsgruppeFilter';
+import { FilterForIndividueltEllerGruppetiltak } from './FilterForIndividueltEllerGruppetiltak';
 
 const Filtermeny = () => {
   const [filter, setFilter] = useAtom(tiltaksgjennomforingsfilter);
@@ -66,6 +67,7 @@ const Filtermeny = () => {
         sortert
         defaultOpen={filter.tiltakstyper.length > 0}
       />
+      <FilterForIndividueltEllerGruppetiltak />
     </div>
   );
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
@@ -16,10 +16,12 @@ type Innsatsgrupper =
 
 export type Tilgjengelighetsstatus = 'Ledig' | 'Venteliste' | 'Stengt';
 export type Oppstart = 'dato' | 'lopende' | 'midlertidig_stengt';
+type TypeTiltak = 'individuelt' | 'gruppe';
 
 export interface Tiltakstype {
   _id: string;
   tiltakstypeNavn: Tiltakstyper;
+  typeTiltak: TypeTiltak;
   beskrivelse?: string;
   innsatsgruppe: Innsatsgruppe;
   varighet?: string;

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
@@ -16,12 +16,12 @@ type Innsatsgrupper =
 
 export type Tilgjengelighetsstatus = 'Ledig' | 'Venteliste' | 'Stengt';
 export type Oppstart = 'dato' | 'lopende' | 'midlertidig_stengt';
-type TypeTiltak = 'individuelt' | 'gruppe';
+type Tiltaksgruppe = 'individuelt' | 'gruppe';
 
 export interface Tiltakstype {
   _id: string;
   tiltakstypeNavn: Tiltakstyper;
-  typeTiltak: TypeTiltak;
+  tiltaksgruppe: Tiltaksgruppe;
   beskrivelse?: string;
   innsatsgruppe: Innsatsgruppe;
   varighet?: string;

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforing.ts
@@ -13,7 +13,7 @@ export default function useTiltaksgjennomforing() {
   ${byggInnsatsgruppeFilter(filter.innsatsgruppe?.nokkel)} 
   ${byggTiltakstypeFilter(filter.tiltakstyper)}
   ${byggSokefilter(filter.search)}
-  ${byggTiltaksgruppeFilter(filter.tiltaksgruppe ?? [])}
+  ${byggTypeTiltakFilterStreng(filter.typeTiltak ?? [])}
   ${byggEnhetOgFylkeFilter()}
   ]
   {
@@ -37,10 +37,10 @@ function byggEnhetOgFylkeFilter(): string {
   return groq`&& ($enhetsId in enheter[]._ref || (enheter[0] == null && $fylkeId == fylke._ref))`;
 }
 
-function byggTiltaksgruppeFilter(tiltaksgrupper: Tiltaksgjennomforingsfiltergruppe<string>[]): string {
-  if (tiltaksgrupper.length === 0) return '';
+function byggTypeTiltakFilterStreng(typeTiltak: Tiltaksgjennomforingsfiltergruppe<string>[]): string {
+  if (typeTiltak.length === 0) return '';
 
-  const tiltaksgruppeStreng = idSomListe(tiltaksgrupper);
+  const tiltaksgruppeStreng = idSomListe(typeTiltak);
 
   return groq`&& tiltakstype->typeTiltak in [${tiltaksgruppeStreng}]`;
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforing.ts
@@ -13,7 +13,7 @@ export default function useTiltaksgjennomforing() {
   ${byggInnsatsgruppeFilter(filter.innsatsgruppe?.nokkel)} 
   ${byggTiltakstypeFilter(filter.tiltakstyper)}
   ${byggSokefilter(filter.search)}
-  ${byggTypeTiltakFilterStreng(filter.typeTiltak ?? [])}
+  ${byggTiltaksgruppeFilterStreng(filter.tiltaksgruppe ?? [])}
   ${byggEnhetOgFylkeFilter()}
   ]
   {
@@ -37,12 +37,12 @@ function byggEnhetOgFylkeFilter(): string {
   return groq`&& ($enhetsId in enheter[]._ref || (enheter[0] == null && $fylkeId == fylke._ref))`;
 }
 
-function byggTypeTiltakFilterStreng(typeTiltak: Tiltaksgjennomforingsfiltergruppe<string>[]): string {
-  if (typeTiltak.length === 0) return '';
+function byggTiltaksgruppeFilterStreng(tiltaksgruppe: Tiltaksgjennomforingsfiltergruppe<string>[]): string {
+  if (tiltaksgruppe.length === 0) return '';
 
-  const tiltaksgruppeStreng = idSomListe(typeTiltak);
+  const tiltaksgruppeStreng = idSomListe(tiltaksgruppe);
 
-  return groq`&& tiltakstype->typeTiltak in [${tiltaksgruppeStreng}]`;
+  return groq`&& tiltakstype->tiltaksgruppe in [${tiltaksgruppeStreng}]`;
 }
 
 function byggInnsatsgruppeFilter(innsatsgruppe?: InnsatsgruppeNokler): string {

--- a/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
@@ -5,7 +5,7 @@ export interface Tiltaksgjennomforingsfilter {
   search?: string;
   innsatsgruppe?: Tiltaksgjennomforingsfiltergruppe<InnsatsgruppeNokler>;
   tiltakstyper: Tiltaksgjennomforingsfiltergruppe<string>[];
-  typeTiltak: Tiltaksgjennomforingsfiltergruppe<string>[];
+  tiltaksgruppe: Tiltaksgjennomforingsfiltergruppe<string>[];
 }
 
 export interface Tiltaksgjennomforingsfiltergruppe<T> {
@@ -18,7 +18,7 @@ export const initialTiltaksgjennomforingsfilter = {
   search: '',
   innsatsgruppe: undefined,
   tiltakstyper: [],
-  typeTiltak: [],
+  tiltaksgruppe: [],
 };
 
 export const tiltaksgjennomforingsfilter = atomWithHash<Tiltaksgjennomforingsfilter>(

--- a/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
@@ -5,7 +5,7 @@ export interface Tiltaksgjennomforingsfilter {
   search?: string;
   innsatsgruppe?: Tiltaksgjennomforingsfiltergruppe<InnsatsgruppeNokler>;
   tiltakstyper: Tiltaksgjennomforingsfiltergruppe<string>[];
-  tiltaksgruppe: Tiltaksgjennomforingsfiltergruppe<string>[];
+  typeTiltak: Tiltaksgjennomforingsfiltergruppe<string>[];
 }
 
 export interface Tiltaksgjennomforingsfiltergruppe<T> {
@@ -18,7 +18,7 @@ export const initialTiltaksgjennomforingsfilter = {
   search: '',
   innsatsgruppe: undefined,
   tiltakstyper: [],
-  tiltaksgruppe: [],
+  typeTiltak: [],
 };
 
 export const tiltaksgjennomforingsfilter = atomWithHash<Tiltaksgjennomforingsfilter>(

--- a/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
@@ -5,6 +5,7 @@ export interface Tiltaksgjennomforingsfilter {
   search?: string;
   innsatsgruppe?: Tiltaksgjennomforingsfiltergruppe<InnsatsgruppeNokler>;
   tiltakstyper: Tiltaksgjennomforingsfiltergruppe<string>[];
+  tiltaksgruppe: Tiltaksgjennomforingsfiltergruppe<string>[];
 }
 
 export interface Tiltaksgjennomforingsfiltergruppe<T> {
@@ -17,6 +18,7 @@ export const initialTiltaksgjennomforingsfilter = {
   search: '',
   innsatsgruppe: undefined,
   tiltakstyper: [],
+  tiltaksgruppe: [],
 };
 
 export const tiltaksgjennomforingsfilter = atomWithHash<Tiltaksgjennomforingsfilter>(

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
@@ -14,6 +14,7 @@ export function usePrepopulerFilter() {
     const matchedInnsatsgruppe = innsatsgrupper?.find(gruppe => gruppe.nokkel === brukerdata?.data?.innsatsgruppe);
     if (matchedInnsatsgruppe) {
       const tiltakstyper = resetFilterTilUtgangspunkt ? [] : filter.tiltakstyper;
+      const tiltaksgruppe = resetFilterTilUtgangspunkt ? [] : filter.tiltaksgruppe;
       const search = resetFilterTilUtgangspunkt ? '' : filter.search;
       const innsatsgruppe = resetFilterTilUtgangspunkt
         ? { id: matchedInnsatsgruppe._id, nokkel: matchedInnsatsgruppe.nokkel, tittel: matchedInnsatsgruppe.tittel }
@@ -22,6 +23,7 @@ export function usePrepopulerFilter() {
         search,
         tiltakstyper,
         innsatsgruppe,
+        tiltaksgruppe,
       });
     }
   }

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
@@ -14,7 +14,7 @@ export function usePrepopulerFilter() {
     const matchedInnsatsgruppe = innsatsgrupper?.find(gruppe => gruppe.nokkel === brukerdata?.data?.innsatsgruppe);
     if (matchedInnsatsgruppe) {
       const tiltakstyper = resetFilterTilUtgangspunkt ? [] : filter.tiltakstyper;
-      const tiltaksgruppe = resetFilterTilUtgangspunkt ? [] : filter.tiltaksgruppe;
+      const typeTiltak = resetFilterTilUtgangspunkt ? [] : filter.typeTiltak;
       const search = resetFilterTilUtgangspunkt ? '' : filter.search;
       const innsatsgruppe = resetFilterTilUtgangspunkt
         ? { id: matchedInnsatsgruppe._id, nokkel: matchedInnsatsgruppe.nokkel, tittel: matchedInnsatsgruppe.tittel }
@@ -23,7 +23,7 @@ export function usePrepopulerFilter() {
         search,
         tiltakstyper,
         innsatsgruppe,
-        tiltaksgruppe,
+        typeTiltak,
       });
     }
   }

--- a/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/hooks/usePrepopulerFilter.ts
@@ -14,7 +14,7 @@ export function usePrepopulerFilter() {
     const matchedInnsatsgruppe = innsatsgrupper?.find(gruppe => gruppe.nokkel === brukerdata?.data?.innsatsgruppe);
     if (matchedInnsatsgruppe) {
       const tiltakstyper = resetFilterTilUtgangspunkt ? [] : filter.tiltakstyper;
-      const typeTiltak = resetFilterTilUtgangspunkt ? [] : filter.typeTiltak;
+      const tiltaksgruppe = resetFilterTilUtgangspunkt ? [] : filter.tiltaksgruppe;
       const search = resetFilterTilUtgangspunkt ? '' : filter.search;
       const innsatsgruppe = resetFilterTilUtgangspunkt
         ? { id: matchedInnsatsgruppe._id, nokkel: matchedInnsatsgruppe.nokkel, tittel: matchedInnsatsgruppe.tittel }
@@ -23,7 +23,7 @@ export function usePrepopulerFilter() {
         search,
         tiltakstyper,
         innsatsgruppe,
-        typeTiltak,
+        tiltaksgruppe,
       });
     }
   }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
@@ -7,7 +7,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       tiltakstypeNavn: 'VTA',
-      typeTiltak: 'gruppe',
+      tiltaksgruppe: 'gruppe',
       beskrivelse: faker.lorem.paragraph(2),
       nokkelinfoKomponenter: [
         {
@@ -52,7 +52,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       tiltakstypeNavn: 'VTA',
-      typeTiltak: 'gruppe',
+      tiltaksgruppe: 'gruppe',
       beskrivelse: faker.lorem.paragraph(2),
       nokkelinfoKomponenter: [
         {
@@ -97,7 +97,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       tiltakstypeNavn: 'VTA',
-      typeTiltak: 'gruppe',
+      tiltaksgruppe: 'gruppe',
       beskrivelse: faker.lorem.paragraph(2),
       nokkelinfoKomponenter: [
         {

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
@@ -7,6 +7,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       tiltakstypeNavn: 'VTA',
+      typeTiltak: 'gruppe',
       beskrivelse: faker.lorem.paragraph(2),
       nokkelinfoKomponenter: [
         {
@@ -51,6 +52,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       tiltakstypeNavn: 'VTA',
+      typeTiltak: 'gruppe',
       beskrivelse: faker.lorem.paragraph(2),
       nokkelinfoKomponenter: [
         {
@@ -95,6 +97,7 @@ export const tiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tiltakstype: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       tiltakstypeNavn: 'VTA',
+      typeTiltak: 'gruppe',
       beskrivelse: faker.lorem.paragraph(2),
       nokkelinfoKomponenter: [
         {

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltakstyper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltakstyper.ts
@@ -4,7 +4,7 @@ export const tiltakstyper: Tiltakstype[] = [
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
     tiltakstypeNavn: 'VTA',
-    typeTiltak: 'gruppe',
+    tiltaksgruppe: 'gruppe',
     beskrivelse: faker.lorem.paragraph(2),
     nokkelinfoKomponenter: [
       {

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltakstyper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltakstyper.ts
@@ -4,6 +4,7 @@ export const tiltakstyper: Tiltakstype[] = [
   {
     _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
     tiltakstypeNavn: 'VTA',
+    typeTiltak: 'gruppe',
     beskrivelse: faker.lorem.paragraph(2),
     nokkelinfoKomponenter: [
       {

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -36,7 +36,7 @@ const ViewTiltakstypeOversikt = () => {
     brukersInnsatsgruppeErIkkeValgt(filter.innsatsgruppe.nokkel) ||
     filter.search !== '' ||
     filter.tiltakstyper.length > 0 ||
-    filter.typeTiltak.length > 0;
+    filter.tiltaksgruppe.length > 0;
 
   return (
     <div className="tiltakstype-oversikt" id="tiltakstype-oversikt" data-testid="tiltakstype-oversikt">
@@ -65,11 +65,11 @@ const ViewTiltakstypeOversikt = () => {
             }
           />
           <FilterTags
-            options={filter.typeTiltak!}
+            options={filter.tiltaksgruppe!}
             handleClick={(id: string) =>
               setFilter({
                 ...filter,
-                typeTiltak: filter.typeTiltak?.filter(gruppe => gruppe.id !== id),
+                tiltaksgruppe: filter.tiltaksgruppe?.filter(gruppe => gruppe.id !== id),
               })
             }
           />

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -36,7 +36,7 @@ const ViewTiltakstypeOversikt = () => {
     brukersInnsatsgruppeErIkkeValgt(filter.innsatsgruppe.nokkel) ||
     filter.search !== '' ||
     filter.tiltakstyper.length > 0 ||
-    filter.tiltaksgruppe.length > 0;
+    filter.typeTiltak.length > 0;
 
   return (
     <div className="tiltakstype-oversikt" id="tiltakstype-oversikt" data-testid="tiltakstype-oversikt">
@@ -65,11 +65,11 @@ const ViewTiltakstypeOversikt = () => {
             }
           />
           <FilterTags
-            options={filter.tiltaksgruppe!}
+            options={filter.typeTiltak!}
             handleClick={(id: string) =>
               setFilter({
                 ...filter,
-                tiltaksgruppe: filter.tiltaksgruppe?.filter(gruppe => gruppe.id !== id),
+                typeTiltak: filter.typeTiltak?.filter(gruppe => gruppe.id !== id),
               })
             }
           />

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.tsx
@@ -35,7 +35,8 @@ const ViewTiltakstypeOversikt = () => {
     filter.innsatsgruppe! === undefined ||
     brukersInnsatsgruppeErIkkeValgt(filter.innsatsgruppe.nokkel) ||
     filter.search !== '' ||
-    filter.tiltakstyper.length > 0;
+    filter.tiltakstyper.length > 0 ||
+    filter.tiltaksgruppe.length > 0;
 
   return (
     <div className="tiltakstype-oversikt" id="tiltakstype-oversikt" data-testid="tiltakstype-oversikt">
@@ -60,6 +61,15 @@ const ViewTiltakstypeOversikt = () => {
               setFilter({
                 ...filter,
                 tiltakstyper: filter.tiltakstyper?.filter(tiltakstype => tiltakstype.id !== id),
+              })
+            }
+          />
+          <FilterTags
+            options={filter.tiltaksgruppe!}
+            handleClick={(id: string) =>
+              setFilter({
+                ...filter,
+                tiltaksgruppe: filter.tiltaksgruppe?.filter(gruppe => gruppe.id !== id),
               })
             }
           />


### PR DESCRIPTION
Legger til støtte for å filtrere på gruppetiltak eller individuelle tiltak.
Endringen går ut på å legge til feltet `typeTiltak` i Sanity på dokumenttypen `tiltakstype`. Her kan man velge om tiltakstypen enten er for individuelle tiltak eller for gruppetiltak.

Oppdaterer så frontend med kode for å legge til filter samt oppdatering av Groq-spørring for å hente tiltaksgjennomføringer fra Sanity.

![image](https://user-images.githubusercontent.com/9053627/191502357-c67a4221-ceb3-459b-8b05-21533b7efe4d.png)
