### PR TITLE
tc-340 Detaljbokser i Preview

### DIFF
--- a/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypeOgTiltaksgjennomforingPreview.tsx
+++ b/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypeOgTiltaksgjennomforingPreview.tsx
@@ -168,7 +168,9 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
               >
                 {tiltaksdata?.regelverkLenker.map((lenke) => {
                   return (
-                    <a href={lenke.regelverkUrl}>{lenke.regelverkLenkeNavn}</a>
+                    <a target="_blank" href={lenke.regelverkUrl}>
+                      {lenke.regelverkLenkeNavn}
+                    </a>
                   );
                 })}
               </div>

--- a/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypeOgTiltaksgjennomforingPreview.tsx
+++ b/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypeOgTiltaksgjennomforingPreview.tsx
@@ -57,7 +57,7 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
     );
   }
 
-  function InfoboksTiltakstype({ children }: any) {
+  function InfoboksFraTiltakstype({ children }: any) {
     return (
       <TekstFraTiltakstype>
         <Infoboks>{children}</Infoboks>
@@ -65,7 +65,7 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
     );
   }
 
-  function InfoboksGjennomforing({ children }: any) {
+  function InfoboksFraGjennomforing({ children }: any) {
     return (
       <TekstFraGjennomforing>
         <Infoboks>{children}</Infoboks>
@@ -202,12 +202,12 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
 
         <div>
           <h2>For hvem</h2>
-          <InfoboksTiltakstype>
+          <InfoboksFraTiltakstype>
             {tiltaksdata.faneinnhold?.forHvemInfoboks}
-          </InfoboksTiltakstype>
-          <InfoboksGjennomforing>
+          </InfoboksFraTiltakstype>
+          <InfoboksFraGjennomforing>
             {displayed.faneinnhold?.forHvemInfoboks}
-          </InfoboksGjennomforing>
+          </InfoboksFraGjennomforing>
           <TekstFraTiltakstype>
             <PortableText value={tiltaksdata.faneinnhold?.forHvem} />
           </TekstFraTiltakstype>
@@ -218,12 +218,12 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
 
         <div>
           <h2>Detaljer og innhold</h2>
-          <InfoboksTiltakstype>
+          <InfoboksFraTiltakstype>
             {tiltaksdata.faneinnhold?.detaljerOgInnholdInfoboks}
-          </InfoboksTiltakstype>
-          <InfoboksGjennomforing>
+          </InfoboksFraTiltakstype>
+          <InfoboksFraGjennomforing>
             {displayed.faneinnhold?.detaljerOgInnholdInfoboks}
-          </InfoboksGjennomforing>
+          </InfoboksFraGjennomforing>
           <TekstFraTiltakstype>
             <PortableText value={tiltaksdata.faneinnhold.detaljerOgInnhold} />
           </TekstFraTiltakstype>
@@ -234,12 +234,12 @@ export function TiltakstypeOgTiltaksgjennomforingPreview({ document }: any) {
 
         <div>
           <h2>Påmelding og varighet</h2>
-          <InfoboksTiltakstype>
+          <InfoboksFraTiltakstype>
             {tiltaksdata.faneinnhold?.pameldingOgVarighetInfoboks}
-          </InfoboksTiltakstype>
-          <InfoboksGjennomforing>
+          </InfoboksFraTiltakstype>
+          <InfoboksFraGjennomforing>
             {displayed.faneinnhold?.pameldingOgVarighetInfoboks}
-          </InfoboksGjennomforing>
+          </InfoboksFraGjennomforing>
           <TekstFraTiltakstype>
             <PortableText
               value={tiltaksdata.faneinnhold?.pameldingOgVarighet}

--- a/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypePreview.tsx
+++ b/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypePreview.tsx
@@ -1,82 +1,117 @@
 import React, { useEffect, useState } from "react";
 import sanityClient from "part:@sanity/base/client";
+import {
+  Infoboks,
+  PreviewContainer,
+  SidemenyDetaljerContainer,
+  SidemenyDetaljerRad,
+} from "./common";
 import { PortableText } from "@portabletext/react";
-import { Infoboks, MarginBottom } from "./common";
+
 const client = sanityClient.withConfig({ apiVersion: "2021-10-21" });
 
 export function TiltakstypePreview({ document }: any) {
   const [tiltaksdata, setTiltaksdata] = useState(null);
+  const { displayed } = document;
 
   useEffect(() => {
     const fetchData = async () => {
       const data = await client.fetch(
-        `*[_type == "tiltakstype" && _id == "${document.displayed._id}"]{..., innsatsgruppe->}[0]`
+        `*[_type == "tiltakstype" && _id == "${document.displayed._id}"]{..., innsatsgruppe->, regelverkLenker[]->}[0]`
       );
       setTiltaksdata(data);
     };
-
     fetchData();
   }, [document]);
 
   function TekstFraTiltakstype({ children }: any) {
-    return <p>{children}</p>;
+    return <span>{children}</span>;
   }
 
-  if (!tiltaksdata) return "Laster tiltaksdata...";
+  function Detaljvisning() {
+    return (
+      <SidemenyDetaljerContainer>
+        <SidemenyDetaljerRad navn="Tiltaksnummer">
+          (Kommer fra tiltaksgjennomføringene)
+        </SidemenyDetaljerRad>
+        <SidemenyDetaljerRad navn="Tiltakstype">
+          {tiltaksdata?.tiltakstypeNavn}
+        </SidemenyDetaljerRad>
+        <SidemenyDetaljerRad navn="Arrangør">
+          (Kommer fra tiltaksgjennomføringene)
+        </SidemenyDetaljerRad>
+        <SidemenyDetaljerRad navn="Innsatsgruppe">
+          {tiltaksdata?.innsatsgruppe?.beskrivelse}
+        </SidemenyDetaljerRad>
+        <SidemenyDetaljerRad navn="Oppstart">
+          (Kommer fra tiltaksgjennomføringene)
+        </SidemenyDetaljerRad>
+        {tiltaksdata?.regelverkLenker && (
+          <SidemenyDetaljerRad navn="Regelverk">
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              {tiltaksdata?.regelverkLenker.map((lenke) => {
+                return (
+                  <a href={lenke.regelverkUrl}>{lenke.regelverkLenkeNavn}</a>
+                );
+              })}
+            </div>
+          </SidemenyDetaljerRad>
+        )}
+      </SidemenyDetaljerContainer>
+    );
+  }
 
-  const { displayed } = document;
+  if (!tiltaksdata) return "Laster...";
+
   return (
-    <div style={{ margin: "64px" }}>
-      <div style={{ maxWidth: "600px" }}>
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          <h1 style={{ borderTop: "1px dotted black", paddingTop: "8px" }}>
-            {displayed.tiltaksgjennomforingNavn}
-          </h1>
-        </div>
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          <p style={{ paddingTop: "4px", paddingBottom: "4px" }}>
-            Tiltakstype: {tiltaksdata.tiltakstypeNavn}
-          </p>
-          <small style={{ border: "1px dashed black", padding: "4px" }}>
-            Boks med nøkkelinformasjon vises ikke i denne forhåndsvisningen
-          </small>
-        </div>
+    <div style={{ margin: "0 64px", maxWidth: "600px" }}>
+      <h1>{tiltaksdata.tiltakstypeNavn}</h1>
+      <Detaljvisning />
+
+      <PreviewContainer>
         <div>
-          <MarginBottom>
-            <h3>Beskrivelse</h3>
-            <TekstFraTiltakstype>
-              {tiltaksdata?.beskrivelse}
-            </TekstFraTiltakstype>
-          </MarginBottom>
-          <MarginBottom>
-            <h3>For hvem</h3>
+          <h2>Beskrivelse</h2>
+          {tiltaksdata?.beskrivelse}
+        </div>
+
+        {(tiltaksdata.faneinnhold?.forHvem ||
+          displayed.faneinnhold?.forHvemInfoboks) && (
+          <div>
+            <h2>For hvem</h2>
             <Infoboks>{displayed.faneinnhold?.forHvemInfoboks}</Infoboks>
-            <TekstFraTiltakstype>
-              <PortableText value={tiltaksdata.faneinnhold?.forHvem} />
-            </TekstFraTiltakstype>
-          </MarginBottom>
-          <MarginBottom>
-            <h3>Detaljer og innhold</h3>
+            <PortableText value={tiltaksdata.faneinnhold?.forHvem} />
+          </div>
+        )}
+
+        {(displayed.faneinnhold?.detaljerOgInnholdInfoboks ||
+          tiltaksdata.faneinnhold.detaljerOgInnhold) && (
+          <div>
+            <h2>Detaljer og innhold</h2>
             <Infoboks>
               {displayed.faneinnhold?.detaljerOgInnholdInfoboks}
             </Infoboks>
-            <TekstFraTiltakstype>
-              <PortableText value={tiltaksdata.faneinnhold.detaljerOgInnhold} />
-            </TekstFraTiltakstype>
-          </MarginBottom>
-          <MarginBottom>
-            <h3>Påmelding og varighet</h3>
+            <PortableText value={tiltaksdata.faneinnhold.detaljerOgInnhold} />
+          </div>
+        )}
+
+        {(displayed.faneinnhold?.pameldingOgVarighetInfoboks ||
+          tiltaksdata.faneinnhold?.pameldingOgVarighet) && (
+          <div>
+            <h2>Påmelding og varighet</h2>
             <Infoboks>
               {displayed.faneinnhold?.pameldingOgVarighetInfoboks}
             </Infoboks>
-            <TekstFraTiltakstype>
-              <PortableText
-                value={tiltaksdata.faneinnhold?.pameldingOgVarighet}
-              />
-            </TekstFraTiltakstype>
-          </MarginBottom>
-        </div>
-      </div>
+            <PortableText
+              value={tiltaksdata.faneinnhold?.pameldingOgVarighet}
+            />
+          </div>
+        )}
+      </PreviewContainer>
     </div>
   );
 }

--- a/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypePreview.tsx
+++ b/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypePreview.tsx
@@ -89,9 +89,9 @@ export function TiltakstypePreview({ document }: any) {
             <PortableText value={tiltaksdata.faneinnhold?.forHvem} />
           </div>
         )}
-
+        {/*{console.log(tiltaksdata)}*/}
         {(displayed.faneinnhold?.detaljerOgInnholdInfoboks ||
-          tiltaksdata.faneinnhold.detaljerOgInnhold) && (
+          tiltaksdata.faneinnhold?.detaljerOgInnhold) && (
           <div>
             <h2>Detaljer og innhold</h2>
             <Infoboks>

--- a/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypePreview.tsx
+++ b/frontend/mulighetsrommet-cms/deskStructures/previews/TiltakstypePreview.tsx
@@ -56,7 +56,9 @@ export function TiltakstypePreview({ document }: any) {
             >
               {tiltaksdata?.regelverkLenker.map((lenke) => {
                 return (
-                  <a href={lenke.regelverkUrl}>{lenke.regelverkLenkeNavn}</a>
+                  <a target="_blank" href={lenke.regelverkUrl}>
+                    {lenke.regelverkLenkeNavn}
+                  </a>
                 );
               })}
             </div>

--- a/frontend/mulighetsrommet-cms/deskStructures/previews/common.tsx
+++ b/frontend/mulighetsrommet-cms/deskStructures/previews/common.tsx
@@ -16,14 +16,14 @@ export function Infoboks({ children }) {
         margin: "5px 0px",
       }}
     >
-      <GrCircleInformation />
+      <GrCircleInformation
+        style={{
+          alignSelf: "center",
+        }}
+      />
       <p>{children}</p>
     </div>
   );
-}
-
-export function MarginBottom({ children }) {
-  return <div style={{ marginBottom: "4rem" }}>{children}</div>;
 }
 
 export function Firkant({ farge }) {
@@ -46,6 +46,63 @@ export function Legend({ farge, children }) {
       <small style={{ marginLeft: "4px", textAlign: "right" }}>
         {children}
       </small>
+    </div>
+  );
+}
+
+export function PreviewContainer({ children }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function SidemenyDetaljerContainer({ children }) {
+  return (
+    <small
+      style={{
+        border: "1px dashed black",
+        padding: "4px 20px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "10px",
+      }}
+    >
+      {children}
+    </small>
+  );
+}
+
+export function SidemenyDetaljerRad({ navn, children }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        height: "auto",
+      }}
+    >
+      <h4
+        style={{
+          margin: "0",
+        }}
+      >
+        {navn}
+      </h4>
+      <p
+        style={{
+          margin: "0",
+        }}
+      >
+        {children}
+      </p>
     </div>
   );
 }

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -50,7 +50,6 @@ export default {
       to: [{ type: "tiltakstype" }],
       validation: (Rule: Rule) => Rule.required(),
     },
-
     {
       name: "tiltaksgjennomforingNavn",
       title: "Navn på tiltaksgjennomføring",
@@ -121,7 +120,7 @@ export default {
         "Her kan du legge til en tekstlig beskrivelse av tiltaksgjennomføringen",
       type: "text",
       rows: 5,
-      validation: (Rule) => Rule.max(300),
+      validation: (Rule) => Rule.max(500),
     },
 
     {

--- a/frontend/mulighetsrommet-cms/schemas/tiltakstype.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltakstype.ts
@@ -18,7 +18,7 @@ export default {
       title: "Beskrivelse",
       type: "text",
       rows: 5,
-      validation: (Rule) => Rule.max(300),
+      validation: (Rule) => Rule.max(500),
       description: "Her kan du skrive en beskrivelse av tiltakstypen",
     },
     {

--- a/frontend/mulighetsrommet-veileder-flate/public/mockServiceWorker.js
+++ b/frontend/mulighetsrommet-veileder-flate/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.47.3).
+ * Mock Service Worker (0.47.4).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/models.ts
@@ -63,8 +63,8 @@ export interface Tiltaksgjennomforing {
   kontaktinfoArrangor?: Arrangor;
   lokasjon: string;
   oppstart: Oppstart;
-  estimert_ventetid?: string;
   oppstartsdato?: string;
+  estimert_ventetid?: string;
   faneinnhold?: {
     forHvemInfoboks?: string;
     forHvem?: object;


### PR DESCRIPTION
- la til detaljboks i preview for tiltakstyper og tiltaksgjennomføringer (se bilder)
- endret på oppsett av kode i preview-filene 

**Preview for tiltakstyper:**
![image](https://user-images.githubusercontent.com/21334782/198238981-5fc2d43e-7438-43cb-a038-aa65fdbcf316.png)

**Preview for tiltaksgjennomføringer:**
![image](https://user-images.githubusercontent.com/21334782/198239045-baacb737-4285-443c-805d-fb9a0b5b1f0e.png)
