### PR TITLE
:sparkles: Eksponerer om tiltakstype har rett på tiltakspenger

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakstypeDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakstypeDbo.kt
@@ -1,9 +1,9 @@
 package no.nav.mulighetsrommet.domain.dbo
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.util.*
 
 @Serializable
@@ -12,9 +12,9 @@ data class TiltakstypeDbo(
     val id: UUID,
     val navn: String,
     val tiltakskode: String,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val fraDato: LocalDateTime? = null,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val tilDato: LocalDateTime? = null,
+    @Serializable(with = LocalDateSerializer::class)
+    val fraDato: LocalDate,
+    @Serializable(with = LocalDateSerializer::class)
+    val tilDato: LocalDate,
     val rettPaaTiltakspenger: Boolean
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakstypeDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakstypeDbo.kt
@@ -1,7 +1,9 @@
 package no.nav.mulighetsrommet.domain.dbo
 
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
+import java.time.LocalDateTime
 import java.util.*
 
 @Serializable
@@ -9,5 +11,10 @@ data class TiltakstypeDbo(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val navn: String,
-    val tiltakskode: String
+    val tiltakskode: String,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val fraDato: LocalDateTime? = null,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val tilDato: LocalDateTime? = null,
+    val rettPaaTiltakspenger: Boolean
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -10,7 +10,7 @@ import java.util.*
 data class TiltaksgjennomforingAdminDto(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    val tiltakstype: TiltakstypeDto,
+    val tiltakstype: Tiltakstype,
     val navn: String?,
     val tiltaksnummer: String,
     val virksomhetsnummer: String?,
@@ -19,4 +19,12 @@ data class TiltaksgjennomforingAdminDto(
     @Serializable(with = LocalDateSerializer::class)
     val sluttDato: LocalDate? = null,
     val enhet: String
-)
+) {
+    @Serializable
+    data class Tiltakstype(
+        @Serializable(with = UUIDSerializer::class)
+        val id: UUID,
+        val navn: String,
+        val arenaKode: String
+    )
+}

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
@@ -10,21 +10,36 @@ import java.util.*
 data class TiltaksgjennomforingDto(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    val tiltakstype: TiltakstypeDto,
+    val tiltakstype: Tiltakstype,
     val navn: String?,
     @Serializable(with = LocalDateSerializer::class)
     val startDato: LocalDate? = null,
     @Serializable(with = LocalDateSerializer::class)
-    val sluttDato: LocalDate? = null,
+    val sluttDato: LocalDate? = null
 ) {
+
+    @Serializable
+    data class Tiltakstype(
+        @Serializable(with = UUIDSerializer::class)
+        val id: UUID,
+        val navn: String,
+        val arenaKode: String
+    )
+
     companion object {
         fun from(tiltaksgjennomforing: TiltaksgjennomforingAdminDto) = tiltaksgjennomforing.run {
             TiltaksgjennomforingDto(
                 id = id,
-                tiltakstype = tiltakstype,
+                tiltakstype = tiltakstype.run {
+                    Tiltakstype(
+                        id = id,
+                        navn = navn,
+                        arenaKode = arenaKode
+                    )
+                },
                 navn = navn,
                 startDato = startDato,
-                sluttDato = sluttDato,
+                sluttDato = sluttDato
             )
         }
     }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltakstypeDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltakstypeDto.kt
@@ -2,7 +2,9 @@ package no.nav.mulighetsrommet.domain.dto
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
+import java.time.LocalDateTime
 import java.util.*
 
 @Serializable
@@ -10,14 +12,22 @@ data class TiltakstypeDto(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val navn: String,
-    val arenaKode: String
+    val arenaKode: String,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val fraDato: LocalDateTime? = null,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val tilDato: LocalDateTime? = null,
+    val rettPaaTiltakspenger: Boolean
 ) {
     companion object {
         fun from(tiltakstype: TiltakstypeDbo) = tiltakstype.run {
             TiltakstypeDto(
                 id = id,
                 navn = navn,
-                arenaKode = tiltakskode
+                arenaKode = tiltakskode,
+                fraDato = fraDato,
+                tilDato = tilDato,
+                rettPaaTiltakspenger = rettPaaTiltakspenger
             )
         }
     }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltakstypeDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltakstypeDto.kt
@@ -2,9 +2,9 @@ package no.nav.mulighetsrommet.domain.dto
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
-import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
+import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.util.*
 
 @Serializable
@@ -13,10 +13,10 @@ data class TiltakstypeDto(
     val id: UUID,
     val navn: String,
     val arenaKode: String,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val fraDato: LocalDateTime? = null,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val tilDato: LocalDateTime? = null,
+    @Serializable(with = LocalDateSerializer::class)
+    val fraDato: LocalDate,
+    @Serializable(with = LocalDateSerializer::class)
+    val tilDato: LocalDate,
     val rettPaaTiltakspenger: Boolean
 ) {
     companion object {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -9,7 +9,6 @@ import no.nav.mulighetsrommet.database.utils.QueryResult
 import no.nav.mulighetsrommet.database.utils.query
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingAdminDto
-import no.nav.mulighetsrommet.domain.dto.TiltakstypeDto
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -260,12 +259,10 @@ class TiltaksgjennomforingRepository(private val db: Database) {
 
     private fun Row.toTiltaksgjennomforingAdminDto() = TiltaksgjennomforingAdminDto(
         id = uuid("id"),
-        tiltakstype = TiltakstypeDto(
+        tiltakstype = TiltaksgjennomforingAdminDto.Tiltakstype(
             id = uuid("tiltakstype_id"),
             navn = string("tiltakstype_navn"),
-            arenaKode = string("tiltakskode"),
-            rettPaaTiltakspenger = true
-
+            arenaKode = string("tiltakskode")
         ),
         navn = stringOrNull("navn"),
         tiltaksnummer = string("tiltaksnummer"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -263,7 +263,9 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         tiltakstype = TiltakstypeDto(
             id = uuid("tiltakstype_id"),
             navn = string("tiltakstype_navn"),
-            arenaKode = string("tiltakskode")
+            arenaKode = string("tiltakskode"),
+            rettPaaTiltakspenger = true
+
         ),
         navn = stringOrNull("navn"),
         tiltaksnummer = string("tiltaksnummer"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
@@ -117,8 +117,8 @@ class TiltakstypeRepository(private val db: Database) {
         id = uuid("id"),
         navn = string("navn"),
         tiltakskode = string("tiltakskode"),
-        fraDato = localDateTimeOrNull("fra_dato"),
-        tilDato = localDateTimeOrNull("til_dato"),
+        fraDato = localDate("fra_dato"),
+        tilDato = localDate("til_dato"),
         rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger")
     )
 
@@ -126,8 +126,8 @@ class TiltakstypeRepository(private val db: Database) {
         id = uuid("id"),
         navn = string("navn"),
         arenaKode = string("tiltakskode"),
-        fraDato = localDateTimeOrNull("fra_dato"),
-        tilDato = localDateTimeOrNull("til_dato"),
+        fraDato = localDate("fra_dato"),
+        tilDato = localDate("til_dato"),
         rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger")
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
@@ -21,11 +21,14 @@ class TiltakstypeRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            insert into tiltakstype (id, navn, tiltakskode)
-            values (:id::uuid, :navn, :tiltakskode)
+            insert into tiltakstype (id, navn, tiltakskode, fra_dato, til_dato, rett_paa_tiltakspenger)
+            values (:id::uuid, :navn, :tiltakskode, :fra_dato, :til_dato, :rett_paa_tiltakspenger)
             on conflict (id)
                 do update set navn        = excluded.navn,
-                              tiltakskode = excluded.tiltakskode
+                              tiltakskode = excluded.tiltakskode,
+                              fra_dato = excluded.fra_dato,
+                              til_dato = excluded.til_dato,
+                              rett_paa_tiltakspenger = excluded.rett_paa_tiltakspenger
             returning *
         """.trimIndent()
 
@@ -38,7 +41,7 @@ class TiltakstypeRepository(private val db: Database) {
     fun get(id: UUID): TiltakstypeDto? {
         @Language("PostgreSQL")
         val query = """
-            select id::uuid, navn, tiltakskode
+            select id::uuid, navn, tiltakskode, fra_dato, til_dato, rett_paa_tiltakspenger
             from tiltakstype
             where id = ?::uuid
         """.trimIndent()
@@ -62,7 +65,7 @@ class TiltakstypeRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            select id, navn, tiltakskode, count(*) OVER() AS full_count
+            select id, navn, tiltakskode, fra_dato, til_dato, rett_paa_tiltakspenger, count(*) OVER() AS full_count
             from tiltakstype
             $where
             limit :limit
@@ -104,18 +107,27 @@ class TiltakstypeRepository(private val db: Database) {
     private fun TiltakstypeDbo.toSqlParameters() = mapOf(
         "id" to id,
         "navn" to navn,
-        "tiltakskode" to tiltakskode
+        "tiltakskode" to tiltakskode,
+        "fra_dato" to fraDato,
+        "til_dato" to tilDato,
+        "rett_paa_tiltakspenger" to rettPaaTiltakspenger
     )
 
     private fun Row.toTiltakstypeDbo() = TiltakstypeDbo(
         id = uuid("id"),
         navn = string("navn"),
-        tiltakskode = string("tiltakskode")
+        tiltakskode = string("tiltakskode"),
+        fraDato = localDateTimeOrNull("fra_dato"),
+        tilDato = localDateTimeOrNull("til_dato"),
+        rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger")
     )
 
     private fun Row.toTiltakstypeDto() = TiltakstypeDto(
         id = uuid("id"),
         navn = string("navn"),
-        arenaKode = string("tiltakskode")
+        arenaKode = string("tiltakskode"),
+        fraDato = localDateTimeOrNull("fra_dato"),
+        tilDato = localDateTimeOrNull("til_dato"),
+        rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger")
     )
 }

--- a/mulighetsrommet-api/src/main/resources/db/migration/V19__add_rettPaaTiltakspenger_to_tiltakstype.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V19__add_rettPaaTiltakspenger_to_tiltakstype.sql
@@ -1,0 +1,4 @@
+alter table tiltakstype
+    add column rett_paa_tiltakspenger bool,
+    add column fra_dato      timestamp,
+    add column til_dato      timestamp;

--- a/mulighetsrommet-api/src/main/resources/db/migration/V19__add_rettPaaTiltakspenger_to_tiltakstype.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V19__add_rettPaaTiltakspenger_to_tiltakstype.sql
@@ -2,3 +2,11 @@ alter table tiltakstype
     add column rett_paa_tiltakspenger bool,
     add column fra_dato      timestamp,
     add column til_dato      timestamp;
+
+update tiltakstype
+    set fra_dato = now(),
+        til_dato = now();
+
+alter table tiltakstype
+    alter column fra_dato set not null,
+    alter column til_dato set not null;

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -24,13 +24,15 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
     val tiltakstype1 = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Arbeidstrening",
-        tiltakskode = "ARBTREN"
+        tiltakskode = "ARBTREN",
+        rettPaaTiltakspenger = true
     )
 
     val tiltakstype2 = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Oppfølging",
-        tiltakskode = "INDOPPFOLG"
+        tiltakskode = "INDOPPFOLG",
+        rettPaaTiltakspenger = true
     )
 
     val tiltak1 = TiltaksgjennomforingDbo(
@@ -73,6 +75,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     id = tiltakstype1.id,
                     navn = tiltakstype1.navn,
                     arenaKode = tiltakstype1.tiltakskode,
+                    rettPaaTiltakspenger = true
                 ),
                 navn = tiltak1.navn,
                 tiltaksnummer = tiltak1.tiltaksnummer,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -11,7 +11,6 @@ import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSc
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingAdminDto
-import no.nav.mulighetsrommet.domain.dto.TiltakstypeDto
 import java.time.LocalDate
 import java.util.*
 
@@ -25,14 +24,18 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         id = UUID.randomUUID(),
         navn = "Arbeidstrening",
         tiltakskode = "ARBTREN",
-        rettPaaTiltakspenger = true
+        rettPaaTiltakspenger = true,
+        fraDato = LocalDate.of(2023, 1, 11),
+        tilDato = LocalDate.of(2023, 1, 12)
     )
 
     val tiltakstype2 = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Oppfølging",
         tiltakskode = "INDOPPFOLG",
-        rettPaaTiltakspenger = true
+        rettPaaTiltakspenger = true,
+        fraDato = LocalDate.of(2023, 1, 11),
+        tilDato = LocalDate.of(2023, 1, 12)
     )
 
     val tiltak1 = TiltaksgjennomforingDbo(
@@ -71,11 +74,10 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             tiltaksgjennomforinger.getAll().second shouldHaveSize 2
             tiltaksgjennomforinger.get(tiltak1.id) shouldBe TiltaksgjennomforingAdminDto(
                 id = tiltak1.id,
-                tiltakstype = TiltakstypeDto(
+                tiltakstype = TiltaksgjennomforingAdminDto.Tiltakstype(
                     id = tiltakstype1.id,
                     navn = tiltakstype1.navn,
                     arenaKode = tiltakstype1.tiltakskode,
-                    rettPaaTiltakspenger = true
                 ),
                 navn = tiltak1.navn,
                 tiltaksnummer = tiltak1.tiltaksnummer,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
@@ -24,14 +24,16 @@ class TiltakstypeRepositoryTest : FunSpec({
             TiltakstypeDbo(
                 id = UUID.randomUUID(),
                 navn = "Arbeidstrening",
-                tiltakskode = "ARBTREN"
+                tiltakskode = "ARBTREN",
+                rettPaaTiltakspenger = true
             )
         )
         tiltakstyper.upsert(
             TiltakstypeDbo(
                 id = UUID.randomUUID(),
                 navn = "Oppfølging",
-                tiltakskode = "INDOPPFOLG"
+                tiltakskode = "INDOPPFOLG",
+                rettPaaTiltakspenger = true
             )
         )
 
@@ -51,7 +53,8 @@ class TiltakstypeRepositoryTest : FunSpec({
                 TiltakstypeDbo(
                     id = UUID.randomUUID(),
                     navn = "$it",
-                    tiltakskode = "$it"
+                    tiltakskode = "$it",
+                    rettPaaTiltakspenger = true
                 )
             )
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
@@ -9,6 +9,7 @@ import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
+import java.time.LocalDate
 import java.util.*
 
 class TiltakstypeRepositoryTest : FunSpec({
@@ -25,7 +26,9 @@ class TiltakstypeRepositoryTest : FunSpec({
                 id = UUID.randomUUID(),
                 navn = "Arbeidstrening",
                 tiltakskode = "ARBTREN",
-                rettPaaTiltakspenger = true
+                rettPaaTiltakspenger = true,
+                fraDato = LocalDate.of(2023, 1, 11),
+                tilDato = LocalDate.of(2023, 1, 12)
             )
         )
         tiltakstyper.upsert(
@@ -33,7 +36,9 @@ class TiltakstypeRepositoryTest : FunSpec({
                 id = UUID.randomUUID(),
                 navn = "Oppfølging",
                 tiltakskode = "INDOPPFOLG",
-                rettPaaTiltakspenger = true
+                rettPaaTiltakspenger = true,
+                fraDato = LocalDate.of(2023, 1, 11),
+                tilDato = LocalDate.of(2023, 1, 12)
             )
         )
 
@@ -54,7 +59,9 @@ class TiltakstypeRepositoryTest : FunSpec({
                     id = UUID.randomUUID(),
                     navn = "$it",
                     tiltakskode = "$it",
-                    rettPaaTiltakspenger = true
+                    rettPaaTiltakspenger = true,
+                    fraDato = LocalDate.of(2023, 1, 11),
+                    tilDato = LocalDate.of(2023, 1, 12)
                 )
             )
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
@@ -40,7 +40,8 @@ class ArenaServiceTest : FunSpec({
     val tiltakstype = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Oppfølging",
-        tiltakskode = "INDOPPFAG"
+        tiltakskode = "INDOPPFAG",
+        rettPaaTiltakspenger = true
     )
 
     val tiltaksgjennomforing = TiltaksgjennomforingDbo(
@@ -66,7 +67,8 @@ class ArenaServiceTest : FunSpec({
     val tiltakstypeIndividuell = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Høyere utdanning",
-        tiltakskode = "HOYEREUTD"
+        tiltakskode = "HOYEREUTD",
+        rettPaaTiltakspenger = true
     )
 
     val tiltakshistorikkIndividuell = TiltakshistorikkDbo.IndividueltTiltak(
@@ -86,7 +88,8 @@ class ArenaServiceTest : FunSpec({
             tiltakstype = TiltakstypeDto(
                 id = tiltakstypeId,
                 navn = tiltakstype.navn,
-                arenaKode = tiltakstype.tiltakskode
+                arenaKode = tiltakstype.tiltakskode,
+                rettPaaTiltakspenger = true
             ),
             navn = navn,
             tiltaksnummer = tiltaksnummer,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaServiceTest.kt
@@ -41,7 +41,9 @@ class ArenaServiceTest : FunSpec({
         id = UUID.randomUUID(),
         navn = "Oppfølging",
         tiltakskode = "INDOPPFAG",
-        rettPaaTiltakspenger = true
+        rettPaaTiltakspenger = true,
+        fraDato = LocalDate.of(2023, 1, 11),
+        tilDato = LocalDate.of(2023, 1, 12)
     )
 
     val tiltaksgjennomforing = TiltaksgjennomforingDbo(
@@ -68,7 +70,9 @@ class ArenaServiceTest : FunSpec({
         id = UUID.randomUUID(),
         navn = "Høyere utdanning",
         tiltakskode = "HOYEREUTD",
-        rettPaaTiltakspenger = true
+        rettPaaTiltakspenger = true,
+        fraDato = LocalDate.of(2023, 1, 11),
+        tilDato = LocalDate.of(2023, 1, 12)
     )
 
     val tiltakshistorikkIndividuell = TiltakshistorikkDbo.IndividueltTiltak(
@@ -85,11 +89,10 @@ class ArenaServiceTest : FunSpec({
     val tiltaksgjennomforingDto = tiltaksgjennomforing.run {
         TiltaksgjennomforingAdminDto(
             id = id,
-            tiltakstype = TiltakstypeDto(
+            tiltakstype = TiltaksgjennomforingAdminDto.Tiltakstype(
                 id = tiltakstypeId,
                 navn = tiltakstype.navn,
                 arenaKode = tiltakstype.tiltakskode,
-                rettPaaTiltakspenger = true
             ),
             navn = navn,
             tiltaksnummer = tiltaksnummer,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.mulighetsrommet.domain.dbo.TiltakshistorikkDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import no.nav.mulighetsrommet.domain.dto.Deltakerstatus
 import no.nav.mulighetsrommet.domain.models.TiltakshistorikkDTO
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -32,7 +33,9 @@ class HistorikkServiceTest : FunSpec({
         id = UUID.randomUUID(),
         navn = "Arbeidstrening",
         tiltakskode = "ARBTREN",
-        rettPaaTiltakspenger = true
+        rettPaaTiltakspenger = true,
+        fraDato = LocalDate.of(2023, 1, 11),
+        tilDato = LocalDate.of(2023, 1, 12)
     )
 
     val tiltaksgjennomforing = TiltaksgjennomforingDbo(
@@ -57,7 +60,9 @@ class HistorikkServiceTest : FunSpec({
         id = UUID.randomUUID(),
         navn = "Høyere utdanning",
         tiltakskode = "HOYEREUTD",
-        rettPaaTiltakspenger = true
+        rettPaaTiltakspenger = true,
+        fraDato = LocalDate.of(2023, 1, 11),
+        tilDato = LocalDate.of(2023, 1, 12)
     )
 
     val tiltakshistorikkIndividuell = TiltakshistorikkDbo.IndividueltTiltak(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/HistorikkServiceTest.kt
@@ -31,7 +31,8 @@ class HistorikkServiceTest : FunSpec({
     val tiltakstype = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Arbeidstrening",
-        tiltakskode = "ARBTREN"
+        tiltakskode = "ARBTREN",
+        rettPaaTiltakspenger = true
     )
 
     val tiltaksgjennomforing = TiltaksgjennomforingDbo(
@@ -55,7 +56,8 @@ class HistorikkServiceTest : FunSpec({
     val tiltakstypeIndividuell = TiltakstypeDbo(
         id = UUID.randomUUID(),
         navn = "Høyere utdanning",
-        tiltakskode = "HOYEREUTD"
+        tiltakskode = "HOYEREUTD",
+        rettPaaTiltakspenger = true
     )
 
     val tiltakshistorikkIndividuell = TiltakshistorikkDbo.IndividueltTiltak(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListe
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
+import java.time.LocalDate
 import java.util.*
 
 class TiltaksgjennomforingServiceTest : FunSpec({
@@ -27,7 +28,9 @@ class TiltaksgjennomforingServiceTest : FunSpec({
                 tiltakstypeId,
                 "",
                 "",
-                rettPaaTiltakspenger = true
+                rettPaaTiltakspenger = true,
+                fraDato = LocalDate.of(2023, 1, 11),
+                tilDato = LocalDate.of(2023, 1, 12)
             )
         )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
@@ -26,7 +26,8 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             TiltakstypeDbo(
                 tiltakstypeId,
                 "",
-                ""
+                "",
+                rettPaaTiltakspenger = true
             )
         )
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -1,6 +1,8 @@
 package no.nav.mulighetsrommet.arena.adapter.consumers
 
+import arrow.core.Either
 import arrow.core.continuations.either
+import arrow.core.flatMap
 import io.ktor.http.*
 import kotlinx.serialization.json.JsonElement
 import no.nav.mulighetsrommet.arena.adapter.ConsumerConfig
@@ -23,7 +25,7 @@ class TiltakEndretConsumer(
     override val config: ConsumerConfig,
     override val events: ArenaEventRepository,
     private val entities: ArenaEntityService,
-    private val client: MulighetsrommetApiClient,
+    private val client: MulighetsrommetApiClient
 ) : ArenaTopicConsumer(
     ArenaTables.Tiltakstype
 ) {
@@ -37,7 +39,7 @@ class TiltakEndretConsumer(
             arenaTable = decoded.table,
             arenaId = decoded.data.TILTAKSKODE,
             payload = payload,
-            status = ArenaEvent.ConsumptionStatus.Pending,
+            status = ArenaEvent.ConsumptionStatus.Pending
         )
     }
 
@@ -47,7 +49,7 @@ class TiltakEndretConsumer(
         val mapping = entities.getOrCreateMapping(event)
         val tiltakstype = decoded.data
             .toTiltakstype(mapping.entityId)
-            .let { entities.upsertTiltakstype(it) }
+            .flatMap { entities.upsertTiltakstype(it) }
             .bind()
 
         val method = if (decoded.operation == ArenaEventData.Operation.Delete) HttpMethod.Delete else HttpMethod.Put
@@ -57,21 +59,25 @@ class TiltakEndretConsumer(
             .bind()
     }
 
-    private fun ArenaTiltak.toTiltakstype(id: UUID) = Tiltakstype(
-        id = id,
-        navn = TILTAKSNAVN,
-        tiltakskode = TILTAKSKODE,
-        fraDato = ArenaUtils.parseNullableTimestamp(DATO_FRA),
-        tilDato = ArenaUtils.parseNullableTimestamp(DATO_TIL),
-        rettPaaTiltakspenger = ArenaUtils.jaNeiTilBoolean(STATUS_BASISYTELSE)
-    )
+    private fun ArenaTiltak.toTiltakstype(id: UUID): Either<ConsumptionError, Tiltakstype> {
+        return Either.catch {
+            Tiltakstype(
+                id = id,
+                navn = TILTAKSNAVN,
+                tiltakskode = TILTAKSKODE,
+                fraDato = ArenaUtils.parseTimestamp(DATO_FRA),
+                tilDato = ArenaUtils.parseTimestamp(DATO_TIL),
+                rettPaaTiltakspenger = ArenaUtils.jaNeiTilBoolean(STATUS_BASISYTELSE)
+            )
+        }.mapLeft { ConsumptionError.InvalidPayload(it.localizedMessage) }
+    }
 
     private fun Tiltakstype.toDomain() = MrTiltakstype(
         id = id,
         navn = navn,
         tiltakskode = tiltakskode,
-        fraDato = fraDato,
-        tilDato = tilDato,
+        fraDato = fraDato.toLocalDate(),
+        tilDato = tilDato.toLocalDate(),
         rettPaaTiltakspenger = rettPaaTiltakspenger
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumer.kt
@@ -62,12 +62,16 @@ class TiltakEndretConsumer(
         navn = TILTAKSNAVN,
         tiltakskode = TILTAKSKODE,
         fraDato = ArenaUtils.parseNullableTimestamp(DATO_FRA),
-        tilDato = ArenaUtils.parseNullableTimestamp(DATO_TIL)
+        tilDato = ArenaUtils.parseNullableTimestamp(DATO_TIL),
+        rettPaaTiltakspenger = ArenaUtils.jaNeiTilBoolean(STATUS_BASISYTELSE)
     )
 
     private fun Tiltakstype.toDomain() = MrTiltakstype(
         id = id,
         navn = navn,
         tiltakskode = tiltakskode,
+        fraDato = fraDato,
+        tilDato = tilDato,
+        rettPaaTiltakspenger = rettPaaTiltakspenger
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltak.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltak.kt
@@ -8,4 +8,5 @@ data class ArenaTiltak(
     val TILTAKSKODE: String,
     val DATO_FRA: String?,
     val DATO_TIL: String?,
+    val STATUS_BASISYTELSE: String
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltak.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltak.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 data class ArenaTiltak(
     val TILTAKSNAVN: String,
     val TILTAKSKODE: String,
-    val DATO_FRA: String?,
-    val DATO_TIL: String?,
+    val DATO_FRA: String,
+    val DATO_TIL: String,
     val STATUS_BASISYTELSE: String
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltakstype.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltakstype.kt
@@ -15,5 +15,6 @@ data class Tiltakstype(
     @Serializable(with = LocalDateTimeSerializer::class)
     val fraDato: LocalDateTime? = null,
     @Serializable(with = LocalDateTimeSerializer::class)
-    val tilDato: LocalDateTime? = null
+    val tilDato: LocalDateTime? = null,
+    val rettPaaTiltakspenger: Boolean
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltakstype.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltakstype.kt
@@ -13,8 +13,8 @@ data class Tiltakstype(
     val navn: String,
     val tiltakskode: String,
     @Serializable(with = LocalDateTimeSerializer::class)
-    val fraDato: LocalDateTime? = null,
+    val fraDato: LocalDateTime,
     @Serializable(with = LocalDateTimeSerializer::class)
-    val tilDato: LocalDateTime? = null,
+    val tilDato: LocalDateTime,
     val rettPaaTiltakspenger: Boolean
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/TiltakstypeRepository.kt
@@ -19,13 +19,14 @@ class TiltakstypeRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            insert into tiltakstype (id, navn, tiltakskode, fra_dato, til_dato)
-            values (:id::uuid, :navn, :tiltakskode, :fra_dato, :til_dato)
+            insert into tiltakstype (id, navn, tiltakskode, fra_dato, til_dato, rett_paa_tiltakspenger)
+            values (:id::uuid, :navn, :tiltakskode, :fra_dato, :til_dato, :rett_paa_tiltakspenger)
             on conflict (id)
                 do update set navn          = excluded.navn,
                               tiltakskode   = excluded.tiltakskode,
                               fra_dato      = excluded.fra_dato,
-                              til_dato      = excluded.til_dato
+                              til_dato      = excluded.til_dato,
+                              rett_paa_tiltakspenger = excluded.rett_paa_tiltakspenger
             returning *
         """.trimIndent()
 
@@ -54,7 +55,7 @@ class TiltakstypeRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            select id, navn, tiltakskode, fra_dato, til_dato
+            select id, navn, tiltakskode, fra_dato, til_dato, rett_paa_tiltakspenger
             from tiltakstype
             where id = ?::uuid
         """.trimIndent()
@@ -71,6 +72,7 @@ class TiltakstypeRepository(private val db: Database) {
         "tiltakskode" to tiltakskode,
         "fra_dato" to fraDato,
         "til_dato" to tilDato,
+        "rett_paa_tiltakspenger" to rettPaaTiltakspenger
     )
 
     private fun Row.toSak() = Tiltakstype(
@@ -78,6 +80,7 @@ class TiltakstypeRepository(private val db: Database) {
         navn = string("navn"),
         tiltakskode = string("tiltakskode"),
         fraDato = localDateTimeOrNull("fra_dato"),
-        tilDato = localDateTimeOrNull("til_dato")
+        tilDato = localDateTimeOrNull("til_dato"),
+        rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger")
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/TiltakstypeRepository.kt
@@ -31,7 +31,7 @@ class TiltakstypeRepository(private val db: Database) {
         """.trimIndent()
 
         queryOf(query, tiltak.toSqlParameters())
-            .map { it.toSak() }
+            .map { it.toTiltakstype() }
             .asSingle
             .let { db.run(it)!! }
     }
@@ -61,7 +61,7 @@ class TiltakstypeRepository(private val db: Database) {
         """.trimIndent()
 
         return queryOf(query, id)
-            .map { it.toSak() }
+            .map { it.toTiltakstype() }
             .asSingle
             .let { db.run(it) }
     }
@@ -75,12 +75,12 @@ class TiltakstypeRepository(private val db: Database) {
         "rett_paa_tiltakspenger" to rettPaaTiltakspenger
     )
 
-    private fun Row.toSak() = Tiltakstype(
+    private fun Row.toTiltakstype() = Tiltakstype(
         id = uuid("id"),
         navn = string("navn"),
         tiltakskode = string("tiltakskode"),
-        fraDato = localDateTimeOrNull("fra_dato"),
-        tilDato = localDateTimeOrNull("til_dato"),
+        fraDato = localDateTime("fra_dato"),
+        tilDato = localDateTime("til_dato"),
         rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger")
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ArenaUtils.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ArenaUtils.kt
@@ -26,4 +26,12 @@ object ArenaUtils {
         "DELAVB", "GJENN_AVB", "GJENN_AVL", "FULLF", "IKKEM" -> Deltakerstatus.AVSLUTTET
         else -> throw Exception("Ukjent deltakerstatus fra Arena")
     }
+
+    fun jaNeiTilBoolean(statusBasisytelse: String): Boolean {
+        return when (statusBasisytelse) {
+            "J" -> true
+            "N" -> false
+            else -> throw Exception("Ukjent verdi ved konvertering av J/N til boolean")
+        }
+    }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ArenaUtils.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/utils/ArenaUtils.kt
@@ -27,11 +27,11 @@ object ArenaUtils {
         else -> throw Exception("Ukjent deltakerstatus fra Arena")
     }
 
-    fun jaNeiTilBoolean(statusBasisytelse: String): Boolean {
-        return when (statusBasisytelse) {
+    fun jaNeiTilBoolean(jaNeiStreng: String): Boolean {
+        return when (jaNeiStreng) {
             "J" -> true
             "N" -> false
-            else -> throw Exception("Ukjent verdi ved konvertering av J/N til boolean")
+            else -> throw Exception("Ukjent verdi ved konvertering av J/N-streng til boolean")
         }
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V21__add_rettPaaTiltakspenger_to_tiltakstype.sql
+++ b/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V21__add_rettPaaTiltakspenger_to_tiltakstype.sql
@@ -1,0 +1,2 @@
+alter table tiltakstype
+    add column rett_paa_tiltakspenger bool;

--- a/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V21__add_rettPaaTiltakspenger_to_tiltakstype.sql
+++ b/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V21__add_rettPaaTiltakspenger_to_tiltakstype.sql
@@ -1,2 +1,4 @@
 alter table tiltakstype
-    add column rett_paa_tiltakspenger bool;
+    add column rett_paa_tiltakspenger bool,
+    alter column fra_dato set not null,
+    alter column til_dato set not null;

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumerTest.kt
@@ -131,8 +131,8 @@ private fun createEvent(operation: ArenaEventData.Operation = Insert, name: Stri
     """{
         "TILTAKSNAVN": "$name",
         "TILTAKSKODE": "INDOPPFAG",
-        "DATO_FRA": null,
-        "DATO_TIL": null,
+        "DATO_FRA": "2022-01-11 00:00:00",
+        "DATO_TIL": "2022-01-15 00:00:00",
         "STATUS_BASISYTELSE": "J"
     }"""
 )

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumerTest.kt
@@ -52,6 +52,9 @@ class TiltakEndretConsumerTest : FunSpec({
         e3.status shouldBe Processed
         database.assertThat("tiltakstype")
             .row().value("navn").isEqualTo("Oppfølging 1")
+
+        database.assertThat("tiltakstype")
+            .row().value("rett_paa_tiltakspenger").isEqualTo(true)
     }
 
     context("api responses") {
@@ -66,6 +69,7 @@ class TiltakEndretConsumerTest : FunSpec({
 
                 val tiltakstype = decodeRequestBody<TiltakstypeDbo>().apply {
                     navn shouldBe "Oppfølging"
+                    rettPaaTiltakspenger shouldBe true
                 }
 
                 tiltakstype.id
@@ -109,7 +113,7 @@ private fun createConsumer(db: Database, engine: HttpClientEngine): TiltakEndret
         tiltakstyper = TiltakstypeRepository(db),
         saker = SakRepository(db),
         tiltaksgjennomforinger = TiltaksgjennomforingRepository(db),
-        deltakere = DeltakerRepository(db),
+        deltakere = DeltakerRepository(db)
     )
 
     return TiltakEndretConsumer(
@@ -128,6 +132,7 @@ private fun createEvent(operation: ArenaEventData.Operation = Insert, name: Stri
         "TILTAKSNAVN": "$name",
         "TILTAKSKODE": "INDOPPFAG",
         "DATO_FRA": null,
-        "DATO_TIL": null
+        "DATO_TIL": null,
+        "STATUS_BASISYTELSE": "J"
     }"""
 )

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakEndretConsumerTest.kt
@@ -20,6 +20,7 @@ import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListe
 import no.nav.mulighetsrommet.database.kotest.extensions.createArenaAdapterDatabaseTestSchema
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
+import java.time.LocalDate
 
 class TiltakEndretConsumerTest : FunSpec({
 
@@ -55,6 +56,12 @@ class TiltakEndretConsumerTest : FunSpec({
 
         database.assertThat("tiltakstype")
             .row().value("rett_paa_tiltakspenger").isEqualTo(true)
+
+        database.assertThat("tiltakstype")
+            .row().value("fra_dato").isEqualTo(LocalDate.of(2022, 1, 11))
+
+        database.assertThat("tiltakstype")
+            .row().value("til_dato").isEqualTo(LocalDate.of(2022, 1, 15))
     }
 
     context("api responses") {

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumerTest.kt
@@ -33,6 +33,7 @@ import no.nav.mulighetsrommet.domain.dbo.TiltakshistorikkDbo
 import no.nav.mulighetsrommet.ktor.createMockEngine
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
 import no.nav.mulighetsrommet.ktor.respondJson
+import java.time.LocalDateTime
 import java.util.*
 
 class TiltakdeltakerEndretConsumerTest : FunSpec({
@@ -72,13 +73,17 @@ class TiltakdeltakerEndretConsumerTest : FunSpec({
             id = UUID.randomUUID(),
             navn = "Oppfølging",
             tiltakskode = "INDOPPFAG",
-            rettPaaTiltakspenger = true
+            rettPaaTiltakspenger = true,
+            fraDato = LocalDateTime.of(2023, 1, 11, 0, 0, 0),
+            tilDato = LocalDateTime.of(2023, 1, 12, 0, 0, 0)
         )
         val tiltakstypeIndividuell = Tiltakstype(
             id = UUID.randomUUID(),
             navn = "Høyere utdanning",
             tiltakskode = "HOYEREUTD",
-            rettPaaTiltakspenger = true
+            rettPaaTiltakspenger = true,
+            fraDato = LocalDateTime.of(2023, 1, 11, 0, 0, 0),
+            tilDato = LocalDateTime.of(2023, 1, 12, 0, 0, 0)
         )
         val sak = Sak(
             sakId = 1,

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakdeltakerEndretConsumerTest.kt
@@ -71,12 +71,14 @@ class TiltakdeltakerEndretConsumerTest : FunSpec({
         val tiltakstypeGruppe = Tiltakstype(
             id = UUID.randomUUID(),
             navn = "Oppfølging",
-            tiltakskode = "INDOPPFAG"
+            tiltakskode = "INDOPPFAG",
+            rettPaaTiltakspenger = true
         )
         val tiltakstypeIndividuell = Tiltakstype(
             id = UUID.randomUUID(),
             navn = "Høyere utdanning",
-            tiltakskode = "HOYEREUTD"
+            tiltakskode = "HOYEREUTD",
+            rettPaaTiltakspenger = true
         )
         val sak = Sak(
             sakId = 1,

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
@@ -30,6 +30,7 @@ import no.nav.mulighetsrommet.ktor.createMockEngine
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
 import no.nav.mulighetsrommet.ktor.respondJson
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.*
 
 class TiltakgjennomforingEndretConsumerTest : FunSpec({
@@ -61,7 +62,9 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
                     id = UUID.randomUUID(),
                     navn = "Oppfølging",
                     tiltakskode = "INDOPPFAG",
-                    rettPaaTiltakspenger = true
+                    rettPaaTiltakspenger = true,
+                    fraDato = LocalDateTime.of(2023, 1, 11, 0, 0, 0),
+                    tilDato = LocalDateTime.of(2023, 1, 12, 0, 0, 0)
                 )
             )
 
@@ -104,7 +107,9 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
             id = UUID.randomUUID(),
             navn = "AMO",
             tiltakskode = "AMO",
-            rettPaaTiltakspenger = false
+            rettPaaTiltakspenger = false,
+            fraDato = LocalDateTime.of(2023, 1, 11, 0, 0, 0),
+            tilDato = LocalDateTime.of(2023, 1, 12, 0, 0, 0)
         )
 
         beforeEach {
@@ -166,7 +171,9 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
             id = UUID.randomUUID(),
             navn = "Oppfølging",
             tiltakskode = "INDOPPFAG",
-            rettPaaTiltakspenger = true
+            rettPaaTiltakspenger = true,
+            fraDato = LocalDateTime.of(2023, 1, 11, 0, 0, 0),
+            tilDato = LocalDateTime.of(2023, 1, 12, 0, 0, 0)
         )
 
         beforeEach {

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/consumers/TiltakgjennomforingEndretConsumerTest.kt
@@ -60,7 +60,8 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
                 Tiltakstype(
                     id = UUID.randomUUID(),
                     navn = "Oppfølging",
-                    tiltakskode = "INDOPPFAG"
+                    tiltakskode = "INDOPPFAG",
+                    rettPaaTiltakspenger = true
                 )
             )
 
@@ -102,7 +103,8 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
         val tiltakstype = Tiltakstype(
             id = UUID.randomUUID(),
             navn = "AMO",
-            tiltakskode = "AMO"
+            tiltakskode = "AMO",
+            rettPaaTiltakspenger = false
         )
 
         beforeEach {
@@ -163,7 +165,8 @@ class TiltakgjennomforingEndretConsumerTest : FunSpec({
         val tiltakstype = Tiltakstype(
             id = UUID.randomUUID(),
             navn = "Oppfølging",
-            tiltakskode = "INDOPPFAG"
+            tiltakskode = "INDOPPFAG",
+            rettPaaTiltakspenger = true
         )
 
         beforeEach {


### PR DESCRIPTION
Henter ut feltet `STATUS_BASISYTELSE` fra Kafka-data fra Arena. Eksponerer dette, sammen med fra- og til-dato for en tiltakstype slik at Team Tiltakspenger (TP) kan få tak i den dataen via vår Kafka-topic for siste-tiltakstyper.