### PR TITLE
:heavy_minus_sign: Fjerner config for poao-gcp-proxy pga ubrukt

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -21,7 +21,6 @@ data class AppConfig(
     val veilarbpersonConfig: ServiceClientConfig,
     val veilarbdialogConfig: ServiceClientConfig,
     val veilarbveilederConfig: ServiceClientConfig,
-    val poaoGcpProxy: ServiceClientConfig,
     val poaoTilgang: ServiceClientConfig,
     val amtEnhetsregister: ServiceClientConfig,
     val arenaAdapter: ServiceClientConfig,

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -56,10 +56,6 @@ app:
     url: https://veilarbdialog.dev-fss-pub.nais.io/veilarbdialog/api
     scope: api://dev-fss.pto.veilarbdialog/.default
 
-  poaoGcpProxy:
-    url: https://poao-gcp-proxy.dev-fss-pub.nais.io
-    scope: api://dev-fss.pto.poao-gcp-proxy/.default
-
   poaoTilgang:
     url: http://poao-tilgang.poao
     scope: api://dev-gcp.poao.poao-tilgang/.default

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -55,10 +55,6 @@ app:
     url: http://localhost:8090/veilarbdialog/api
     scope: default
 
-  poaoGcpProxy:
-    url: http://localhost:8090
-    scope: default
-
   poaoTilgang:
     url: http://localhost:8090/poao-tilgang
     scope: default

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -53,10 +53,6 @@ app:
     url: https://veilarbdialog.prod-fss-pub.nais.io/veilarbdialog/api
     scope: api://prod-fss.pto.veilarbdialog/.default
 
-  poaoGcpProxy:
-    url: https://poao-gcp-proxy.prod-fss-pub.nais.io
-    scope: api://prod-fss.pto.poao-gcp-proxy/.default
-
   poaoTilgang:
     url: http://poao-tilgang.poao
     scope: api://prod-gcp.poao.poao-tilgang/.default

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
@@ -29,7 +29,6 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     veilarbpersonConfig = createServiceClientConfig("veilarbperson"),
     veilarbveilederConfig = createServiceClientConfig("veilarbveileder"),
     veilarbdialogConfig = createServiceClientConfig("veilarbdialog"),
-    poaoGcpProxy = createServiceClientConfig("poaogcpproxy"),
     poaoTilgang = createServiceClientConfig("poaotilgang"),
     amtEnhetsregister = createServiceClientConfig("amtenhetsregister"),
     msGraphConfig = createServiceClientConfig("ms-graph"),


### PR DESCRIPTION
poao-gcp-proxy er ikke i bruk lenger så vi kan fjerne configen