### PR TITLE
API for lagring av del-med-bruker info til db

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/DelMedBruker.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/DelMedBruker.kt
@@ -1,0 +1,19 @@
+package no.nav.mulighetsrommet.domain.models
+
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.serializers.DateSerializer
+import java.time.LocalDateTime
+
+@Serializable
+data class DelMedBruker(
+    val id: String? = null,
+    val bruker_fnr: String,
+    val navident: String,
+    val tiltaksnummer: String,
+    @Serializable(with = DateSerializer::class)
+    val created_at: LocalDateTime? = null,
+    @Serializable(with = DateSerializer::class)
+    val updated_at: LocalDateTime? = null,
+    val created_by: String? = null,
+    val updated_by: String? = null
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -50,6 +50,7 @@ fun Application.configure(config: AppConfig) {
             veilederRoutes()
             frontendLoggerRoutes()
             dialogRoutes()
+            delMedBrukerRoutes()
         }
         authenticate(AuthProvider.AzureAdMachineToMachine.name) {
             arenaRoutes()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -170,6 +170,7 @@ private fun services(
         }
         PoaoTilgangService(client)
     }
+    single { DelMedBrukerService(get()) }
 }
 
 private fun erLokalUtvikling(): Boolean {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DelMedBrukerRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DelMedBrukerRoutes.kt
@@ -1,0 +1,66 @@
+package no.nav.mulighetsrommet.api.routes.v1
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.mulighetsrommet.api.plugins.getNavIdent
+import no.nav.mulighetsrommet.api.services.DelMedBrukerService
+import no.nav.mulighetsrommet.api.services.PoaoTilgangService
+import no.nav.mulighetsrommet.domain.models.DelMedBruker
+import no.nav.mulighetsrommet.secure_log.SecureLog
+import org.koin.ktor.ext.inject
+
+fun Route.delMedBrukerRoutes() {
+    val secureLog = SecureLog.logger
+    val delMedBrukerService by inject<DelMedBrukerService>()
+    val poaoTilgang: PoaoTilgangService by inject()
+
+    route("/api/v1/delMedBruker") {
+        post {
+            poaoTilgang.verifyAccessToModia(getNavIdent())
+            val payload = call.receive<DelMedBruker>()
+            delMedBrukerService.lagreDelMedBruker(payload).map {
+                call.respond(it)
+            }.mapLeft {
+                secureLog.error("Klarte ikke lagre informasjon om deling med bruker", it.error)
+                call.respondText(
+                    "Klarte ikke lagre informasjon om deling med bruker",
+                    status = HttpStatusCode.InternalServerError
+                )
+            }
+        }
+
+        get {
+            poaoTilgang.verifyAccessToModia(getNavIdent())
+            val fnr = call.request.queryParameters["fnr"] ?: return@get call.respondText(
+                "Mangler eller ugyldig fnr til bruker",
+                status = HttpStatusCode.BadRequest
+            )
+            val navident = call.request.queryParameters["navident"] ?: return@get call.respondText(
+                "Mangler eller ugyldig navident til veileder",
+                status = HttpStatusCode.BadRequest
+            )
+            val tiltaksnummer = call.request.queryParameters["tiltaksnummer"] ?: return@get call.respondText(
+                "Mangler eller ugyldig tiltaksnummer",
+                status = HttpStatusCode.BadRequest
+            )
+
+            delMedBrukerService.getDeltMedBruker(fnr, navident, tiltaksnummer).map {
+                if (it == null) {
+                    call.respondText(
+                        status = HttpStatusCode.NoContent,
+                        text = "Fant ikke innslag om at veilder har delt tiltak med bruker tidligere"
+                    )
+                }
+                call.respond(it!!)
+            }.mapLeft {
+                call.respondText(
+                    status = HttpStatusCode.NoContent,
+                    text = "Fant ikke innslag om at veilder har delt tiltak med bruker tidligere"
+                )
+            }
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerService.kt
@@ -1,0 +1,55 @@
+package no.nav.mulighetsrommet.api.services
+
+import io.ktor.server.plugins.*
+import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.utils.DatabaseMapper
+import no.nav.mulighetsrommet.database.Database
+import no.nav.mulighetsrommet.database.utils.QueryResult
+import no.nav.mulighetsrommet.database.utils.query
+import no.nav.mulighetsrommet.domain.models.DelMedBruker
+import no.nav.mulighetsrommet.secure_log.SecureLog
+import org.intellij.lang.annotations.Language
+
+class DelMedBrukerService(private val db: Database) {
+    private val secureLog = SecureLog.logger
+
+    fun lagreDelMedBruker(data: DelMedBruker): QueryResult<DelMedBruker> = query {
+        secureLog.info("Veileder (${data.navident}) deler tiltak med tiltaksnummer: '${data.tiltaksnummer}' med bruker (${data.bruker_fnr})")
+
+        if (data.bruker_fnr.trim().length != 11) {
+            secureLog.warn("Brukers fnr er ikke 11 tegn. Innsendt: ${data.bruker_fnr}")
+            throw BadRequestException("Brukers fnr er ikke 11 tegn")
+        }
+
+        if (data.navident.trim().length != 6) {
+            secureLog.warn("Veilders NAVident er ikke 6 tegn. NAVident sendt inn: ${data.navident}")
+            throw BadRequestException("Veileders NAVident er ikke 6 tegn")
+        }
+
+        @Language("PostgreSQL")
+        val query = """
+            insert into del_med_bruker(bruker_fnr, navident, tiltaksnummer, created_by, updated_by) 
+            values(?, ?, ?, ?, ?)
+            returning *
+        """.trimIndent()
+        data.run { queryOf(query, data.bruker_fnr, data.navident, data.tiltaksnummer, data.navident, data.navident) }
+            .map {
+                DatabaseMapper.toDelMedBruker(it)
+            }
+            .asSingle
+            .let { db.run(it)!! }
+    }
+
+    fun getDeltMedBruker(fnr: String, navident: String, tiltaksnummer: String): QueryResult<DelMedBruker?> = query {
+        @Language("PostgreSQL")
+        val query = """
+            select * from del_med_bruker where bruker_fnr = ? and navident = ? and tiltaksnummer = ? order by created_at desc
+        """.trimIndent()
+        queryOf(
+            query,
+            fnr,
+            navident,
+            tiltaksnummer
+        ).map { DatabaseMapper.toDelMedBruker(it) }.asSingle.let { db.run(it) }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/PoaoTilgangService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/PoaoTilgangService.kt
@@ -22,7 +22,7 @@ class PoaoTilgangService(
         }
 
         if (!access) {
-            throw StatusException(HttpStatusCode.Forbidden, "Mangler tilgang til Modia Arbeidsrettet ppfølging")
+            throw StatusException(HttpStatusCode.Forbidden, "Mangler tilgang til Modia Arbeidsrettet oppfølging")
         }
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/DatabaseMapper.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/DatabaseMapper.kt
@@ -14,7 +14,7 @@ object DatabaseMapper {
             id = row.int("id"),
             navn = row.string("navn"),
             innsatsgruppe = row.int("innsatsgruppe_id"),
-            tiltakskode = row.string("tiltakskode"),
+            tiltakskode = row.string("tiltakskode")
         )
 
     fun toTiltaksgjennomforing(row: Row): Tiltaksgjennomforing =
@@ -31,7 +31,7 @@ object DatabaseMapper {
 
     fun toInnsatsgruppe(row: Row): Innsatsgruppe = Innsatsgruppe(
         id = row.int("id"),
-        navn = row.string("navn"),
+        navn = row.string("navn")
     )
 
     fun toDeltaker(row: Row): Deltaker = Deltaker(
@@ -69,7 +69,7 @@ object DatabaseMapper {
         arrangorId = row.intOrNull("arrangor_id"),
         sakId = row.int("sak_id"),
         apentForInnsok = row.boolean("apent_for_innsok"),
-        antallPlasser = row.intOrNull("antall_plasser"),
+        antallPlasser = row.intOrNull("antall_plasser")
     )
 
     fun toAdapterTiltakdeltaker(row: Row): AdapterTiltakdeltaker = AdapterTiltakdeltaker(
@@ -79,5 +79,16 @@ object DatabaseMapper {
         fraDato = row.localDateTimeOrNull("fra_dato"),
         tilDato = row.localDateTimeOrNull("til_dato"),
         status = Deltakerstatus.valueOf(row.string("status"))
+    )
+
+    fun toDelMedBruker(row: Row): DelMedBruker = DelMedBruker(
+        id = row.string("id"),
+        bruker_fnr = row.string("bruker_fnr"),
+        navident = row.string("navident"),
+        tiltaksnummer = row.string("tiltaksnummer"),
+        created_at = row.localDateTime("created_at"),
+        updated_at = row.localDateTime("updated_at"),
+        created_by = row.string("created_by"),
+        updated_by = row.string("updated_by")
     )
 }

--- a/mulighetsrommet-api/src/main/resources/db/migration/V6__add_table_del_med_bruker.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V6__add_table_del_med_bruker.sql
@@ -1,0 +1,14 @@
+create table del_med_bruker
+(
+    id            serial                  not null primary key,
+    bruker_fnr    text                    not null,
+    navident      text                    not null,
+    tiltaksnummer text                    not null,
+    created_at    timestamp default now() not null,
+    updated_at    timestamp default now() not null,
+    created_by    text,
+    updated_by    text
+);
+
+create index del_med_bruker_oppslag
+    on del_med_bruker (bruker_fnr, navident, tiltaksnummer);

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerServiceTest.kt
@@ -1,0 +1,76 @@
+package no.nav.mulighetsrommet.api.services
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.string.shouldContain
+import io.ktor.server.plugins.*
+import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseListener
+import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
+import no.nav.mulighetsrommet.domain.models.DelMedBruker
+import org.assertj.db.api.Assertions.assertThat
+import org.assertj.db.type.Table
+
+class DelMedBrukerServiceTest : FunSpec({
+    testOrder = TestCaseOrder.Sequential
+
+    val listener = FlywayDatabaseListener(createApiDatabaseTestSchema())
+
+    register(listener)
+
+    context("DelMedBrukerService") {
+        val service = DelMedBrukerService(listener.db)
+        val payload = DelMedBruker(
+            bruker_fnr = "12345678910",
+            navident = "nav123",
+            tiltaksnummer = "123456"
+        )
+
+        test("Insert del med bruker-data") {
+            val table = Table(listener.db.getDatasource(), "del_med_bruker")
+            service.lagreDelMedBruker(payload)
+            assertThat(table).row(0)
+                .column("id").value().isEqualTo(1)
+                .column("bruker_fnr").value().isEqualTo("12345678910")
+                .column("navident").value().isEqualTo("nav123")
+                .column("tiltaksnummer").value().isEqualTo("123456")
+        }
+
+        test("Lagre til tabell feiler dersom input for veileders navident er feil") {
+            val payloadMedFeilData = payload.copy(
+                navident = "nav12345"
+            )
+            val exception = shouldThrow<BadRequestException> {
+                service.lagreDelMedBruker(payloadMedFeilData)
+            }
+
+            exception.message shouldContain "Veileders NAVident er ikke 6 tegn"
+        }
+
+        test("Lagre til tabell feiler dersom input for brukers fnr er ulikt 11 tegn") {
+            val payloadMedFeilData = payload.copy(
+                bruker_fnr = "12345678910123"
+            )
+            val exception = shouldThrow<BadRequestException> {
+                service.lagreDelMedBruker(payloadMedFeilData)
+            }
+
+            exception.message shouldContain "Brukers fnr er ikke 11 tegn"
+        }
+
+        test("Les fra tabell") {
+            val table = Table(listener.db.getDatasource(), "del_med_bruker")
+            service.getDeltMedBruker(
+                fnr = "12345678910",
+                navident = "nav123",
+                tiltaksnummer = "123456"
+            ).map {
+                assertThat(table).row(0)
+                    .column("id").value().isEqualTo(1)
+                    .column("bruker_fnr").value().isEqualTo(it?.bruker_fnr ?: "")
+                    .column("navident").value().isEqualTo(it?.navident ?: "")
+                    .column("tiltaksnummer").value().isEqualTo(it?.tiltaksnummer ?: "")
+            }
+        }
+    }
+})


### PR DESCRIPTION
Denne PRen gjør følgende:
* Oppretter en ny databasetabell `del_med_bruker` som skal brukes for å persisterer info om hvilke tiltak veileder har delt med bruker.
* Setter opp to nye API-endepunkt `/api/v1/delMedBruker` som godtar `POST` og `GET` for å lagre info om deling av tiltak med bruker, samt henting av info om delt tiltak som kan brukes i frontend for å fortelle veileder at de har delt tiltak tidligere.