### PR TITLE
:recycle: Fikser noe styling som var tatt bort

### DIFF
--- a/frontend/mr-admin-flate/src/AutentisertFagansvarligApp.tsx
+++ b/frontend/mr-admin-flate/src/AutentisertFagansvarligApp.tsx
@@ -3,6 +3,7 @@ import { RootLayout } from "./layouts/RootLayout";
 import { ErrorPage } from "./pages/ErrorPage";
 import { TiltaksgjennomforingPage } from "./pages/tiltaksgjennomforinger/DetaljerTiltaksgjennomforingPage";
 import { OpprettTiltaksgruppe } from "./pages/tiltaksgrupper/opprett-tiltaksgrupper/OpprettTiltaksgruppePage";
+import { TiltaksgruppeDetaljerPage } from "./pages/tiltaksgrupper/TiltaksgruppeDetaljerPage";
 import { TiltaksgrupperPage } from "./pages/tiltaksgrupper/TiltaksgrupperPage";
 import { DetaljerTiltakstypePage } from "./pages/tiltakstyper/DetaljerTiltakstypePage";
 import { TiltakstyperPage } from "./pages/tiltakstyper/TiltakstyperPage";
@@ -13,7 +14,7 @@ export default function AutentisertFagansvarligApp() {
       <Route
         path="tiltakstyper"
         element={
-          <RootLayout fagansvarlig>
+          <RootLayout>
             <TiltakstyperPage />
           </RootLayout>
         }
@@ -22,7 +23,7 @@ export default function AutentisertFagansvarligApp() {
       <Route
         path="tiltaksgrupper"
         element={
-          <RootLayout fagansvarlig>
+          <RootLayout>
             <TiltaksgrupperPage />
           </RootLayout>
         }
@@ -31,8 +32,17 @@ export default function AutentisertFagansvarligApp() {
       <Route
         path="tiltaksgrupper/opprett"
         element={
-          <RootLayout fagansvarlig>
+          <RootLayout>
             <OpprettTiltaksgruppe />
+          </RootLayout>
+        }
+        errorElement={<ErrorPage />}
+      />
+      <Route
+        path="tiltaksgrupper/:tiltaksgruppeId"
+        element={
+          <RootLayout>
+            <TiltaksgruppeDetaljerPage />
           </RootLayout>
         }
         errorElement={<ErrorPage />}
@@ -40,7 +50,7 @@ export default function AutentisertFagansvarligApp() {
       {/* <Route
         path="tiltakstyper/opprett"
         element={
-          <RootLayout fagansvarlig>
+          <RootLayout>
             <OpprettTiltakstype />
           </RootLayout>
         }
@@ -49,7 +59,7 @@ export default function AutentisertFagansvarligApp() {
       <Route
         path="tiltakstyper/:tiltakstypeId"
         element={
-          <RootLayout fagansvarlig>
+          <RootLayout>
             <DetaljerTiltakstypePage />
           </RootLayout>
         }
@@ -58,7 +68,7 @@ export default function AutentisertFagansvarligApp() {
       <Route
         path="tiltakstyper/:tiltakstypeId/tiltaksgjennomforing/:tiltaksgjennomforingId"
         element={
-          <RootLayout fagansvarlig>
+          <RootLayout>
             <TiltaksgjennomforingPage fagansvarlig />
           </RootLayout>
         }

--- a/frontend/mr-admin-flate/src/api/tiltaksgrupper/useTiltaksgrupper.ts
+++ b/frontend/mr-admin-flate/src/api/tiltaksgrupper/useTiltaksgrupper.ts
@@ -1,20 +1,30 @@
+import { useParams } from "react-router-dom";
+
 export type Tiltaksgruppe = {
   id: string;
   navn: string;
   arenaKode: string;
 };
 
+const tiltaksgrupper = [
+  { id: "1", navn: "Arbeidsmarkedsbedrift", arenaKode: "AMD" },
+  { id: "2", navn: "Arbeidspraksis", arenaKode: "ARBPRAKS" },
+  { id: "3", navn: "Avklaring", arenaKode: "AVKLARING" },
+  { id: "4", navn: "Bedriftsintern opplæring", arenaKode: "BIO" },
+  { id: "5", navn: "Egenetablering", arenaKode: "ETAB" },
+  { id: "6", navn: "Forsøk", arenaKode: "FORSØK" },
+  { id: "7", navn: "Jobbskapningsprosjekter", arenaKode: "JOBBSKAP" },
+  { id: "8", navn: "Lønnstilskudd", arenaKode: "LONNTILS" },
+  { id: "9", navn: "Midlertidig sysselsetting", arenaKode: "MIDDSYS" },
+  { id: "10", navn: "Opplæring", arenaKode: "OPPL" },
+];
+
 export function useTiltaksgrupper(): Tiltaksgruppe[] {
-  return [
-    { id: "1", navn: "Arbeidsmarkedsbedrift", arenaKode: "AMD" },
-    { id: "2", navn: "Arbeidspraksis", arenaKode: "ARBPRAKS" },
-    { id: "3", navn: "Avklaring", arenaKode: "AVKLARING" },
-    { id: "4", navn: "Bedriftsintern opplæring", arenaKode: "BIO" },
-    { id: "5", navn: "Egenetablering", arenaKode: "ETAB" },
-    { id: "6", navn: "Forsøk", arenaKode: "FORSØK" },
-    { id: "7", navn: "Jobbskapningsprosjekter", arenaKode: "JOBBSKAP" },
-    { id: "8", navn: "Lønnstilskudd", arenaKode: "LONNTILS" },
-    { id: "9", navn: "Midlertidig sysselsetting", arenaKode: "MIDDSYS" },
-    { id: "10", navn: "Opplæring", arenaKode: "OPPL" },
-  ];
+  return tiltaksgrupper;
+}
+
+export function useTiltaksgruppe(): Tiltaksgruppe | undefined {
+  const { tiltaksgruppeId } = useParams<{ tiltaksgruppeId: string }>();
+
+  return tiltaksgrupper.find((gruppe) => gruppe.id === tiltaksgruppeId);
 }

--- a/frontend/mr-admin-flate/src/components/listeelementer/Listeelementer.module.scss
+++ b/frontend/mr-admin-flate/src/components/listeelementer/Listeelementer.module.scss
@@ -1,3 +1,9 @@
+.oversikt {
+  margin: 0;
+  margin-top: 1rem;
+  padding: 0;
+}
+
 .under_oversikt {
   display: flex;
   justify-content: space-between;

--- a/frontend/mr-admin-flate/src/layouts/RootLayout.tsx
+++ b/frontend/mr-admin-flate/src/layouts/RootLayout.tsx
@@ -2,19 +2,25 @@ import { ReactNode } from "react";
 import styles from "./RootLayout.module.scss";
 import { ForsideTiltaksansvarlig } from "../pages/forside/ForsideTiltaksansvarlig";
 import { ForsideFagansvarlig } from "../pages/forside/ForsideFagansvarlig";
+import { useHentAnsatt } from "../api/ansatt/useHentAnsatt";
+import { hentAnsattsRolle } from "../tilgang/tilgang";
 
 interface RootLayoutProps {
-  fagansvarlig?: boolean;
   children: ReactNode;
 }
 
-export function RootLayout({
-  fagansvarlig = false,
-  children,
-}: RootLayoutProps) {
+export function RootLayout({ children }: RootLayoutProps) {
+  const { data, isLoading } = useHentAnsatt();
+  if (isLoading) return null;
+
+  const tilgang = hentAnsattsRolle(data);
   return (
     <>
-      {fagansvarlig ? <ForsideFagansvarlig /> : <ForsideTiltaksansvarlig />}
+      {tilgang === "FAGANSVARLIG" ? (
+        <ForsideFagansvarlig />
+      ) : (
+        <ForsideTiltaksansvarlig />
+      )}
       <main className={styles.container}>{children}</main>
     </>
   );

--- a/frontend/mr-admin-flate/src/pages/tiltaksgrupper/TiltaksgruppeDetaljerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgrupper/TiltaksgruppeDetaljerPage.tsx
@@ -1,0 +1,14 @@
+import { useTiltaksgruppe } from "../../api/tiltaksgrupper/useTiltaksgrupper";
+import { Tilbakelenke } from "../../components/navigering/Tilbakelenke";
+
+export function TiltaksgruppeDetaljerPage() {
+  const tiltaksgruppe = useTiltaksgruppe();
+  return (
+    <>
+      <Tilbakelenke>Tilbake</Tilbakelenke>
+      <h1>
+        {tiltaksgruppe?.navn} - {tiltaksgruppe?.arenaKode}
+      </h1>
+    </>
+  );
+}


### PR DESCRIPTION
Henter ansatts tilgang direkte i rootlayout-componenten, så slipper vi
å sende inn en property
