### PR TITLE
✨ Sort på oppstartsdato legger løpende oppstart først

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/support/e2e.js
@@ -120,6 +120,10 @@ Cypress.Commands.add('antallFiltertagsKvalifiseringsgruppe', (kvalifiseringsgrup
   }
 });
 
+Cypress.Commands.add('resetSortering', () => {
+  cy.getByTestId('sortering-select').select('tiltakstypeNavn-ascending');
+});
+
 function terminalLog(violations) {
   cy.task(
     'log',

--- a/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
@@ -55,7 +55,10 @@ const Tiltaksgjennomforingsoversikt = () => {
     };
   };
 
-  const sorter = (tiltaksgjennomforinger: Tiltaksgjennomforing[]): Tiltaksgjennomforing[] => {
+  const sorter = (
+    tiltaksgjennomforinger: Tiltaksgjennomforing[],
+    forceOrder: 'ascending' | 'descending' = 'ascending'
+  ): Tiltaksgjennomforing[] => {
     return tiltaksgjennomforinger.sort((a, b) => {
       const sort = getSort(sortValue);
 
@@ -73,7 +76,7 @@ const Tiltaksgjennomforingsoversikt = () => {
         if (orderBy === 'oppstart') {
           const dateB = b.oppstart === 'lopende' ? new Date() : new Date(b.oppstartsdato);
           const dateA = a.oppstart === 'lopende' ? new Date() : new Date(a.oppstartsdato);
-          return compare(dateA, dateB);
+          return forceOrder === 'ascending' ? compare(dateA, dateB) : compare(dateB, dateA);
         } else if (orderBy === 'tiltakstypeNavn') {
           return compare(a.tiltakstype.tiltakstypeNavn, b.tiltakstype.tiltakstypeNavn);
         } else {
@@ -87,17 +90,31 @@ const Tiltaksgjennomforingsoversikt = () => {
 
   const lopendeOppstartForst = (
     lopendeGjennomforinger: Tiltaksgjennomforing[],
-    gjennomforingerMedOppstart: Tiltaksgjennomforing[]
+    gjennomforingerMedOppstartIFremtiden: Tiltaksgjennomforing[],
+    gjennomforingerMedOppstartHarVaert: Tiltaksgjennomforing[]
   ): Tiltaksgjennomforing[] => {
-    return [...lopendeGjennomforinger, ...sorter(gjennomforingerMedOppstart)];
+    return [
+      ...lopendeGjennomforinger,
+      ...sorter(gjennomforingerMedOppstartIFremtiden),
+      ...sorter(gjennomforingerMedOppstartHarVaert, 'descending'),
+    ];
   };
 
   const lopendeGjennomforinger = tiltaksgjennomforinger.filter(gj => gj.oppstart === 'lopende');
-  const gjennomforingerMedOppstart = tiltaksgjennomforinger.filter(gj => gj.oppstart !== 'lopende');
+  const gjennomforingerMedOppstartIFremtiden = tiltaksgjennomforinger.filter(
+    gj => gj.oppstart !== 'lopende' && new Date(gj.oppstartsdato!!) >= new Date()
+  );
+  const gjennomforingerMedOppstartHarVaert = tiltaksgjennomforinger.filter(
+    gj => gj.oppstart !== 'lopende' && new Date(gj.oppstartsdato!!) <= new Date()
+  );
 
   const gjennomforingerForSide = (
     getSort(sortValue).orderBy === 'oppstart'
-      ? lopendeOppstartForst(lopendeGjennomforinger, gjennomforingerMedOppstart)
+      ? lopendeOppstartForst(
+          lopendeGjennomforinger,
+          gjennomforingerMedOppstartIFremtiden,
+          gjennomforingerMedOppstartHarVaert
+        )
       : sorter(tiltaksgjennomforinger)
   ).slice((page - 1) * elementsPerPage, page * elementsPerPage);
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sorteringmeny/Sorteringsmeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sorteringmeny/Sorteringsmeny.tsx
@@ -15,11 +15,12 @@ export const Sorteringsmeny = ({ sortValue, setSortValue }: Props) => {
       size="small"
       label="Hvilket felt ønsker du å sortere listen på?"
       hideLabel
+      data-testid="sortering-select"
     >
       <option value="tiltakstypeNavn-ascending">Sorter etter:</option>
       <option value="lokasjon-ascending">Lokasjon a-å</option>
       <option value="lokasjon-descending">Lokasjon å-a</option>
-      <option value="oppstart-asscending">Oppstartsdato</option>
+      <option value="oppstart-ascending">Oppstartsdato</option>
       <option value="tiltaksgjennomforingNavn-ascending">Tittel a-å</option>
       <option value="tiltaksgjennomforingNavn-descending">Tittel å-a</option>
     </Select>


### PR DESCRIPTION
Ved sortering på oppstartsdato så blir rekkefølgen følgende:
1. Alle tiltaksgjennomføringer med løpende oppstart legges først i rekken
2. Alle tiltaksgjennomføringer som har en oppstartsdato som ikke har vært enda blir sortert nærmest dagens dato
3. Alle tiltaksgjennomføringer som har en oppstartsdato som har vært blir sortert nærmest dagens dato

Det foregår avklaringer på om vi skal markere gjennomføringer som har hatt en oppstartsdato på noen måte. Enten visuelt, eller om de skal bort fra oversikten. Det gjenstår å se.

Har lagt til Cypress-test som sjekker at sortering på løpende først fungerer

Organiserer også litt i Cypress-testene for å få litt bedre oversikt.