### PR TITLE
Infoboks for preview av tiltaksgjennomføringer

### DIFF
--- a/frontend/mulighetsrommet-cms/deskStructures/commonStructure.js
+++ b/frontend/mulighetsrommet-cms/deskStructures/commonStructure.js
@@ -86,9 +86,7 @@ export function commonStructure() {
                         '_type == "tiltaksgjennomforing" && $redaktorId in redaktor[]._ref'
                       )
                       .params({ redaktorId })
-                      .defaultOrdering([
-                        { field: "_createdAt", direction: "desc" },
-                      ])
+                      .defaultOrdering(ORDER_BY_CREATEDAT_FIELD)
                   )
               ),
             S.listItem()

--- a/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypeOgTiltaksgjennomforingPreview.tsx
+++ b/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypeOgTiltaksgjennomforingPreview.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import sanityClient from "part:@sanity/base/client";
 import Switch from "react-switch";
-import { Legend, MarginBottom, tilListe } from "./common";
+import { Infoboks, Legend, MarginBottom, tilListe } from "./common";
 
 const client = sanityClient.withConfig({ apiVersion: "2021-10-21" });
 
@@ -10,7 +10,7 @@ const gjennomforingsfarge = "#881D0C";
 
 export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
   const [tiltaksdata, setTiltaksdata] = useState(null);
-  const [fargekodet, setFargekodet] = useState(false);
+  const [fargekodet, setFargekodet] = useState(true);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -25,13 +25,21 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
 
   function TekstFraTiltakstype({ children }) {
     return (
-      <p style={{ color: fargekodet ? tiltaksfarge : "black" }}>{children}</p>
+      <p
+        title="Tekst hentet fra informasjon om tiltakstypen"
+        style={{ color: fargekodet ? tiltaksfarge : "black" }}
+      >
+        {children}
+      </p>
     );
   }
 
   function TekstFraGjennomforing({ children }) {
     return (
-      <p style={{ color: fargekodet ? gjennomforingsfarge : "black" }}>
+      <p
+        title="Tekst hentet fra informasjon om tiltaksgjennomføringen"
+        style={{ color: fargekodet ? gjennomforingsfarge : "black" }}
+      >
         {children}
       </p>
     );
@@ -119,6 +127,8 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
           </MarginBottom>
           <MarginBottom>
             <h3>For hvem</h3>
+            <Infoboks>{tiltaksdata.faneinnhold?.forHvemInfoboks}</Infoboks>
+            <Infoboks>{displayed.faneinnhold?.forHvemInfoboks}</Infoboks>
             <TekstFraTiltakstype>
               {tiltaksdata.faneinnhold?.forHvem?.map(tilListe)}
             </TekstFraTiltakstype>
@@ -128,6 +138,12 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
           </MarginBottom>
           <MarginBottom>
             <h3>Detaljer og innhold</h3>
+            <Infoboks>
+              {tiltaksdata.faneinnhold?.detaljerOgInnholdInfoboks}
+            </Infoboks>
+            <Infoboks>
+              {displayed.faneinnhold?.detaljerOgInnholdInfoboks}
+            </Infoboks>
             <TekstFraTiltakstype>
               {tiltaksdata.faneinnhold.detaljerOgInnhold.map((el) => {
                 return tilListe(el);
@@ -139,6 +155,12 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
           </MarginBottom>
           <MarginBottom>
             <h3>Påmelding og varighet</h3>
+            <Infoboks>
+              {tiltaksdata.faneinnhold?.pameldingOgVarighetInfoboks}
+            </Infoboks>
+            <Infoboks>
+              {displayed.faneinnhold?.pameldingOgVarighetInfoboks}
+            </Infoboks>
             <TekstFraTiltakstype>
               {tiltaksdata.faneinnhold?.pameldingOgVarighet?.map(tilListe)}
             </TekstFraTiltakstype>

--- a/frontend/mulighetsrommet-cms/deskStructures/previews/common.tsx
+++ b/frontend/mulighetsrommet-cms/deskStructures/previews/common.tsx
@@ -35,6 +35,7 @@ export function Infoboks({ children }) {
         alignItems: "baseline",
         gap: "10px",
         padding: "0px 10px",
+        margin: "5px 0px",
       }}
     >
       <GrCircleInformation />

--- a/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
+++ b/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
@@ -32,9 +32,10 @@ export default {
   fields: [
     {
       name: "forHvemInfoboks",
-      title: "For hvem - infoboks",
+      title:
+        'Ekstra viktig informasjon til veileder som legger seg i blå infoboks under fanen "For hvem"',
       description:
-        "Hvis denne har innhold, vises det i en infoboks i fanen 'For hvem'",
+        'Bruk denne tekstboksen for informasjon som skal være ekstra fremtredende for veilederne. Bruk gjerne "forhåndsvisning av tiltaksgjennomføring for å få et inntrykk av hvordan det vil se ut."',
       ...infoboksOptions,
       group: "forHvem",
     },
@@ -55,9 +56,10 @@ export default {
     },
     {
       name: "detaljerOgInnholdInfoboks",
-      title: "Detaljer og innhold - infoboks",
+      title:
+        'Ekstra viktig informasjon til veileder som legger seg i blå infoboks under fanen "Detaljer og innhold"',
       description:
-        "Hvis denne har innhold, vises det i en infoboks i fanen 'Detaljer og innhold'",
+        'Bruk denne tekstboksen for informasjon som skal være ekstra fremtredende for veilederne. Bruk gjerne "forhåndsvisning av tiltaksgjennomføring for å få et inntrykk av hvordan det vil se ut."',
       ...infoboksOptions,
       group: "detaljerOgInnhold",
     },
@@ -78,9 +80,10 @@ export default {
     },
     {
       name: "pameldingOgVarighetInfoboks",
-      title: "Påmelding og varighet - infoboks",
+      title:
+        'Ekstra viktig informasjon til veileder som legger seg i blå infoboks under fanen "Påmelding og varighet"',
       description:
-        "Hvis denne har innhold, vises det i en infoboks i fanen 'Påmelding og varighet'",
+        'Bruk denne tekstboksen for informasjon som skal være ekstra fremtredende for veilederne. Bruk gjerne "forhåndsvisning av tiltaksgjennomføring for å få et inntrykk av hvordan det vil se ut."',
       ...infoboksOptions,
       group: "pameldingOgVarighet",
     },

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -263,13 +263,15 @@ export default {
     select: {
       title: "tiltaksgjennomforingNavn",
       tiltakstypeNavn: "tiltakstype.tiltakstypeNavn",
-      fylke: "fylke.navn",
+      arrangornavn: "kontaktinfoArrangor.selskapsnavn",
     },
     prepare: (selection) => {
-      const { title, tiltakstypeNavn, fylke } = selection;
+      const { title, tiltakstypeNavn, arrangornavn } = selection;
       return {
         title,
-        subtitle: `${fylke} - ${tiltakstypeNavn}`,
+        subtitle: arrangornavn
+          ? `${arrangornavn} - ${tiltakstypeNavn}`
+          : `${tiltakstypeNavn}`,
       };
     },
   },


### PR DESCRIPTION
* Legger til infoboks i preview for tiltaksgjennomføringer
* Lar fargevelger for preview for tiltaksgjennomføringer være "på" by default.
* Viser arrangørnavn når det er satt i subitle, istedenfor for fylke
