### PR TITLE
Ansatt-data kan være null

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AnsattService.kt
@@ -33,13 +33,12 @@ private fun mapAdGruppeTilTilgang(adGruppe: AdGruppe): Tilgang? {
         else -> null
     }
 }
-
 @Serializable
 data class AnsattData(
-    val etternavn: String?,
-    val fornavn: String?,
-    val ident: String?,
-    val navn: String?,
+    val etternavn: String? = null,
+    val fornavn: String? = null,
+    val ident: String? = null,
+    val navn: String? = null,
     val tilganger: Set<Tilgang>,
     val hovedenhet: String,
     val hovedenhetNavn: String


### PR DESCRIPTION
Når vi henter ansattdata så bruker vi veilarbveileder som igjen bruker NOM. NOM går mot lønnsystemet til NAV og det vil si at feks. trygdeetaten-brukere i dev og eksterne konsulenter som logger seg inn i prod (Signe, Sondre, meg selv osv.) ikke vil få returnert data. Derfor må vi godta at data kan være null. 