### PR TITLE
Test replaceState for filter-atom

### DIFF
--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -21,8 +21,14 @@ export const tiltakstypefilter = atomWithHash<{
   sok: string;
   status: Tiltakstypestatus;
   kategori?: Tiltakstypekategori;
-}>("tiltakstypefilter", {
-  sok: "",
-  status: Tiltakstypestatus.AKTIV,
-  kategori: Tiltakstypekategori.GRUPPE,
-});
+}>(
+  "tiltakstypefilter",
+  {
+    sok: "",
+    status: Tiltakstypestatus.AKTIV,
+    kategori: Tiltakstypekategori.GRUPPE,
+  },
+  {
+    setHash: "replaceState",
+  }
+);

--- a/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/atoms/atoms.ts
@@ -25,7 +25,10 @@ export const initialTiltaksgjennomforingsfilter = {
 
 export const tiltaksgjennomforingsfilter = atomWithHash<Tiltaksgjennomforingsfilter>(
   'filter',
-  initialTiltaksgjennomforingsfilter
+  initialTiltaksgjennomforingsfilter,
+  {
+    setHash: 'replaceState',
+  }
 );
 
 export const paginationAtom = atomWithHash('page', 1);


### PR DESCRIPTION
Ved å replace state så legges det ikke en entry på history stacken til browseren, og dermed vil frem og tilbake-knapper fungere som forventet ved navigering