### PR TITLE
Splitt ArenaService i både service og repository

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -23,6 +23,7 @@ import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClient
 import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClientImpl
 import no.nav.mulighetsrommet.api.clients.veileder.VeilarbveilederClient
 import no.nav.mulighetsrommet.api.clients.veileder.VeilarbveilederClientImpl
+import no.nav.mulighetsrommet.api.repositories.ArenaRepository
 import no.nav.mulighetsrommet.api.services.*
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.DatabaseConfig
@@ -42,6 +43,7 @@ fun Application.configureDependencyInjection(appConfig: AppConfig) {
 
         modules(
             db(appConfig.database),
+            repositories(),
             services(
                 appConfig,
                 veilarbvedsstotte(appConfig),
@@ -155,6 +157,10 @@ private fun tokenClientProviderForMachineToMachine(config: AppConfig): MachineTo
             .buildMachineToMachineTokenClient()
         false -> AzureAdTokenClientBuilder.builder().withNaisDefaults().buildMachineToMachineTokenClient()
     }
+}
+
+private fun repositories() = module {
+   single { ArenaRepository(get()) }
 }
 
 private fun services(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -160,7 +160,7 @@ private fun tokenClientProviderForMachineToMachine(config: AppConfig): MachineTo
 }
 
 private fun repositories() = module {
-   single { ArenaRepository(get()) }
+    single { ArenaRepository(get()) }
 }
 
 private fun services(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/ArenaRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/ArenaRepository.kt
@@ -1,0 +1,189 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.utils.DatabaseMapper
+import no.nav.mulighetsrommet.database.Database
+import no.nav.mulighetsrommet.database.utils.QueryResult
+import no.nav.mulighetsrommet.database.utils.query
+import no.nav.mulighetsrommet.domain.adapter.AdapterSak
+import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
+import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
+import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
+import org.intellij.lang.annotations.Language
+import org.slf4j.LoggerFactory
+
+class ArenaRepository(val db: Database) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun upsertTiltakstype(tiltakstype: AdapterTiltak): QueryResult<AdapterTiltak> = query {
+        logger.info("Lagrer tiltakstype tiltakskode=${tiltakstype.tiltakskode}")
+
+        @Language("PostgreSQL")
+        val query = """
+            insert into tiltakstype (navn, innsatsgruppe_id, tiltakskode, fra_dato, til_dato)
+            values (?, ?, ?, ?, ?)
+            on conflict (tiltakskode)
+                do update set navn             = excluded.navn,
+                              innsatsgruppe_id = excluded.innsatsgruppe_id,
+                              tiltakskode      = excluded.tiltakskode,
+                              fra_dato         = excluded.fra_dato,
+                              til_dato         = excluded.til_dato
+            returning *
+        """.trimIndent()
+
+        tiltakstype.run { queryOf(query, navn, innsatsgruppe, tiltakskode, fraDato, tilDato) }
+            .map { DatabaseMapper.toAdapterTiltak(it) }
+            .asSingle
+            .let { db.run(it)!! }
+    }
+
+    fun deleteTiltakstype(tiltakstype: AdapterTiltak): QueryResult<Unit> = query {
+        logger.info("Sletter tiltakstype tiltakskode=${tiltakstype.tiltakskode}")
+
+        @Language("PostgreSQL")
+        val query = """
+            delete from tiltakstype
+            where tiltakskode = ?
+        """.trimIndent()
+
+        tiltakstype.run { queryOf(query, tiltakskode) }
+            .asExecute
+            .let { db.run(it) }
+    }
+
+    fun upsertTiltaksgjennomforing(
+        tiltak: AdapterTiltaksgjennomforing
+    ): QueryResult<AdapterTiltaksgjennomforing> = query {
+        logger.info("Lagrer tiltak id=${tiltak.id}, tiltakskode=${tiltak.tiltakskode}, sakId=${tiltak.sakId}")
+
+        @Language("PostgreSQL")
+        val query = """
+            insert into tiltaksgjennomforing (navn,
+                                              arrangor_id,
+                                              tiltakskode,
+                                              arena_id,
+                                              fra_dato,
+                                              til_dato, sak_id,
+                                              apent_for_innsok,
+                                              antall_plasser)
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            on conflict (arena_id)
+                do update set navn             = excluded.navn,
+                              arrangor_id      = excluded.arrangor_id,
+                              tiltakskode      = excluded.tiltakskode,
+                              arena_id         = excluded.arena_id,
+                              fra_dato         = excluded.fra_dato,
+                              til_dato         = excluded.til_dato,
+                              sak_id           = excluded.sak_id,
+                              apent_for_innsok = excluded.apent_for_innsok,
+                              antall_plasser   = excluded.antall_plasser
+            returning *
+        """.trimIndent()
+
+        tiltak
+            .run {
+                queryOf(
+                    query,
+                    navn,
+                    arrangorId,
+                    tiltakskode,
+                    id,
+                    fraDato,
+                    tilDato,
+                    sakId,
+                    apentForInnsok,
+                    antallPlasser
+                )
+            }
+            .map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }
+            .asSingle
+            .let { db.run(it)!! }
+    }
+
+    fun upsertTiltaksgjennomforing(tiltak: AdapterTiltaksgjennomforing): QueryResult<Unit> = query {
+        logger.info("Sletter tiltak id=${tiltak.id}, tiltakskode=${tiltak.tiltakskode}, sakId=${tiltak.sakId}")
+
+        @Language("PostgreSQL")
+        val query = """
+            delete from tiltaksgjennomforing
+            where arena_id = ?
+        """.trimIndent()
+
+        query {
+            tiltak.run { queryOf(query, id) }
+                .asExecute
+                .let { db.run(it) }
+        }
+    }
+
+    fun upsertDeltaker(deltaker: AdapterTiltakdeltaker): QueryResult<AdapterTiltakdeltaker> = query {
+        logger.info("Lagrer deltaker id=${deltaker.id}, tiltak=${deltaker.tiltaksgjennomforingId}")
+
+        @Language("PostgreSQL")
+        val query = """
+            insert into deltaker (arena_id, tiltaksgjennomforing_id, person_id, fra_dato, til_dato, status)
+            values (?, ?, ?, ?, ?, ?::deltakerstatus)
+            on conflict (arena_id)
+            do update set
+                arena_id = excluded.arena_id,
+                tiltaksgjennomforing_id = excluded.tiltaksgjennomforing_id,
+                person_id = excluded.person_id,
+                fra_dato = excluded.fra_dato,
+                til_dato = excluded.til_dato,
+                status = excluded.status
+            returning *
+        """.trimIndent()
+
+        deltaker.run { queryOf(query, id, tiltaksgjennomforingId, personId, fraDato, tilDato, status.name) }
+            .map { DatabaseMapper.toAdapterTiltakdeltaker(it) }
+            .asSingle
+            .let { db.run(it)!! }
+    }
+
+    fun deleteDeltaker(deltaker: AdapterTiltakdeltaker): QueryResult<Unit> = query {
+        logger.info("Sletter deltaker id=${deltaker.id}, tiltak=${deltaker.tiltaksgjennomforingId}")
+
+        @Language("PostgreSQL")
+        val query = """
+            delete from deltaker
+            where arena_id = ?
+        """.trimIndent()
+
+        deltaker.run { queryOf(query, id) }
+            .asExecute
+            .let { db.run(it) }
+    }
+
+    fun updateTiltaksgjennomforingWithSak(sak: AdapterSak): QueryResult<AdapterTiltaksgjennomforing?> = query {
+        logger.info("Oppdaterer tiltak med sak sakId=${sak.id} tiltaksnummer=${sak.lopenummer}")
+
+        @Language("PostgreSQL")
+        val query = """
+            update tiltaksgjennomforing set tiltaksnummer = ?, aar = ?
+            where sak_id = ?
+            returning *
+        """.trimIndent()
+
+        sak.run { queryOf(query, lopenummer, aar, id) }
+            .map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }
+            .asSingle
+            .let { db.run(it) }
+    }
+
+    fun unsetSakOnTiltaksgjennomforing(sak: AdapterSak): QueryResult<AdapterTiltaksgjennomforing?> = query {
+        logger.info("Fjerner referanse til sak for tiltak sakId=${sak.id} tiltaksnummer=${sak.lopenummer}")
+
+        @Language("PostgreSQL")
+        val query = """
+            update tiltaksgjennomforing set tiltaksnummer = null, aar = null
+            where sak_id = ?
+            returning *
+        """.trimIndent()
+
+        sak.run { queryOf(query, id) }
+            .map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }
+            .asSingle
+            .let { db.run(it) }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/ArenaRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/ArenaRepository.kt
@@ -12,7 +12,7 @@ import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 
-class ArenaRepository(val db: Database) {
+class ArenaRepository(private val db: Database) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -101,7 +101,7 @@ class ArenaRepository(val db: Database) {
             .let { db.run(it)!! }
     }
 
-    fun upsertTiltaksgjennomforing(tiltak: AdapterTiltaksgjennomforing): QueryResult<Unit> = query {
+    fun deleteTiltaksgjennomforing(tiltak: AdapterTiltaksgjennomforing): QueryResult<Unit> = query {
         logger.info("Sletter tiltak id=${tiltak.id}, tiltakskode=${tiltak.tiltakskode}, sakId=${tiltak.sakId}")
 
         @Language("PostgreSQL")

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/ArenaRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/ArenaRepository.kt
@@ -64,7 +64,8 @@ class ArenaRepository(private val db: Database) {
                                               tiltakskode,
                                               arena_id,
                                               fra_dato,
-                                              til_dato, sak_id,
+                                              til_dato,
+                                              sak_id,
                                               apent_for_innsok,
                                               antall_plasser)
             values (?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
@@ -25,7 +25,7 @@ fun Route.arenaRoutes() {
     route("/api/v1/arena/") {
         put("tiltakstype") {
             val tiltakstype = call.receive<AdapterTiltak>()
-            arenaService.upsertTiltakstype(tiltakstype)
+            arenaService.createOrUpdate(tiltakstype)
                 .map { call.respond(it) }
                 .mapLeft {
                     logError(logger, it.error)
@@ -35,7 +35,7 @@ fun Route.arenaRoutes() {
 
         delete("tiltakstype") {
             val tiltakstype = call.receive<AdapterTiltak>()
-            arenaService.deleteTiltakstype(tiltakstype)
+            arenaService.remove(tiltakstype)
                 .map { call.response.status(HttpStatusCode.OK) }
                 .mapLeft {
                     logError(logger, it.error)
@@ -45,7 +45,7 @@ fun Route.arenaRoutes() {
 
         put("tiltaksgjennomforing") {
             val tiltaksgjennomforing = call.receive<AdapterTiltaksgjennomforing>()
-            arenaService.upsertTiltaksgjennomforing(tiltaksgjennomforing)
+            arenaService.createOrUpdate(tiltaksgjennomforing)
                 .map { call.respond(it) }
                 .mapLeft {
                     logError(logger, it.error)
@@ -55,7 +55,7 @@ fun Route.arenaRoutes() {
 
         delete("tiltaksgjennomforing") {
             val tiltaksgjennomforing = call.receive<AdapterTiltaksgjennomforing>()
-            arenaService.deleteTiltaksgjennomforing(tiltaksgjennomforing)
+            arenaService.remove(tiltaksgjennomforing)
                 .map { call.response.status(HttpStatusCode.OK) }
                 .mapLeft {
                     logError(logger, it.error)
@@ -65,7 +65,7 @@ fun Route.arenaRoutes() {
 
         put("deltaker") {
             val deltaker = call.receive<AdapterTiltakdeltaker>()
-            arenaService.upsertDeltaker(deltaker)
+            arenaService.createOrUpdate(deltaker)
                 .map { call.respond(HttpStatusCode.OK, it) }
                 .mapLeft {
                     when (it) {
@@ -82,7 +82,7 @@ fun Route.arenaRoutes() {
 
         delete("deltaker") {
             val deltaker = call.receive<AdapterTiltakdeltaker>()
-            arenaService.deleteDeltaker(deltaker)
+            arenaService.remove(deltaker)
                 .map { call.response.status(HttpStatusCode.OK) }
                 .mapLeft {
                     logError(logger, it.error)
@@ -92,7 +92,7 @@ fun Route.arenaRoutes() {
 
         put("sak") {
             val sak = call.receive<AdapterSak>()
-            arenaService.updateTiltaksgjennomforingWithSak(sak)
+            arenaService.setTiltaksnummerFor(sak)
                 .map {
                     val response = it ?: HttpStatusCode.Conflict
                     call.respond(response)
@@ -105,7 +105,7 @@ fun Route.arenaRoutes() {
 
         delete("sak") {
             val sak = call.receive<AdapterSak>()
-            arenaService.unsetSakOnTiltaksgjennomforing(sak)
+            arenaService.removeTiltaksnummerFor(sak)
                 .map { call.response.status(HttpStatusCode.OK) }
                 .mapLeft {
                     logError(logger, it.error)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
@@ -92,7 +92,7 @@ fun Route.arenaRoutes() {
 
         put("sak") {
             val sak = call.receive<AdapterSak>()
-            arenaService.setTiltaksnummerFor(sak)
+            arenaService.setTiltaksnummerWith(sak)
                 .map {
                     val response = it ?: HttpStatusCode.Conflict
                     call.respond(response)
@@ -105,7 +105,7 @@ fun Route.arenaRoutes() {
 
         delete("sak") {
             val sak = call.receive<AdapterSak>()
-            arenaService.removeTiltaksnummerFor(sak)
+            arenaService.removeTiltaksnummerWith(sak)
                 .map { call.response.status(HttpStatusCode.OK) }
                 .mapLeft {
                     logError(logger, it.error)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
@@ -28,7 +28,7 @@ class ArenaService(private val arenaRepository: ArenaRepository) {
 
     fun remove(deltaker: AdapterTiltakdeltaker) = arenaRepository.deleteDeltaker(deltaker)
 
-    fun setTiltaksnummerFor(tiltaksgjennomforing: AdapterTiltaksgjennomforing, sak: AdapterSak) = arenaRepository.updateTiltaksgjennomforingWithSak(sak)
+    fun setTiltaksnummerWith(sak: AdapterSak) = arenaRepository.updateTiltaksgjennomforingWithSak(sak)
 
-    fun removeTiltaksnummerFor(tiltaksgjennomforing: AdapterTiltaksgjennomforing, sak: AdapterSak) = arenaRepository.unsetSakOnTiltaksgjennomforing(sak)
+    fun removeTiltaksnummerWith(sak: AdapterSak) = arenaRepository.unsetSakOnTiltaksgjennomforing(sak)
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.services
 
 import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.repositories.ArenaRepository
 import no.nav.mulighetsrommet.api.utils.DatabaseMapper
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.QueryResult
@@ -9,180 +10,25 @@ import no.nav.mulighetsrommet.domain.adapter.AdapterSak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
+import no.nav.mulighetsrommet.domain.models.Tiltakstype
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 
-class ArenaService(private val db: Database) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+class ArenaService(private val arenaRepository: ArenaRepository) {
 
-    fun upsertTiltakstype(tiltakstype: AdapterTiltak): QueryResult<AdapterTiltak> = query {
-        logger.info("Lagrer tiltakstype tiltakskode=${tiltakstype.tiltakskode}")
+    fun createOrUpdate(tiltaksgjennomforing: AdapterTiltaksgjennomforing) = arenaRepository.upsertTiltaksgjennomforing(tiltaksgjennomforing)
 
-        @Language("PostgreSQL")
-        val query = """
-            insert into tiltakstype (navn, innsatsgruppe_id, tiltakskode, fra_dato, til_dato)
-            values (?, ?, ?, ?, ?)
-            on conflict (tiltakskode)
-                do update set navn             = excluded.navn,
-                              innsatsgruppe_id = excluded.innsatsgruppe_id,
-                              tiltakskode      = excluded.tiltakskode,
-                              fra_dato         = excluded.fra_dato,
-                              til_dato         = excluded.til_dato
-            returning *
-        """.trimIndent()
+    fun createOrUpdate(tiltakstype: AdapterTiltak) = arenaRepository.upsertTiltakstype(tiltakstype)
 
-        tiltakstype.run { queryOf(query, navn, innsatsgruppe, tiltakskode, fraDato, tilDato) }
-            .map { DatabaseMapper.toAdapterTiltak(it) }
-            .asSingle
-            .let { db.run(it)!! }
-    }
+    fun createOrUpdate(deltaker: AdapterTiltakdeltaker) = arenaRepository.upsertDeltaker(deltaker)
 
-    fun deleteTiltakstype(tiltakstype: AdapterTiltak): QueryResult<Unit> = query {
-        logger.info("Sletter tiltakstype tiltakskode=${tiltakstype.tiltakskode}")
+    fun remove(tiltaksgjennomforing: AdapterTiltaksgjennomforing) = arenaRepository.deleteTiltaksgjennomforing(tiltaksgjennomforing)
 
-        @Language("PostgreSQL")
-        val query = """
-            delete from tiltakstype
-            where tiltakskode = ?
-        """.trimIndent()
+    fun remove(tiltakstype: AdapterTiltak) = arenaRepository.deleteTiltakstype(tiltakstype)
 
-        tiltakstype.run { queryOf(query, tiltakskode) }
-            .asExecute
-            .let { db.run(it) }
-    }
+    fun remove(deltaker: AdapterTiltakdeltaker) = arenaRepository.deleteDeltaker(deltaker)
 
-    fun upsertTiltaksgjennomforing(
-        tiltak: AdapterTiltaksgjennomforing
-    ): QueryResult<AdapterTiltaksgjennomforing> = query {
-        logger.info("Lagrer tiltak id=${tiltak.id}, tiltakskode=${tiltak.tiltakskode}, sakId=${tiltak.sakId}")
+    fun setTiltaksnummerFor(tiltaksgjennomforing: AdapterTiltaksgjennomforing, sak: AdapterSak) = arenaRepository.updateTiltaksgjennomforingWithSak(sak)
 
-        @Language("PostgreSQL")
-        val query = """
-            insert into tiltaksgjennomforing (navn,
-                                              arrangor_id,
-                                              tiltakskode,
-                                              arena_id,
-                                              fra_dato,
-                                              til_dato, sak_id,
-                                              apent_for_innsok,
-                                              antall_plasser)
-            values (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            on conflict (arena_id)
-                do update set navn             = excluded.navn,
-                              arrangor_id      = excluded.arrangor_id,
-                              tiltakskode      = excluded.tiltakskode,
-                              arena_id         = excluded.arena_id,
-                              fra_dato         = excluded.fra_dato,
-                              til_dato         = excluded.til_dato,
-                              sak_id           = excluded.sak_id,
-                              apent_for_innsok = excluded.apent_for_innsok,
-                              antall_plasser   = excluded.antall_plasser
-            returning *
-        """.trimIndent()
-
-        tiltak
-            .run {
-                queryOf(
-                    query,
-                    navn,
-                    arrangorId,
-                    tiltakskode,
-                    id,
-                    fraDato,
-                    tilDato,
-                    sakId,
-                    apentForInnsok,
-                    antallPlasser
-                )
-            }
-            .map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }
-            .asSingle
-            .let { db.run(it)!! }
-    }
-
-    fun deleteTiltaksgjennomforing(tiltak: AdapterTiltaksgjennomforing): QueryResult<Unit> = query {
-        logger.info("Sletter tiltak id=${tiltak.id}, tiltakskode=${tiltak.tiltakskode}, sakId=${tiltak.sakId}")
-
-        @Language("PostgreSQL")
-        val query = """
-            delete from tiltaksgjennomforing
-            where arena_id = ?
-        """.trimIndent()
-
-        query {
-            tiltak.run { queryOf(query, id) }
-                .asExecute
-                .let { db.run(it) }
-        }
-    }
-
-    fun upsertDeltaker(deltaker: AdapterTiltakdeltaker): QueryResult<AdapterTiltakdeltaker> = query {
-        logger.info("Lagrer deltaker id=${deltaker.id}, tiltak=${deltaker.tiltaksgjennomforingId}")
-
-        @Language("PostgreSQL")
-        val query = """
-            insert into deltaker (arena_id, tiltaksgjennomforing_id, person_id, fra_dato, til_dato, status)
-            values (?, ?, ?, ?, ?, ?::deltakerstatus)
-            on conflict (arena_id)
-            do update set
-                arena_id = excluded.arena_id,
-                tiltaksgjennomforing_id = excluded.tiltaksgjennomforing_id,
-                person_id = excluded.person_id,
-                fra_dato = excluded.fra_dato,
-                til_dato = excluded.til_dato,
-                status = excluded.status
-            returning *
-        """.trimIndent()
-
-        deltaker.run { queryOf(query, id, tiltaksgjennomforingId, personId, fraDato, tilDato, status.name) }
-            .map { DatabaseMapper.toAdapterTiltakdeltaker(it) }
-            .asSingle
-            .let { db.run(it)!! }
-    }
-
-    fun deleteDeltaker(deltaker: AdapterTiltakdeltaker): QueryResult<Unit> = query {
-        logger.info("Sletter deltaker id=${deltaker.id}, tiltak=${deltaker.tiltaksgjennomforingId}")
-
-        @Language("PostgreSQL")
-        val query = """
-            delete from deltaker
-            where arena_id = ?
-        """.trimIndent()
-
-        deltaker.run { queryOf(query, id) }
-            .asExecute
-            .let { db.run(it) }
-    }
-
-    fun updateTiltaksgjennomforingWithSak(sak: AdapterSak): QueryResult<AdapterTiltaksgjennomforing?> = query {
-        logger.info("Oppdaterer tiltak med sak sakId=${sak.id} tiltaksnummer=${sak.lopenummer}")
-
-        @Language("PostgreSQL")
-        val query = """
-            update tiltaksgjennomforing set tiltaksnummer = ?, aar = ?
-            where sak_id = ?
-            returning *
-        """.trimIndent()
-
-        sak.run { queryOf(query, lopenummer, aar, id) }
-            .map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }
-            .asSingle
-            .let { db.run(it) }
-    }
-
-    fun unsetSakOnTiltaksgjennomforing(sak: AdapterSak): QueryResult<AdapterTiltaksgjennomforing?> = query {
-        logger.info("Fjerner referanse til sak for tiltak sakId=${sak.id} tiltaksnummer=${sak.lopenummer}")
-
-        @Language("PostgreSQL")
-        val query = """
-            update tiltaksgjennomforing set tiltaksnummer = null, aar = null
-            where sak_id = ?
-            returning *
-        """.trimIndent()
-
-        sak.run { queryOf(query, id) }
-            .map { DatabaseMapper.toAdapterTiltaksgjennomforing(it) }
-            .asSingle
-            .let { db.run(it) }
-    }
+    fun removeTiltaksnummerFor(tiltaksgjennomforing: AdapterTiltaksgjennomforing, sak: AdapterSak) = arenaRepository.unsetSakOnTiltaksgjennomforing(sak)
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
@@ -1,18 +1,10 @@
 package no.nav.mulighetsrommet.api.services
 
-import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.repositories.ArenaRepository
-import no.nav.mulighetsrommet.api.utils.DatabaseMapper
-import no.nav.mulighetsrommet.database.Database
-import no.nav.mulighetsrommet.database.utils.QueryResult
-import no.nav.mulighetsrommet.database.utils.query
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltakdeltaker
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltaksgjennomforing
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
-import org.intellij.lang.annotations.Language
-import org.slf4j.LoggerFactory
 
 class ArenaService(private val arenaRepository: ArenaRepository) {
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import no.nav.mulighetsrommet.api.clients.arena.VeilarbarenaClient
+import no.nav.mulighetsrommet.api.repositories.ArenaRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
@@ -25,7 +26,7 @@ class HistorikkServiceTest : FunSpec({
     val listener = extension(FlywayDatabaseListener(createApiDatabaseTestSchema()))
 
     beforeSpec {
-        val arenaService = ArenaService(listener.db)
+        val arenaRepository = ArenaRepository(listener.db)
 
         val tiltakstype = AdapterTiltak(
             navn = "Arbeidstrening",
@@ -58,10 +59,10 @@ class HistorikkServiceTest : FunSpec({
             aar = 2022
         )
 
-        arenaService.upsertTiltakstype(tiltakstype)
-        arenaService.upsertTiltaksgjennomforing(tiltaksgjennomforing)
-        arenaService.upsertDeltaker(deltaker)
-        arenaService.updateTiltaksgjennomforingWithSak(sak)
+        arenaRepository.upsertTiltakstype(tiltakstype)
+        arenaRepository.upsertTiltaksgjennomforing(tiltaksgjennomforing)
+        arenaRepository.upsertDeltaker(deltaker)
+        arenaRepository.updateTiltaksgjennomforingWithSak(sak)
     }
 
     test("henter historikk for bruker basert på person id med arrangørnavn") {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import no.nav.mulighetsrommet.api.repositories.ArenaRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
 import no.nav.mulighetsrommet.domain.adapter.AdapterSak
@@ -24,12 +25,12 @@ class TiltaksgjennomforingServiceTest : FunSpec({
     register(listener)
 
     context("CRUD") {
-        val arenaService = ArenaService(listener.db)
+        val arenaRepository = ArenaRepository(listener.db)
 
         val service = TiltaksgjennomforingService(listener.db)
 
         beforeAny {
-            arenaService.upsertTiltakstype(
+            arenaRepository.upsertTiltakstype(
                 AdapterTiltak(
                     navn = "Arbeidstrening",
                     innsatsgruppe = 1,
@@ -38,7 +39,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
                     tilDato = LocalDateTime.now().plusYears(1)
                 )
             )
-            arenaService.upsertTiltakstype(
+            arenaRepository.upsertTiltakstype(
                 AdapterTiltak(
                     navn = "Oppfølging",
                     innsatsgruppe = 2,
@@ -69,17 +70,17 @@ class TiltaksgjennomforingServiceTest : FunSpec({
         }
 
         test("should return empty result when tiltak are missing tiltaksnummer") {
-            arenaService.upsertTiltaksgjennomforing(tiltak1)
-            arenaService.upsertTiltaksgjennomforing(tiltak2)
+            arenaRepository.upsertTiltaksgjennomforing(tiltak1)
+            arenaRepository.upsertTiltaksgjennomforing(tiltak2)
 
             service.getTiltaksgjennomforinger() shouldBe listOf()
         }
 
         test("should get tiltak when they have been assigned tiltaksnummer") {
-            arenaService.updateTiltaksgjennomforingWithSak(
+            arenaRepository.updateTiltaksgjennomforingWithSak(
                 AdapterSak(id = 1, lopenummer = 11, aar = 2022)
             )
-            arenaService.updateTiltaksgjennomforingWithSak(
+            arenaRepository.updateTiltaksgjennomforingWithSak(
                 AdapterSak(id = 2, lopenummer = 22, aar = 2022)
             )
 
@@ -121,11 +122,11 @@ class TiltaksgjennomforingServiceTest : FunSpec({
         context("tilgjengelighetsstatus") {
             context("when tiltak is closed for applications") {
                 beforeAny {
-                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(apentForInnsok = false))
+                    arenaRepository.upsertTiltaksgjennomforing(tiltak1.copy(apentForInnsok = false))
                 }
 
                 afterAny {
-                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(apentForInnsok = true))
+                    arenaRepository.upsertTiltaksgjennomforing(tiltak1.copy(apentForInnsok = true))
                 }
 
                 test("should have tilgjengelighet set to STENGT") {
@@ -135,7 +136,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
 
             context("when there are no limits to available seats") {
                 beforeAny {
-                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = null))
+                    arenaRepository.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = null))
                 }
 
                 test("should have tilgjengelighet set to APENT_FOR_INNSOK") {
@@ -145,7 +146,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
 
             context("when there are no available seats") {
                 beforeAny {
-                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 0))
+                    arenaRepository.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 0))
                 }
 
                 test("should have tilgjengelighet set to VENTELISTE") {
@@ -155,9 +156,9 @@ class TiltaksgjennomforingServiceTest : FunSpec({
 
             context("when all available seats are occupied by deltakelser with status DELTAR") {
                 beforeAny {
-                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 1))
+                    arenaRepository.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 1))
 
-                    arenaService.upsertDeltaker(
+                    arenaRepository.upsertDeltaker(
                         AdapterTiltakdeltaker(
                             id = 1,
                             tiltaksgjennomforingId = tiltak1.id,
@@ -174,9 +175,9 @@ class TiltaksgjennomforingServiceTest : FunSpec({
 
             context("when deltakelser are no longer DELTAR") {
                 beforeAny {
-                    arenaService.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 1))
+                    arenaRepository.upsertTiltaksgjennomforing(tiltak1.copy(antallPlasser = 1))
 
-                    arenaService.upsertDeltaker(
+                    arenaRepository.upsertDeltaker(
                         AdapterTiltakdeltaker(
                             id = 1,
                             tiltaksgjennomforingId = tiltak1.id,
@@ -193,7 +194,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
         }
 
         test("should delete tiltak") {
-            arenaService.deleteTiltaksgjennomforing(tiltak1)
+            arenaRepository.deleteTiltaksgjennomforing(tiltak1)
 
             service.getTiltaksgjennomforingById(tiltak1.id) shouldBe null
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.mulighetsrommet.api.services
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import no.nav.mulighetsrommet.api.repositories.ArenaRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
 import no.nav.mulighetsrommet.domain.adapter.AdapterTiltak
@@ -17,7 +18,7 @@ class TiltakstypeServiceTest : FunSpec({
     register(listener)
 
     beforeSpec {
-        val arenaService = ArenaService(listener.db)
+        val arenaRepository = ArenaRepository(listener.db)
 
         val tiltakstype = AdapterTiltak(
             navn = "Arbeidstrening",
@@ -35,8 +36,8 @@ class TiltakstypeServiceTest : FunSpec({
             tilDato = LocalDateTime.now().plusYears(1)
         )
 
-        arenaService.upsertTiltakstype(tiltakstype)
-        arenaService.upsertTiltakstype(tiltakstype2)
+        arenaRepository.upsertTiltakstype(tiltakstype)
+        arenaRepository.upsertTiltakstype(tiltakstype2)
     }
 
     context("CRUD") {


### PR DESCRIPTION
Refaktorerer `ArenaService` til både service og repository. Gjorde om navngiving for å prøve å lage noe konsistent.
