### PR TITLE
:sparkles: Henter hovedenhet for innlogget ansatt via ms-graph api

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -22,6 +22,7 @@ data class AppConfig(
     val poaoGcpProxy: ServiceClientConfig,
     val poaoTilgang: ServiceClientConfig,
     val amtEnhetsregister: ServiceClientConfig,
+    val msGraphConfig: ServiceClientConfig
 )
 
 data class AuthConfig(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClient.kt
@@ -1,0 +1,7 @@
+package no.nav.mulighetsrommet.api.clients.msgraph
+
+import java.util.UUID
+
+interface MicrosoftGraphClient {
+    suspend fun hentHovedenhetForBruker(navAnsattAzureId: UUID): String
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -8,8 +8,10 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
 import no.nav.mulighetsrommet.secure_log.SecureLog
+import org.slf4j.LoggerFactory
 import java.util.*
 
+private val log = LoggerFactory.getLogger(MicrosoftGraphClientImpl::class.java)
 private val secureLog = SecureLog.logger
 
 class MicrosoftGraphClientImpl(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -1,0 +1,42 @@
+package no.nav.mulighetsrommet.api.clients.msgraph
+
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.cache.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.secure_log.SecureLog
+import java.util.*
+
+private val secureLog = SecureLog.logger
+
+class MicrosoftGraphClientImpl(
+    private val baseUrl: String,
+    private val tokenProvider: () -> String,
+    clientEngine: HttpClientEngine = CIO.create()
+) : MicrosoftGraphClient {
+    val client = httpJsonClient(clientEngine).config {
+        install(HttpCache)
+    }
+
+    override suspend fun hentHovedenhetForBruker(navAnsattAzureId: UUID): String {
+        val response = client.get("$baseUrl/v1.0/users/$navAnsattAzureId?\$select=streetAddress") {
+            bearerAuth(tokenProvider())
+        }
+
+        if ((response.status == HttpStatusCode.NotFound) || (response.status == HttpStatusCode.NoContent)) {
+            secureLog.warn("Klarte ikke finne bruker med azure-id: $navAnsattAzureId")
+            throw RuntimeException("Klarte ikke finne bruker med azure-id. Finnes brukeren i AD?")
+        }
+
+        val user = response.body<MSGraphUser>()
+        return user.streetAddress // Hovedenhet finnes på streetAddress-egenskapen til bruker
+    }
+}
+
+@kotlinx.serialization.Serializable
+data class MSGraphUser(
+    val streetAddress: String
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AnsattService.kt
@@ -8,17 +8,20 @@ import java.util.*
 
 class AnsattService(
     private val veilarbveilederClient: VeilarbveilederClient,
-    private val poaoTilgangService: PoaoTilgangService
+    private val poaoTilgangService: PoaoTilgangService,
+    private val microsoftGraphService: MicrosoftGraphService
 ) {
     suspend fun hentAnsattData(accessToken: String, navAnsattAzureId: UUID): AnsattData {
         val data = veilarbveilederClient.hentVeilederdata(accessToken, navAnsattAzureId)
+        val hovedenhet = microsoftGraphService.hentHovedEnhetForNavAnsatt(navAnsattAzureId)
         val azureAdGrupper = poaoTilgangService.hentAdGrupper(navAnsattAzureId)
         return AnsattData(
             etternavn = data?.etternavn,
             fornavn = data?.fornavn,
             ident = data?.ident,
             navn = data?.navn,
-            tilganger = azureAdGrupper.mapNotNull(::mapAdGruppeTilTilgang).toSet()
+            tilganger = azureAdGrupper.mapNotNull(::mapAdGruppeTilTilgang).toSet(),
+            hovedenhet = hovedenhet
         )
     }
 }
@@ -36,7 +39,8 @@ data class AnsattData(
     val fornavn: String?,
     val ident: String?,
     val navn: String?,
-    val tilganger: Set<Tilgang>
+    val tilganger: Set<Tilgang>,
+    val hovedenhet: String
 )
 
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphService.kt
@@ -1,0 +1,31 @@
+package no.nav.mulighetsrommet.api.services
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.prometheus.client.cache.caffeine.CacheMetricsCollector
+import no.nav.mulighetsrommet.api.clients.msgraph.MicrosoftGraphClient
+import no.nav.mulighetsrommet.ktor.plugins.Metrikker
+import no.nav.mulighetsrommet.utils.CacheUtils
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+class MicrosoftGraphService(private val client: MicrosoftGraphClient) {
+
+    private val hovedenhetCache: Cache<UUID, String> = Caffeine.newBuilder()
+        .expireAfterWrite(4, TimeUnit.HOURS)
+        .maximumSize(500)
+        .recordStats()
+        .build()
+
+    init {
+        val cacheMetrics: CacheMetricsCollector =
+            CacheMetricsCollector().register(Metrikker.appMicrometerRegistry.prometheusRegistry)
+        cacheMetrics.addCache("hovedenhetCache", hovedenhetCache)
+    }
+
+    suspend fun hentHovedEnhetForNavAnsatt(navAnsattAzureId: UUID): String {
+        return CacheUtils.tryCacheFirstNotNull(hovedenhetCache, navAnsattAzureId) {
+            client.hentHovedenhetForBruker(navAnsattAzureId)
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -60,3 +60,7 @@ app:
   amtEnhetsregister:
     url: http://amt-enhetsregister.amt
     scope: api://dev-gcp.amt.amt-enhetsregister/.default
+
+  msGraphConfig:
+    url: https://graph.microsoft.com
+    scope: https://graph.microsoft.com/.default

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -61,3 +61,7 @@ app:
   amtEnhetsregister:
     url: http://localhost:8090/amt-enhetsregister
     scope: default
+
+  msGraphConfig:
+    url: http://localhost:8090/ms-graph
+    scope: default

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -57,3 +57,7 @@ app:
   amtEnhetsregister:
     url: http://amt-enhetsregister.amt
     scope: api://prod-gcp.amt.amt-enhetsregister/.default
+
+  msGraphConfig:
+    url: https://graph.microsoft.com
+    scope: https://graph.microsoft.com/.default

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yml
@@ -583,6 +583,8 @@ components:
           type: array
           items:
             type: string
+        hovedenhet:
+          type: string
 
     Innsatsgruppe:
       type: string

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
@@ -30,6 +30,7 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     poaoGcpProxy = createServiceClientConfig("poaogcpproxy"),
     poaoTilgang = createServiceClientConfig("poaotilgang"),
     amtEnhetsregister = createServiceClientConfig("amtenhetsregister"),
+    msGraphConfig = createServiceClientConfig("ms-graph")
 )
 
 fun createKafkaConfig(): KafkaConfig {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.api.services
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.core.test.TestCaseOrder
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -12,8 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import java.util.*
 
 class MicrosoftGraphServiceTest : FunSpec({
-
-    testOrder = TestCaseOrder.Sequential
     val navAnsattAzureId = UUID.randomUUID()
 
     context("Hent hovedenhet for nav-ansatt") {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
@@ -1,0 +1,55 @@
+package no.nav.mulighetsrommet.api.services
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCaseOrder
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.mulighetsrommet.api.clients.msgraph.MSGraphUser
+import no.nav.mulighetsrommet.api.clients.msgraph.MicrosoftGraphClient
+import org.assertj.core.api.Assertions.assertThat
+import java.util.*
+
+class MicrosoftGraphServiceTest : FunSpec({
+
+    testOrder = TestCaseOrder.Sequential
+    val navAnsattAzureId = UUID.randomUUID()
+
+    context("Hent hovedenhet for nav-ansatt") {
+        test("Når man kaller hentHovedenhet for en nav ansatts azureId får man svar og repeterende forespørsler kommer fra cache") {
+            val mockResponse = MSGraphUser(streetAddress = "2990")
+
+            val client: MicrosoftGraphClient = mockk()
+            coEvery {
+                client.hentHovedenhetForBruker(navAnsattAzureId)
+            } returns mockResponse.streetAddress
+
+            val service = MicrosoftGraphService(client)
+            val result = service.hentHovedEnhetForNavAnsatt(navAnsattAzureId)
+
+            service.hentHovedEnhetForNavAnsatt(navAnsattAzureId)
+            service.hentHovedEnhetForNavAnsatt(navAnsattAzureId)
+            service.hentHovedEnhetForNavAnsatt(navAnsattAzureId)
+
+            assertThat(result).isEqualTo("2990")
+            coVerify(exactly = 1) {
+                client.hentHovedenhetForBruker(navAnsattAzureId)
+            }
+        }
+
+        test("Når man kaller hentHovedenhet og ikke finner bruker skal det kastes en feil") {
+
+            val client: MicrosoftGraphClient = mockk()
+            coEvery {
+                client.hentHovedenhetForBruker(UUID.randomUUID())
+            } throws RuntimeException("Klarte ikke hente bruker")
+
+            val service = MicrosoftGraphService(client)
+
+            shouldThrow<RuntimeException> {
+                service.hentHovedEnhetForNavAnsatt(navAnsattAzureId)
+            }
+        }
+    }
+})

--- a/mulighetsrommet-api/wiremock/mappings/ms-graph.json
+++ b/mulighetsrommet-api/wiremock/mappings/ms-graph.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/ms-graph/v1.0/users/([\\d\\D]*)"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "streetAddress": "2990"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
Denne PRen introduserer henting av brukers hovedenhet via Microsoft Graph-api'et (AzureAD) og legger det på ansattdata slik at det kan brukes i backend og frontend for filtrering