### PR TITLE
Setter maks lengde på søk til 50 tegn

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Sokefelt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/Sokefelt.tsx
@@ -20,6 +20,7 @@ const Sokefelt = ({ sokefilter, setSokefilter }: SokeFilterProps) => {
       aria-label="Søk etter tiltak"
       data-testid="filter_sokefelt"
       size="small"
+      maxLength={50}
     />
   );
 };


### PR DESCRIPTION
Om man ikke finner det man søker etter
på 50 tegn så bør vi heller se på filterne våre tenker jeg
