### PR TITLE
Fikset uthenting av tiltaksnummer i groq-spørringer

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforing.ts
@@ -24,7 +24,7 @@ export default function useTiltaksgjennomforing() {
     oppstart,
     oppstartsdato,
     estimert_ventetid,
-    tiltaksnummer,
+    "tiltaksnummer": tiltaksnummer.current,
     kontaktinfoArrangor->{selskapsnavn},
     tiltakstype->{tiltakstypeNavn},
     tilgjengelighetsstatus

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforingByTiltaksnummer.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforingByTiltaksnummer.ts
@@ -6,11 +6,11 @@ import { useSanity } from './useSanity';
 export default function useTiltaksgjennomforingByTiltaksnummer() {
   const tiltaksnummer = useGetTiltaksnummerFraUrl();
   return useSanity<Tiltaksgjennomforing>(
-    groq`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) && tiltaksnummer == ${tiltaksnummer}] {
+    groq`*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) && tiltaksnummer.current == '${tiltaksnummer}'] {
     _id,
     tiltaksgjennomforingNavn,
     beskrivelse,
-    tiltaksnummer,
+    "tiltaksnummer": tiltaksnummer.current,
     lokasjon,
     oppstart,
     oppstartsdato,


### PR DESCRIPTION
Siden vi har gått over til type = slug for tiltaksnummer så måtte groq-spørringene justeres for å ikke brekke frontend.