### PR TITLE
:bug: Auditlogger dersom veileder ikke får sett tiltakshistorikk

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
@@ -38,18 +38,17 @@ fun Route.brukerRoutes() {
 
     route("/api/v1/bruker/historikk") {
         get {
-            poaoTilgangService.verifyAccessToUserFromVeileder(getNavAnsattAzureId(), getNorskIdent())
-            historikkService.hentHistorikkForBruker(getNorskIdent())?.let {
+            poaoTilgangService.verifyAccessToUserFromVeileder(getNavAnsattAzureId(), getNorskIdent()) {
+                auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' forsøkte, men fikk ikke sett tiltakshistorikken for bruker med ident: '${getNorskIdent()}'."))
+                call.respondText(
+                    "Klarte ikke hente historikk for bruker",
+                    status = HttpStatusCode.InternalServerError
+                )
+            }
+            historikkService.hentHistorikkForBruker(getNorskIdent()).let {
                 auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' har sett på tiltakshistorikken for bruker med ident: '${getNorskIdent()}'."))
                 call.respond(it)
             }
-                ?: run {
-                    auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' fikk ikke sett på tiltakshistorikken for bruker med ident: '${getNorskIdent()}'."))
-                    call.respondText(
-                        "Klarte ikke hente historikk for bruker",
-                        status = HttpStatusCode.InternalServerError
-                    )
-                }
         }
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
@@ -16,10 +16,12 @@ import no.nav.mulighetsrommet.api.services.HistorikkService
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
 import no.nav.mulighetsrommet.api.utils.getAccessToken
 import no.nav.mulighetsrommet.audit_log.AuditLog
+import no.nav.mulighetsrommet.secure_log.SecureLog
 import org.koin.ktor.ext.inject
 
 fun Route.brukerRoutes() {
     val auditLog = AuditLog.auditLogger
+    val secureLog = SecureLog.logger
     val brukerService: BrukerService by inject()
     val historikkService: HistorikkService by inject()
     val poaoTilgangService: PoaoTilgangService by inject()
@@ -40,10 +42,7 @@ fun Route.brukerRoutes() {
         get {
             poaoTilgangService.verifyAccessToUserFromVeileder(getNavAnsattAzureId(), getNorskIdent()) {
                 auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' forsøkte, men fikk ikke sett tiltakshistorikken for bruker med ident: '${getNorskIdent()}'."))
-                call.respondText(
-                    "Klarte ikke hente historikk for bruker",
-                    status = HttpStatusCode.InternalServerError
-                )
+                secureLog.warn("NAV-ansatt med ident: '${getNavIdent()}' har ikke tilgang til bruker med ident: '${getNorskIdent()}'")
             }
             historikkService.hentHistorikkForBruker(getNorskIdent()).let {
                 auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' har sett på tiltakshistorikken for bruker med ident: '${getNorskIdent()}'."))


### PR DESCRIPTION
Legger til en optional block bak `verifyAccessToUserFromVeileder` slik at dersom man ikke har tilgang invoker blokken og kan gjøre audit-logging feks. I vårt tilfelle audit-logger vi og returnerer en 500-feil til klienten.