### PR TITLE
Eksplisitt bredde på filtermeny

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Filtermeny.module.scss
@@ -1,7 +1,5 @@
 :global(.mulighetsrommet-veileder-flate) {
   .tiltakstype_oversikt_filtermeny {
-    width: 15rem;
-    height: 100%;
     border-right: 1px solid var(--navds-semantic-color-border-muted);
     padding: 1rem 0.5rem 1rem 0;
     transition: top 0.2s ease 0s, max-height 0.2s ease 0s;

--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-oversikt/ViewTiltakstypeOversikt.module.scss
@@ -1,6 +1,6 @@
 .tiltakstype_oversikt {
   display: grid;
-  grid-template-columns: 15rem auto;
+  grid-template-columns: 336px auto;
   grid-template-rows: minmax(3rem, min-content) min-content auto;
   grid-gap: 1rem;
   min-height: 86vh;


### PR DESCRIPTION
Legger på samme bredde på filtermeny som filteret som brukes i Oversikten (336 px)

**Før**
![Skjermbilde 2022-11-03 kl  13 03 38](https://user-images.githubusercontent.com/9053627/199716216-320416a7-8be4-4731-92e2-d7cfd9bb8802.png)

**Etter**
![Skjermbilde 2022-11-03 kl  13 03 47](https://user-images.githubusercontent.com/9053627/199716236-128acd39-10ee-459f-bfc5-357fc6498f77.png)
