### PR TITLE
Refactor/separate dbos from dtos

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/DeltakerDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/DeltakerDbo.kt
@@ -1,22 +1,22 @@
-package no.nav.mulighetsrommet.domain.dto
+package no.nav.mulighetsrommet.domain.dbo
 
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
 
 @Serializable
-data class TiltaksgjennomforingDto(
+data class DeltakerDbo(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    val tiltakstype: TiltakstypeDto,
-    val navn: String?,
-    val tiltaksnummer: String,
-    val virksomhetsnummer: String?,
+    @Serializable(with = UUIDSerializer::class)
+    val tiltaksgjennomforingId: UUID,
+    val norskIdent: String,
+    val status: Deltakerstatus,
     @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
     @Serializable(with = LocalDateTimeSerializer::class)
-    val tilDato: LocalDateTime? = null,
-    val enhet: String
+    val tilDato: LocalDateTime? = null
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -1,7 +1,7 @@
 package no.nav.mulighetsrommet.domain.dbo
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.domain.serializers.DateSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
@@ -15,9 +15,9 @@ data class TiltaksgjennomforingDbo(
     val tiltakstypeId: UUID,
     val tiltaksnummer: String,
     val virksomhetsnummer: String?,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val tilDato: LocalDateTime? = null,
     val enhet: String
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -1,4 +1,4 @@
-package no.nav.mulighetsrommet.domain.models
+package no.nav.mulighetsrommet.domain.dbo
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.serializers.DateSerializer
@@ -7,11 +7,12 @@ import java.time.LocalDateTime
 import java.util.*
 
 @Serializable
-data class TiltaksgjennomforingMedTiltakstype(
+data class TiltaksgjennomforingDbo(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    val tiltakstype: Tiltakstype,
     val navn: String?,
+    @Serializable(with = UUIDSerializer::class)
+    val tiltakstypeId: UUID,
     val tiltaksnummer: String,
     val virksomhetsnummer: String?,
     @Serializable(with = DateSerializer::class)

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakstypeDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakstypeDbo.kt
@@ -1,11 +1,11 @@
-package no.nav.mulighetsrommet.domain.models
+package no.nav.mulighetsrommet.domain.dbo
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
-import java.util.UUID
+import java.util.*
 
 @Serializable
-data class Tiltakstype(
+data class TiltakstypeDbo(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val navn: String,

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Deltakerstatus.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Deltakerstatus.kt
@@ -1,0 +1,8 @@
+package no.nav.mulighetsrommet.domain.dto
+
+enum class Deltakerstatus {
+    IKKE_AKTUELL,
+    VENTER,
+    DELTAR,
+    AVSLUTTET
+}

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
@@ -1,18 +1,18 @@
-package no.nav.mulighetsrommet.domain.models
+package no.nav.mulighetsrommet.domain.dto
 
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.models.Tiltakstype
 import no.nav.mulighetsrommet.domain.serializers.DateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
 
 @Serializable
-data class Tiltaksgjennomforing(
+data class TiltaksgjennomforingDto(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
+    val tiltakstype: Tiltakstype,
     val navn: String?,
-    @Serializable(with = UUIDSerializer::class)
-    val tiltakstypeId: UUID,
     val tiltaksnummer: String,
     val virksomhetsnummer: String?,
     @Serializable(with = DateSerializer::class)

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
@@ -2,7 +2,7 @@ package no.nav.mulighetsrommet.domain.dto
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.models.Tiltakstype
-import no.nav.mulighetsrommet.domain.serializers.DateSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
@@ -15,9 +15,9 @@ data class TiltaksgjennomforingDto(
     val navn: String?,
     val tiltaksnummer: String,
     val virksomhetsnummer: String?,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val tilDato: LocalDateTime? = null,
     val enhet: String
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltakstypeDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltakstypeDto.kt
@@ -1,0 +1,13 @@
+package no.nav.mulighetsrommet.domain.dto
+
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
+import java.util.*
+
+@Serializable
+data class TiltakstypeDto(
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID,
+    val navn: String,
+    val kode: String
+)

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/DelMedBruker.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/DelMedBruker.kt
@@ -1,7 +1,7 @@
 package no.nav.mulighetsrommet.domain.models
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.domain.serializers.DateSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import java.time.LocalDateTime
 
 @Serializable
@@ -11,9 +11,9 @@ data class DelMedBruker(
     val navident: String,
     val tiltaksnummer: String,
     val dialogId: String,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val created_at: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val updated_at: LocalDateTime? = null,
     val created_by: String? = null,
     val updated_by: String? = null

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/Deltaker.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/Deltaker.kt
@@ -1,31 +1,11 @@
 package no.nav.mulighetsrommet.domain.models
 
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
-
-enum class Deltakerstatus {
-    IKKE_AKTUELL,
-    VENTER,
-    DELTAR,
-    AVSLUTTET
-}
-
-@Serializable
-data class Deltaker(
-    @Serializable(with = UUIDSerializer::class)
-    val id: UUID,
-    @Serializable(with = UUIDSerializer::class)
-    val tiltaksgjennomforingId: UUID,
-    val norskIdent: String,
-    val status: Deltakerstatus,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val fraDato: LocalDateTime? = null,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val tilDato: LocalDateTime? = null
-)
 
 @Serializable
 data class HistorikkForDeltakerDTO(

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/Deltaker.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/Deltaker.kt
@@ -1,7 +1,7 @@
 package no.nav.mulighetsrommet.domain.models
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.domain.serializers.DateSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
@@ -21,9 +21,9 @@ data class Deltaker(
     val tiltaksgjennomforingId: UUID,
     val norskIdent: String,
     val status: Deltakerstatus,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val tilDato: LocalDateTime? = null
 )
 
@@ -31,9 +31,9 @@ data class Deltaker(
 data class HistorikkForDeltakerDTO(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val tilDato: LocalDateTime? = null,
     val status: Deltakerstatus,
     val tiltaksnavn: String?,
@@ -45,9 +45,9 @@ data class HistorikkForDeltakerDTO(
 data class HistorikkForDeltaker(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val tilDato: LocalDateTime? = null,
     val status: Deltakerstatus,
     val tiltaksnavn: String?,

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/TiltaksgjennomforingMedTiltakstype.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/TiltaksgjennomforingMedTiltakstype.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 import java.util.*
 
 @Serializable
-data class Tiltaksgjennomforing(
+data class TiltaksgjennomforingMedTiltakstype(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val navn: String?,
@@ -15,6 +15,8 @@ data class Tiltaksgjennomforing(
     val tiltakstypeId: UUID,
     val tiltaksnummer: String,
     val virksomhetsnummer: String?,
+    val tiltakskode: String,
+    val tiltakstypeNavn: String,
     @Serializable(with = DateSerializer::class)
     val fraDato: LocalDateTime? = null,
     @Serializable(with = DateSerializer::class)

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/TiltaksgjennomforingMedTiltakstype.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/models/TiltaksgjennomforingMedTiltakstype.kt
@@ -10,13 +10,10 @@ import java.util.*
 data class TiltaksgjennomforingMedTiltakstype(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
+    val tiltakstype: Tiltakstype,
     val navn: String?,
-    @Serializable(with = UUIDSerializer::class)
-    val tiltakstypeId: UUID,
     val tiltaksnummer: String,
     val virksomhetsnummer: String?,
-    val tiltakskode: String,
-    val tiltakstypeNavn: String,
     @Serializable(with = DateSerializer::class)
     val fraDato: LocalDateTime? = null,
     @Serializable(with = DateSerializer::class)

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/serializers/LocalDateTimeSerializer.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/serializers/LocalDateTimeSerializer.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import java.time.LocalDateTime
 
-object DateSerializer : KSerializer<LocalDateTime> {
+object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
     override val descriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): LocalDateTime {

--- a/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useTiltaksgjennomforingById.ts
+++ b/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useTiltaksgjennomforingById.ts
@@ -13,10 +13,8 @@ export function useTiltaksgjennomforingById() {
   }
 
   return useQuery(QueryKeys.tiltaksgjennomforing(tiltaksgjennomforingId), () =>
-    mulighetsrommetClient.tiltaksgjennomforinger.getTiltaksgjennomforingMedTiltakstype(
-      {
-        id: tiltaksgjennomforingId,
-      }
-    )
+    mulighetsrommetClient.tiltaksgjennomforinger.getTiltaksgjennomforing({
+      id: tiltaksgjennomforingId,
+    })
   );
 }

--- a/frontend/mr-admin-flate/src/components/sok/SokEtterTiltaksgjennomforing.tsx
+++ b/frontend/mr-admin-flate/src/components/sok/SokEtterTiltaksgjennomforing.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { mulighetsrommetClient } from "../../api/clients";
 import { z } from "zod";
-import { TiltaksgjennomforingMedTiltakstype } from "mulighetsrommet-api-client/build/models/TiltaksgjennomforingMedTiltakstype";
+import { Tiltaksgjennomforing } from "mulighetsrommet-api-client";
 
 const sokeSchema = z.object({
   tiltaksnummer: z.number().positive(),
@@ -12,9 +12,7 @@ const sokeSchema = z.object({
 export function SokEtterTiltaksgjennomforing() {
   const navigate = useNavigate();
   const [error, setError] = useState("");
-  const [results, setResults] = useState<TiltaksgjennomforingMedTiltakstype[]>(
-    []
-  );
+  const [results, setResults] = useState<Tiltaksgjennomforing[]>([]);
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/Tiltaksgjennomforing.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/Tiltaksgjennomforing.tsx
@@ -25,8 +25,8 @@ export function Tiltaksgjennomforingrad({
         <BodyLong>{tiltaksgjennomforing.navn}</BodyLong>
       </Link>
       <BodyShort size="small">{tiltaksgjennomforing.tiltaksnummer}</BodyShort>
-      <BodyShort size="small" title={tiltaksgjennomforing.tiltakskode}>
-        {tiltaksgjennomforing.tiltakstypeNavn}
+      <BodyShort size="small" title={tiltaksgjennomforing.tiltakstype.tiltakskode}>
+        {tiltaksgjennomforing.tiltakstype.navn}
       </BodyShort>
       <BodyShort size="small">
         {tiltaksgjennomforing.virksomhetsnummer}

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/Tiltaksgjennomforing.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/Tiltaksgjennomforing.tsx
@@ -1,11 +1,11 @@
 import { Next } from "@navikt/ds-icons";
 import { BodyLong, BodyShort } from "@navikt/ds-react";
 import { Link } from "react-router-dom";
-import { TiltaksgjennomforingMedTiltakstype } from "../../../../mulighetsrommet-api-client";
+import { Tiltaksgjennomforing } from "mulighetsrommet-api-client";
 import styles from "./Tiltaksgjennomforing.module.scss";
 
 interface Props {
-  tiltaksgjennomforing: TiltaksgjennomforingMedTiltakstype;
+  tiltaksgjennomforing: Tiltaksgjennomforing;
   fagansvarlig?: boolean;
 }
 
@@ -25,7 +25,7 @@ export function Tiltaksgjennomforingrad({
         <BodyLong>{tiltaksgjennomforing.navn}</BodyLong>
       </Link>
       <BodyShort size="small">{tiltaksgjennomforing.tiltaksnummer}</BodyShort>
-      <BodyShort size="small" title={tiltaksgjennomforing.tiltakstype.tiltakskode}>
+      <BodyShort size="small" title={tiltaksgjennomforing.tiltakstype.kode}>
         {tiltaksgjennomforing.tiltakstype.navn}
       </BodyShort>
       <BodyShort size="small">

--- a/frontend/mr-admin-flate/src/components/tiltakstyper/Tiltakstyperad.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltakstyper/Tiltakstyperad.tsx
@@ -1,4 +1,4 @@
-import { Tiltakstype } from "../../../../mulighetsrommet-api-client";
+import { Tiltakstype } from "mulighetsrommet-api-client";
 import { BodyLong, BodyShort } from "@navikt/ds-react";
 import styles from "./Tiltakstyperad.module.scss";
 import { Next } from "@navikt/ds-icons";
@@ -14,7 +14,7 @@ export function Tiltakstyperad({ tiltakstype }: Props) {
       <Link to={`${tiltakstype.id}`}>
         <BodyLong size={"medium"}>{tiltakstype.navn}</BodyLong>
       </Link>
-      <BodyShort size={"small"}>{tiltakstype.tiltakskode}</BodyShort>
+      <BodyShort size={"small"}>{tiltakstype.kode}</BodyShort>
       <div className={styles.pil}>
         <Next />
       </div>

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/DetaljerTiltaksgjennomforingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/DetaljerTiltaksgjennomforingPage.tsx
@@ -44,9 +44,9 @@ export function TiltaksgjennomforingPage() {
         <dt>Tiltaksnummer</dt>
         <dd>{tiltaksgjennomforing.tiltaksnummer}</dd>
         <dt>Tiltakstype</dt>
-        <dd>{tiltaksgjennomforing.tiltakstypeNavn}</dd>
+        <dd>{tiltaksgjennomforing.tiltakstype.navn}</dd>
         <dt>Kode for tiltakstype:</dt>
-        <dd>{tiltaksgjennomforing.tiltakskode}</dd>
+        <dd>{tiltaksgjennomforing.tiltakstype.tiltakskode}</dd>
         <dt>Virksomhetsnummer</dt>
         <dd>{tiltaksgjennomforing.virksomhetsnummer}</dd>
         <dt>Startdato</dt>

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/DetaljerTiltaksgjennomforingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/DetaljerTiltaksgjennomforingPage.tsx
@@ -46,7 +46,7 @@ export function TiltaksgjennomforingPage() {
         <dt>Tiltakstype</dt>
         <dd>{tiltaksgjennomforing.tiltakstype.navn}</dd>
         <dt>Kode for tiltakstype:</dt>
-        <dd>{tiltaksgjennomforing.tiltakstype.tiltakskode}</dd>
+        <dd>{tiltaksgjennomforing.tiltakstype.kode}</dd>
         <dt>Virksomhetsnummer</dt>
         <dd>{tiltaksgjennomforing.virksomhetsnummer}</dd>
         <dt>Startdato</dt>

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
@@ -34,7 +34,7 @@ export function DetaljerTiltakstypePage() {
       </Heading>
       <dl>
         <dt>Tiltakskode:</dt>
-        <dd>{tiltakstype.tiltakskode}</dd>
+        <dd>{tiltakstype.kode}</dd>
       </dl>
       <TiltaksgjennomforingslisteForTiltakstyper
         tiltakstype={tiltakstype}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/ikkeKvalifisertVarsel/BrukerKvalifisererIkkeVarsel.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/ikkeKvalifisertVarsel/BrukerKvalifisererIkkeVarsel.tsx
@@ -2,7 +2,7 @@ import { Alert } from '@navikt/ds-react';
 import { useBrukerHarRettPaaTiltak } from '../../hooks/useBrukerHarRettPaaTiltak';
 import appStyles from '../../App.module.scss';
 import styles from './BrukerKvalifisererIkkeVarsel.module.scss';
-import { Innsatsgruppe } from '../../../../mulighetsrommet-api-client/build/models/Innsatsgruppe';
+import { Innsatsgruppe } from 'mulighetsrommet-api-client';
 import { useHentBrukerdata } from '../../core/api/queries/useHentBrukerdata';
 
 export function BrukerKvalifisererIkkeVarsel() {

--- a/frontend/mulighetsrommet-veileder-flate/src/components/ikkeKvalifisertVarsel/FiltrertFeilInnsatsgruppeVarsel.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/ikkeKvalifisertVarsel/FiltrertFeilInnsatsgruppeVarsel.tsx
@@ -3,7 +3,7 @@ import { useHentBrukerdata } from '../../core/api/queries/useHentBrukerdata';
 import appStyles from '../../App.module.scss';
 import styles from './BrukerKvalifisererIkkeVarsel.module.scss';
 import { Tiltaksgjennomforingsfilter } from '../../core/atoms/atoms';
-import { Innsatsgruppe } from '../../../../mulighetsrommet-api-client/build/models/Innsatsgruppe';
+import { Innsatsgruppe } from 'mulighetsrommet-api-client';
 
 interface FiltrertFeilInnsatsgruppeVarselProps {
   filter: Tiltaksgjennomforingsfilter;

--- a/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Heading, Loader, Pagination } from '@navikt/ds-react';
+import { Alert, Button, Loader, Pagination } from '@navikt/ds-react';
 import { useAtom } from 'jotai';
 import { RESET } from 'jotai/utils';
 import { useEffect, useState } from 'react';

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -2,7 +2,7 @@ import SanityClient from '@sanity/client';
 import { rest, RestHandler } from 'msw';
 import { badReq, ok } from './responses';
 import { historikk } from '../fixtures/historikk';
-import { DelMedBruker } from '../../../../mulighetsrommet-api-client/build/models/DelMedBruker';
+import { DelMedBruker } from 'mulighetsrommet-api-client';
 
 export const apiHandlers: RestHandler[] = [
   rest.get('*/api/v1/bruker', req => {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/DeltakerRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/DeltakerRepository.kt
@@ -5,8 +5,8 @@ import kotliquery.queryOf
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.QueryResult
 import no.nav.mulighetsrommet.database.utils.query
-import no.nav.mulighetsrommet.domain.models.Deltaker
-import no.nav.mulighetsrommet.domain.models.Deltakerstatus
+import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -15,7 +15,7 @@ class DeltakerRepository(private val db: Database) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun upsert(deltaker: Deltaker): QueryResult<Deltaker> = query {
+    fun upsert(deltaker: DeltakerDbo): QueryResult<DeltakerDbo> = query {
         logger.info("Lagrer deltaker id=${deltaker.id}")
 
         @Language("PostgreSQL")
@@ -32,7 +32,7 @@ class DeltakerRepository(private val db: Database) {
         """.trimIndent()
 
         queryOf(query, deltaker.toSqlParameters())
-            .map { it.toDeltaker() }
+            .map { it.toDeltakerDbo() }
             .asSingle
             .let { db.run(it)!! }
     }
@@ -51,7 +51,7 @@ class DeltakerRepository(private val db: Database) {
             .let { db.run(it) }
     }
 
-    private fun Deltaker.toSqlParameters() = mapOf(
+    private fun DeltakerDbo.toSqlParameters() = mapOf(
         "id" to id,
         "tiltaksgjennomforing_id" to tiltaksgjennomforingId,
         "norsk_ident" to norskIdent,
@@ -60,7 +60,7 @@ class DeltakerRepository(private val db: Database) {
         "til_dato" to tilDato,
     )
 
-    private fun Row.toDeltaker() = Deltaker(
+    private fun Row.toDeltakerDbo() = DeltakerDbo(
         id = uuid("id"),
         tiltaksgjennomforingId = uuid("tiltaksgjennomforing_id"),
         norskIdent = string("norsk_ident"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -7,8 +7,8 @@ import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.QueryResult
 import no.nav.mulighetsrommet.database.utils.query
-import no.nav.mulighetsrommet.domain.models.Tiltaksgjennomforing
-import no.nav.mulighetsrommet.domain.models.TiltaksgjennomforingMedTiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingDto
 import no.nav.mulighetsrommet.domain.models.Tiltakstype
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
@@ -18,7 +18,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun upsert(tiltaksgjennomforing: Tiltaksgjennomforing): QueryResult<Tiltaksgjennomforing> = query {
+    fun upsert(tiltaksgjennomforing: TiltaksgjennomforingDbo): QueryResult<TiltaksgjennomforingDbo> = query {
         logger.info("Lagrer tiltaksgjennomføring id=${tiltaksgjennomforing.id}")
 
         @Language("PostgreSQL")
@@ -42,7 +42,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             .let { db.run(it)!! }
     }
 
-    fun get(id: UUID): TiltaksgjennomforingMedTiltakstype? {
+    fun get(id: UUID): TiltaksgjennomforingDto? {
         @Language("PostgreSQL")
         val query = """
             select tg.id::uuid,
@@ -65,7 +65,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             .let { db.run(it) }
     }
 
-    fun getAll(pagination: PaginationParams = PaginationParams()): Pair<Int, List<TiltaksgjennomforingMedTiltakstype>> {
+    fun getAll(pagination: PaginationParams = PaginationParams()): Pair<Int, List<TiltaksgjennomforingDto>> {
         @Language("PostgreSQL")
         val query = """
             select tg.id::uuid,
@@ -98,7 +98,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
     fun getAllByTiltakstypeId(
         id: UUID,
         pagination: PaginationParams = PaginationParams()
-    ): Pair<Int, List<TiltaksgjennomforingMedTiltakstype>> {
+    ): Pair<Int, List<TiltaksgjennomforingDto>> {
         @Language("PostgreSQL")
         val query = """
             select tg.id::uuid,
@@ -132,7 +132,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
     fun getAllByEnhet(
         enhet: String,
         pagination: PaginationParams
-    ): Pair<Int, List<TiltaksgjennomforingMedTiltakstype>> {
+    ): Pair<Int, List<TiltaksgjennomforingDto>> {
         @Language("PostgreSQL")
         val query = """
             select tg.id::uuid,
@@ -163,7 +163,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         return Pair(totaltAntall, tiltaksgjennomforinger)
     }
 
-    fun sok(filter: Sokefilter): List<TiltaksgjennomforingMedTiltakstype> {
+    fun sok(filter: Sokefilter): List<TiltaksgjennomforingDto> {
         @Language("PostgreSQL")
         val query = """
             select tg.id::uuid,
@@ -202,7 +202,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             .let { db.run(it) }
     }
 
-    private fun Tiltaksgjennomforing.toSqlParameters() = mapOf(
+    private fun TiltaksgjennomforingDbo.toSqlParameters() = mapOf(
         "id" to id,
         "navn" to navn,
         "tiltakstype_id" to tiltakstypeId,
@@ -213,7 +213,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "enhet" to enhet
     )
 
-    private fun Row.toTiltaksgjennomforing() = Tiltaksgjennomforing(
+    private fun Row.toTiltaksgjennomforing() = TiltaksgjennomforingDbo(
         id = uuid("id"),
         navn = stringOrNull("navn"),
         tiltakstypeId = uuid("tiltakstype_id"),
@@ -224,7 +224,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         enhet = string("enhet")
     )
 
-    private fun Row.toTiltaksgjennomforingMedTiltakstype() = TiltaksgjennomforingMedTiltakstype(
+    private fun Row.toTiltaksgjennomforingMedTiltakstype() = TiltaksgjennomforingDto(
         id = uuid("id"),
         tiltakstype = Tiltakstype(
             id = uuid("tiltakstype_id"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -9,7 +9,7 @@ import no.nav.mulighetsrommet.database.utils.QueryResult
 import no.nav.mulighetsrommet.database.utils.query
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingDto
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
+import no.nav.mulighetsrommet.domain.dto.TiltakstypeDto
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -37,7 +37,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         """.trimIndent()
 
         queryOf(query, tiltaksgjennomforing.toSqlParameters())
-            .map { it.toTiltaksgjennomforing() }
+            .map { it.toTiltaksgjennomforingDbo() }
             .asSingle
             .let { db.run(it)!! }
     }
@@ -60,7 +60,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             where tg.id = ?::uuid
         """.trimIndent()
         return queryOf(query, id)
-            .map { it.toTiltaksgjennomforingMedTiltakstype() }
+            .map { it.toTiltaksgjennomforingDto() }
             .asSingle
             .let { db.run(it) }
     }
@@ -85,7 +85,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         """.trimIndent()
         val results = queryOf(query, pagination.limit, pagination.offset)
             .map {
-                it.int("full_count") to it.toTiltaksgjennomforingMedTiltakstype()
+                it.int("full_count") to it.toTiltaksgjennomforingDto()
             }
             .asList
             .let { db.run(it) }
@@ -119,7 +119,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         """.trimIndent()
         val results = queryOf(query, id, pagination.limit, pagination.offset)
             .map {
-                it.int("full_count") to it.toTiltaksgjennomforingMedTiltakstype()
+                it.int("full_count") to it.toTiltaksgjennomforingDto()
             }
             .asList
             .let { db.run(it) }
@@ -153,7 +153,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         """.trimIndent()
         val results = queryOf(query, enhet, pagination.limit, pagination.offset)
             .map {
-                it.int("full_count") to it.toTiltaksgjennomforingMedTiltakstype()
+                it.int("full_count") to it.toTiltaksgjennomforingDto()
             }
             .asList
             .let { db.run(it) }
@@ -182,7 +182,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         """.trimIndent()
         return queryOf(query, filter.tiltaksnummer)
             .map {
-                it.toTiltaksgjennomforingMedTiltakstype()
+                it.toTiltaksgjennomforingDto()
             }
             .asList
             .let { db.run(it) }
@@ -213,7 +213,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "enhet" to enhet
     )
 
-    private fun Row.toTiltaksgjennomforing() = TiltaksgjennomforingDbo(
+    private fun Row.toTiltaksgjennomforingDbo() = TiltaksgjennomforingDbo(
         id = uuid("id"),
         navn = stringOrNull("navn"),
         tiltakstypeId = uuid("tiltakstype_id"),
@@ -224,12 +224,12 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         enhet = string("enhet")
     )
 
-    private fun Row.toTiltaksgjennomforingMedTiltakstype() = TiltaksgjennomforingDto(
+    private fun Row.toTiltaksgjennomforingDto() = TiltaksgjennomforingDto(
         id = uuid("id"),
-        tiltakstype = Tiltakstype(
+        tiltakstype = TiltakstypeDto(
             id = uuid("tiltakstype_id"),
             navn = string("tiltakstype_navn"),
-            tiltakskode = string("tiltakskode"),
+            kode = string("tiltakskode"),
         ),
         navn = stringOrNull("navn"),
         tiltaksnummer = string("tiltaksnummer"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
@@ -6,7 +6,8 @@ import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.QueryResult
 import no.nav.mulighetsrommet.database.utils.query
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
+import no.nav.mulighetsrommet.domain.dto.TiltakstypeDto
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -15,7 +16,7 @@ class TiltakstypeRepository(private val db: Database) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun upsert(tiltakstype: Tiltakstype): QueryResult<Tiltakstype> = query {
+    fun upsert(tiltakstype: TiltakstypeDbo): QueryResult<TiltakstypeDbo> = query {
         logger.info("Lagrer tiltakstype id=${tiltakstype.id}")
 
         @Language("PostgreSQL")
@@ -29,26 +30,26 @@ class TiltakstypeRepository(private val db: Database) {
         """.trimIndent()
 
         queryOf(query, tiltakstype.toSqlParameters())
-            .map { it.toTiltakstype() }
+            .map { it.toTiltakstypeDbo() }
             .asSingle
             .let { db.run(it)!! }
     }
 
-    fun getTiltakstypeById(id: UUID): Tiltakstype? {
+    fun get(id: UUID): TiltakstypeDto? {
         @Language("PostgreSQL")
         val query = """
             select id::uuid, navn, tiltakskode
             from tiltakstype
             where id = ?::uuid
         """.trimIndent()
-        val queryResult = queryOf(query, id).map { it.toTiltakstype() }.asSingle
+        val queryResult = queryOf(query, id).map { it.toTiltakstypeDto() }.asSingle
         return db.run(queryResult)
     }
 
     fun getAll(
         search: String? = null,
         paginationParams: PaginationParams = PaginationParams()
-    ): Pair<Int, List<Tiltakstype>> {
+    ): Pair<Int, List<TiltakstypeDto>> {
         val parameters = mapOf(
             "search" to "%$search%",
             "limit" to paginationParams.limit,
@@ -70,7 +71,7 @@ class TiltakstypeRepository(private val db: Database) {
 
         val results = queryOf(query, parameters)
             .map {
-                it.int("full_count") to it.toTiltakstype()
+                it.int("full_count") to it.toTiltakstypeDto()
             }
             .asList
             .let { db.run(it) }
@@ -100,15 +101,21 @@ class TiltakstypeRepository(private val db: Database) {
         ?.let { "where $it" }
         ?: ""
 
-    private fun Tiltakstype.toSqlParameters() = mapOf(
+    private fun TiltakstypeDbo.toSqlParameters() = mapOf(
         "id" to id,
         "navn" to navn,
         "tiltakskode" to tiltakskode
     )
 
-    private fun Row.toTiltakstype() = Tiltakstype(
+    private fun Row.toTiltakstypeDbo() = TiltakstypeDbo(
         id = uuid("id"),
         navn = string("navn"),
         tiltakskode = string("tiltakskode")
+    )
+
+    private fun Row.toTiltakstypeDto() = TiltakstypeDto(
+        id = uuid("id"),
+        navn = string("navn"),
+        kode = string("tiltakskode")
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
@@ -9,9 +9,9 @@ import io.ktor.util.logging.*
 import io.ktor.util.pipeline.*
 import no.nav.mulighetsrommet.api.services.ArenaService
 import no.nav.mulighetsrommet.database.utils.DatabaseOperationError
+import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.domain.models.Deltaker
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import org.koin.ktor.ext.inject
 import org.postgresql.util.PSQLException
 
@@ -22,7 +22,7 @@ fun Route.arenaRoutes() {
 
     route("/api/v1/arena/") {
         put("tiltakstype") {
-            val tiltakstype = call.receive<Tiltakstype>()
+            val tiltakstype = call.receive<TiltakstypeDbo>()
             arenaService.upsert(tiltakstype)
                 .map { call.respond(it) }
                 .mapLeft {
@@ -30,8 +30,9 @@ fun Route.arenaRoutes() {
                     call.respond(HttpStatusCode.InternalServerError, "Kunne ikke oppdatere tiltakstype")
                 }
         }
+
         delete("tiltakstype") {
-            val tiltakstype = call.receive<Tiltakstype>()
+            val tiltakstype = call.receive<TiltakstypeDbo>()
             arenaService.remove(tiltakstype)
                 .map { call.response.status(HttpStatusCode.OK) }
                 .mapLeft {
@@ -39,6 +40,7 @@ fun Route.arenaRoutes() {
                     call.respond(HttpStatusCode.InternalServerError, "Kunne ikke slette tiltakstype")
                 }
         }
+
         put("tiltaksgjennomforing") {
             val tiltaksgjennomforing = call.receive<TiltaksgjennomforingDbo>()
             arenaService.upsert(tiltaksgjennomforing)
@@ -48,6 +50,7 @@ fun Route.arenaRoutes() {
                     call.respond(HttpStatusCode.InternalServerError, "Kunne ikke opprette tiltak")
                 }
         }
+
         delete("tiltaksgjennomforing") {
             val tiltaksgjennomforing = call.receive<TiltaksgjennomforingDbo>()
             arenaService.remove(tiltaksgjennomforing)
@@ -57,8 +60,9 @@ fun Route.arenaRoutes() {
                     call.respond(HttpStatusCode.InternalServerError, "Kunne ikke slette tiltak")
                 }
         }
+
         put("deltaker") {
-            val deltaker = call.receive<Deltaker>()
+            val deltaker = call.receive<DeltakerDbo>()
             arenaService.upsert(deltaker)
                 .map { call.respond(HttpStatusCode.OK, it) }
                 .mapLeft {
@@ -66,6 +70,7 @@ fun Route.arenaRoutes() {
                         is DatabaseOperationError.ForeignKeyViolation -> {
                             call.respond(HttpStatusCode.Conflict, "Kunne ikke opprette deltaker")
                         }
+
                         else -> {
                             logError(logger, it.error)
                             call.respond(HttpStatusCode.InternalServerError, "Kunne ikke opprette deltaker")
@@ -73,8 +78,9 @@ fun Route.arenaRoutes() {
                     }
                 }
         }
+
         delete("deltaker") {
-            val deltaker = call.receive<Deltaker>()
+            val deltaker = call.receive<DeltakerDbo>()
             arenaService.remove(deltaker)
                 .map { call.response.status(HttpStatusCode.OK) }
                 .mapLeft {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaRoutes.kt
@@ -9,8 +9,8 @@ import io.ktor.util.logging.*
 import io.ktor.util.pipeline.*
 import no.nav.mulighetsrommet.api.services.ArenaService
 import no.nav.mulighetsrommet.database.utils.DatabaseOperationError
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.models.Deltaker
-import no.nav.mulighetsrommet.domain.models.Tiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.models.Tiltakstype
 import org.koin.ktor.ext.inject
 import org.postgresql.util.PSQLException
@@ -40,7 +40,7 @@ fun Route.arenaRoutes() {
                 }
         }
         put("tiltaksgjennomforing") {
-            val tiltaksgjennomforing = call.receive<Tiltaksgjennomforing>()
+            val tiltaksgjennomforing = call.receive<TiltaksgjennomforingDbo>()
             arenaService.upsert(tiltaksgjennomforing)
                 .map { call.respond(it) }
                 .mapLeft {
@@ -49,7 +49,7 @@ fun Route.arenaRoutes() {
                 }
         }
         delete("tiltaksgjennomforing") {
-            val tiltaksgjennomforing = call.receive<Tiltaksgjennomforing>()
+            val tiltaksgjennomforing = call.receive<TiltaksgjennomforingDbo>()
             arenaService.remove(tiltaksgjennomforing)
                 .map { call.response.status(HttpStatusCode.OK) }
                 .mapLeft {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
@@ -39,7 +39,7 @@ fun Route.tiltakstypeRoutes() {
                 "Mangler eller ugyldig id",
                 status = HttpStatusCode.BadRequest
             )
-            val tiltakstype = tiltakstyper.getTiltakstypeById(id) ?: return@get call.respondText(
+            val tiltakstype = tiltakstyper.get(id) ?: return@get call.respondText(
                 "Det finnes ikke noe tiltakstype med id $id",
                 status = HttpStatusCode.NotFound
             )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
@@ -4,9 +4,9 @@ import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.database.utils.QueryResult
+import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.domain.models.Deltaker
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 
 class ArenaService(
     private val tiltakstypeRepository: TiltakstypeRepository,
@@ -18,11 +18,11 @@ class ArenaService(
         return tiltaksgjennomforingRepository.upsert(tiltaksgjennomforing)
     }
 
-    fun upsert(tiltakstype: Tiltakstype): QueryResult<Tiltakstype> {
+    fun upsert(tiltakstype: TiltakstypeDbo): QueryResult<TiltakstypeDbo> {
         return tiltakstypeRepository.upsert(tiltakstype)
     }
 
-    fun upsert(deltaker: Deltaker): QueryResult<Deltaker> {
+    fun upsert(deltaker: DeltakerDbo): QueryResult<DeltakerDbo> {
         return deltakerRepository.upsert(deltaker)
     }
 
@@ -30,11 +30,11 @@ class ArenaService(
         return tiltaksgjennomforingRepository.delete(tiltaksgjennomforing.id)
     }
 
-    fun remove(tiltakstype: Tiltakstype): QueryResult<Unit> {
+    fun remove(tiltakstype: TiltakstypeDbo): QueryResult<Unit> {
         return tiltakstypeRepository.delete(tiltakstype.id)
     }
 
-    fun remove(deltaker: Deltaker): QueryResult<Unit> {
+    fun remove(deltaker: DeltakerDbo): QueryResult<Unit> {
         return deltakerRepository.delete(deltaker.id)
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaService.kt
@@ -4,8 +4,8 @@ import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.database.utils.QueryResult
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.models.Deltaker
-import no.nav.mulighetsrommet.domain.models.Tiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.models.Tiltakstype
 
 class ArenaService(
@@ -14,7 +14,7 @@ class ArenaService(
     private val deltakerRepository: DeltakerRepository
 ) {
 
-    fun upsert(tiltaksgjennomforing: Tiltaksgjennomforing): QueryResult<Tiltaksgjennomforing> {
+    fun upsert(tiltaksgjennomforing: TiltaksgjennomforingDbo): QueryResult<TiltaksgjennomforingDbo> {
         return tiltaksgjennomforingRepository.upsert(tiltaksgjennomforing)
     }
 
@@ -26,7 +26,7 @@ class ArenaService(
         return deltakerRepository.upsert(deltaker)
     }
 
-    fun remove(tiltaksgjennomforing: Tiltaksgjennomforing): QueryResult<Unit> {
+    fun remove(tiltaksgjennomforing: TiltaksgjennomforingDbo): QueryResult<Unit> {
         return tiltaksgjennomforingRepository.delete(tiltaksgjennomforing.id)
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/HistorikkService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/HistorikkService.kt
@@ -3,7 +3,7 @@ package no.nav.mulighetsrommet.api.services
 import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.database.Database
-import no.nav.mulighetsrommet.domain.models.Deltakerstatus
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import no.nav.mulighetsrommet.domain.models.HistorikkForDeltaker
 import no.nav.mulighetsrommet.domain.models.HistorikkForDeltakerDTO
 import no.nav.mulighetsrommet.secure_log.SecureLog

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -2,19 +2,19 @@ package no.nav.mulighetsrommet.api.services
 
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.utils.PaginationParams
-import no.nav.mulighetsrommet.domain.models.TiltaksgjennomforingMedTiltakstype
+import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingDto
 
 class TiltaksgjennomforingService(private val tiltaksgjennomforingRepository: TiltaksgjennomforingRepository) {
 
-    fun getAll(paginationParams: PaginationParams): Pair<Int, List<TiltaksgjennomforingMedTiltakstype>> {
+    fun getAll(paginationParams: PaginationParams): Pair<Int, List<TiltaksgjennomforingDto>> {
         return tiltaksgjennomforingRepository.getAll(paginationParams)
     }
 
-    fun sok(filter: Sokefilter): List<TiltaksgjennomforingMedTiltakstype> {
+    fun sok(filter: Sokefilter): List<TiltaksgjennomforingDto> {
         return tiltaksgjennomforingRepository.sok(filter)
     }
 
-    fun getAllByEnhet(enhet: String, paginationParams: PaginationParams): Pair<Int, List<TiltaksgjennomforingMedTiltakstype>> {
+    fun getAllByEnhet(enhet: String, paginationParams: PaginationParams): Pair<Int, List<TiltaksgjennomforingDto>> {
         return tiltaksgjennomforingRepository.getAllByEnhet(enhet, paginationParams)
     }
 }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yml
@@ -51,7 +51,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginertTiltaksgjennomforingMedTiltakstype"
+                $ref: "#/components/schemas/PaginertTiltaksgjennomforing"
 
   /api/v1/tiltaksgjennomforinger/{id}:
     parameters:
@@ -59,14 +59,14 @@ paths:
     get:
       tags:
         - Tiltaksgjennomforinger
-      operationId: getTiltaksgjennomforingMedTiltakstype
+      operationId: getTiltaksgjennomforing
       responses:
         200:
           description: The specified tiltaksgjennomføring with data about tiltakstype.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TiltaksgjennomforingMedTiltakstype"
+                $ref: "#/components/schemas/Tiltaksgjennomforing"
         404:
           description: "The specified tiltaksgjennomføring was not found."
           content:
@@ -100,7 +100,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginertTiltaksgjennomforingMedTiltakstype"
+                $ref: "#/components/schemas/PaginertTiltaksgjennomforing"
         404:
           description: "Fant ingen tiltaksgjennomføringer med gitt tiltakstype id."
           content:
@@ -134,7 +134,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginertTiltaksgjennomforingMedTiltakstype"
+                $ref: "#/components/schemas/PaginertTiltaksgjennomforing"
         404:
           description: "Fant ingen tiltaksgjennomføringer for enhet"
           content:
@@ -161,7 +161,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/TiltaksgjennomforingMedTiltakstype"
+                  $ref: "#/components/schemas/Tiltaksgjennomforing"
 
   /api/v1/tiltakstyper:
     get:
@@ -448,59 +448,22 @@ components:
           items:
             $ref: "#/components/schemas/Tiltaksgjennomforing"
 
-
-    PaginertTiltaksgjennomforingMedTiltakstype:
-      type: object
-      required:
-        - pagination
-        - data
-      properties:
-        pagination:
-          $ref: "#/components/schemas/Pagination"
-        data:
-          type: array
-          items:
-            $ref: "#/components/schemas/TiltaksgjennomforingMedTiltakstype"
-
     Tiltakstype:
       type: object
       required:
         - id
         - navn
-        - tiltakskode
+        - kode
       properties:
         id:
           type: string
           format: uuid
         navn:
           type: string
-        tiltakskode:
+        kode:
           $ref: "#/components/schemas/Tiltakskode"
 
     Tiltaksgjennomforing:
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
-        navn:
-          type: string
-        tiltaksnummer:
-          type: string
-        tiltakstypeId:
-          type: string
-          format: uuid
-        virksomhetsnummer:
-          type: string
-      required:
-        - id
-        - navn
-        - tiltakskode
-        - tiltaksnummer
-        - tiltakstypeId
-        - virksomhetsnummer
-
-    TiltaksgjennomforingMedTiltakstype:
       type: object
       properties:
         id:
@@ -520,11 +483,10 @@ components:
           type: string
       required:
         - id
-        - navn
         - tiltakstype
+        - navn
         - tiltaksnummer
         - virksomhetsnummer
-        - tiltakskode
 
     Tiltakskode:
       type: string
@@ -774,21 +736,3 @@ components:
           type: string
         updated_by:
           type: string
-
-  examples:
-    Tiltakstype:
-      summary: "Tiltakstype eksempel"
-      value:
-        id: "afb69ca8-ddff-45be-9fd0-8f968519468d"
-        navn: "Ny tiltakstype"
-        tiltakskode: "SPA"
-
-    Tiltaksgjennomforing:
-      summary: "Tiltaksgjennomføring eksempel"
-      value:
-        id: null
-        navn: "Ny tiltaksgjennomføring"
-        tiltakstypeId: "afb69ca8-ddff-45be-9fd0-8f968519468d"
-        tiltaksnummer: 1234
-        virksomhetsnummer: '2022'
-        tiltakskode: 'ABIST'

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yml
@@ -506,18 +506,13 @@ components:
         id:
           type: string
           format: uuid
+        tiltakstype:
+          $ref: "#/components/schemas/Tiltakstype"
         navn:
           type: string
         tiltaksnummer:
           type: string
-        tiltakstypeId:
-          type: string
-          format: uuid
         virksomhetsnummer:
-          type: string
-        tiltakskode:
-          type: string
-        tiltakstypeNavn:
           type: string
         fraDato:
           type: string
@@ -526,12 +521,10 @@ components:
       required:
         - id
         - navn
-        - tiltakskode
+        - tiltakstype
         - tiltaksnummer
-        - tiltakstypeId
         - virksomhetsnummer
         - tiltakskode
-        - tiltakstypeNavn
 
     Tiltakskode:
       type: string

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -8,8 +8,8 @@ import no.nav.mulighetsrommet.api.utils.DEFAULT_PAGINATION_LIMIT
 import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
-import no.nav.mulighetsrommet.domain.models.Tiltaksgjennomforing
-import no.nav.mulighetsrommet.domain.models.TiltaksgjennomforingMedTiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingDto
 import no.nav.mulighetsrommet.domain.models.Tiltakstype
 import java.time.LocalDateTime
 import java.util.*
@@ -32,7 +32,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         tiltakskode = "INDOPPFOLG"
     )
 
-    val tiltak1 = Tiltaksgjennomforing(
+    val tiltak1 = TiltaksgjennomforingDbo(
         id = UUID.randomUUID(),
         navn = "Oppfølging",
         tiltakstypeId = tiltakstype1.id,
@@ -43,7 +43,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         enhet = "2990"
     )
 
-    val tiltak2 = Tiltaksgjennomforing(
+    val tiltak2 = TiltaksgjennomforingDbo(
         id = UUID.randomUUID(),
         navn = "Trening",
         tiltakstypeId = tiltakstype2.id,
@@ -66,7 +66,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             tiltaksgjennomforinger.upsert(tiltak2)
 
             tiltaksgjennomforinger.getAll().second shouldHaveSize 2
-            tiltaksgjennomforinger.get(tiltak1.id) shouldBe TiltaksgjennomforingMedTiltakstype(
+            tiltaksgjennomforinger.get(tiltak1.id) shouldBe TiltaksgjennomforingDto(
                 id = tiltak1.id,
                 tiltakstype = Tiltakstype(
                     id = tiltakstype1.id,
@@ -196,7 +196,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
         (1..105).forEach {
             tiltaksgjennomforinger.upsert(
-                Tiltaksgjennomforing(
+                TiltaksgjennomforingDbo(
                     id = UUID.randomUUID(),
                     navn = "$it",
                     tiltakstypeId = tiltakstype1.id,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -9,8 +9,9 @@ import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingDto
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
+import no.nav.mulighetsrommet.domain.dto.TiltakstypeDto
 import java.time.LocalDateTime
 import java.util.*
 
@@ -20,13 +21,13 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
 
     val database = extension(FlywayDatabaseTestListener(createApiDatabaseTestSchema()))
 
-    val tiltakstype1 = Tiltakstype(
+    val tiltakstype1 = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Arbeidstrening",
         tiltakskode = "ARBTREN"
     )
 
-    val tiltakstype2 = Tiltakstype(
+    val tiltakstype2 = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Oppfølging",
         tiltakskode = "INDOPPFOLG"
@@ -68,10 +69,10 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             tiltaksgjennomforinger.getAll().second shouldHaveSize 2
             tiltaksgjennomforinger.get(tiltak1.id) shouldBe TiltaksgjennomforingDto(
                 id = tiltak1.id,
-                tiltakstype = Tiltakstype(
+                tiltakstype = TiltakstypeDto(
                     id = tiltakstype1.id,
                     navn = tiltakstype1.navn,
-                    tiltakskode = tiltakstype1.tiltakskode,
+                    kode = tiltakstype1.tiltakskode,
                 ),
                 navn = tiltak1.navn,
                 tiltaksnummer = tiltak1.tiltaksnummer,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -68,12 +68,14 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             tiltaksgjennomforinger.getAll().second shouldHaveSize 2
             tiltaksgjennomforinger.get(tiltak1.id) shouldBe TiltaksgjennomforingMedTiltakstype(
                 id = tiltak1.id,
+                tiltakstype = Tiltakstype(
+                    id = tiltakstype1.id,
+                    navn = tiltakstype1.navn,
+                    tiltakskode = tiltakstype1.tiltakskode,
+                ),
                 navn = tiltak1.navn,
-                tiltakstypeId = tiltakstype1.id,
                 tiltaksnummer = tiltak1.tiltaksnummer,
                 virksomhetsnummer = tiltak1.virksomhetsnummer,
-                tiltakskode = tiltakstype1.tiltakskode,
-                tiltakstypeNavn = tiltakstype1.navn,
                 fraDato = tiltak1.fraDato,
                 tilDato = tiltak1.tilDato,
                 enhet = tiltak1.enhet

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
@@ -8,7 +8,7 @@ import no.nav.mulighetsrommet.api.utils.DEFAULT_PAGINATION_LIMIT
 import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import java.util.*
 
 class TiltakstypeRepositoryTest : FunSpec({
@@ -21,14 +21,14 @@ class TiltakstypeRepositoryTest : FunSpec({
         val tiltakstyper = TiltakstypeRepository(database.db)
 
         tiltakstyper.upsert(
-            Tiltakstype(
+            TiltakstypeDbo(
                 id = UUID.randomUUID(),
                 navn = "Arbeidstrening",
                 tiltakskode = "ARBTREN"
             )
         )
         tiltakstyper.upsert(
-            Tiltakstype(
+            TiltakstypeDbo(
                 id = UUID.randomUUID(),
                 navn = "Oppfølging",
                 tiltakskode = "INDOPPFOLG"
@@ -48,7 +48,7 @@ class TiltakstypeRepositoryTest : FunSpec({
 
         (1..105).forEach {
             tiltakstyper.upsert(
-                Tiltakstype(
+                TiltakstypeDbo(
                     id = UUID.randomUUID(),
                     navn = "$it",
                     tiltakskode = "$it"

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
@@ -7,10 +7,10 @@ import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
+import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.domain.models.Deltaker
-import no.nav.mulighetsrommet.domain.models.Deltakerstatus
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import org.assertj.db.api.Assertions.assertThat
 import org.assertj.db.type.Table
 import java.time.LocalDateTime
@@ -29,7 +29,7 @@ class ArenaServiceTest : FunSpec({
         val deltakerRepository = DeltakerRepository(database.db)
         val service = ArenaService(tiltakstypeRepository, tiltaksgjennomforingRepository, deltakerRepository)
 
-        val tiltakstype = Tiltakstype(
+        val tiltakstype = TiltakstypeDbo(
             id = UUID.randomUUID(),
             navn = "Arbeidstrening",
             tiltakskode = "ARBTREN"
@@ -46,7 +46,7 @@ class ArenaServiceTest : FunSpec({
             enhet = "2990"
         )
 
-        val deltaker = Deltaker(
+        val deltaker = DeltakerDbo(
             id = UUID.randomUUID(),
             tiltaksgjennomforingId = tiltaksgjennomforing.id,
             norskIdent = "12345678910",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
@@ -7,9 +7,9 @@ import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.models.Deltaker
 import no.nav.mulighetsrommet.domain.models.Deltakerstatus
-import no.nav.mulighetsrommet.domain.models.Tiltaksgjennomforing
 import no.nav.mulighetsrommet.domain.models.Tiltakstype
 import org.assertj.db.api.Assertions.assertThat
 import org.assertj.db.type.Table
@@ -35,7 +35,7 @@ class ArenaServiceTest : FunSpec({
             tiltakskode = "ARBTREN"
         )
 
-        val tiltaksgjennomforing = Tiltaksgjennomforing(
+        val tiltaksgjennomforing = TiltaksgjennomforingDbo(
             id = UUID.randomUUID(),
             navn = "Arbeidstrening",
             tiltakstypeId = tiltakstype.id,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
@@ -10,11 +10,11 @@ import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
+import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.domain.models.Deltaker
-import no.nav.mulighetsrommet.domain.models.Deltakerstatus
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import no.nav.mulighetsrommet.domain.models.HistorikkForDeltakerDTO
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
 import java.time.LocalDateTime
 import java.util.*
 
@@ -25,7 +25,7 @@ class HistorikkServiceTest : FunSpec({
 
     val database = extension(FlywayDatabaseTestListener(createApiDatabaseTestSchema()))
 
-    val tiltakstype = Tiltakstype(
+    val tiltakstype = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Arbeidstrening",
         tiltakskode = "ARBTREN",
@@ -40,7 +40,7 @@ class HistorikkServiceTest : FunSpec({
         enhet = "2990"
     )
 
-    val deltaker = Deltaker(
+    val deltaker = DeltakerDbo(
         id = UUID.randomUUID(),
         tiltaksgjennomforingId = tiltaksgjennomforing.id,
         norskIdent = "12345678910",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
@@ -10,7 +10,11 @@ import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
-import no.nav.mulighetsrommet.domain.models.*
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.domain.models.Deltaker
+import no.nav.mulighetsrommet.domain.models.Deltakerstatus
+import no.nav.mulighetsrommet.domain.models.HistorikkForDeltakerDTO
+import no.nav.mulighetsrommet.domain.models.Tiltakstype
 import java.time.LocalDateTime
 import java.util.*
 
@@ -27,7 +31,7 @@ class HistorikkServiceTest : FunSpec({
         tiltakskode = "ARBTREN",
     )
 
-    val tiltaksgjennomforing = Tiltaksgjennomforing(
+    val tiltaksgjennomforing = TiltaksgjennomforingDbo(
         id = UUID.randomUUID(),
         navn = "Arbeidstrening",
         tiltakstypeId = tiltakstype.id,

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -17,7 +17,7 @@ import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.*
-import no.nav.mulighetsrommet.domain.models.Tiltakstype as MrTiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo as MrTiltakstype
 
 class TiltakEndretConsumer(
     override val config: ConsumerConfig,

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumer.kt
@@ -19,7 +19,7 @@ import no.nav.mulighetsrommet.arena.adapter.utils.ProcessingUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.*
-import no.nav.mulighetsrommet.domain.models.Deltaker as MrDeltaker
+import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo as MrDeltaker
 
 class TiltakdeltakerEndretConsumer(
     override val config: ConsumerConfig,

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumer.kt
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
-import no.nav.mulighetsrommet.domain.models.Tiltaksgjennomforing as MrTiltaksgjennomforing
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo as MrTiltaksgjennomforing
 
 class TiltakgjennomforingEndretConsumer(
     override val config: ConsumerConfig,

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Deltaker.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Deltaker.kt
@@ -1,7 +1,7 @@
 package no.nav.mulighetsrommet.arena.adapter.models.db
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.domain.models.Deltakerstatus
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Deltaker.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Deltaker.kt
@@ -2,7 +2,7 @@ package no.nav.mulighetsrommet.arena.adapter.models.db
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.models.Deltakerstatus
-import no.nav.mulighetsrommet.domain.serializers.DateSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
@@ -14,9 +14,9 @@ data class Deltaker(
     val tiltaksdeltakerId: Int,
     val tiltaksgjennomforingId: Int,
     val personId: Int,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val tilDato: LocalDateTime? = null,
     val status: Deltakerstatus
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltaksgjennomforing.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltaksgjennomforing.kt
@@ -1,7 +1,7 @@
 package no.nav.mulighetsrommet.arena.adapter.models.db
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.domain.serializers.DateSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
@@ -15,9 +15,9 @@ data class Tiltaksgjennomforing(
     val tiltakskode: String,
     val arrangorId: Int?,
     val navn: String?,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val tilDato: LocalDateTime? = null,
     val apentForInnsok: Boolean = true,
     val antallPlasser: Int? = null,

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltakstype.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltakstype.kt
@@ -1,7 +1,7 @@
 package no.nav.mulighetsrommet.arena.adapter.models.db
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.domain.serializers.DateSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDateTime
 import java.util.*
@@ -12,8 +12,8 @@ data class Tiltakstype(
     val id: UUID,
     val navn: String,
     val tiltakskode: String,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
-    @Serializable(with = DateSerializer::class)
+    @Serializable(with = LocalDateTimeSerializer::class)
     val tilDato: LocalDateTime? = null
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/DeltakerRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/DeltakerRepository.kt
@@ -6,7 +6,7 @@ import no.nav.mulighetsrommet.arena.adapter.models.db.Deltaker
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.QueryResult
 import no.nav.mulighetsrommet.database.utils.query
-import no.nav.mulighetsrommet.domain.models.Deltakerstatus
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import org.intellij.lang.annotations.Language
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ProcessingUtils.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ProcessingUtils.kt
@@ -1,6 +1,6 @@
 package no.nav.mulighetsrommet.arena.adapter.utils
 
-import no.nav.mulighetsrommet.domain.models.Deltakerstatus
+import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumerTest.kt
@@ -18,7 +18,7 @@ import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createArenaAdapterDatabaseTestSchema
-import no.nav.mulighetsrommet.domain.models.Tiltakstype
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
 
 class TiltakEndretConsumerTest : FunSpec({
@@ -64,7 +64,7 @@ class TiltakEndretConsumerTest : FunSpec({
             val generatedId = engine.requestHistory.last().run {
                 method shouldBe HttpMethod.Put
 
-                val tiltakstype = decodeRequestBody<Tiltakstype>().apply {
+                val tiltakstype = decodeRequestBody<TiltakstypeDbo>().apply {
                     navn shouldBe "Oppfølging"
                 }
 
@@ -76,7 +76,7 @@ class TiltakEndretConsumerTest : FunSpec({
             engine.requestHistory.last().run {
                 method shouldBe HttpMethod.Delete
 
-                decodeRequestBody<Tiltakstype>().apply {
+                decodeRequestBody<TiltakstypeDbo>().apply {
                     id shouldBe generatedId
                 }
             }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumerTest.kt
@@ -25,7 +25,7 @@ import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createArenaAdapterDatabaseTestSchema
-import no.nav.mulighetsrommet.domain.models.Deltaker
+import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
 import no.nav.mulighetsrommet.ktor.createMockEngine
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
 import no.nav.mulighetsrommet.ktor.respondJson
@@ -203,7 +203,7 @@ class TiltakdeltakerEndretConsumerTest : FunSpec({
                 val generatedId = engine.requestHistory.last().run {
                     method shouldBe HttpMethod.Put
 
-                    val deltaker = decodeRequestBody<Deltaker>().apply {
+                    val deltaker = decodeRequestBody<DeltakerDbo>().apply {
                         tiltaksgjennomforingId shouldBe tiltaksgjennomforing.id
                         norskIdent shouldBe "12345678910"
                     }
@@ -216,7 +216,7 @@ class TiltakdeltakerEndretConsumerTest : FunSpec({
                 engine.requestHistory.last().run {
                     method shouldBe HttpMethod.Delete
 
-                    decodeRequestBody<Deltaker>().apply {
+                    decodeRequestBody<DeltakerDbo>().apply {
                         id shouldBe generatedId
                     }
                 }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
@@ -22,7 +22,7 @@ import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createArenaAdapterDatabaseTestSchema
-import no.nav.mulighetsrommet.domain.models.Tiltaksgjennomforing
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.ktor.createMockEngine
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
 import no.nav.mulighetsrommet.ktor.respondJson
@@ -264,7 +264,7 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
                         method shouldBe HttpMethod.Put
 
                         val tiltaksgjennomforing =
-                            decodeRequestBody<Tiltaksgjennomforing>().apply {
+                            decodeRequestBody<TiltaksgjennomforingDbo>().apply {
                                 tiltakstypeId shouldBe tiltakstype.id
                                 tiltaksnummer shouldBe "2022#123"
                                 virksomhetsnummer shouldBe "123456"
@@ -292,7 +292,7 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
                 engine.requestHistory.last().run {
                     method shouldBe HttpMethod.Delete
 
-                    decodeRequestBody<Tiltaksgjennomforing>().apply {
+                    decodeRequestBody<TiltaksgjennomforingDbo>().apply {
                         id shouldBe generatedId
                     }
                 }


### PR DESCRIPTION
- Splitter opp tiltakstype, gjennomføring i egen Dbo og Dto og flytter Deltaker til Dbo
  - Gjør det litt enklere å resonnere rundt hvordan en entitet lagres på disk og hvordan en entitet ekponeres utad
  - Det gjenstår fortsatt å gjøre tilsvarende endringer for andre modeller, der det måtte være ønskelig (brukerhistorikk, del med bruker etc)
- Forenkler api'et ved kun å eksponere TiltaksgjennomforingDto, som inkluderer tiltakstypen, i stedet for å operere med to forskjellige views på gjennomføringer