### PR TITLE
Audit-logger deling med bruker og visning av tiltakshistorikk

### DIFF
--- a/common/ktor/build.gradle.kts
+++ b/common/ktor/build.gradle.kts
@@ -20,6 +20,10 @@ dependencies {
     // Metrikker
     implementation("io.micrometer:micrometer-registry-prometheus:1.9.3")
 
+    // Audit-logging
+    val navCommonModules = "2.2022.11.10_08.37-7216bb5b1ede"
+    implementation("no.nav.common:audit-log:$navCommonModules")
+
     val hopliteVersion = "2.4.0"
     api("com.sksamuel.hoplite:hoplite-core:$hopliteVersion")
     api("com.sksamuel.hoplite:hoplite-yaml:$hopliteVersion")

--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/audit_log/AuditLog.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/audit_log/AuditLog.kt
@@ -1,0 +1,7 @@
+package no.nav.mulighetsrommet.audit_log
+
+import no.nav.common.audit_log.log.AuditLoggerImpl
+
+object AuditLog {
+    val auditLogger = AuditLoggerImpl()
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -72,7 +72,7 @@ export function DelMedBrukerContent({
     const overskrift = `Tiltak gjennom NAV: ${tiltaksgjennomforingsnavn}`;
     const tekst = sySammenDeletekst();
     try {
-      const res = await mulighetsrommetClient.dialogen.delMedDialogen({ fnr, requestBody: { overskrift, tekst } });
+      const res = await mulighetsrommetClient.dialogen.delMedDialogen({ requestBody: { overskrift, tekst } });
       if (skalLagreAtViDelerMedBruker && tiltaksnummer) {
         await lagreVeilederHarDeltTiltakMedBruker(res.id, tiltaksnummer);
         refetchOmVeilederHarDeltMedBruker();

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentHistorikk.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentHistorikk.ts
@@ -8,7 +8,7 @@ export function useHentHistorikk(prefetch: boolean = true) {
   const fnr = useHentFnrFraUrl();
   return useQuery<HistorikkForBruker[], any>(
     [QueryKeys.Historikk, fnr],
-    () => mulighetsrommetClient.historikk.hentHistorikkForBruker({ fnr }),
+    () => mulighetsrommetClient.historikk.hentHistorikkForBruker(),
     { enabled: prefetch }
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -5,7 +5,7 @@ import { historikk } from '../fixtures/historikk';
 import { DelMedBruker } from '../../../../mulighetsrommet-api-client/build/models/DelMedBruker';
 
 export const apiHandlers: RestHandler[] = [
-  rest.get('*/api/v1/bruker', (req, res, ctx) => {
+  rest.get('*/api/v1/bruker', req => {
     const fnr = req.url.searchParams.get('fnr');
 
     if (typeof fnr !== 'string') {
@@ -30,7 +30,7 @@ export const apiHandlers: RestHandler[] = [
     });
   }),
 
-  rest.get('*/api/v1/veileder', (req, res, ctx) => {
+  rest.get('*/api/v1/veileder', () => {
     return ok({
       etternavn: 'VEILEDERSEN',
       fornavn: 'VEILEDER',
@@ -39,7 +39,7 @@ export const apiHandlers: RestHandler[] = [
     });
   }),
 
-  rest.post('*/api/v1/dialog', (req, res, ctx) => {
+  rest.post('*/api/v1/dialog', () => {
     return ok({
       id: '12345',
     });
@@ -58,13 +58,7 @@ export const apiHandlers: RestHandler[] = [
     return ok(result);
   }),
 
-  rest.get('*/api/v1/bruker/historikk', async req => {
-    const fnr = req.url.searchParams.get('fnr');
-
-    if (!(typeof fnr === 'string')) {
-      return badReq("'fnr' must be specified");
-    }
-
+  rest.get('*/api/v1/bruker/historikk', () => {
     return ok(historikk);
   }),
 

--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -74,8 +74,9 @@ dependencies {
     implementation("io.insert-koin:koin-ktor:$koinVersion")
     implementation("io.insert-koin:koin-logger-slf4j:$koinVersion")
 
-    val navCommonModules = "2.2022.09.09_12.09-f56d40d6d405"
+    val navCommonModules = "2.2022.11.10_08.37-7216bb5b1ede"
     implementation("no.nav.common:token-client:$navCommonModules")
+    implementation("no.nav.common:audit-log:$navCommonModules")
 
     // Tilgangskontroll
     val poaoTilgangClient = "ce474aded50b50200827dba1ce319043f53d5e7f" // Full SHA fra git-commit

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -8,7 +8,7 @@ import no.nav.mulighetsrommet.ktor.plugins.SentryConfig
 
 data class Config(
     val server: ServerConfig,
-    val app: AppConfig
+    val app: AppConfig,
 )
 
 data class AppConfig(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
@@ -63,5 +63,5 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getNavIdent(): String {
 }
 
 fun <T : Any> PipelineContext<T, ApplicationCall>.getNorskIdent(): String {
-    return call.request.header("nav-norskident") ?: ""
+    return call.request.header("nav-norskident") ?: throw StatusException(HttpStatusCode.BadRequest, "nav-norskident mangler i headers")
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
@@ -38,13 +38,8 @@ fun Route.brukerRoutes() {
     route("/api/v1/bruker/historikk") {
         get {
             poaoTilgangService.verifyAccessToUserFromVeileder(getNavIdent(), getNorskIdent())
-            val fnr = call.request.queryParameters["fnr"] ?: return@get call.respondText(
-                "Mangler eller ugyldig fnr",
-                status = HttpStatusCode.BadRequest
-            )
             val accessToken = call.getAccessToken()
-            auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' forsøker å se på tiltakshistorikken for bruker med ident: '${getNorskIdent()}'."))
-            historikkService.hentHistorikkForBruker(fnr, accessToken)?.let {
+            historikkService.hentHistorikkForBruker(getNorskIdent(), accessToken)?.let {
                 auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' har sett på tiltakshistorikken for bruker med ident: '${getNorskIdent()}'."))
                 call.respond(it)
             }
@@ -63,7 +58,7 @@ private fun PipelineContext<Unit, ApplicationCall>.createAuditMessage(msg: Strin
     return CefMessage.builder()
         .applicationName("mulighetsrommet-api")
         .event(CefMessageEvent.ACCESS)
-        .name("Arbeidsmarkedstiltak")
+        .name("Arbeidsmarkedstiltak - Vis tiltakshistorikk")
         .severity(CefMessageSeverity.INFO)
         .sourceUserId(getNavIdent())
         .destinationUserId(getNorskIdent())

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DialogRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DialogRoutes.kt
@@ -5,15 +5,21 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.util.pipeline.*
+import no.nav.common.audit_log.cef.CefMessage
+import no.nav.common.audit_log.cef.CefMessageEvent
+import no.nav.common.audit_log.cef.CefMessageSeverity
 import no.nav.mulighetsrommet.api.plugins.getNavIdent
 import no.nav.mulighetsrommet.api.plugins.getNorskIdent
 import no.nav.mulighetsrommet.api.services.DialogRequest
 import no.nav.mulighetsrommet.api.services.DialogService
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
 import no.nav.mulighetsrommet.api.utils.getAccessToken
+import no.nav.mulighetsrommet.audit_log.AuditLog
 import org.koin.ktor.ext.inject
 
 fun Route.dialogRoutes() {
+    val auditLog = AuditLog.auditLogger
     val dialogService: DialogService by inject()
     val poaoTilgangService: PoaoTilgangService by inject()
 
@@ -26,8 +32,27 @@ fun Route.dialogRoutes() {
                 status = HttpStatusCode.BadRequest
             )
             val accessToken = call.getAccessToken()
+            auditLog.log(createAuditMessage(dialogRequest))
             val response = dialogService.sendMeldingTilDialogen(fnr, accessToken, dialogRequest)
             response?.let { call.respond(response) } ?: call.respond(HttpStatusCode.Conflict)
         }
     }
+}
+
+private fun PipelineContext<Unit, ApplicationCall>.createAuditMessage(
+    dialogRequest: DialogRequest
+): CefMessage? {
+    return CefMessage.builder()
+        .applicationName("mulighetsrommet-api")
+        .event(CefMessageEvent.CREATE)
+        .name("Arbeidsmarkedstiltak")
+        .severity(CefMessageSeverity.INFO)
+        .sourceUserId(getNavIdent())
+        .destinationUserId(getNorskIdent())
+        .timeEnded(System.currentTimeMillis())
+        .extension(
+            "msg",
+            "NAV-ansatt med ident: '${getNavIdent()}' har delt informasjon om tiltaket '${dialogRequest.overskrift}' til bruker med ident: '${getNorskIdent()}'."
+        )
+        .build()
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DialogRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DialogRoutes.kt
@@ -27,13 +27,8 @@ fun Route.dialogRoutes() {
         post {
             poaoTilgangService.verifyAccessToUserFromVeileder(getNavIdent(), getNorskIdent())
             val dialogRequest = call.receive<DialogRequest>()
-            val fnr = call.request.queryParameters["fnr"] ?: return@post call.respondText(
-                "Mangler eller ugyldig fnr",
-                status = HttpStatusCode.BadRequest
-            )
             val accessToken = call.getAccessToken()
-            auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' prøver å dele informasjon om tiltaket '${dialogRequest.overskrift}' til bruker med ident: '${getNorskIdent()}'."))
-            val response = dialogService.sendMeldingTilDialogen(fnr, accessToken, dialogRequest)
+            val response = dialogService.sendMeldingTilDialogen(getNorskIdent(), accessToken, dialogRequest)
             response?.let {
                 auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' har delt informasjon om tiltaket '${dialogRequest.overskrift}' til bruker med ident: '${getNorskIdent()}'."))
                 call.respond(response)
@@ -51,7 +46,7 @@ private fun PipelineContext<Unit, ApplicationCall>.createAuditMessage(
     return CefMessage.builder()
         .applicationName("mulighetsrommet-api")
         .event(CefMessageEvent.CREATE)
-        .name("Arbeidsmarkedstiltak")
+        .name("Arbeidsmarkedstiltak - Del med bruker")
         .severity(CefMessageSeverity.INFO)
         .sourceUserId(getNavIdent())
         .destinationUserId(getNorskIdent())

--- a/mulighetsrommet-api/src/main/resources/logback-local.xml
+++ b/mulighetsrommet-api/src/main/resources/logback-local.xml
@@ -1,0 +1,19 @@
+<included scan="true" scanPeriod="30 seconds">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5relative %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="secureLogger" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="no.nav.mulighetsrommet" level="INFO"/>
+    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="io.netty" level="INFO"/>
+</included>

--- a/mulighetsrommet-api/src/main/resources/logback-nais.xml
+++ b/mulighetsrommet-api/src/main/resources/logback-nais.xml
@@ -1,0 +1,42 @@
+<included scan="true" scanPeriod="30 seconds">
+    <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <appender name="stdout_json" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <!-- https://doc.nais.io/observability/logs/examples/#issues-with-long-log-messages -->
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <exclude>java\.util\.concurrent\..*</exclude>
+                <exclude>org\.apache\.tomcat\..*</exclude>
+                <exclude>org\.apache\.coyote\..*</exclude>
+                <exclude>org\.apache\.catalina\..*</exclude>
+                <exclude>org\.springframework\.web\..*</exclude>
+                <exclude>io\.ktor\..*</exclude>
+            </throwableConverter>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="stdout_json"/>
+    </root>
+
+    <logger name="secureLogger" level="INFO" additivity="false">
+        <appender-ref ref="secureLog"/>
+    </logger>
+
+    <logger name="no.nav.mulighetsrommet" level="INFO"/>
+    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="io.netty" level="INFO"/>
+    <include resource="no/nav/common/audit_log/logback-naudit.xml"/>
+</included>

--- a/mulighetsrommet-api/src/main/resources/logback.xml
+++ b/mulighetsrommet-api/src/main/resources/logback.xml
@@ -38,4 +38,5 @@
     <logger name="no.nav.mulighetsrommet" level="INFO"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
+    <include resource="no/nav/common/audit_log/logback-naudit.xml"/>
 </configuration>

--- a/mulighetsrommet-api/src/main/resources/logback.xml
+++ b/mulighetsrommet-api/src/main/resources/logback.xml
@@ -1,42 +1,10 @@
 <configuration>
-    <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/secure-logs/secure.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>1</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>50MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="stdout_json" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <!-- https://doc.nais.io/observability/logs/examples/#issues-with-long-log-messages -->
-            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-                <maxDepthPerThrowable>30</maxDepthPerThrowable>
-                <exclude>java\.util\.concurrent\..*</exclude>
-                <exclude>org\.apache\.tomcat\..*</exclude>
-                <exclude>org\.apache\.coyote\..*</exclude>
-                <exclude>org\.apache\.catalina\..*</exclude>
-                <exclude>org\.springframework\.web\..*</exclude>
-                <exclude>io\.ktor\..*</exclude>
-            </throwableConverter>
-        </encoder>
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="stdout_json"/>
-    </root>
-
-    <logger name="secureLogger" level="INFO" additivity="false">
-        <appender-ref ref="secureLog"/>
-    </logger>
-
-    <logger name="no.nav.mulighetsrommet" level="INFO"/>
-    <logger name="org.eclipse.jetty" level="INFO"/>
-    <logger name="io.netty" level="INFO"/>
-    <include resource="no/nav/common/audit_log/logback-naudit.xml"/>
+    <if condition='isDefined("NAIS_CLUSTER_NAME")'>
+        <then>
+            <include resource="logback-nais.xml"/>
+        </then>
+        <else>
+            <include resource="logback-local.xml"/>
+        </else>
+    </if>
 </configuration>

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yml
@@ -229,12 +229,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/DialogRequest"
-      parameters:
-        - in: query
-          name: fnr
-          schema:
-            type: string
-          description: SSN for the user which will be used to filter based on the users 'oppfølgingsenhet'
       responses:
         200:
           description: Dialog response
@@ -254,12 +248,6 @@ paths:
       tags:
         - Historikk
       operationId: hentHistorikkForBruker
-      parameters:
-        - in: query
-          name: fnr
-          schema:
-            type: string
-          description: SSN for the user which will be used to fetch 'historikk' for user
       responses:
         200:
           description: Historical data about the user

--- a/mulighetsrommet-api/src/test/kotlin/DevApplication.kt
+++ b/mulighetsrommet-api/src/test/kotlin/DevApplication.kt
@@ -1,0 +1,12 @@
+import com.sksamuel.hoplite.ConfigLoader
+import no.nav.mulighetsrommet.api.Config
+import no.nav.mulighetsrommet.api.configure
+import no.nav.mulighetsrommet.ktor.startKtorApplication
+
+fun main() {
+    val (server, app) = ConfigLoader().loadConfigOrThrow<Config>("/application-local.yaml")
+
+    startKtorApplication(server) {
+        configure(app)
+    }
+}


### PR DESCRIPTION
Audit-logger følgende hendelser i løsningen vår:

1. Visning av tiltakshistorikk
2. Deling av info om tiltak med bruker

I begge hendelsene så logges det før vi vet om hendelsen gikk ok eller feilet. I tillegg logges det dersom det gikk ok eller feilet. På den måten kan man lese ut fra en logg at `Veileder X forsøker .....` og med tilhørende `Veileder X fikk til ....` eller `Veileder X fikk ikke til ....`.