### PR TITLE
Feature/test with more resources

### DIFF
--- a/mulighetsrommet-api/.nais/nais-prod.yaml
+++ b/mulighetsrommet-api/.nais/nais-prod.yaml
@@ -23,7 +23,7 @@ spec:
     initialDelay: 20
   replicas:
     min: 2
-    max: 10
+    max: 4
     cpuThresholdPercentage: 75
   resources:
     limits:

--- a/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
@@ -26,12 +26,12 @@ spec:
     max: 2
     cpuThresholdPercentage: 75
   resources:
-    limits:
-      cpu: "1"
-      memory: 1024Mi
     requests:
       cpu: 250m
       memory: 512Mi
+    limits:
+      cpu: 2000m
+      memory: 4096Mi
   gcp:
     sqlInstances:
       - type: POSTGRES_14

--- a/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
@@ -23,15 +23,15 @@ spec:
     initialDelay: 20
   replicas:
     min: 2
-    max: 10
+    max: 4
     cpuThresholdPercentage: 75
   resources:
-    limits:
-      cpu: "1"
-      memory: 2048Mi
     requests:
       cpu: 250m
-      memory: 1024Mi
+      memory: 512Mi
+    limits:
+      cpu: 2000m
+      memory: 4096Mi
   gcp:
     sqlInstances:
       - type: POSTGRES_14

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/RetryFailedEvents.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/RetryFailedEvents.kt
@@ -3,22 +3,45 @@ package no.nav.mulighetsrommet.arena.adapter.tasks
 import com.github.kagkarlsson.scheduler.task.helper.RecurringTask
 import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
+import org.slf4j.LoggerFactory
 
 class RetryFailedEvents(private val config: Config, private val arenaEventService: ArenaEventService) {
 
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     data class Config(
-        val delayOfMinutes: Int
+        val delayOfMinutes: Int,
+        val schedulerStatePollDelay: Long = 1000,
     )
 
     fun toTask(): RecurringTask<Void> {
         return Tasks
-            .recurring("retry-failed-events", FixedDelay.ofMinutes(config.delayOfMinutes))
-            .execute { _, _ ->
+            .recurring("retry-failed-events", FixedDelay.ofSeconds(config.delayOfMinutes))
+            .execute { instance, context ->
+                logger.info("Running task ${instance.taskName}")
+
                 runBlocking {
-                    arenaEventService.retryEvents(status = ArenaEvent.ConsumptionStatus.Failed)
+                    val job = async {
+                        arenaEventService.retryEvents(status = ArenaEvent.ConsumptionStatus.Failed)
+                    }
+
+                    while (job.isActive) {
+                        if (context.schedulerState.isShuttingDown) {
+                            logger.info("Stopping task ${instance.taskName} due to shutdown signal")
+
+                            job.cancelAndJoin()
+
+                            logger.info("Task ${instance.taskName} stopped")
+                        }
+
+                        delay(config.schedulerStatePollDelay)
+                    }
                 }
             }
     }

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
@@ -16,7 +16,7 @@ app:
       url: http://localhost:8080
       scope: default
     arenaEventService:
-      channelCapacity: 10
+      channelCapacity: 2
       numChannelConsumers: 1
       maxRetries: 1
     arenaOrdsProxy:


### PR DESCRIPTION
- Øker CPU limits for arena-adapter. Dette ser ut til å hjelpe på CPU-throttling under gjenspilling av events, selv om det ikke utgjør store forskjellen på hvor mange events vi får prosessert per minutt. Er antagelig noen andre deler i systemet som setter begrensninger
- Oppdatert til RetryFailedEvents-task til å gjøre en graceful shutdown slik at man ikke trenger å vente lenge på at en ny pod skal ta opp jobben om den blir avbrutt midt i en stor gjenspilling. Funker lokalt, håper det funker på nais :crossed_fingers: 