### PR TITLE
:sparkles: Infomelding om å ikke dele personopplysninger

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -101,18 +101,25 @@ export function DelMedBrukerContent({
       )}
 
       {visPersonligMelding ? (
-        <Textarea
-          ref={personligHilsenRef}
-          className={delemodalStyles.personligHilsen}
-          size="medium"
-          value={state.hilsen}
-          label=""
-          hideLabel
-          onChange={redigerHilsen}
-          maxLength={MAKS_ANTALL_TEGN_HILSEN}
-          data-testid="textarea_hilsen"
-          error={handleError()}
-        />
+        <>
+          <Textarea
+            ref={personligHilsenRef}
+            className={delemodalStyles.personligHilsen}
+            size="medium"
+            value={state.hilsen}
+            label=""
+            hideLabel
+            onChange={redigerHilsen}
+            maxLength={MAKS_ANTALL_TEGN_HILSEN}
+            data-testid="textarea_hilsen"
+            error={handleError()}
+          />
+          <p>
+            <Alert inline variant="info">
+              Ikke del personopplysninger i din personlige hilsen
+            </Alert>
+          </p>
+        </>
       ) : null}
       {!veiledernavn && (
         <ErrorMessage className={delemodalStyles.feilmeldinger}>• Kunne ikke hente veileders navn</ErrorMessage>


### PR DESCRIPTION
Legger til en Alert variant=info som forteller veileder at de ikke må dele personopplysninger i fritekstfeltet.

![image](https://user-images.githubusercontent.com/9053627/210205016-a0f5217d-a661-4e2b-977b-8ef415ce0b1f.png)
