### PR TITLE
BUGFIX Lagrer tiltaksnummer ved del med bruker

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -4,6 +4,7 @@ import { Dispatch, useRef } from 'react';
 import { mulighetsrommetClient } from '../../../core/api/clients';
 import { useFeatureToggles } from '../../../core/api/feature-toggles';
 import { useHentDeltMedBrukerStatus } from '../../../core/api/queries/useHentDeltMedbrukerStatus';
+import useTiltaksgjennomforingById from '../../../core/api/queries/useTiltaksgjennomforingById';
 import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
 import { erPreview } from '../../../utils/Utils';
 import modalStyles from '../Modal.module.scss';
@@ -32,6 +33,7 @@ export function DelMedBrukerContent({
 }: Props) {
   const senderTilDialogen = state.sendtStatus === 'SENDER';
   const tekstfeltRef = useRef<HTMLTextAreaElement | null>(null);
+  const { data: tiltaksgjennomforing } = useTiltaksgjennomforingById();
   const features = useFeatureToggles();
   const skalLagreAtViDelerMedBruker =
     features.isSuccess && features.data['mulighetsrommet.lagre-del-tiltak-med-bruker'];
@@ -60,7 +62,7 @@ export function DelMedBrukerContent({
     try {
       const res = await mulighetsrommetClient.dialogen.delMedDialogen({ fnr, requestBody: { overskrift, tekst } });
       if (skalLagreAtViDelerMedBruker) {
-        await lagreVeilederHarDeltTiltakMedBruker(res.id);
+        await lagreVeilederHarDeltTiltakMedBruker(res.id, tiltaksgjennomforing?.tiltaksnummer?.toString());
         refetchOmVeilederHarDeltMedBruker();
       }
       dispatch({ type: 'Sendt ok', payload: res.id });

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -34,6 +34,7 @@ export function DelMedBrukerContent({
   const senderTilDialogen = state.sendtStatus === 'SENDER';
   const tekstfeltRef = useRef<HTMLTextAreaElement | null>(null);
   const { data: tiltaksgjennomforing } = useTiltaksgjennomforingById();
+  const tiltaksnummer = tiltaksgjennomforing?.tiltaksnummer?.toString();
   const features = useFeatureToggles();
   const skalLagreAtViDelerMedBruker =
     features.isSuccess && features.data['mulighetsrommet.lagre-del-tiltak-med-bruker'];
@@ -61,8 +62,8 @@ export function DelMedBrukerContent({
     const { tekst } = state;
     try {
       const res = await mulighetsrommetClient.dialogen.delMedDialogen({ fnr, requestBody: { overskrift, tekst } });
-      if (skalLagreAtViDelerMedBruker) {
-        await lagreVeilederHarDeltTiltakMedBruker(res.id, tiltaksgjennomforing?.tiltaksnummer?.toString());
+      if (skalLagreAtViDelerMedBruker && tiltaksnummer) {
+        await lagreVeilederHarDeltTiltakMedBruker(res.id, tiltaksnummer);
         refetchOmVeilederHarDeltMedBruker();
       }
       dispatch({ type: 'Sendt ok', payload: res.id });

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentDeltMedbrukerStatus.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentDeltMedbrukerStatus.ts
@@ -4,30 +4,31 @@ import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
 import { erPreview } from '../../../utils/Utils';
 import { mulighetsrommetClient } from '../clients';
 import { QueryKeys } from '../query-keys';
-import { useGetTiltaksgjennomforingIdFraUrl } from './useGetTiltaksgjennomforingIdFraUrl';
 import { useHentVeilederdata } from './useHentVeilederdata';
+import useTiltaksgjennomforingById from './useTiltaksgjennomforingById';
 
 export function useHentDeltMedBrukerStatus() {
-  const tiltaksnummer = useGetTiltaksgjennomforingIdFraUrl();
+  const { data: tiltaksgjennomforing } = useTiltaksgjennomforingById();
   const { data: veilederData } = useHentVeilederdata();
-  const bruker_fnr = useHentFnrFraUrl();
+  const brukerFnr = useHentFnrFraUrl();
+
   const { data: sistDeltMedBruker, refetch } = useQuery<DelMedBruker>(
-    [QueryKeys.DeltMedBrukerStatus, bruker_fnr, tiltaksnummer],
+    [QueryKeys.DeltMedBrukerStatus, brukerFnr, tiltaksgjennomforing?._id],
     () =>
       mulighetsrommetClient.delMedBruker.getDelMedBruker({
-        fnr: bruker_fnr,
-        tiltaksnummer,
+        fnr: brukerFnr,
+        tiltaksnummer: tiltaksgjennomforing?.tiltaksnummer?.toString()!!,
       }),
-    { enabled: !erPreview }
+    { enabled: !erPreview || !tiltaksgjennomforing?.tiltaksnummer }
   );
 
-  async function lagreVeilederHarDeltTiltakMedBruker(dialogId: string) {
+  async function lagreVeilederHarDeltTiltakMedBruker(dialogId: string, tiltaksnummer: string) {
     if (!veilederData?.ident) return;
 
     try {
       const res = await mulighetsrommetClient.delMedBruker.postDelMedBruker({
         tiltaksnummer,
-        requestBody: { bruker_fnr, navident: veilederData?.ident, tiltaksnummer, dialogId },
+        requestBody: { bruker_fnr: brukerFnr, navident: veilederData?.ident, tiltaksnummer, dialogId },
       });
 
       if (!res.ok) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerService.kt
@@ -9,9 +9,11 @@ import no.nav.mulighetsrommet.database.utils.query
 import no.nav.mulighetsrommet.domain.models.DelMedBruker
 import no.nav.mulighetsrommet.secure_log.SecureLog
 import org.intellij.lang.annotations.Language
+import org.slf4j.LoggerFactory
 
 class DelMedBrukerService(private val db: Database) {
     private val secureLog = SecureLog.logger
+    private val log = LoggerFactory.getLogger(this.javaClass)
 
     fun lagreDelMedBruker(data: DelMedBruker): QueryResult<DelMedBruker> = query {
         secureLog.info("Veileder (${data.navident}) deler tiltak med tiltaksnummer: '${data.tiltaksnummer}' med bruker (${data.bruker_fnr})")
@@ -26,6 +28,11 @@ class DelMedBrukerService(private val db: Database) {
                 "Veileders NAVident er tomt. Kan ikke lagre info om tiltak."
             )
             throw BadRequestException("Veileders NAVident er ikke 6 tegn")
+        }
+
+        if (data.tiltaksnummer.trim().isEmpty()) {
+            log.warn("Tiltaksnummer er ikke sendt med ved lagring av del med bruker. Kan derfor ikke lagre.")
+            throw BadRequestException("Tiltaksnummer må inkluderes")
         }
 
         @Language("PostgreSQL")


### PR DESCRIPTION
For en stund tilbake endret vi fra tiltaksnummer i url til å benytte sanity-id. Blant annet fordi individuelle tiltakstyper ikke har et tiltaksnummer. Som en regresjon av det så benyttet vi nå plutselig id'en som tiltaksnummer ved lagring av hvilket tiltak en veileder velger å dele med en bruker. Denne PRen fikser det slik at det er tiltaksnummer vi lagrer korrekt.