### PR TITLE
Lagt til rediger-knapp for del med bruker

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/Modal.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/Modal.module.scss
@@ -18,3 +18,11 @@
 .muted {
   color: var(--navds-semantic-color-text-muted);
 }
+
+.mt_0 {
+  margin-top: 0;
+}
+
+.mb_0 {
+  margin-bottom: 0;
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/Modal.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/Modal.module.scss
@@ -1,14 +1,20 @@
 .overstyrte_styles_fra_ds_modal {
-  width: 40rem;
+  min-width: 40rem;
   padding: 1rem;
 }
 
 .modal_btngroup {
   display: flex;
   gap: 1rem;
-  margin: 0.5rem 0;
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  justify-content: space-between;
 }
 
 .modal_btngroup_success {
   justify-content: space-evenly;
+}
+
+.muted {
+  color: var(--navds-semantic-color-text-muted);
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -1,0 +1,136 @@
+import { Alert, Button, Heading, Textarea } from '@navikt/ds-react';
+import classNames from 'classnames';
+import { Dispatch, useRef } from 'react';
+import { mulighetsrommetClient } from '../../../core/api/clients';
+import { useFeatureToggles } from '../../../core/api/feature-toggles';
+import { useHentDeltMedBrukerStatus } from '../../../core/api/queries/useHentDeltMedbrukerStatus';
+import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
+import { erPreview } from '../../../utils/Utils';
+import modalStyles from '../Modal.module.scss';
+import { logDelMedbrukerEvent } from './Delemodal';
+import delemodalStyles from './Delemodal.module.scss';
+import { Actions, State } from './DelemodalActions';
+
+interface Props {
+  tiltaksgjennomforingsnavn: string;
+  startTekst: string;
+  onCancel: () => void;
+  state: State;
+  dispatch: Dispatch<Actions>;
+}
+
+export function DelMedBrukerContent({ tiltaksgjennomforingsnavn, startTekst, onCancel, state, dispatch }: Props) {
+  const senderTilDialogen = state.sendtStatus === 'SENDER';
+  const tekstfeltRef = useRef<HTMLTextAreaElement | null>(null);
+  const features = useFeatureToggles();
+  const skalLagreAtViDelerMedBruker =
+    features.isSuccess && features.data['mulighetsrommet.lagre-del-tiltak-med-bruker'];
+  const { lagreVeilederHarDeltTiltakMedBruker, refetch: refetchOmVeilederHarDeltMedBruker } =
+    useHentDeltMedBrukerStatus();
+  const fnr = useHentFnrFraUrl();
+
+  const getAntallTegn = () => {
+    if (startTekst.length === 0) {
+      return 750;
+    }
+    return startTekst.length + 200;
+  };
+
+  const handleError = () => {
+    if (state.tekst.length === 0) return 'Kan ikke sende tom melding.';
+  };
+
+  const handleSend = async () => {
+    if (state.tekst.trim().length > getAntallTegn()) return;
+    logDelMedbrukerEvent('Delte med bruker');
+
+    dispatch({ type: 'Send melding' });
+    const overskrift = `Tiltak gjennom NAV: ${tiltaksgjennomforingsnavn}`;
+    const { tekst } = state;
+    try {
+      const res = await mulighetsrommetClient.dialogen.delMedDialogen({ fnr, requestBody: { overskrift, tekst } });
+      if (skalLagreAtViDelerMedBruker) {
+        await lagreVeilederHarDeltTiltakMedBruker(res.id);
+        refetchOmVeilederHarDeltMedBruker();
+      }
+      dispatch({ type: 'Sendt ok', payload: res.id });
+    } catch {
+      dispatch({ type: 'Sending feilet' });
+      logDelMedbrukerEvent('Del med bruker feilet');
+    }
+  };
+  const fokuserTekstfelt = () => {
+    dispatch({ type: 'Redigerer tekstfelt' });
+    logDelMedbrukerEvent('Redigerer tekstfelt');
+    tekstfeltRef?.current?.focus();
+  };
+
+  const tilbakestillTekstfelt = () => {
+    dispatch({ type: 'Tilbakestill tekstfelt' });
+  };
+  return (
+    <div>
+      <p className={classNames(modalStyles.muted, modalStyles.mt_0)} data-testid="modal_header">
+        Del med bruker
+      </p>
+      <Heading size="large" level="1">
+        {'Tiltak gjennom NAV: ' + tiltaksgjennomforingsnavn}
+      </Heading>
+
+      <Textarea
+        value={state.tekst}
+        onChange={e => dispatch({ type: 'Sett tekst', payload: e.currentTarget.value })}
+        label=""
+        minRows={10}
+        maxRows={50}
+        data-testid="textarea_tilbakemelding"
+        maxLength={getAntallTegn()}
+        error={handleError()}
+        ref={tekstfeltRef}
+        className={delemodalStyles.textarea}
+      />
+      <div className={modalStyles.modal_btngroup}>
+        <div className={delemodalStyles.btn_row}>
+          <Button
+            onClick={handleSend}
+            data-testid="modal_btn-send"
+            disabled={senderTilDialogen || state.tekst.length === 0 || erPreview}
+          >
+            {senderTilDialogen ? 'Sender...' : 'Send via Dialogen'}
+          </Button>
+
+          <Button variant="tertiary" onClick={onCancel} data-testid="modal_btn-cancel" disabled={senderTilDialogen}>
+            Avbryt
+          </Button>
+        </div>
+        <div>
+          {state.redigererTekstfelt ? (
+            <Button
+              variant="tertiary"
+              onClick={tilbakestillTekstfelt}
+              data-testid="modal_btn-cancel"
+              disabled={senderTilDialogen}
+            >
+              Tilbakestill
+            </Button>
+          ) : (
+            <Button
+              variant="tertiary"
+              onClick={fokuserTekstfelt}
+              data-testid="modal_btn-rediger"
+              disabled={senderTilDialogen}
+            >
+              Rediger melding
+            </Button>
+          )}
+        </div>
+      </div>
+      {erPreview && (
+        <Alert variant="warning">
+          Det er ikke mulig å dele tiltak med bruker i forhåndsvisning. Brukers navn og veileders navn blir automatisk
+          satt utenfor forhåndsvisningsmodus.
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerFeiletContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerFeiletContent.tsx
@@ -1,0 +1,42 @@
+import { ErrorColored } from '@navikt/ds-icons';
+import { Heading, BodyShort, Button } from '@navikt/ds-react';
+import classNames from 'classnames';
+import { Dispatch } from 'react';
+import Lenke from '../../lenke/Lenke';
+import modalStyles from '../Modal.module.scss';
+import delemodalStyles from './Delemodal.module.scss';
+import { Actions } from './DelemodalActions';
+
+interface Props {
+  dispatch: Dispatch<Actions>;
+  onCancel: () => void;
+}
+
+export function DelMedBrukerFeiletContent({ dispatch, onCancel }: Props) {
+  return (
+    <div className={classNames(delemodalStyles.delemodal_tilbakemelding)}>
+      <ErrorColored className={delemodalStyles.delemodal_svg} />
+      <Heading level="1" size="large" data-testid="modal_header">
+        Tiltaket kunne ikke deles med brukeren
+      </Heading>
+      <BodyShort>
+        Vi kunne ikke dele informasjon digitalt med denne brukeren. Dette kan være fordi hen ikke ønsker eller kan
+        benytte de digitale tjenestene våre.{' '}
+        <Lenke
+          isExternal
+          to="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Manuell-oppf%C3%B8lging-i-Modia-arbeidsrettet-oppf%C3%B8lging.aspx"
+        >
+          Les mer om manuell oppfølging{' '}
+        </Lenke>
+      </BodyShort>
+      <div className={modalStyles.modal_btngroup}>
+        <Button variant="primary" onClick={() => dispatch({ type: 'Reset' })} data-testid="modal_btn-reset">
+          Prøv på nytt
+        </Button>
+        <Button variant="secondary" onClick={onCancel} data-testid="modal_btn-cancel">
+          Lukk
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.module.scss
@@ -1,8 +1,9 @@
 .delemodal {
-  background-color: red;
-
   &_tilbakemelding {
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     .modal_btngroup {
       justify-content: space-around;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.module.scss
@@ -1,5 +1,5 @@
 .delemodal {
-  background-color: #f7f7f7;
+  background-color: red;
 
   &_tilbakemelding {
     text-align: center;
@@ -14,4 +14,12 @@
     height: auto;
     align-self: center;
   }
+
+  .btn_row button {
+    margin-right: 1rem;
+  }
+}
+
+.textarea {
+  margin-top: 1rem;
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -1,18 +1,15 @@
-import { ErrorColored, SuccessColored } from '@navikt/ds-icons';
-import { Alert, BodyShort, Button, Heading, Modal, Textarea } from '@navikt/ds-react';
+import { Modal } from '@navikt/ds-react';
 import classNames from 'classnames';
-import { useReducer, useRef } from 'react';
-import { mulighetsrommetClient } from '../../../core/api/clients';
-import { useFeatureToggles } from '../../../core/api/feature-toggles';
+import { useReducer } from 'react';
 import { logEvent } from '../../../core/api/logger';
-import { useHentDeltMedBrukerStatus } from '../../../core/api/queries/useHentDeltMedbrukerStatus';
-import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
-import { useNavigerTilDialogen } from '../../../hooks/useNavigerTilDialogen';
-import { capitalize, erPreview } from '../../../utils/Utils';
-import Lenke from '../../lenke/Lenke';
+import { capitalize } from '../../../utils/Utils';
 import modalStyles from '../Modal.module.scss';
 import delemodalStyles from './Delemodal.module.scss';
 import { Actions, State } from './DelemodalActions';
+import { DelMedBrukerContent } from './DelMedBrukerContent';
+import { DelMedBrukerFeiletContent } from './DelMedBrukerFeiletContent';
+import { Infomelding } from './Infomelding';
+import { SendtOkContent } from './SendtOkContent';
 
 export const logDelMedbrukerEvent = (
   action:
@@ -36,7 +33,7 @@ interface DelemodalProps {
   veiledernavn?: string;
 }
 
-function reducer(state: State, action: Actions): State {
+export function reducer(state: State, action: Actions): State {
   switch (action.type) {
     case 'Avbryt':
       return { ...state, sendtStatus: 'IKKE_SENDT', tekst: state.malTekst };
@@ -59,7 +56,7 @@ function reducer(state: State, action: Actions): State {
   }
 }
 
-function initInitialState(startTekst: string): State {
+export function initInitialState(startTekst: string): State {
   return {
     tekst: startTekst,
     sendtStatus: 'IKKE_SENDT',
@@ -77,70 +74,15 @@ const Delemodal = ({
   chattekst,
   veiledernavn = '',
 }: DelemodalProps) => {
-  const startText = `${chattekst
+  const startTekst = `${chattekst
     .replace('<Fornavn>', capitalize(brukerNavn))
     .replace('<tiltaksnavn>', tiltaksgjennomforingsnavn)}\n\nHilsen ${veiledernavn}`;
-  const [state, dispatch] = useReducer(reducer, startText, initInitialState);
-  const fnr = useHentFnrFraUrl();
-  const features = useFeatureToggles();
-  const skalLagreAtViDelerMedBruker =
-    features.isSuccess && features.data['mulighetsrommet.lagre-del-tiltak-med-bruker'];
-  const { lagreVeilederHarDeltTiltakMedBruker, refetch: refetchOmVeilederHarDeltMedBruker } =
-    useHentDeltMedBrukerStatus();
-  const { navigerTilDialogen } = useNavigerTilDialogen();
-  const senderTilDialogen = state.sendtStatus === 'SENDER';
-  const tekstfeltRef = useRef<HTMLTextAreaElement | null>(null);
-
-  const getAntallTegn = () => {
-    if (startText.length === 0) {
-      return 750;
-    }
-    return startText.length + 200;
-  };
-
-  const handleError = () => {
-    if (state.tekst.length === 0) return 'Kan ikke sende tom melding.';
-  };
-
-  const handleSend = async () => {
-    if (state.tekst.trim().length > getAntallTegn()) return;
-    logDelMedbrukerEvent('Delte med bruker');
-
-    dispatch({ type: 'Send melding' });
-    const overskrift = `Tiltak gjennom NAV: ${tiltaksgjennomforingsnavn}`;
-    const { tekst } = state;
-    try {
-      const res = await mulighetsrommetClient.dialogen.delMedDialogen({ fnr, requestBody: { overskrift, tekst } });
-      if (skalLagreAtViDelerMedBruker) {
-        // TODO Fjern sjekk og toggle mulighetsrommet.lagre-del-tiltak-med-bruker når vi har avklart med jurister at det er ok å lagre fnr til bruker i db
-        await lagreVeilederHarDeltTiltakMedBruker(res.id);
-        refetchOmVeilederHarDeltMedBruker();
-      }
-      dispatch({ type: 'Sendt ok', payload: res.id });
-    } catch {
-      dispatch({ type: 'Sending feilet' });
-      logDelMedbrukerEvent('Del med bruker feilet');
-    }
-  };
+  const [state, dispatch] = useReducer(reducer, startTekst, initInitialState);
 
   const clickCancel = (log = true) => {
     setModalOpen();
     dispatch({ type: 'Avbryt' });
     log && logDelMedbrukerEvent('Avbrutt del med bruker');
-  };
-
-  const gaTilDialogen = () => {
-    navigerTilDialogen(fnr, state.dialogId);
-  };
-
-  const fokuserTekstfelt = () => {
-    dispatch({ type: 'Redigerer tekstfelt' });
-    logDelMedbrukerEvent('Redigerer tekstfelt');
-    tekstfeltRef?.current?.focus();
-  };
-
-  const tilbakestillTekstfelt = () => {
-    dispatch({ type: 'Tilbakestill tekstfelt' });
   };
 
   return (
@@ -154,122 +96,24 @@ const Delemodal = ({
       data-testid="delemodal"
     >
       <Modal.Content>
-        {state.sendtStatus !== 'SENDT_OK' && state.sendtStatus !== 'SENDING_FEILET' && (
-          <div>
-            <p className={modalStyles.muted} data-testid="modal_header">
-              Del med bruker
-            </p>
-            <Heading size="large" level="1">
-              {'Tiltak gjennom NAV: ' + tiltaksgjennomforingsnavn}
-            </Heading>
-
-            <Textarea
-              value={state.tekst}
-              onChange={e => dispatch({ type: 'Sett tekst', payload: e.currentTarget.value })}
-              label=""
-              minRows={10}
-              maxRows={50}
-              data-testid="textarea_tilbakemelding"
-              maxLength={getAntallTegn()}
-              error={handleError()}
-              ref={tekstfeltRef}
-              className={delemodalStyles.textarea}
+        {!['SENDT_OK', 'SENDING_FEILET'].includes(state.sendtStatus) && (
+          <>
+            <DelMedBrukerContent
+              tiltaksgjennomforingsnavn={tiltaksgjennomforingsnavn}
+              startTekst={startTekst}
+              onCancel={clickCancel}
+              state={state}
+              dispatch={dispatch}
             />
-            <div className={modalStyles.modal_btngroup}>
-              <div className={delemodalStyles.btn_row}>
-                <Button
-                  onClick={handleSend}
-                  data-testid="modal_btn-send"
-                  disabled={senderTilDialogen || state.tekst.length === 0 || erPreview}
-                >
-                  {senderTilDialogen ? 'Sender...' : 'Send via Dialogen'}
-                </Button>
-
-                <Button
-                  variant="tertiary"
-                  onClick={() => clickCancel()}
-                  data-testid="modal_btn-cancel"
-                  disabled={senderTilDialogen}
-                >
-                  Avbryt
-                </Button>
-              </div>
-              <div>
-                {state.redigererTekstfelt ? (
-                  <Button
-                    variant="tertiary"
-                    onClick={tilbakestillTekstfelt}
-                    data-testid="modal_btn-cancel"
-                    disabled={senderTilDialogen}
-                  >
-                    Tilbakestill
-                  </Button>
-                ) : (
-                  <Button
-                    variant="tertiary"
-                    onClick={fokuserTekstfelt}
-                    data-testid="modal_btn-cancel"
-                    disabled={senderTilDialogen}
-                  >
-                    Rediger melding
-                  </Button>
-                )}
-              </div>
-            </div>
-            {erPreview && (
-              <Alert variant="warning">
-                Det er ikke mulig å dele tiltak med bruker i forhåndsvisning. Brukers navn og veileders navn blir
-                automatisk satt utenfor forhåndsvisningsmodus.
-              </Alert>
-            )}
-          </div>
+            <Infomelding>
+              Kandidatene vil få et varsel fra NAV, og kan logge inn på nav.no for å lese meldingen
+            </Infomelding>
+          </>
         )}
-        {state.sendtStatus === 'SENDT_OK' && (
-          <div className={delemodalStyles.delemodal_tilbakemelding}>
-            <SuccessColored className={delemodalStyles.delemodal_svg} />
-            <Heading level="1" size="large" data-testid="modal_header">
-              Meldingen er sendt
-            </Heading>
-            <BodyShort>Du kan fortsette dialogen om dette tiltaket i Dialogen.</BodyShort>
-            <div className={classNames(modalStyles.modal_btngroup, modalStyles.modal_btngroup_success)}>
-              <Button variant="primary" onClick={gaTilDialogen} data-testid="modal_btn-dialog">
-                Gå til Dialogen
-              </Button>
-              <Button variant="secondary" onClick={() => clickCancel(false)} data-testid="modal_btn-cancel">
-                Lukk
-              </Button>
-            </div>
-          </div>
-        )}
+        {state.sendtStatus === 'SENDT_OK' && <SendtOkContent state={state} onCancel={clickCancel} />}
         {state.sendtStatus === 'SENDING_FEILET' && (
-          <div className={classNames(delemodalStyles.delemodal_tilbakemelding)}>
-            <ErrorColored className={delemodalStyles.delemodal_svg} />
-            <Heading level="1" size="large" data-testid="modal_header">
-              Tiltaket kunne ikke deles med brukeren
-            </Heading>
-            <BodyShort>
-              Vi kunne ikke dele informasjon digitalt med denne brukeren. Dette kan være fordi hen ikke ønsker eller kan
-              benytte de digitale tjenestene våre.{' '}
-              <Lenke
-                isExternal
-                to="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Manuell-oppf%C3%B8lging-i-Modia-arbeidsrettet-oppf%C3%B8lging.aspx"
-              >
-                Les mer om manuell oppfølging{' '}
-              </Lenke>
-            </BodyShort>
-            <div className={modalStyles.modal_btngroup}>
-              <Button variant="primary" onClick={() => dispatch({ type: 'Reset' })} data-testid="modal_btn-reset">
-                Prøv på nytt
-              </Button>
-              <Button variant="secondary" onClick={() => clickCancel()} data-testid="modal_btn-cancel">
-                Lukk
-              </Button>
-            </div>
-          </div>
+          <DelMedBrukerFeiletContent dispatch={dispatch} onCancel={clickCancel} />
         )}
-        <p className={modalStyles.muted}>
-          Kandidatene vil få et varsel fra NAV, og kan logge inn på nav.no for å lese meldingen
-        </p>
       </Modal.Content>
     </Modal>
   );

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -1,21 +1,26 @@
-import { Alert, BodyShort, Button, Heading, Ingress, Modal, Textarea } from '@navikt/ds-react';
-import { useReducer } from 'react';
+import { ErrorColored, SuccessColored } from '@navikt/ds-icons';
+import { Alert, BodyShort, Button, Heading, Modal, Textarea } from '@navikt/ds-react';
+import classNames from 'classnames';
+import { useReducer, useRef } from 'react';
+import { mulighetsrommetClient } from '../../../core/api/clients';
+import { useFeatureToggles } from '../../../core/api/feature-toggles';
 import { logEvent } from '../../../core/api/logger';
+import { useHentDeltMedBrukerStatus } from '../../../core/api/queries/useHentDeltMedbrukerStatus';
 import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
+import { useNavigerTilDialogen } from '../../../hooks/useNavigerTilDialogen';
+import { capitalize, erPreview } from '../../../utils/Utils';
+import Lenke from '../../lenke/Lenke';
 import modalStyles from '../Modal.module.scss';
 import delemodalStyles from './Delemodal.module.scss';
 import { Actions, State } from './DelemodalActions';
-import Lenke from '../../lenke/Lenke';
-import { mulighetsrommetClient } from '../../../core/api/clients';
-import { ErrorColored, SuccessColored } from '@navikt/ds-icons';
-import { capitalize, erPreview } from '../../../utils/Utils';
-import { useHentDeltMedBrukerStatus } from '../../../core/api/queries/useHentDeltMedbrukerStatus';
-import { useFeatureToggles } from '../../../core/api/feature-toggles';
-import { useNavigerTilDialogen } from '../../../hooks/useNavigerTilDialogen';
-import classNames from 'classnames';
 
 export const logDelMedbrukerEvent = (
-  action: 'Åpnet dialog' | 'Delte med bruker' | 'Del med bruker feilet' | 'Avbrutt del med bruker'
+  action:
+    | 'Åpnet dialog'
+    | 'Delte med bruker'
+    | 'Del med bruker feilet'
+    | 'Avbrutt del med bruker'
+    | 'Redigerer tekstfelt'
 ) => {
   logEvent('mulighetsrommet.del-med-bruker', {
     value: action,
@@ -45,6 +50,10 @@ function reducer(state: State, action: Actions): State {
       return { ...state, tekst: action.payload, sendtStatus: 'IKKE_SENDT' };
     case 'Reset':
       return initInitialState(state.tekst);
+    case 'Redigerer tekstfelt':
+      return { ...state, redigererTekstfelt: true };
+    case 'Tilbakestill tekstfelt':
+      return initInitialState(state.malTekst);
     default:
       return state;
   }
@@ -56,6 +65,7 @@ function initInitialState(startTekst: string): State {
     sendtStatus: 'IKKE_SENDT',
     dialogId: '',
     malTekst: startTekst,
+    redigererTekstfelt: false,
   };
 }
 
@@ -79,6 +89,7 @@ const Delemodal = ({
     useHentDeltMedBrukerStatus();
   const { navigerTilDialogen } = useNavigerTilDialogen();
   const senderTilDialogen = state.sendtStatus === 'SENDER';
+  const tekstfeltRef = useRef<HTMLTextAreaElement | null>(null);
 
   const getAntallTegn = () => {
     if (startText.length === 0) {
@@ -122,6 +133,16 @@ const Delemodal = ({
     navigerTilDialogen(fnr, state.dialogId);
   };
 
+  const fokuserTekstfelt = () => {
+    dispatch({ type: 'Redigerer tekstfelt' });
+    logDelMedbrukerEvent('Redigerer tekstfelt');
+    tekstfeltRef?.current?.focus();
+  };
+
+  const tilbakestillTekstfelt = () => {
+    dispatch({ type: 'Tilbakestill tekstfelt' });
+  };
+
   return (
     <Modal
       shouldCloseOnOverlayClick={false}
@@ -132,94 +153,124 @@ const Delemodal = ({
       aria-label="modal"
       data-testid="delemodal"
     >
-      {state.sendtStatus !== 'SENDT_OK' && state.sendtStatus !== 'SENDING_FEILET' && (
-        <Modal.Content>
-          <Heading size="large" level="1" data-testid="modal_header">
-            Del tiltak med bruker
-          </Heading>
-          <Ingress>{'Tiltak gjennom NAV: ' + tiltaksgjennomforingsnavn}</Ingress>
-          <BodyShort size="small">
-            Bruker blir varslet på SMS/e-post, og kan se informasjon om tiltaket i aktivitetsplanen på Min side.
-          </BodyShort>
-          <Textarea
-            value={state.tekst}
-            onChange={e => dispatch({ type: 'Sett tekst', payload: e.currentTarget.value })}
-            label=""
-            minRows={10}
-            maxRows={50}
-            data-testid="textarea_tilbakemelding"
-            maxLength={getAntallTegn()}
-            error={handleError()}
-          />
-          <div className={modalStyles.modal_btngroup}>
-            <Button
-              onClick={handleSend}
-              data-testid="modal_btn-send"
-              disabled={senderTilDialogen || state.tekst.length === 0 || erPreview}
-            >
-              {senderTilDialogen ? 'Sender...' : 'Send via Dialogen'}
-            </Button>
+      <Modal.Content>
+        {state.sendtStatus !== 'SENDT_OK' && state.sendtStatus !== 'SENDING_FEILET' && (
+          <div>
+            <p className={modalStyles.muted} data-testid="modal_header">
+              Del med bruker
+            </p>
+            <Heading size="large" level="1">
+              {'Tiltak gjennom NAV: ' + tiltaksgjennomforingsnavn}
+            </Heading>
 
-            <Button
-              variant="secondary"
-              onClick={() => clickCancel()}
-              data-testid="modal_btn-cancel"
-              disabled={senderTilDialogen}
-            >
-              Avbryt
-            </Button>
+            <Textarea
+              value={state.tekst}
+              onChange={e => dispatch({ type: 'Sett tekst', payload: e.currentTarget.value })}
+              label=""
+              minRows={10}
+              maxRows={50}
+              data-testid="textarea_tilbakemelding"
+              maxLength={getAntallTegn()}
+              error={handleError()}
+              ref={tekstfeltRef}
+              className={delemodalStyles.textarea}
+            />
+            <div className={modalStyles.modal_btngroup}>
+              <div className={delemodalStyles.btn_row}>
+                <Button
+                  onClick={handleSend}
+                  data-testid="modal_btn-send"
+                  disabled={senderTilDialogen || state.tekst.length === 0 || erPreview}
+                >
+                  {senderTilDialogen ? 'Sender...' : 'Send via Dialogen'}
+                </Button>
+
+                <Button
+                  variant="tertiary"
+                  onClick={() => clickCancel()}
+                  data-testid="modal_btn-cancel"
+                  disabled={senderTilDialogen}
+                >
+                  Avbryt
+                </Button>
+              </div>
+              <div>
+                {state.redigererTekstfelt ? (
+                  <Button
+                    variant="tertiary"
+                    onClick={tilbakestillTekstfelt}
+                    data-testid="modal_btn-cancel"
+                    disabled={senderTilDialogen}
+                  >
+                    Tilbakestill
+                  </Button>
+                ) : (
+                  <Button
+                    variant="tertiary"
+                    onClick={fokuserTekstfelt}
+                    data-testid="modal_btn-cancel"
+                    disabled={senderTilDialogen}
+                  >
+                    Rediger melding
+                  </Button>
+                )}
+              </div>
+            </div>
+            {erPreview && (
+              <Alert variant="warning">
+                Det er ikke mulig å dele tiltak med bruker i forhåndsvisning. Brukers navn og veileders navn blir
+                automatisk satt utenfor forhåndsvisningsmodus.
+              </Alert>
+            )}
           </div>
-          {erPreview && (
-            <Alert variant="warning">
-              Det er ikke mulig å dele tiltak med bruker i forhåndsvisning. Brukers navn og veileders navn blir
-              automatisk satt utenfor forhåndsvisningsmodus.
-            </Alert>
-          )}
-        </Modal.Content>
-      )}
-      {state.sendtStatus === 'SENDT_OK' && (
-        <Modal.Content className={delemodalStyles.delemodal_tilbakemelding}>
-          <SuccessColored className={delemodalStyles.delemodal_svg} />
-          <Heading level="1" size="large" data-testid="modal_header">
-            Meldingen er sendt
-          </Heading>
-          <BodyShort>Du kan fortsette dialogen om dette tiltaket i Dialogen.</BodyShort>
-          <div className={classNames(modalStyles.modal_btngroup, modalStyles.modal_btngroup_success)}>
-            <Button variant="primary" onClick={gaTilDialogen} data-testid="modal_btn-dialog">
-              Gå til Dialogen
-            </Button>
-            <Button variant="secondary" onClick={() => clickCancel(false)} data-testid="modal_btn-cancel">
-              Lukk
-            </Button>
+        )}
+        {state.sendtStatus === 'SENDT_OK' && (
+          <div className={delemodalStyles.delemodal_tilbakemelding}>
+            <SuccessColored className={delemodalStyles.delemodal_svg} />
+            <Heading level="1" size="large" data-testid="modal_header">
+              Meldingen er sendt
+            </Heading>
+            <BodyShort>Du kan fortsette dialogen om dette tiltaket i Dialogen.</BodyShort>
+            <div className={classNames(modalStyles.modal_btngroup, modalStyles.modal_btngroup_success)}>
+              <Button variant="primary" onClick={gaTilDialogen} data-testid="modal_btn-dialog">
+                Gå til Dialogen
+              </Button>
+              <Button variant="secondary" onClick={() => clickCancel(false)} data-testid="modal_btn-cancel">
+                Lukk
+              </Button>
+            </div>
           </div>
-        </Modal.Content>
-      )}
-      {state.sendtStatus === 'SENDING_FEILET' && (
-        <Modal.Content className={classNames(delemodalStyles.delemodal_tilbakemelding)}>
-          <ErrorColored className={delemodalStyles.delemodal_svg} />
-          <Heading level="1" size="large" data-testid="modal_header">
-            Tiltaket kunne ikke deles med brukeren
-          </Heading>
-          <BodyShort>
-            Vi kunne ikke dele informasjon digitalt med denne brukeren. Dette kan være fordi hen ikke ønsker eller kan
-            benytte de digitale tjenestene våre.{' '}
-            <Lenke
-              isExternal
-              to="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Manuell-oppf%C3%B8lging-i-Modia-arbeidsrettet-oppf%C3%B8lging.aspx"
-            >
-              Les mer om manuell oppfølging{' '}
-            </Lenke>
-          </BodyShort>
-          <div className={modalStyles.modal_btngroup}>
-            <Button variant="primary" onClick={() => dispatch({ type: 'Reset' })} data-testid="modal_btn-reset">
-              Prøv på nytt
-            </Button>
-            <Button variant="secondary" onClick={() => clickCancel()} data-testid="modal_btn-cancel">
-              Lukk
-            </Button>
+        )}
+        {state.sendtStatus === 'SENDING_FEILET' && (
+          <div className={classNames(delemodalStyles.delemodal_tilbakemelding)}>
+            <ErrorColored className={delemodalStyles.delemodal_svg} />
+            <Heading level="1" size="large" data-testid="modal_header">
+              Tiltaket kunne ikke deles med brukeren
+            </Heading>
+            <BodyShort>
+              Vi kunne ikke dele informasjon digitalt med denne brukeren. Dette kan være fordi hen ikke ønsker eller kan
+              benytte de digitale tjenestene våre.{' '}
+              <Lenke
+                isExternal
+                to="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-arbeidsrettet-brukeroppfolging/SitePages/Manuell-oppf%C3%B8lging-i-Modia-arbeidsrettet-oppf%C3%B8lging.aspx"
+              >
+                Les mer om manuell oppfølging{' '}
+              </Lenke>
+            </BodyShort>
+            <div className={modalStyles.modal_btngroup}>
+              <Button variant="primary" onClick={() => dispatch({ type: 'Reset' })} data-testid="modal_btn-reset">
+                Prøv på nytt
+              </Button>
+              <Button variant="secondary" onClick={() => clickCancel()} data-testid="modal_btn-cancel">
+                Lukk
+              </Button>
+            </div>
           </div>
-        </Modal.Content>
-      )}
+        )}
+        <p className={modalStyles.muted}>
+          Kandidatene vil få et varsel fra NAV, og kan logge inn på nav.no for å lese meldingen
+        </p>
+      </Modal.Content>
     </Modal>
   );
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelemodalActions.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelemodalActions.tsx
@@ -3,6 +3,7 @@ export interface State {
   sendtStatus: Status;
   dialogId: string;
   malTekst: string;
+  redigererTekstfelt: boolean;
 }
 
 export type Status = 'IKKE_SENDT' | 'SENDER' | 'SENDT_OK' | 'SENDING_FEILET';
@@ -33,10 +34,20 @@ export interface RESET_ACTION {
   type: 'Reset';
 }
 
+export interface REDIGERER_TEKSTFELT_ACTION {
+  type: 'Redigerer tekstfelt';
+}
+
+export interface TILBAKESTILL_TEKSTFELT_ACTION {
+  type: 'Tilbakestill tekstfelt';
+}
+
 export type Actions =
   | SEND_MELDING_ACTION
   | SET_TEKST_ACTION
   | AVBRYT_ACTION
   | SENDT_OK_ACTION
   | SENDING_FEILET_ACTION
-  | RESET_ACTION;
+  | RESET_ACTION
+  | REDIGERER_TEKSTFELT_ACTION
+  | TILBAKESTILL_TEKSTFELT_ACTION;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Infomelding.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Infomelding.tsx
@@ -1,0 +1,7 @@
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import modalStyles from '../Modal.module.scss';
+
+export function Infomelding({ children }: { children: ReactNode }) {
+  return <p className={classNames(modalStyles.muted, modalStyles.mb_0)}>{children}</p>;
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/SendtOkContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/SendtOkContent.tsx
@@ -1,0 +1,40 @@
+import { SuccessColored } from '@navikt/ds-icons';
+import { BodyShort, Button, Heading } from '@navikt/ds-react';
+import classNames from 'classnames';
+import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
+import { useNavigerTilDialogen } from '../../../hooks/useNavigerTilDialogen';
+import modalStyles from '../Modal.module.scss';
+import delemodalStyles from './Delemodal.module.scss';
+import { State } from './DelemodalActions';
+
+interface Props {
+  onCancel: (value: boolean) => void;
+  state: State;
+}
+
+export function SendtOkContent({ onCancel, state }: Props) {
+  const fnr = useHentFnrFraUrl();
+  const { navigerTilDialogen } = useNavigerTilDialogen();
+
+  return (
+    <div className={delemodalStyles.delemodal_tilbakemelding}>
+      <SuccessColored className={delemodalStyles.delemodal_svg} />
+      <Heading level="1" size="large" data-testid="modal_header">
+        Meldingen er sendt
+      </Heading>
+      <BodyShort>Du kan fortsette dialogen om dette tiltaket i Dialogen.</BodyShort>
+      <div className={classNames(modalStyles.modal_btngroup, modalStyles.modal_btngroup_success)}>
+        <Button
+          variant="primary"
+          onClick={() => navigerTilDialogen(fnr, state.dialogId)}
+          data-testid="modal_btn-dialog"
+        >
+          Gå til Dialogen
+        </Button>
+        <Button variant="secondary" onClick={() => onCancel(false)} data-testid="modal_btn-cancel">
+          Lukk
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltaksgjennomforingDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltaksgjennomforingDetaljer.tsx
@@ -37,7 +37,7 @@ const ViewTiltaksgjennomforingDetaljer = () => {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
   const fnr = useHentFnrFraUrl();
   const { data: tiltaksgjennomforing, isLoading, isError } = useTiltaksgjennomforingById();
-  const [delemodalApen, setDelemodalApen] = useState<boolean>(true); // TODO Sett tilbake til false
+  const [delemodalApen, setDelemodalApen] = useState<boolean>(false);
   const brukerdata = useHentBrukerdata();
   const veilederdata = useHentVeilederdata();
   const { getUrlTilDialogen } = useNavigerTilDialogen();

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltaksgjennomforingDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltaksgjennomforingDetaljer.tsx
@@ -37,7 +37,7 @@ const ViewTiltaksgjennomforingDetaljer = () => {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
   const fnr = useHentFnrFraUrl();
   const { data: tiltaksgjennomforing, isLoading, isError } = useTiltaksgjennomforingById();
-  const [delemodalApen, setDelemodalApen] = useState<boolean>(false);
+  const [delemodalApen, setDelemodalApen] = useState<boolean>(true); // TODO Sett tilbake til false
   const brukerdata = useHentBrukerdata();
   const veilederdata = useHentVeilederdata();
   const { getUrlTilDialogen } = useNavigerTilDialogen();


### PR DESCRIPTION
Denne PRen implementerer visuelle endringer på del med bruker-modalen, samt "ny" funksjonalitet for å redigere teksten via en knapp. Trykk på knapp for å redigere vil bare gi fokus til tekstfeltet. Man kan også tilbakestille teksten.

**Før**
![Skjermbilde 2022-11-01 kl  09 09 33](https://user-images.githubusercontent.com/9053627/199188140-fd7146a1-964a-4479-98d9-a709b3dc301d.png)

**Etter**
![Skjermbilde 2022-11-01 kl  09 09 43](https://user-images.githubusercontent.com/9053627/199188163-7194c753-d9e7-457d-a7ae-c9c8a0deea40.png)

**I redigeringsmodus**
![image](https://user-images.githubusercontent.com/9053627/199188443-08059fe6-892c-4a97-9475-4eb056c68b51.png)
