### PR TITLE
Justerer på nøkkelinfo-komponenten

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/nokkelinfo/Nokkelinfo.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/nokkelinfo/Nokkelinfo.module.scss
@@ -1,5 +1,6 @@
 .container {
   display: flex;
+  margin-top: 1.5rem;
 }
 
 .nokkelinfo {
@@ -10,26 +11,35 @@
   border-right: 1px solid var(--navds-semantic-color-border-muted);
   padding: 0.5rem 2% 0.5rem 0;
   margin-right: 1rem;
+  min-width: 250px;
+}
+
+.content {
+  display: flex;
+  justify-content: space-between;
 }
 
 .heading {
   display: flex;
   flex-direction: row;
   gap: 1rem;
-
-  :global(.navds-heading) {
-    font-weight: unset;
-  }
+  color: var(--navds-semantic-color-text-muted);
 }
 
 .tekst {
   font-size: 30px;
   line-height: unset;
+  margin: 0;
+  padding: 0;
 }
 
 :global(.mulighetsrommet-veileder-flate) {
   :global(.navds-popover__content) {
     max-width: 400px;
+  }
+
+  :global(.navds-heading) {
+    font-weight: unset;
   }
 
   :global(.navds-popover__arrow::before) {

--- a/frontend/mulighetsrommet-veileder-flate/src/components/nokkelinfo/Nokkelinfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/nokkelinfo/Nokkelinfo.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Heading, HelpText } from '@navikt/ds-react';
+import { Heading, HelpText } from '@navikt/ds-react';
 import { NokkelinfoKomponenter } from '../../core/api/models';
 import styles from './Nokkelinfo.module.scss';
 
@@ -12,17 +12,17 @@ const Nokkelinfo = ({ nokkelinfoKomponenter }: NokkelinfoProps) => {
       {nokkelinfoKomponenter.map((nokkelinfo: NokkelinfoKomponenter, index: number) => {
         return (
           <div className={styles.nokkelinfo} key={index}>
-            <div className={styles.heading}>
-              <Heading size="xsmall" level="2">
-                {nokkelinfo.tittel}
-              </Heading>
+            <div className={styles.content}>
+              <p className={styles.tekst}>{nokkelinfo.innhold}</p>
               {nokkelinfo.hjelpetekst && (
                 <HelpText title="Se hvordan prosenten er regnet ut" placement="right" style={{ maxWidth: '400px' }}>
                   {nokkelinfo.hjelpetekst}
                 </HelpText>
               )}
             </div>
-            <BodyShort className={styles.tekst}>{nokkelinfo.innhold}</BodyShort>
+            <Heading className={styles.heading} size="xsmall" level="2">
+              {nokkelinfo.tittel}
+            </Heading>
           </div>
         );
       })}


### PR DESCRIPTION
**Før**
![Skjermbilde 2022-10-31 kl  15 03 19](https://user-images.githubusercontent.com/9053627/199026642-4a5dae04-36c8-4033-9e6b-96f25898ae01.png)

**Etter**
![Skjermbilde 2022-10-31 kl  15 03 31](https://user-images.githubusercontent.com/9053627/199026684-79d411ba-fa20-48e5-82c5-2fc3a932663f.png)

Mindre justeringer på design for nøkkelinfo-komponenten. Flytter blant annet innhold over tittel for at det skal komme tydeligere frem. Gir også litt mer margin mellom nøkkelinfo og beskrivelse. 

Utgangspunkt er Tom S. skisser her https://www.figma.com/file/wRDUjC61AQKcZdvyVjvaSH/Fremtidige-konsepter?node-id=1876%3A46884