### PR TITLE
Henter ut enhet fra AETATENHET_ANSVARLIG på en sak

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/Tiltaksgjennomforing.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/Tiltaksgjennomforing.kt
@@ -18,9 +18,9 @@ data class Tiltaksgjennomforing(
     @Serializable(with = DateSerializer::class)
     val fraDato: LocalDateTime? = null,
     @Serializable(with = DateSerializer::class)
-    val tilDato: LocalDateTime? = null
+    val tilDato: LocalDateTime? = null,
+    val enhet: String? = null
 )
-
 
 @Serializable
 data class TiltaksgjennomforingMedTiltakstype(
@@ -36,5 +36,6 @@ data class TiltaksgjennomforingMedTiltakstype(
     @Serializable(with = DateSerializer::class)
     val fraDato: LocalDateTime? = null,
     @Serializable(with = DateSerializer::class)
-    val tilDato: LocalDateTime? = null
+    val tilDato: LocalDateTime? = null,
+    val enhet: String? = null
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -31,7 +31,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                               virksomhetsnummer = excluded.virksomhetsnummer,
                               fra_dato          = excluded.fra_dato,
                               til_dato          = excluded.til_dato,
-                              enhet          = excluded.enhet
+                              enhet             = excluded.enhet
             returning *
         """.trimIndent()
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
@@ -16,7 +16,6 @@ import org.koin.ktor.ext.inject
 import org.postgresql.util.PSQLException
 
 fun Route.arenaRoutes() {
-
     val logger = application.environment.log
 
     val arenaService: ArenaService by inject()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -86,7 +86,7 @@ fun Route.tiltaksgjennomforingRoutes() {
         }
 
         get("sok") {
-            val tiltaksnummer = call.request.queryParameters.get("tiltaksnummer") ?: return@get call.respondText(
+            val tiltaksnummer = call.request.queryParameters["tiltaksnummer"] ?: return@get call.respondText(
                 "Mangler query-param 'tiltaksnummer'",
                 status = HttpStatusCode.BadRequest
             )

--- a/mulighetsrommet-api/src/main/resources/db/migration/V12__enhet_to_table_tiltaksgjennomforing.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V12__enhet_to_table_tiltaksgjennomforing.sql
@@ -1,0 +1,2 @@
+alter table tiltaksgjennomforing
+    add column enhet text;

--- a/mulighetsrommet-api/src/main/resources/db/migration/V13__index_for_enhet.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V13__index_for_enhet.sql
@@ -1,0 +1,2 @@
+create index enhet_idx
+    on tiltaksgjennomforing(enhet);

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -38,7 +38,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         tiltaksnummer = "12345",
         virksomhetsnummer = "123456789",
         fraDato = LocalDateTime.of(2022, 1, 1, 8, 0),
-        tilDato = LocalDateTime.of(2022, 1, 1, 8, 0)
+        tilDato = LocalDateTime.of(2022, 1, 1, 8, 0),
+        enhet = "2990"
     )
 
     val tiltak2 = Tiltaksgjennomforing(
@@ -46,7 +47,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         navn = "Trening",
         tiltakstypeId = tiltakstype2.id,
         tiltaksnummer = "54321",
-        virksomhetsnummer = "123456789"
+        virksomhetsnummer = "123456789",
+        enhet = "2990"
     )
 
     context("CRUD") {
@@ -186,7 +188,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     navn = "$it",
                     tiltakstypeId = tiltakstype1.id,
                     tiltaksnummer = "$it",
-                    virksomhetsnummer = "123456789"
+                    virksomhetsnummer = "123456789",
+                    enhet = "2990"
                 )
             )
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
@@ -42,7 +42,8 @@ class ArenaServiceTest : FunSpec({
             tiltaksnummer = "12345",
             virksomhetsnummer = "123456789",
             fraDato = LocalDateTime.of(2022, 11, 11, 0, 0),
-            tilDato = LocalDateTime.of(2023, 11, 11, 0, 0)
+            tilDato = LocalDateTime.of(2023, 11, 11, 0, 0),
+            enhet = "2990"
         )
 
         val deltaker = Deltaker(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
@@ -32,7 +32,8 @@ class HistorikkServiceTest : FunSpec({
         navn = "Arbeidstrening",
         tiltakstypeId = tiltakstype.id,
         tiltaksnummer = "12345",
-        virksomhetsnummer = "123456789"
+        virksomhetsnummer = "123456789",
+        enhet = "2990"
     )
 
     val deltaker = Deltaker(

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -117,6 +117,7 @@ class TiltakgjennomforingEndretConsumer(
             tiltaksnummer = "${sak.aar}#${sak.lopenummer}",
             virksomhetsnummer = virksomhetsnummer,
             fraDato = fraDato,
-            tilDato = tilDato
+            tilDato = tilDato,
+            enhet = sak.enhet
         )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaSak.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaSak.kt
@@ -8,4 +8,5 @@ data class ArenaSak(
     val SAKSKODE: String,
     val AAR: Int,
     val LOPENRSAK: Int,
+    val AETATENHET_ANSVARLIG: String?
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Sak.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Sak.kt
@@ -7,4 +7,5 @@ data class Sak(
     val sakId: Int,
     val lopenummer: Int,
     val aar: Int,
+    val enhet: String
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/SakRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/SakRepository.kt
@@ -18,8 +18,8 @@ class SakRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            insert into sak(sak_id, lopenummer, aar)
-            values (:sak_id, :lopenummer, :aar)
+            insert into sak(sak_id, lopenummer, aar, enhet)
+            values (:sak_id, :lopenummer, :aar, :enhet)
             on conflict (sak_id)
                 do update set lopenummer = excluded.lopenummer,
                               aar        = excluded.aar
@@ -51,7 +51,7 @@ class SakRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            select sak_id, lopenummer, aar
+            select sak_id, lopenummer, aar, enhet
             from sak
             where sak_id = ?
         """.trimIndent()
@@ -66,11 +66,13 @@ class SakRepository(private val db: Database) {
         "sak_id" to sakId,
         "lopenummer" to lopenummer,
         "aar" to aar,
+        "enhet" to enhet
     )
 
     private fun Row.toSak() = Sak(
         sakId = int("sak_id"),
         lopenummer = int("lopenummer"),
-        aar = int("aar")
+        aar = int("aar"),
+        enhet = string("enhet")
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V18__column_enhet_for_table_sak.sql
+++ b/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V18__column_enhet_for_table_sak.sql
@@ -1,0 +1,2 @@
+alter table sak
+add column enhet text;

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/SakEndretConsumerTest.kt
@@ -93,6 +93,7 @@ private fun createEvent(
         "SAK_ID": 1,
         "SAKSKODE": "$sakskode",
         "AAR": 2022,
-        "LOPENRSAK": $lopenummer
+        "LOPENRSAK": $lopenummer,
+        "AETATENHET_ANSVARLIG": "2990"
     }"""
 )

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumerTest.kt
@@ -65,7 +65,8 @@ class TiltakdeltakerEndretConsumerTest : FunSpec({
         val sak = Sak(
             sakId = 1,
             lopenummer = 123,
-            aar = 2022
+            aar = 2022,
+            enhet = "2990"
         )
         val tiltaksgjennomforing = Tiltaksgjennomforing(
             id = UUID.randomUUID(),

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
@@ -71,7 +71,8 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
                 Sak(
                     sakId = 13572352,
                     lopenummer = 123,
-                    aar = 2022
+                    aar = 2022,
+                    enhet = "2990"
                 )
             )
 
@@ -100,7 +101,8 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
                 Sak(
                     sakId = 13572352,
                     lopenummer = 123,
-                    aar = 2022
+                    aar = 2022,
+                    enhet = "2990"
                 )
             )
 


### PR DESCRIPTION
Vi henter ut data fra feltet `AETATENHET_ANSVARLIG` som ligger på en sak fra Arena slik at vi kan tilgjengeliggjøre hvilke enhet en tiltaksgjennomføring tilhører og kan lage views i admin-flate som viser enhetens gjennomføringer.