### PR TITLE
Sortering på tiltakstypenavn for tiltaksgjennomføringer

### DIFF
--- a/frontend/mulighetsrommet-cms/deskStructures/commonStructure.js
+++ b/frontend/mulighetsrommet-cms/deskStructures/commonStructure.js
@@ -47,6 +47,11 @@ export function commonStructure() {
                         '_type == "tiltaksgjennomforing" && $enhet in enheter[]._ref'
                       )
                       .params({ enhet })
+                      .menuItems([
+                        ...S.documentTypeList(
+                          "tiltaksgjennomforing"
+                        ).getMenuItems(),
+                      ])
                   )
               ),
             S.listItem()
@@ -70,6 +75,11 @@ export function commonStructure() {
                         '_type == "tiltaksgjennomforing" && ($enhet == fylke._ref)'
                       )
                       .params({ enhet })
+                      .menuItems([
+                        ...S.documentTypeList(
+                          "tiltaksgjennomforing"
+                        ).getMenuItems(),
+                      ])
                   )
               ),
 
@@ -87,6 +97,11 @@ export function commonStructure() {
                       )
                       .params({ redaktorId })
                       .defaultOrdering(ORDER_BY_CREATEDAT_FIELD)
+                      .menuItems([
+                        ...S.documentTypeList(
+                          "tiltaksgjennomforing"
+                        ).getMenuItems(),
+                      ])
                   )
               ),
             S.listItem()

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -259,6 +259,44 @@ export default {
       },
     },
   ],
+  orderings: [
+    {
+      title: "Tiltakstype A->Å",
+      by: [
+        {
+          field: "tiltakstype.tiltakstypeNavn",
+          direction: "asc",
+        },
+      ],
+    },
+    {
+      title: "Tiltakstype Å->A",
+      by: [
+        {
+          field: "tiltakstype.tiltakstypeNavn",
+          direction: "desc",
+        },
+      ],
+    },
+    {
+      title: "Tiltaksnavn A->Å",
+      by: [
+        {
+          field: "tiltaksgjennomforingNavn",
+          direction: "asc",
+        },
+      ],
+    },
+    {
+      title: "Tiltaksnavn Å->A",
+      by: [
+        {
+          field: "tiltaksgjennomforingNavn",
+          direction: "desc",
+        },
+      ],
+    },
+  ],
   preview: {
     select: {
       title: "tiltaksgjennomforingNavn",


### PR DESCRIPTION
Legger til custom sortering for tiltakstypenavn og tiltaksgjennomføringsnavn
for tiltaksgjennomføringer vist gjennom commonStructure etter tilbakemelding og ønske
fra tiltaksansvarlig redaktør
