### PR TITLE
:sparkles: Filtrer på tiltakstypestatuser

### DIFF
--- a/frontend/mr-admin-flate/src/api/QueryKeys.ts
+++ b/frontend/mr-admin-flate/src/api/QueryKeys.ts
@@ -1,6 +1,12 @@
+import { TiltakstypeStatus } from "mulighetsrommet-api-client";
+
 export const QueryKeys = {
   tiltakstype: (id?: string) => [id, "tiltakstype"] as const,
-  tiltakstyper: (filter: string, page?: number) => [filter, page, "tiltakstyper"] as const,
+  tiltakstyper: (
+    sokestreng: string,
+    status: TiltakstypeStatus,
+    page?: number
+  ) => [sokestreng, status, page, "tiltakstyper"] as const,
   tiltaksgjennomforinger: (page?: number) =>
     [page, "tiltaksgjennomforinger"] as const,
   tiltaksgjennomforing: (id?: string) => [id, "tiltaksgjennomforing"] as const,

--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -1,5 +1,6 @@
 import { atomWithHash } from "jotai-location";
 import { atomWithStorage } from "jotai/utils";
+import { TiltakstypeStatus } from "mulighetsrommet-api-client";
 import { Rolle } from "../tilgang/tilgang";
 
 export const paginationAtom = atomWithHash("page", 1);
@@ -13,4 +14,7 @@ export const rolleAtom = atomWithStorage<Rolle | undefined>(
   undefined
 );
 
-export const tiltakstypefilter = atomWithHash<string>("tiltakstypefilter", "");
+export const tiltakstypefilter = atomWithHash<{
+  sok: string;
+  status: TiltakstypeStatus;
+}>("tiltakstypefilter", { sok: "", status: TiltakstypeStatus.AKTIV });

--- a/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstyper.ts
+++ b/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstyper.ts
@@ -4,15 +4,19 @@ import { QueryKeys } from "../QueryKeys";
 import { useAtom } from "jotai";
 import { PAGE_SIZE } from "../../constants";
 import { paginationAtom, tiltakstypefilter } from "../atoms";
+import { TiltakstypeStatus } from "mulighetsrommet-api-client";
 
 export function useTiltakstyper() {
   const [page] = useAtom(paginationAtom);
   const [sokefilter] = useAtom(tiltakstypefilter);
-  return useQuery(QueryKeys.tiltakstyper(sokefilter, page), () =>
-    mulighetsrommetClient.tiltakstyper.getTiltakstyper({
-      search: sokefilter !== "" ? sokefilter : undefined,
-      page,
-      size: PAGE_SIZE,
-    })
+  return useQuery(
+    QueryKeys.tiltakstyper(sokefilter.sok, sokefilter.status, page),
+    () =>
+      mulighetsrommetClient.tiltakstyper.getTiltakstyper({
+        search: sokefilter.sok !== "" ? sokefilter.sok : undefined,
+        status: sokefilter.status ?? TiltakstypeStatus.AKTIV,
+        page,
+        size: PAGE_SIZE,
+      })
   );
 }

--- a/frontend/mr-admin-flate/src/pages/Page.module.scss
+++ b/frontend/mr-admin-flate/src/pages/Page.module.scss
@@ -13,4 +13,7 @@
   margin-bottom: 1.5rem;
   padding-top: 1.5rem;
   border-top: solid 1px var(--a-border-divider);
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
 }

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/TiltakstyperPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/TiltakstyperPage.tsx
@@ -1,10 +1,10 @@
-import { Button, Heading, Search } from "@navikt/ds-react";
+import { Button, Heading, Search, Select } from "@navikt/ds-react";
+import { useAtom } from "jotai";
+import { ChangeEvent } from "react";
 import { Link } from "react-router-dom";
+import { tiltakstypefilter } from "../../api/atoms";
 import { useFeatureToggles } from "../../api/features/feature-toggles";
 import { TiltakstyperOversikt } from "../../components/tiltakstyper/TiltakstyperOversikt";
-import React from "react";
-import { useAtom } from "jotai";
-import { tiltakstypefilter } from "../../api/atoms";
 import styles from "../Page.module.scss";
 
 export function TiltakstyperPage() {
@@ -23,16 +23,30 @@ export function TiltakstyperPage() {
       </div>
       <div className={styles.filterseksjon}>
         <Search
-          label=""
-          placeholder=""
-          hideLabel
+          label="Søk etter tiltakstype"
+          hideLabel={false}
           variant="simple"
-          onChange={(e: string) => setSokefilter(e)}
-          value={sokefilter}
+          onChange={(sok: string) => setSokefilter({ ...sokefilter, sok })}
+          value={sokefilter.sok}
           aria-label="Søk etter tiltakstype"
           data-testid="filter_sokefelt"
           size="small"
         />
+        <Select
+          label="Filtrer på statuser"
+          size="small"
+          value={sokefilter.status}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+            setSokefilter({
+              ...sokefilter,
+              status: e.currentTarget.value as any,
+            })
+          }
+        >
+          <option value="AKTIV">Aktive</option>
+          <option value="PLANLAGT">Planlagte</option>
+          <option value="UTFASET">Utfasede</option>
+        </Select>
       </div>
       <TiltakstyperOversikt />
     </>

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -183,6 +183,7 @@ private fun services(appConfig: AppConfig) = module {
     single { DelMedBrukerService(get()) }
     single { MicrosoftGraphService(get()) }
     single { TiltaksgjennomforingService(get(), get()) }
+    single { TiltakstypeService(get()) }
 }
 
 private fun createOboTokenClient(config: AppConfig): OnBehalfOfTokenClient {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
@@ -4,32 +4,34 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
-import no.nav.mulighetsrommet.api.routes.v1.responses.PaginatedResponse
-import no.nav.mulighetsrommet.api.routes.v1.responses.Pagination
+import no.nav.mulighetsrommet.api.services.TiltakstypeService
 import no.nav.mulighetsrommet.api.utils.getPaginationParams
 import no.nav.mulighetsrommet.utils.toUUID
 import org.koin.ktor.ext.inject
 
 fun Route.tiltakstypeRoutes() {
-    val tiltakstyper: TiltakstypeRepository by inject()
+    val tiltakstypeService: TiltakstypeService by inject()
 
     route("/api/v1/internal/tiltakstyper") {
         get {
             val search = call.request.queryParameters["search"]
+            val status =
+                call.request.queryParameters["status"]?.let { status -> Status.valueOf(status) }
 
             val paginationParams = getPaginationParams()
 
-            val (totalCount, items) = tiltakstyper.getAll(search, paginationParams)
+            if (status != null) {
+                call.respond(
+                    tiltakstypeService.getWithFilter(
+                        TiltakstypeFilter(search = search, status = status),
+                        paginationParams
+                    )
+                )
+            }
 
             call.respond(
-                PaginatedResponse(
-                    data = items,
-                    pagination = Pagination(
-                        totalCount = totalCount,
-                        currentPage = paginationParams.page,
-                        pageSize = paginationParams.limit
-                    )
+                tiltakstypeService.getAll(
+                    paginationParams
                 )
             )
         }
@@ -39,7 +41,7 @@ fun Route.tiltakstypeRoutes() {
                 "Mangler eller ugyldig id",
                 status = HttpStatusCode.BadRequest
             )
-            val tiltakstype = tiltakstyper.get(id) ?: return@get call.respondText(
+            val tiltakstype = tiltakstypeService.getById(id) ?: return@get call.respondText(
                 "Det finnes ikke noe tiltakstype med id $id",
                 status = HttpStatusCode.NotFound
             )
@@ -47,4 +49,13 @@ fun Route.tiltakstypeRoutes() {
             call.respond(tiltakstype)
         }
     }
+}
+
+data class TiltakstypeFilter(
+    val search: String?,
+    val status: Status
+)
+
+enum class Status {
+    AKTIV, PLANLAGT, UTFASET
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
@@ -1,0 +1,51 @@
+package no.nav.mulighetsrommet.api.services
+
+import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
+import no.nav.mulighetsrommet.api.routes.v1.TiltakstypeFilter
+import no.nav.mulighetsrommet.api.routes.v1.responses.PaginatedResponse
+import no.nav.mulighetsrommet.api.routes.v1.responses.Pagination
+import no.nav.mulighetsrommet.api.utils.PaginationParams
+import no.nav.mulighetsrommet.domain.dto.TiltakstypeDto
+import java.util.*
+
+class TiltakstypeService(private val tiltakstypeRepository: TiltakstypeRepository) {
+    fun getAll(
+        paginationParams: PaginationParams
+    ): PaginatedResponse<TiltakstypeDto> {
+        val (totalCount, items) = tiltakstypeRepository.getAll(
+            paginationParams
+        )
+
+        return PaginatedResponse(
+            data = items,
+            pagination = Pagination(
+                totalCount = totalCount,
+                currentPage = paginationParams.page,
+                pageSize = paginationParams.limit
+            )
+        )
+    }
+
+    fun getWithFilter(
+        tiltakstypeFilter: TiltakstypeFilter,
+        paginationParams: PaginationParams
+    ): PaginatedResponse<TiltakstypeDto> {
+        val (totalCount, items) = tiltakstypeRepository.getAll(
+            tiltakstypeFilter,
+            paginationParams
+        )
+
+        return PaginatedResponse(
+            data = items,
+            pagination = Pagination(
+                totalCount = totalCount,
+                currentPage = paginationParams.page,
+                pageSize = paginationParams.limit
+            )
+        )
+    }
+
+    fun getById(id: UUID): TiltakstypeDto? {
+        return tiltakstypeRepository.get(id)
+    }
+}

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -235,6 +235,11 @@ paths:
             type: string
           description: Search for tiltakstyper
         - in: query
+          name: status
+          schema:
+            $ref: "#/components/schemas/TiltakstypeStatus"
+          description: Status for tiltakstyper
+        - in: query
           name: page
           schema:
             type: number
@@ -638,6 +643,13 @@ components:
         - SITUASJONSBESTEMT_INNSATS
         - SPESIELT_TILPASSET_INNSATS
         - VARIG_TILPASSET_INNSATS
+
+    TiltakstypeStatus:
+      type: string
+      enum:
+        - AKTIV
+        - PLANLAGT
+        - UTFASET
 
     Oppfolgingsenhet:
       type: object

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
@@ -4,6 +4,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import no.nav.mulighetsrommet.api.routes.v1.Status
+import no.nav.mulighetsrommet.api.routes.v1.TiltakstypeFilter
 import no.nav.mulighetsrommet.api.utils.DEFAULT_PAGINATION_LIMIT
 import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
@@ -43,8 +45,8 @@ class TiltakstypeRepositoryTest : FunSpec({
         )
 
         tiltakstyper.getAll().second shouldHaveSize 2
-        tiltakstyper.getAll(search = "Førerhund").second shouldHaveSize 0
-        tiltakstyper.getAll(search = "Arbeidstrening").second shouldHaveSize 1
+        tiltakstyper.getAll(TiltakstypeFilter(search = "Førerhund", status = Status.AKTIV)).second shouldHaveSize 0
+        tiltakstyper.getAll(TiltakstypeFilter(search = "Arbeidstrening", status = Status.UTFASET)).second shouldHaveSize 1
     }
 
     context("pagination") {


### PR DESCRIPTION
Legger til støtte for å filtrere på aktive, planlagte og utfasede tiltakstyper. Disse "statusene" er kun utledet basert på fra- og til-dato for en tiltakstype i databasen.

Reglene er: 
**Aktiv:** Dagens dato er større eller lik fra_dato og mindre eller lik til_dato
**Planlagt:** Dagens dato er mindre enn fra_dato
**Utfaset:** Dagens dato er større enn til_dato

Søkefilteret søker nå i datasettet basert på valgt status. Dvs. at dersom man har valgt "planlagt" og det bare ligger Arbeidstrening i planlagt, så får man ikke treff på oppfølging feks. 

**Skjermbilder**
![image](https://user-images.githubusercontent.com/9053627/213705679-d854d9f3-585b-406d-a343-a0f6c02784ff.png)

![image](https://user-images.githubusercontent.com/9053627/213706088-67e99283-17e1-458e-b5cc-eb06abc6d84d.png)

![image](https://user-images.githubusercontent.com/9053627/213706136-4ef0e3f5-a5b3-4463-817a-6c2893d5ce73.png)

