### PR TITLE
Fjern eksplisitt høyde på filter-tag

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tags/Filtertag.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tags/Filtertag.module.scss
@@ -15,11 +15,10 @@
 
   :global(.navds-tag--info) {
     border: unset;
-    height: 32px;
     font-size: 1rem;
     line-height: 1.25rem;
     border-radius: 4px;
-    background-color: #CCE1FF;
+    background-color: #cce1ff;
     border: unset;
   }
 }


### PR DESCRIPTION
Fjerner eksplisitt høyde så vi ikke går tom for plass ved små skjermer og lange tagger