### PR TITLE
:bricks: Oppsett for Kafka-producer i api

### DIFF
--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/env/NaisEnv.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/env/NaisEnv.kt
@@ -4,8 +4,7 @@ enum class NaisEnv(val clusterName: String) {
 
     Local("local"),
     DevGCP("dev-gcp"),
-    ProdGCP("prod-gcp"),
-    ;
+    ProdGCP("prod-gcp");
 
     companion object {
         fun current(): NaisEnv = when (System.getenv("NAIS_CLUSTER_NAME")) {

--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -74,9 +74,10 @@ dependencies {
     implementation("io.insert-koin:koin-ktor:$koinVersion")
     implementation("io.insert-koin:koin-logger-slf4j:$koinVersion")
 
-    val navCommonModules = "2.2022.11.10_08.37-7216bb5b1ede"
+    val navCommonModules = "2.2022.11.16_15.18-421ec713e2a0"
     implementation("no.nav.common:token-client:$navCommonModules")
     implementation("no.nav.common:audit-log:$navCommonModules")
+    implementation("no.nav.common:kafka:$navCommonModules")
 
     // Tilgangskontroll
     val poaoTilgangClient = "ce474aded50b50200827dba1ce319043f53d5e7f" // Full SHA fra git-commit

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -11,6 +11,7 @@ data class Config(
 
 data class AppConfig(
     val database: DatabaseConfig,
+    val kafka: KafkaConfig,
     val auth: AuthConfig,
     val sanity: SanityConfig,
     val sentry: SentryConfig? = null,
@@ -29,6 +30,11 @@ data class AppConfig(
 
 data class AuthConfig(
     val azure: AuthProvider
+)
+
+data class KafkaConfig(
+    val producerId: String,
+    val brokerUrl: String?
 )
 
 data class AuthProvider(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -34,7 +34,7 @@ data class AuthConfig(
 
 data class KafkaConfig(
     val producerId: String,
-    val brokerUrl: String?
+    val brokerUrl: String? = null
 )
 
 data class AuthProvider(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -33,6 +33,7 @@ import no.nav.mulighetsrommet.api.services.kafka.KafkaProducerService
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.DatabaseConfig
 import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
+import no.nav.mulighetsrommet.env.NaisEnv
 import no.nav.poao_tilgang.client.PoaoTilgangHttpClient
 import org.apache.kafka.common.serialization.StringSerializer
 import org.koin.core.module.Module
@@ -72,7 +73,7 @@ private fun db(databaseConfig: DatabaseConfig): Module {
 }
 
 private fun kafka(kafkaConfig: KafkaConfig): KafkaProducerService<String, String> {
-    if (erLokalUtvikling()) {
+    if (NaisEnv.current().isLocal()) {
         return KafkaProducerService(
             KafkaProducerClientBuilder.builder<String, String>()
                 .withProperties(
@@ -166,7 +167,7 @@ private fun amtenhetsregister(config: AppConfig): AmtEnhetsregisterClient {
 }
 
 private fun tokenClientProvider(config: AppConfig): AzureAdOnBehalfOfTokenClient {
-    return when (erLokalUtvikling()) {
+    return when (NaisEnv.current().isLocal()) {
         true -> AzureAdTokenClientBuilder.builder()
             .withClientId(config.auth.azure.audience)
             .withPrivateJwk(createRSAKeyForLokalUtvikling("azure").toJSONString())
@@ -177,7 +178,7 @@ private fun tokenClientProvider(config: AppConfig): AzureAdOnBehalfOfTokenClient
 }
 
 private fun tokenClientProviderForMachineToMachine(config: AppConfig): MachineToMachineTokenClient {
-    return when (erLokalUtvikling()) {
+    return when (NaisEnv.current().isLocal()) {
         true -> AzureAdTokenClientBuilder.builder()
             .withClientId(config.auth.azure.audience)
             .withPrivateJwk(createRSAKeyForLokalUtvikling("azure").toJSONString())
@@ -233,10 +234,6 @@ private fun services(
     }
     single { DelMedBrukerService(get()) }
     single { kafka(appConfig.kafka) }
-}
-
-private fun erLokalUtvikling(): Boolean {
-    return System.getenv("NAIS_CLUSTER_NAME") == null
 }
 
 private fun createRSAKeyForLokalUtvikling(keyID: String): RSAKey = KeyPairGenerator

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/kafka/KafkaProducerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/kafka/KafkaProducerService.kt
@@ -1,0 +1,10 @@
+package no.nav.mulighetsrommet.api.services.kafka
+
+import no.nav.common.kafka.producer.KafkaProducerClient
+import org.apache.kafka.clients.producer.ProducerRecord
+
+class KafkaProducerService<K, V>(private val kafkaProducerClient: KafkaProducerClient<K, V>) {
+    fun produserMelding(topic: String, key: K, value: V) {
+        kafkaProducerClient.sendSync(ProducerRecord(topic, key, value))
+    }
+}

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -11,6 +11,9 @@ app:
     password: ${DB_PASSWORD}
     maximumPoolSize: 10
 
+  kafka:
+    producerId: "mulighetsrommet-api-kafka-producer.v1"
+
   auth:
     azure:
       issuer: ${AZURE_OPENID_CONFIG_ISSUER}

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -11,6 +11,10 @@ app:
     password: valp
     maximumPoolSize: 10
 
+  kafka:
+    producerId: "mulighetsrommet-api-kafka-producer.v1"
+    brokerUrl: "http://localhost:29092"
+
   auth:
     azure:
       issuer: http://localhost:8081/azure

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -11,6 +11,9 @@ app:
     password: ${DB_PASSWORD}
     maximumPoolSize: 10
 
+  kafka:
+    producerId: "mulighetsrommet-api-kafka-producer.v1"
+
   auth:
     azure:
       issuer: ${AZURE_OPENID_CONFIG_ISSUER}

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
@@ -20,6 +20,7 @@ fun <R> withMulighetsrommetApp(
 fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     database = createApiDatabaseTestSchema(),
     auth = createAuthConfig(oauth),
+    kafka = createKafkaConfig(),
     sanity = createSanityConfig(),
     veilarboppfolgingConfig = createServiceClientConfig("veilarboppfolging"),
     veilarbvedtaksstotteConfig = createServiceClientConfig("veilarbvedtaksstotte"),
@@ -32,6 +33,12 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     amtEnhetsregister = createServiceClientConfig("amtenhetsregister"),
     arenaOrdsProxy = createServiceClientConfig("arenaordsproxy")
 )
+
+fun createKafkaConfig(): KafkaConfig {
+    return KafkaConfig(
+        "producer-id"
+    )
+}
 
 fun createServiceClientConfig(url: String): ServiceClientConfig {
     return ServiceClientConfig(

--- a/mulighetsrommet-arena-adapter/build.gradle.kts
+++ b/mulighetsrommet-arena-adapter/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-client-logging:$ktorVersion")
 
-    val navCommonModules = "2.2022.09.09_12.09-f56d40d6d405"
+    val navCommonModules = "2.2022.11.16_15.18-421ec713e2a0"
     implementation("no.nav.common:kafka:$navCommonModules")
     implementation("no.nav.common:token-client:$navCommonModules")
 

--- a/mulighetsrommet-arena-adapter/build.gradle.kts
+++ b/mulighetsrommet-arena-adapter/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-client-logging:$ktorVersion")
 
-    val navCommonModules = "2.2022.11.16_15.18-421ec713e2a0"
+    val navCommonModules = "2.2022.09.09_12.09-f56d40d6d405"
     implementation("no.nav.common:kafka:$navCommonModules")
     implementation("no.nav.common:token-client:$navCommonModules")
 


### PR DESCRIPTION
Setter opp producer for kafka for mulighetsrommet-api. Har testet lokalt at producer får koblet seg til localhost:29092 (kafdrop) og at meldinger ble produsert på en topic vi testet.