### PR TITLE
WIP Ta i mot tiltakstypedata til backend

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/OpprettTiltakstypeDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/OpprettTiltakstypeDto.kt
@@ -1,0 +1,73 @@
+package no.nav.mulighetsrommet.domain.dto
+
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
+import java.time.LocalDate
+
+@Serializable
+data class OpprettTiltakstypeDto(
+    val tiltakstypenavn: String,
+    @Serializable(with = LocalDateSerializer::class)
+    val fraDato: LocalDate,
+    @Serializable(with = LocalDateSerializer::class)
+    val tilDato: LocalDate,
+    val tiltaksgruppekode: Tiltaksgruppekode,
+    val tiltakskode: String,
+    val rettTilTiltakspenger: Boolean,
+    val administrasjonskode: Administrasjonskode,
+    val kopiAvTilsagnsbrev: Boolean,
+    val harAnskaffelse: Boolean,
+    val rammeavtale: Rammeavtale? = null,
+    val opplaringsgruppe: Opplaringsgruppe,
+    val handlingsplan: Handlingsplan,
+    val harObligatoriskSluttdato: Boolean,
+    val harStatusSluttdato: Boolean,
+    val harStatusMeldeplikt: Boolean,
+    val harStatusVedtak: Boolean,
+    val harStatusIAAvtale: Boolean,
+    val harStatusTilleggstonad: Boolean,
+    val harStatusUtdanning: Boolean,
+    val harAutomatiskTilsagnsbrev: Boolean,
+    val harStatusBegrunnelseInnsok: Boolean,
+    val harStatusHenvisningsbrev: Boolean,
+    val harStatusKopibrev: Boolean
+)
+
+@Serializable
+enum class Tiltaksgruppekode {
+    AFT,
+    AMB,
+    ARBPRAKS,
+    ARBRREHAB,
+    ARBTREN,
+    AVKLARING,
+    BEHPSSAM,
+    ETAB,
+    FORSOK,
+    LONNTILS,
+    OPPFOLG,
+    OPPL,
+    TILRETTE,
+    UTFAS,
+    VARIGASV,
+}
+
+@Serializable
+enum class Administrasjonskode {
+    AMO, IND, INST
+}
+
+@Serializable
+enum class Rammeavtale {
+    SKAL, KAN, IKKE
+}
+
+@Serializable
+enum class Opplaringsgruppe {
+    AMO, UTD
+}
+
+@Serializable
+enum class Handlingsplan {
+    SOK, LAG, TIL
+}

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/opprett-tiltakstyper/OpprettTiltakstypeComponents.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/opprett-tiltakstyper/OpprettTiltakstypeComponents.tsx
@@ -8,7 +8,7 @@ import {
 } from "@navikt/ds-react";
 import { FieldHookConfig, useField } from "formik";
 import { SchemaValues } from "./OpprettTiltakstypeSchemaValidation";
-import { formaterDato } from "../../../utils/Utils";
+import { datoStrengUtenTid, formaterDato } from "../../../utils/Utils";
 
 export function Tekstfelt({
   label,
@@ -74,8 +74,8 @@ export function Datovelger() {
   const { datepickerProps, toInputProps, fromInputProps } =
     UNSAFE_useRangeDatepicker({
       onRangeChange: (val) => {
-        fraDatoHelper.setValue(formaterDato(val?.from));
-        tilDatoHelper.setValue(formaterDato(val?.to));
+        fraDatoHelper.setValue(datoStrengUtenTid(val?.from));
+        tilDatoHelper.setValue(datoStrengUtenTid(val?.to));
       },
     });
 

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -19,3 +19,15 @@ export function formaterDato(dato?: string | Date, fallback = ""): string {
 
   return result;
 }
+
+const zeroPad = (value: number): string => {
+  return value < 10 ? `0${value}` : value.toString();
+};
+
+export const datoStrengUtenTid = (date?: Date): string => {
+  if (!date) return "";
+
+  return `${date.getUTCFullYear()}-${zeroPad(date.getUTCMonth() + 1)}-${zeroPad(
+    date.getUTCDay()
+  )}`;
+};

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
@@ -2,12 +2,14 @@ package no.nav.mulighetsrommet.api.routes.v1
 
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.api.routes.v1.responses.PaginatedResponse
 import no.nav.mulighetsrommet.api.routes.v1.responses.Pagination
 import no.nav.mulighetsrommet.api.utils.getPaginationParams
+import no.nav.mulighetsrommet.domain.dto.OpprettTiltakstypeDto
 import no.nav.mulighetsrommet.utils.toUUID
 import org.koin.ktor.ext.inject
 
@@ -44,6 +46,13 @@ fun Route.tiltakstypeRoutes() {
                 status = HttpStatusCode.NotFound
             )
 
+            call.respond(tiltakstype)
+        }
+
+        put {
+            val tiltakstype = call.receive<OpprettTiltakstypeDto>()
+            // TODO Lagre i database (PS: Må opprette db-migrering for tiltakstype)
+            // TODO Returnere tiltakstype etter lagring i db
             call.respond(tiltakstype)
         }
     }


### PR DESCRIPTION
Starter arbeid med en domenemodell i backend for opprettelse av tiltakstype. 

Det er flere ting jeg er usikker på:
- Skal vi ha en egen dto for opprettelse av tiltakstype som kommer fra admin-flate?
- Koden som lager en dato-streng som Kotlin er happy med virker hacky, men den er kanskje ok? 