### PR TITLE
Fjerner voxmedia/github-action-slack-notify-build@v1 fra gh actions

### DIFF
--- a/.github/workflows/mulighetsrommet-api.yaml
+++ b/.github/workflows/mulighetsrommet-api.yaml
@@ -35,15 +35,6 @@ jobs:
         uses: ./.github/actions/setup-backend
       - name: Build with Gradle
         run: ./gradlew :mulighetsrommet-api:build
-      - name: Notify slack fail
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: C026FHSRFEJ
-          status: FAILED
-          color: danger
       - name: Build and push Docker image
         working-directory: mulighetsrommet-api
         if: github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/mulighetsrommet-arena-adapter-manager.yaml
+++ b/.github/workflows/mulighetsrommet-arena-adapter-manager.yaml
@@ -32,16 +32,7 @@ jobs:
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
       - name: Build
-        run: npx turbo run build --filter=arena-adapter-manager
-      - name: Notify slack fail
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: C026FHSRFEJ
-          status: FAILED
-          color: danger
+        run: npx turbo run build --filter=arena-adapter-manager 
       - uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/.github/workflows/mulighetsrommet-arena-adapter.yaml
+++ b/.github/workflows/mulighetsrommet-arena-adapter.yaml
@@ -35,15 +35,6 @@ jobs:
         uses: ./.github/actions/setup-backend
       - name: Build with Gradle
         run: ./gradlew :mulighetsrommet-arena-adapter:build
-      - name: Notify slack fail
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: C026FHSRFEJ
-          status: FAILED
-          color: danger
       - name: Build and push Docker image
         working-directory: mulighetsrommet-arena-adapter
         if: github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/mulighetsrommet-veileder-flate-mock.yaml
+++ b/.github/workflows/mulighetsrommet-veileder-flate-mock.yaml
@@ -46,15 +46,6 @@ jobs:
           wait-on: http://localhost:3000
           start: npm start
           install: false
-      - name: Notify slack fail
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: C026FHSRFEJ
-          status: FAILED
-          color: danger
       - name: Build and publish Docker image
         if: github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch'
         working-directory: frontend/mulighetsrommet-veileder-flate

--- a/.github/workflows/mulighetsrommet-veileder-flate.yaml
+++ b/.github/workflows/mulighetsrommet-veileder-flate.yaml
@@ -48,15 +48,6 @@ jobs:
           wait-on: http://localhost:3000
           start: npm start
           install: false
-      - name: Notify slack fail
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: C026FHSRFEJ
-          status: FAILED
-          color: danger
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:
@@ -94,15 +85,7 @@ jobs:
           wait-on: http://localhost:3000
           start: npm start
           install: false
-      - name: Notify slack fail
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: C026FHSRFEJ
-          status: FAILED
-          color: danger
+      
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:


### PR DESCRIPTION
Fjerner voxmedia/github-action-slack-notify-build@v1 siden den virker å være lite maintained, bruker fortsatt node12 og spyr ut deprecation warnings. I tillegg har alle på teamet mutet #team-valp-spam så vi trenger ikke denne. Vi finner et alternativ for fremtiden om nødvendig.