### PR TITLE
:sparkles: Kan raskt endre rolle ved lokal utvikling

### DIFF
--- a/frontend/mr-admin-flate/src/components/EndreRolle/EndreRolleVedLokalUtvikling.tsx
+++ b/frontend/mr-admin-flate/src/components/EndreRolle/EndreRolleVedLokalUtvikling.tsx
@@ -1,0 +1,40 @@
+import { Select } from "@navikt/ds-react";
+import React from "react";
+import { useVisForMiljo } from "../../hooks/useVisForMiljo";
+
+const ROLLE_KEY_LS = "valp-rolle-adminflate";
+
+interface Props {
+  gjelderForMiljo: string[];
+}
+
+export function EndreRolleVedLokalUtvikling({ gjelderForMiljo }: Props) {
+  const visForMiljo = useVisForMiljo(gjelderForMiljo);
+  if (!visForMiljo) return null;
+
+  const rolleValgtFraLocalStorage =
+    window.localStorage.getItem(ROLLE_KEY_LS) ?? "tiltaksansvarlig";
+
+  const onRolleChanged = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    e.preventDefault();
+    window.localStorage.setItem(ROLLE_KEY_LS, e.currentTarget.value);
+    window.location.reload();
+  };
+
+  return (
+    <details style={{ padding: "1rem" }}>
+      <summary>Velg rolle</summary>
+      <Select
+        onChange={onRolleChanged}
+        label="Velg rolle"
+        hideLabel
+        size="small"
+        style={{ width: "10rem" }}
+        value={rolleValgtFraLocalStorage}
+      >
+        <option value="tiltaksansvarlig">Tiltaksansvarlig</option>
+        <option value="fagansvarlig">Fagansvarlig</option>
+      </Select>
+    </details>
+  );
+}

--- a/frontend/mr-admin-flate/src/components/Miljobanner/MiljoBanner.tsx
+++ b/frontend/mr-admin-flate/src/components/Miljobanner/MiljoBanner.tsx
@@ -1,16 +1,16 @@
 import { Alert, Heading, Button } from "@navikt/ds-react";
 import { useState } from "react";
+import { useVisForMiljo } from "../../hooks/useVisForMiljo";
 import styles from "./MiljoBanner.module.scss";
 
-const WHITELIST_BANNER = ["labs.nais.io"] as const;
+const WHITELIST_BANNER = ["labs.nais.io"];
 
 export function MiljoBanner() {
   const [vis, setVis] = useState(true);
+  const visForMiljo = useVisForMiljo(WHITELIST_BANNER);
   const url = window?.location?.host;
 
-  if (
-    !WHITELIST_BANNER.find((el) => url.toLowerCase().includes(el.toLowerCase()))
-  ) {
+  if (!visForMiljo) {
     return null;
   }
 

--- a/frontend/mr-admin-flate/src/hooks/useVisForMiljo.ts
+++ b/frontend/mr-admin-flate/src/hooks/useVisForMiljo.ts
@@ -1,0 +1,7 @@
+export function useVisForMiljo(miljoer: string[]): boolean {
+  const url = window?.location?.host;
+
+  return (
+    miljoer.findIndex((el) => url.toLowerCase().includes(el.toLowerCase())) > -1
+  );
+}

--- a/frontend/mr-admin-flate/src/main.tsx
+++ b/frontend/mr-admin-flate/src/main.tsx
@@ -9,6 +9,7 @@ import "./index.css";
 import { App } from "./App";
 import { BrowserRouter as Router } from "react-router-dom";
 import { AdministratorHeader } from "./components/AdministratorHeader";
+import { EndreRolleVedLokalUtvikling } from "./components/EndreRolle/EndreRolleVedLokalUtvikling";
 
 const queryClient = new QueryClient();
 
@@ -29,6 +30,9 @@ function render() {
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
         <MiljoBanner />
+        <EndreRolleVedLokalUtvikling
+          gjelderForMiljo={["127.0.0.1", "labs.nais.io"]}
+        />
         <Router basename={import.meta.env.BASE_URL}>
           <AdministratorHeader />
           <App />

--- a/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
+++ b/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
@@ -1,6 +1,6 @@
 // src/mocks/handlers.js
 import { rest } from "msw";
-import { mockAnsatt } from "./fixtures/mock_ansatt";
+import { mockTiltaksansvarlig, mockFagansvarlig } from "./fixtures/mock_ansatt";
 import { mockTiltaksgjennomforinger } from "./fixtures/mock_tiltaksgjennomforinger";
 import { mockTiltakstyper } from "./fixtures/mock_tiltakstyper";
 
@@ -22,6 +22,17 @@ export const apiHandlers = [
   }),
 
   rest.get("*/api/v1/ansatt/me", (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(mockAnsatt));
+    const rolleValgt =
+      window.localStorage.getItem("valp-rolle-adminflate") ??
+      "tiltaksansvarlig";
+
+    return res(
+      ctx.status(200),
+      ctx.json(
+        rolleValgt === "tiltaksansvarlig"
+          ? mockTiltaksansvarlig
+          : mockFagansvarlig
+      )
+    );
   }),
 ];

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_ansatt.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_ansatt.ts
@@ -1,7 +1,15 @@
-export const mockAnsatt = {
+export const mockTiltaksansvarlig = {
   etternavn: "Tiltaksansvarlig",
   fornavn: "Tilda",
   ident: "T99876",
   navn: "Tiltakansvarlig, Tilda",
   tilganger: ["FLATE"],
+};
+
+export const mockFagansvarlig = {
+  etternavn: "Fagansvarlig",
+  fornavn: "Frode",
+  ident: "F18765",
+  navn: "Fagansvarlig, Frode",
+  tilganger: ["FAGANSVARLIG"],
 };


### PR DESCRIPTION
Ved lokal utvikling eller i labs-miljø bruker vi msw for mock-data. Denne PRen tilgjengeliggjør en funksjon for å endre mellom tiltak- og fagansvarlig på en rask og enkel måte.