### PR TITLE
Konsekvent bruk av snake_case for css-styling

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/README.md
+++ b/frontend/mulighetsrommet-veileder-flate/README.md
@@ -6,6 +6,7 @@ Flate rettet mot veiledere for behandling av tiltaksinformasjon.
 
 - [Teknologier](#teknologier)
 - [Kom i gang](#kom-i-gang)
+- [kodestil](#kodestil)
   - [Forutsetninger](#forutsetninger)
   - [Steg for steg](#steg-for-steg)
 
@@ -26,6 +27,9 @@ Flate rettet mot veiledere for behandling av tiltaksinformasjon.
 # <a name="kom-i-gang"></a>Kom i gang
 
 For å komme i gang kan du hoppe rett til [Steg for steg](#steg-for-steg) gitt at du har satt opp alt under [Forutsetinger](#forutsetninger).
+
+# <a name="kodestil"></a>Kodestil
+For styling bruker vi css modules med .scss-filendelse. Vi skriver klassenavn med snake_case. Det vil si underscore som separator i klassenavn.
 
 ## <a name="forutsetninger"></a>Forutsetninger
 

--- a/frontend/mulighetsrommet-veileder-flate/src/App.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/App.module.scss
@@ -1,4 +1,4 @@
-.app__container {
+.app_container {
   background-color: var(--navds-semantic-color-canvas-background);
 }
 

--- a/frontend/mulighetsrommet-veileder-flate/src/App.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>
-      <div className={styles.app__container}>
+      <div className={styles.app_container}>
         <div className={APPLICATION_NAME}>
           <QueryClientProvider client={queryClient}>
             <Router>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/fakedoor/FakeDoor.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/fakedoor/FakeDoor.module.scss
@@ -1,4 +1,4 @@
-.fakedoorContainer {
+.fakedoor_container {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -15,7 +15,7 @@
   }
 }
 
-.fakedoorTextContainer {
+.fakedoor_text_container {
   color: white;
   width: 60%;
   min-width: 500px;
@@ -25,12 +25,11 @@
   }
 }
 
-.fakedoorHeader {
+.fakedoor_header {
   font-size: 1.5rem;
   font-weight: 600;
 }
 
-.fakedoorImage {
+.fakedoor_image {
   overflow: hidden;
 }
-

--- a/frontend/mulighetsrommet-veileder-flate/src/components/fakedoor/FakeDoor.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/fakedoor/FakeDoor.tsx
@@ -3,9 +3,9 @@ import imgUrl from '../../illustrasjonfakedoor.png';
 
 const FakeDoor = () => {
   return (
-    <div className={styles.fakedoorContainer}>
-      <div className={styles.fakedoorTextContainer}>
-        <h1 className={styles.fakedoorHeader}>Takk for at du deltok i piloten</h1>
+    <div className={styles.fakedoor_container}>
+      <div className={styles.fakedoor_text_container}>
+        <h1 className={styles.fakedoor_header}>Takk for at du deltok i piloten</h1>
         <div>
           <div>
             Piloten om arbeidsmarkedstiltak er nå avsluttet. Tusen takk for at du var med på å teste den nye tjenesten.
@@ -14,7 +14,7 @@ const FakeDoor = () => {
           <br />
         </div>
       </div>
-      <div className={styles.fakedoorImage}>
+      <div className={styles.fakedoor_image}>
         <img src={imgUrl} id="fakedoor-bilde" alt="Illustrasjon av løsning" />
       </div>
     </div>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/feedback/Feedback.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/feedback/Feedback.module.scss
@@ -9,7 +9,7 @@
   }
 }
 
-.feedBackModal {
+.feedback_modal {
   width: 468px;
   background-color: #fff;
   box-shadow: 0 6px 10px 0 #6a6a6a;
@@ -20,11 +20,11 @@
   bottom: 6rem;
   padding: 1rem;
 
-  &__heading {
+  &_heading {
     margin-bottom: 1rem;
   }
 
-  &__forms {
+  &_forms {
     color: #fff;
     background-color: #0067c5;
     padding: 0.7rem 1rem;
@@ -35,38 +35,12 @@
     }
   }
 
-  &__textarea {
+  &_textarea {
     margin-bottom: 1rem;
   }
 
-  &__slideIn {
+  &_slideIn {
     bottom: 100px;
     animation: 0.33s ease-out slide-in;
   }
 }
-
-.feedbackBtn {
-  box-shadow: 0 6px 10px 0 #6a6a6a;
-  transition: all 0.1s ease-in-out;
-  z-index: 1000;
-  text-align: center;
-  position: fixed;
-  right: 1rem;
-  bottom: 1rem;
-  border-radius: 50%;
-  width: 4rem;
-  height: 4rem;
-  color: #000;
-  background-color: #fff;
-
-  &:hover {
-    width: 4.5rem;
-    height: 4.5rem;
-  }
-
-  &__icon {
-    width: 2rem;
-    height: auto;
-  }
-}
-

--- a/frontend/mulighetsrommet-veileder-flate/src/components/feedback/FeedbackButton.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/feedback/FeedbackButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@navikt/ds-react';
 import { Close, DialogReport } from '@navikt/ds-icons';
-import styles from './Feedback.module.scss';
+import styles from './Feedbackbutton.module.scss';
 
 interface FeedbackButtonProps {
   handleClick: () => void;
@@ -11,14 +11,14 @@ interface FeedbackButtonProps {
 const FeedbackButton = ({ handleClick, isModalOpen }: FeedbackButtonProps) => {
   return (
     <Button
-      className={styles.feedbackBtn}
+      className={styles.feedback_button}
       onClick={handleClick}
       title="Hjelp oss å bli bedre ved å dele tilbakemeldingen din."
     >
       {isModalOpen ? (
-        <Close aria-label="Lukk" className={styles.feedbackBtn__icon} />
+        <Close aria-label="Lukk" className={styles.feedback_button_icon} />
       ) : (
-        <DialogReport aria-label="Åpne tilbakemeldingsundersøkelse" className={styles.feedbackBtn__icon} />
+        <DialogReport aria-label="Åpne tilbakemeldingsundersøkelse" className={styles.feedback_button_icon} />
       )}
     </Button>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/components/feedback/FeedbackModalForms.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/feedback/FeedbackModalForms.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
 import { BodyShort, Detail, Heading } from '@navikt/ds-react';
-import styles from './Feedback.module.scss';
-import Lenke from '../lenke/Lenke';
 import classNames from 'classnames';
 import Show from '../../utils/Show';
+import Lenke from '../lenke/Lenke';
+import styles from './Feedback.module.scss';
 
 interface FeedbackModalProps {
   isModalOpen: boolean;
@@ -13,11 +12,11 @@ const FeedbackModalForms = ({ isModalOpen }: FeedbackModalProps) => {
   return (
     <Show if={isModalOpen}>
       <div
-        className={classNames(styles.feedBackModal, {
-          [styles.feedBackModal__slideIn]: isModalOpen,
+        className={classNames(styles.feedback_modal, {
+          [styles.feedBackModal_slideIn]: isModalOpen,
         })}
       >
-        <div className={styles.feedBackModal__heading}>
+        <div className={styles.feedBackModal_heading}>
           <Heading size="large" level="1">
             Tilbakemelding
           </Heading>
@@ -29,7 +28,7 @@ const FeedbackModalForms = ({ isModalOpen }: FeedbackModalProps) => {
         <Lenke
           isExternal
           to="https://forms.office.com/r/gGtRvL8Niv"
-          className={classNames(styles.feedBackModal__forms, styles.feedBackModal__textarea)}
+          className={classNames(styles.feedBackModal_forms, styles.feedBackModal_textarea)}
         >
           Gi tilbakemelding
         </Lenke>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/feedback/Feedbackbutton.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/feedback/Feedbackbutton.module.scss
@@ -1,0 +1,24 @@
+.feedback_button {
+  box-shadow: 0 6px 10px 0 #6a6a6a;
+  transition: all 0.1s ease-in-out;
+  z-index: 1000;
+  text-align: center;
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  border-radius: 50%;
+  width: 4rem;
+  height: 4rem;
+  color: #000;
+  background-color: #fff;
+
+  &:hover {
+    width: 4.5rem;
+    height: 4.5rem;
+  }
+
+  &_icon {
+    width: 2rem;
+    height: auto;
+  }
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/feilmelding/Feilmelding.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/feilmelding/Feilmelding.module.scss
@@ -1,5 +1,4 @@
-
-.feilmeldingContainer {
+.feilmelding_container {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -18,4 +17,3 @@
     height: auto;
   }
 }
-

--- a/frontend/mulighetsrommet-veileder-flate/src/components/feilmelding/Feilmelding.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/feilmelding/Feilmelding.tsx
@@ -19,7 +19,7 @@ export const Feilmelding = ({ children, ikonvariant }: FeilmeldingProps) => {
   };
 
   return (
-    <div data-testid="feilmelding-container" aria-live="assertive" className={styles.feilmeldingContainer}>
+    <div data-testid="feilmelding-container" aria-live="assertive" className={styles.feilmelding_container}>
       {ikon()}
       {children}
     </div>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.module.scss
@@ -1,5 +1,4 @@
-
-.tiltakstypeOversiktFiltermeny {
+.tiltakstype_oversikt_filtermeny {
   width: 15rem;
   height: 100%;
   border-right: 1px solid var(--navds-semantic-color-border-muted);
@@ -13,7 +12,7 @@
   grid-row-end: 4;
 }
 
-.filtermenyHeading {
+.filtermeny_heading {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.tsx
@@ -11,8 +11,8 @@ const Filtermeny = () => {
   usePrepopulerFilter();
 
   return (
-    <div className={styles.tiltakstypeOversiktFiltermeny}>
-      <Heading size="medium" level="1" className={styles.filtermenyHeading} role="heading">
+    <div className={styles.tiltakstype_oversikt_filtermeny}>
+      <Heading size="medium" level="1" className={styles.filtermeny_heading} role="heading">
         Filter
       </Heading>
       <Fritekstfilter />

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.module.scss
@@ -1,4 +1,4 @@
-.historikkModal {
+.historikk_modal {
   width: 50rem;
   max-width: 70%;
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/HistorikkButton.tsx
@@ -12,7 +12,7 @@ export function HistorikkButton() {
     <>
       <Button onClick={toggleModal}>Historikk</Button>
       <StandardModal
-        className={styles.historikkModal}
+        className={styles.historikk_modal}
         hideButtons
         modalOpen={apneModal}
         setModalOpen={toggleModal}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/Statusbadge.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/Statusbadge.module.scss
@@ -1,4 +1,4 @@
-.historikkForBrukerStatusbadge {
+.historikk_for_bruker_statusbadge {
   display: inline-block;
   text-align: center;
   border-radius: 5%;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/historikk/Statusbadge.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/historikk/Statusbadge.tsx
@@ -4,7 +4,7 @@ import styles from './Statusbadge.module.scss';
 
 export function StatusBadge({ status }: { status?: HistorikkForBruker.status }) {
   return (
-    <div className={classNames(styles.historikkForBrukerStatusbadge, styles[status as unknown as any])}>
+    <div className={classNames(styles.historikk_for_bruker_statusbadge, styles[status as unknown as any])}>
       {statustekst(status)}
     </div>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/components/kopiknapp/Kopiknapp.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/kopiknapp/Kopiknapp.module.scss
@@ -8,7 +8,7 @@
   }
 }
 
-.kopiknappTooltip {
+.kopiknapp_tooltip {
   background-color: var(--navds-semantic-color-component-background-inverted);
   color: var(--navds-semantic-color-text-inverted);
   border-radius: var(--navds-border-radius-small);

--- a/frontend/mulighetsrommet-veileder-flate/src/components/kopiknapp/Kopiknapp.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/kopiknapp/Kopiknapp.tsx
@@ -29,7 +29,7 @@ const Kopiknapp = ({ kopitekst, dataTestId }: KopiknappProps) => {
   }, [showTooltip]);
 
   return (
-    <Tooltip placement="top" content="Kopiert" className={styles.kopiknappTooltip} open={showTooltip} role="tooltip">
+    <Tooltip placement="top" content="Kopiert" className={styles.kopiknapp_tooltip} open={showTooltip} role="tooltip">
       <Button
         size="xsmall"
         variant="tertiary"

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/Modal.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/Modal.module.scss
@@ -1,4 +1,4 @@
-.overstyrteStylesFraDSModal {
+.overstyrte_styles_fra_ds_modal {
   width: 40rem;
   padding: 1rem;
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/StandardModal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/StandardModal.tsx
@@ -44,7 +44,7 @@ const StandardModal = ({
       closeButton
       open={modalOpen}
       onClose={setModalOpen}
-      className={classNames(styles.overstyrteStylesFraDSModal, className)}
+      className={classNames(styles.overstyrte_styles_fra_ds_modal, className)}
       aria-label="modal"
     >
       <Modal.Content>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.module.scss
@@ -2,7 +2,7 @@
 .delemodal {
   background-color: #f7f7f7;
 
-  &__tilbakemelding {
+  &_tilbakemelding {
     text-align: center;
 
     .modal_btngroup {
@@ -10,7 +10,7 @@
     }
   }
 
-  &__svg {
+  &_svg {
     width: 3rem;
     height: auto;
     align-self: center;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -128,7 +128,7 @@ const Delemodal = ({
       closeButton={false}
       open={modalOpen}
       onClose={clickCancel}
-      className={classNames(modalStyles.overstyrteStylesFraDSModal, delemodalStyles.delemodal)}
+      className={classNames(modalStyles.overstyrte_styles_fra_ds_modal, delemodalStyles.delemodal)}
       aria-label="modal"
       data-testid="delemodal"
     >
@@ -171,10 +171,8 @@ const Delemodal = ({
         </Modal.Content>
       )}
       {state.sendtStatus === 'SENDT_OK' && (
-        <Modal.Content
-          className={classNames(delemodalStyles.delemodal__tilbakemelding, delemodalStyles.delemodal__success)}
-        >
-          <SuccessColored className={delemodalStyles.delemodal__svg} />
+        <Modal.Content className={classNames(delemodalStyles.delemodal_tilbakemelding)}>
+          <SuccessColored className={delemodalStyles.delemodal_svg} />
           <Heading level="1" size="large" data-testid="modal_header">
             Meldingen er sendt
           </Heading>
@@ -190,10 +188,8 @@ const Delemodal = ({
         </Modal.Content>
       )}
       {state.sendtStatus === 'SENDING_FEILET' && (
-        <Modal.Content
-          className={classNames(delemodalStyles.delemodal__tilbakemelding, delemodalStyles.delemodal__success)}
-        >
-          <ErrorColored className={delemodalStyles.delemodal__svg} />
+        <Modal.Content className={classNames(delemodalStyles.delemodal_tilbakemelding)}>
+          <ErrorColored className={delemodalStyles.delemodal_svg} />
           <Heading level="1" size="large" data-testid="modal_header">
             Tiltaket kunne ikke deles med brukeren
           </Heading>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -191,7 +191,7 @@ const TiltaksgjennomforingsTabell = () => {
             <Table.ColumnHeader
               sortKey="tiltaksgjennomforingNavn"
               sortable
-              className={styles.tabell__kolonne__tiltaksnavn}
+              className={styles.tabell_tiltaksnavn}
               data-testid="tabellheader_tiltaksnavn"
             >
               Tiltaksnavn
@@ -227,7 +227,7 @@ const TiltaksgjennomforingsTabell = () => {
               tilgjengelighetsstatus,
             }) => (
               <Table.Row key={_id}>
-                <Table.DataCell className={styles.tabell__tiltaksnavn}>
+                <Table.DataCell className={styles.tabell_tiltaksnavn}>
                   <Lenke
                     to={`tiltak/${tiltaksnummer}#filter=${encodeURIComponent(JSON.stringify(filter))}`}
                     isInline
@@ -237,8 +237,8 @@ const TiltaksgjennomforingsTabell = () => {
                   </Lenke>
                   <div>{kontaktinfoArrangor?.selskapsnavn}</div>
                 </Table.DataCell>
-                <Table.DataCell data-testid="tabell_tiltaksnummer" className={classNames(styles.tabell__tiltaksnummer)}>
-                  <div className={styles.tabellWrapper}>
+                <Table.DataCell data-testid="tabell_tiltaksnummer" className={classNames(styles.tabell_tiltaksnummer)}>
+                  <div className={styles.tabell_wrapper}>
                     {tiltaksnummer} <Kopiknapp kopitekst={tiltaksnummer!.toString()} dataTestId="tabell_knapp_kopier" />
                   </div>
                 </Table.DataCell>
@@ -251,7 +251,7 @@ const TiltaksgjennomforingsTabell = () => {
           )}
         </Table.Body>
       </Table>
-      <div className={styles.underTabell}>
+      <div className={styles.under_tabell}>
         {tiltaksgjennomforinger.length > 0 ? (
           <>
             <Heading level="1" size="xsmall" data-testid="antall-tiltak">

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabell/tabell.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabell/tabell.module.scss
@@ -1,4 +1,4 @@
-.filterLoader {
+.filter_loader {
   display: block;
   margin: 0 auto;
 }
@@ -11,7 +11,7 @@
   }
 }
 
-.tabellWrapper {
+.tabell_wrapper {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -22,11 +22,11 @@
 }
 
 .tabell {
-  &__tiltaksnavn {
+  &_tiltaksnavn {
     font-weight: bold;
   }
 
-  &__tiltaksnummer {
+  &_tiltaksnummer {
     padding-right: 1.5rem;
 
     @media (max-width: 1400px) {
@@ -34,14 +34,8 @@
     }
   }
 
-  &__kolonne {
-    &__tiltaksnavn {
-      width: 25%;
-    }
-  }
-
-  &__alert {
-    max-width: unset;
+  &_tiltaksnavn {
+    width: 25%;
   }
 }
 
@@ -57,7 +51,7 @@
   }
 }
 
-.underTabell {
+.under_tabell {
   display: flex;
   justify-content: space-between;
   margin-top: 1rem;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/Detaljerfane.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/Detaljerfane.module.scss
@@ -1,4 +1,4 @@
-.tiltaksdetaljer {
+w.tiltaksdetaljer {
   &_alert {
     margin-bottom: 1rem;
   }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/Detaljerfane.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/Detaljerfane.module.scss
@@ -1,13 +1,13 @@
 .tiltaksdetaljer {
-  &__alert {
+  &_alert {
     margin-bottom: 1rem;
   }
 
-  &__maksbredde {
+  &_maksbredde {
     max-width: 100ch;
   }
 
-  &__innsiktheader {
+  &_innsiktheader {
     font-size: 16px;
     font-weight: bold;
     margin-top: 1rem;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/detaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/detaljerFane.tsx
@@ -1,6 +1,6 @@
 import { Alert } from '@navikt/ds-react';
 import { PortableText } from '@portabletext/react';
-import styles from './Detaljfane.module.scss';
+import styles from './Detaljerfane.module.scss';
 
 interface DetaljerFaneProps {
   tiltaksgjennomforingAlert?: string;
@@ -16,14 +16,14 @@ const DetaljerFane = ({
   tiltakstype,
 }: DetaljerFaneProps) => {
   return (
-    <div className={styles.tiltaksdetaljer__maksbredde}>
+    <div className={styles.tiltaksdetaljer_maksbredde}>
       {tiltakstypeAlert && (
-        <Alert variant="info" className={styles.tiltaksdetaljer__alert}>
+        <Alert variant="info" className={styles.tiltaksdetaljer_alert}>
           {tiltakstypeAlert}
         </Alert>
       )}
       {tiltaksgjennomforingAlert && (
-        <Alert variant="info" className={styles.tiltaksdetaljer__alert}>
+        <Alert variant="info" className={styles.tiltaksdetaljer_alert}>
           {tiltaksgjennomforingAlert}
         </Alert>
       )}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/innsikt/BarChart.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/innsikt/BarChart.tsx
@@ -8,7 +8,7 @@ import { SeriesPoint } from '@visx/shape/lib/types';
 import { useTooltip, useTooltipInPortal, defaultStyles } from '@visx/tooltip';
 import { StatistikkFraCsvFil } from '../../../core/api/models';
 import useHentStatistikkFraFil from '../../../hooks/useHentStatistikkFraFil';
-import styles from '../Detaljfane.module.scss';
+import styles from '../Detaljerfane.module.scss';
 import barchartStyles from './Barchart.module.scss';
 import { Datapunkt } from './Datapunkt';
 import { localPoint } from '@visx/event';
@@ -202,7 +202,7 @@ export default function BarChart({ tiltakstype, width, height, margin = defaultM
 
   return width < 10 ? null : (
     <div>
-      <div style={{ width }} className={styles.tiltaksdetaljer__innsiktheader}>
+      <div style={{ width }} className={styles.tiltaksdetaljer_innsiktheader}>
         Status etter avgang siste {SISTE_AAR} år ({dataForVisning[0].År})
       </div>
 
@@ -297,15 +297,15 @@ export default function BarChart({ tiltakstype, width, height, margin = defaultM
       </div>
       {tooltipOpen && tooltipData && (
         <TooltipInPortal top={tooltipTop} left={tooltipLeft} style={tooltipStyles}>
-          <div className={classNames(barchartStyles.tooltipContainer, barchartStyles.tooltipContainer_row)}>
+          <div className={classNames(barchartStyles.tooltip_container, barchartStyles.tooltip_container_row)}>
             <div>
-              <span className={barchartStyles.tooltipColorIcon} style={{ background: colorScale(tooltipData.key) }} />
+              <span className={barchartStyles.tooltip_color_icon} style={{ background: colorScale(tooltipData.key) }} />
             </div>
-            <div className={barchartStyles.tooltipContainer_column}>
-              <span className={classNames(barchartStyles.tooltipData_text, barchartStyles.tooltipData_number)}>
+            <div className={barchartStyles.tooltip_container_column}>
+              <span className={classNames(barchartStyles.tooltip_data_text, barchartStyles.tooltip_data_number)}>
                 {tooltipData.bar.data[tooltipData.key].toFixed(2)}%
               </span>
-              <span className={classNames(barchartStyles.tooltipData_text, barchartStyles.tooltipData_label)}>
+              <span className={classNames(barchartStyles.tooltip_data_text, barchartStyles.tooltip_data_label)}>
                 {tooltipData.key}
               </span>
             </div>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/innsikt/Barchart.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/innsikt/Barchart.module.scss
@@ -1,4 +1,4 @@
-.tooltipContainer {
+.tooltip_container {
   display: flex;
   gap: 10px;
   justify-content: center;
@@ -13,14 +13,14 @@
   }
 }
 
-.tooltipColorIcon {
+.tooltip_color_icon {
   width: 10px;
   height: 10px;
   display: inline-block;
   border-radius: 50%;
 }
 
-.tooltipData {
+.tooltip_data {
   &_text {
     display: block;
     padding: 2px 0px;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/innsikt/Forskningsrapport.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/innsikt/Forskningsrapport.tsx
@@ -1,6 +1,6 @@
 import { PortableText } from '@portabletext/react';
 import { Forskningsrapport as ForskningsrapportType } from '../../../core/api/models';
-import styles from '../Detaljfane.module.scss';
+import styles from '../Detaljerfane.module.scss';
 import forskningStyles from './Forskningsrapport.module.scss';
 
 interface Props {
@@ -13,7 +13,7 @@ export function Forskningsrapport({ forskningsrapporter }: Props) {
       {forskningsrapporter.map(rapport => {
         return (
           <div key={rapport._id}>
-            <h2 className={styles.tiltaksdetaljer__innsiktheader}>{rapport.tittel}</h2>
+            <h2 className={styles.tiltaksdetaljer_innsiktheader}>{rapport.tittel}</h2>
             <PortableText value={rapport.beskrivelse} />
             <ul className={forskningStyles.forskningsrapport__lenkeliste}>
               {rapport.lenker?.map(({ lenke, lenkenavn }, index) => {

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/innsikt/InnsiktsFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/innsikt/InnsiktsFane.tsx
@@ -1,7 +1,7 @@
 import { Alert, Loader } from '@navikt/ds-react';
 import useResizeObserver from 'use-resize-observer';
 import { useTiltakstyperMedTiltakstypenavn } from '../../../core/api/queries/useTiltakstypeMedTiltakstypenavn';
-import styles from '../Detaljfane.module.scss';
+import styles from '../Detaljerfane.module.scss';
 import BarChart from './BarChart';
 import { Forskningsrapport } from './Forskningsrapport';
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
@@ -1,5 +1,6 @@
 import { BodyShort, Heading, Label } from '@navikt/ds-react';
 import { Arrangor } from '../../../core/api/models';
+import styles from './Arrangorinfo.module.scss';
 
 interface ArrangorProps {
   arrangorinfo: Arrangor;
@@ -8,15 +9,15 @@ interface ArrangorProps {
 const ArrangorInfo = ({ arrangorinfo }: ArrangorProps) => {
   return (
     <>
-      <Heading size="small" level="3" className="kontaktinfo__navn">
+      <Heading size="small" level="3" className={styles.navn}>
         {arrangorinfo.selskapsnavn}
       </Heading>
-      <div className="kontaktinfo__container">
-        <div className="kontaktinfo__rad">
+      <div className={styles.container}>
+        <div className={styles.rad}>
           <Label size="small">Telefon</Label>
           <BodyShort>{arrangorinfo.telefonnummer}</BodyShort>
         </div>
-        <div className="kontaktinfo__rad">
+        <div className={styles.rad}>
           <Label size="small">Adresse</Label>
           <BodyShort>{arrangorinfo.adresse}</BodyShort>
         </div>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/Arrangorinfo.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/Arrangorinfo.module.scss
@@ -1,0 +1,14 @@
+.navn {
+  margin-bottom: 0.2rem;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.rad {
+  display: grid;
+  grid-template-columns: 6rem auto;
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.module.scss
@@ -3,22 +3,8 @@
   margin: 18px 0;
   grid-template-columns: auto auto;
   gap: 2rem;
-  &__header {
-    margin-bottom: 0.5rem;
-  }
+}
 
-  &__container {
-    margin-bottom: 1rem;
-  }
-  &__navn {
-    margin-bottom: 0.2rem;
-  }
-  &__container {
-    display: flex;
-    flex-direction: column;
-  }
-  &__rad {
-    display: grid;
-    grid-template-columns: 6rem auto;
-  }
+.header {
+  margin-bottom: 0.5rem;
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.tsx
@@ -13,13 +13,13 @@ const KontaktinfoFane = ({ tiltaksansvarlige, arrangorinfo }: KontaktinfoFanePro
   return (
     <div className={styles.kontaktinfo}>
       <div>
-        <Heading size="large" level="2" className={styles.kontaktinfo__header}>
+        <Heading size="large" level="2" className={styles.header}>
           Arrangør
         </Heading>
         {arrangorinfo ? <ArrangorInfo arrangorinfo={arrangorinfo} /> : null}
       </div>
       <div>
-        <Heading size="large" level="2" className={styles.kontaktinfo__header}>
+        <Heading size="large" level="2" className={styles.header}>
           Tiltaksansvarlig
         </Heading>
         <TiltaksansvarligInfo tiltaksansvarlige={tiltaksansvarlige} />

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/TiltaksansvarligInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/TiltaksansvarligInfo.tsx
@@ -1,7 +1,6 @@
 import { BodyShort, Heading, Label } from '@navikt/ds-react';
-import React from 'react';
-import styles from './KontaktinfoFane.module.scss';
 import { Tiltaksansvarlig } from '../../../core/api/models';
+import styles from './Arrangorinfo.module.scss';
 
 const TEAMS_DYPLENKE = 'https://teams.microsoft.com/l/chat/0/0?users=';
 
@@ -14,22 +13,22 @@ const TiltaksansvarligInfo = ({ tiltaksansvarlige }: TiltaksansvarligProps) => {
     <>
       {tiltaksansvarlige.map(tiltaksansvarlig => {
         return (
-          <div className={styles.kontaktinfo__container} key={tiltaksansvarlig._id}>
-            <Heading size="small" level="3" className={styles.kontaktinfo__navn}>
+          <div className={styles.container} key={tiltaksansvarlig._id}>
+            <Heading size="small" level="3" className={styles.navn}>
               {tiltaksansvarlig.navn}
             </Heading>
-            <div className={styles.kontaktinfo__container}>
-              <div className={styles.kontaktinfo__rad}>
+            <div className={styles.container}>
+              <div className={styles.rad}>
                 <Label size="small">Telefon</Label>
                 <BodyShort>{tiltaksansvarlig.telefonnummer}</BodyShort>
               </div>
-              <div className={styles.kontaktinfo__rad}>
+              <div className={styles.rad}>
                 <Label size="small">Epost</Label>
                 <BodyShort>
                   <a href={`mailto:${tiltaksansvarlig.epost}`}>{tiltaksansvarlig.epost}</a>
                 </BodyShort>
               </div>
-              <div className={styles.kontaktinfo__rad}>
+              <div className={styles.rad}>
                 <Label size="small">Teams</Label>
                 <BodyShort>
                   <a target="_blank" href={`${TEAMS_DYPLENKE}${encodeURIComponent(tiltaksansvarlig.epost)}`}>
@@ -37,7 +36,7 @@ const TiltaksansvarligInfo = ({ tiltaksansvarlige }: TiltaksansvarligProps) => {
                   </a>
                 </BodyShort>
               </div>
-              <div className={styles.kontaktinfo__rad}>
+              <div className={styles.rad}>
                 <Label size="small">Enhet</Label>
                 <BodyShort>{tiltaksansvarlig.enhet}</BodyShort>
               </div>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tags/FilterTag.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tags/FilterTag.tsx
@@ -23,7 +23,7 @@ const FilterTag = ({ options, handleClick }: FilterTagsProps) => {
           >
             {filtertype.tittel}
             <Ikonknapp
-              className={styles.overstyrtIkonknapp}
+              className={styles.overstyrt_ikon_knapp}
               handleClick={() => handleClick(filtertype.id)}
               ariaLabel="Lukke"
               data-testid={`filtertag_lukkeknapp_${kebabCase(filtertype.tittel)}`}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tags/Filtertag.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tags/Filtertag.module.scss
@@ -6,7 +6,7 @@
   justify-content: center;
 }
 
-.overstyrtIkonknapp {
+.overstyrt_ikon_knapp {
   padding: var(--navds-spacing-1) 0;
   margin-left: 0.2rem;
   padding-left: 0.4rem;

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltaksgjennomforingDetaljer.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltaksgjennomforingDetaljer.module.scss
@@ -1,4 +1,4 @@
-.filterLoader {
+.filter_loader {
   display: block;
   margin: 0 auto;
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltakstypeDetaljer.tsx
@@ -46,7 +46,7 @@ const ViewTiltakstypeDetaljer = () => {
   };
 
   if (isLoading) {
-    return <Loader className={styles.filterLoader} size="xlarge" />;
+    return <Loader className={styles.filter_loader} size="xlarge" />;
   }
 
   if (isError) {


### PR DESCRIPTION
Fjerner doble underscores og klassenavn med camelCase og erstatter med snake_case

![https://media.giphy.com/media/sjr7k1uuO0B0c/giphy.gif](https://media.giphy.com/media/sjr7k1uuO0B0c/giphy.gif)