### PR TITLE
Kvitter oss med litt prop-drilling

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
@@ -14,7 +14,7 @@ const TiltaksdetaljerFane = () => {
   const [fane, setFane] = useAtom(faneAtom);
   if (!data) return null;
 
-  const { tiltakstype, kontaktinfoTiltaksansvarlige, kontaktinfoArrangor, faneinnhold } = data;
+  const { tiltakstype, faneinnhold } = data;
   const faneoverskrifter = ['For hvem', 'Detaljer og innhold', 'Påmelding og varighet', 'Kontaktinfo', 'Innsikt'];
   const tabValueTilFaneoverSkrifter: { [key: string]: string } = {
     tab1: faneoverskrifter[0],
@@ -71,7 +71,7 @@ const TiltaksdetaljerFane = () => {
         />
       </Tabs.Panel>
       <Tabs.Panel value="tab4" data-testid="tab4">
-        <KontaktinfoFane tiltaksansvarlige={kontaktinfoTiltaksansvarlige} arrangorinfo={kontaktinfoArrangor} />
+        <KontaktinfoFane />
       </Tabs.Panel>
       <Tabs.Panel value="tab5" data-testid="tab5">
         <InnsiktsFane tiltakstype={tiltakstype.tiltakstypeNavn} />

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
@@ -1,25 +1,28 @@
 import { BodyShort, Heading, Label } from '@navikt/ds-react';
-import { Arrangor } from '../../../core/api/models';
+import useTiltaksgjennomforingByTiltaksnummer from '../../../core/api/queries/useTiltaksgjennomforingByTiltaksnummer';
 import styles from './Arrangorinfo.module.scss';
 
-interface ArrangorProps {
-  arrangorinfo: Arrangor;
-}
+const ArrangorInfo = () => {
+  const { data } = useTiltaksgjennomforingByTiltaksnummer();
+  if (!data) return null;
 
-const ArrangorInfo = ({ arrangorinfo }: ArrangorProps) => {
+  const { kontaktinfoArrangor } = data;
+
+  if (!kontaktinfoArrangor) return null;
+
   return (
     <>
       <Heading size="small" level="3" className={styles.navn}>
-        {arrangorinfo.selskapsnavn}
+        {kontaktinfoArrangor?.selskapsnavn}
       </Heading>
       <div className={styles.container}>
         <div className={styles.rad}>
           <Label size="small">Telefon</Label>
-          <BodyShort>{arrangorinfo.telefonnummer}</BodyShort>
+          <BodyShort>{kontaktinfoArrangor?.telefonnummer}</BodyShort>
         </div>
         <div className={styles.rad}>
           <Label size="small">Adresse</Label>
-          <BodyShort>{arrangorinfo.adresse}</BodyShort>
+          <BodyShort>{kontaktinfoArrangor?.adresse}</BodyShort>
         </div>
       </div>
     </>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.tsx
@@ -1,28 +1,22 @@
 import { Heading } from '@navikt/ds-react';
-import { Arrangor, Tiltaksansvarlig } from '../../../core/api/models';
 import ArrangorInfo from './ArrangorInfo';
 import styles from './KontaktinfoFane.module.scss';
 import TiltaksansvarligInfo from './TiltaksansvarligInfo';
 
-interface KontaktinfoFaneProps {
-  tiltaksansvarlige: Tiltaksansvarlig[];
-  arrangorinfo?: Arrangor;
-}
-
-const KontaktinfoFane = ({ tiltaksansvarlige, arrangorinfo }: KontaktinfoFaneProps) => {
+const KontaktinfoFane = () => {
   return (
     <div className={styles.kontaktinfo}>
       <div>
         <Heading size="large" level="2" className={styles.header}>
           Arrangør
         </Heading>
-        {arrangorinfo ? <ArrangorInfo arrangorinfo={arrangorinfo} /> : null}
+        <ArrangorInfo />
       </div>
       <div>
         <Heading size="large" level="2" className={styles.header}>
           Tiltaksansvarlig
         </Heading>
-        <TiltaksansvarligInfo tiltaksansvarlige={tiltaksansvarlige} />
+        <TiltaksansvarligInfo />
       </div>
     </div>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/TiltaksansvarligInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/TiltaksansvarligInfo.tsx
@@ -1,14 +1,14 @@
 import { BodyShort, Heading, Label } from '@navikt/ds-react';
-import { Tiltaksansvarlig } from '../../../core/api/models';
+import useTiltaksgjennomforingByTiltaksnummer from '../../../core/api/queries/useTiltaksgjennomforingByTiltaksnummer';
 import styles from './Arrangorinfo.module.scss';
 
 const TEAMS_DYPLENKE = 'https://teams.microsoft.com/l/chat/0/0?users=';
 
-interface TiltaksansvarligProps {
-  tiltaksansvarlige: Tiltaksansvarlig[];
-}
+const TiltaksansvarligInfo = () => {
+  const { data } = useTiltaksgjennomforingByTiltaksnummer();
+  if (!data) return null;
 
-const TiltaksansvarligInfo = ({ tiltaksansvarlige }: TiltaksansvarligProps) => {
+  const { kontaktinfoTiltaksansvarlige: tiltaksansvarlige } = data;
   return (
     <>
       {tiltaksansvarlige.map(tiltaksansvarlig => {


### PR DESCRIPTION
Siden vi bruker react-query kan vi fint gjøre en "ekstra" spørring i komponenten som trenger dataene, uten å måtte prop-drille oss nedover. Koden blir da mer lesbar og enklere å refaktorere senere.