### PR TITLE
Oppsett for db-scheduler for API

### DIFF
--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -102,4 +102,7 @@ dependencies {
     // OpenAPI
     // PS: Hvis man oppdaterer denne må man også rename mappen til riktig versjon i resources
     runtimeOnly("org.webjars:swagger-ui:4.14.0")
+
+    // DB-scheduler
+    implementation("com.github.kagkarlsson:db-scheduler:11.6")
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -1,5 +1,6 @@
 package no.nav.mulighetsrommet.api
 
+import com.github.kagkarlsson.scheduler.Scheduler
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.routing.*
@@ -56,5 +57,15 @@ fun Application.configure(config: AppConfig) {
         authenticate(AuthProvider.AzureAdTiltaksgjennomforingApp.name) {
             externalRoutes()
         }
+    }
+
+    val scheduler: Scheduler by inject()
+
+    environment.monitor.subscribe(ApplicationStarted) {
+        scheduler.start()
+    }
+
+    environment.monitor.subscribe(ApplicationStopPreparing) {
+        scheduler.stop()
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api
 
 import no.nav.mulighetsrommet.api.producers.TiltaksgjennomforingKafkaProducer
 import no.nav.mulighetsrommet.api.producers.TiltakstypeKafkaProducer
+import no.nav.mulighetsrommet.api.tasks.SynchronizeNorgEnheter
 import no.nav.mulighetsrommet.database.FlywayDatabaseConfig
 import no.nav.mulighetsrommet.ktor.ServerConfig
 
@@ -24,7 +25,8 @@ data class AppConfig(
     val poaoTilgang: ServiceClientConfig,
     val amtEnhetsregister: ServiceClientConfig,
     val arenaAdapter: ServiceClientConfig,
-    val msGraphConfig: ServiceClientConfig
+    val msGraphConfig: ServiceClientConfig,
+    val tasks: TaskConfig
 )
 
 data class AuthConfig(
@@ -62,4 +64,8 @@ data class SwaggerConfig(
 data class ServiceClientConfig(
     val url: String,
     val scope: String
+)
+
+data class TaskConfig(
+    val synchronizeNorgEnheter: SynchronizeNorgEnheter.Config
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNorgEnheter.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNorgEnheter.kt
@@ -1,0 +1,21 @@
+package no.nav.mulighetsrommet.api.tasks
+
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask
+import com.github.kagkarlsson.scheduler.task.helper.Tasks
+import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay
+import org.slf4j.LoggerFactory
+
+class SynchronizeNorgEnheter(config: Config) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    data class Config(
+        val delayOfMinutes: Int,
+        val schedulerStatePollDelay: Long = 1000
+    )
+
+    val task: RecurringTask<Void> = Tasks
+        .recurring("synchronize-norg2-enheter", FixedDelay.ofMinutes(config.delayOfMinutes))
+        .execute { instance, context ->
+            // TODO Synkroniser enheter fra NORG
+        }
+}

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -71,3 +71,7 @@ app:
   arenaAdapter:
     url: http://mulighetsrommet-arena-adapter
     scope:  api://dev-gcp.team-mulighetsrommet.mulighetsrommet-arena-adapter/.default
+
+  tasks:
+    synchronizeNorgEnheter:
+      delayOfMinutes: 90

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -70,3 +70,7 @@ app:
   arenaAdapter:
     url: http://0.0.0.0:8084
     scope: default
+
+  tasks:
+    synchronizeNorgEnheter:
+      delayOfMinutes: 1

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -68,3 +68,7 @@ app:
   arenaAdapter:
     url: http://mulighetsrommet-arena-adapter
     scope: api://prod-gcp.team-mulighetsrommet.mulighetsrommet-arena-adapter/.default
+
+  tasks:
+    synchronizeNorgEnheter:
+      delayOfMinutes: 90

--- a/mulighetsrommet-api/src/main/resources/db/migration/V26__db_scheduler.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V26__db_scheduler.sql
@@ -1,0 +1,18 @@
+create table scheduled_tasks
+(
+    task_name            text                     not null,
+    task_instance        text                     not null,
+    task_data            bytea,
+    execution_time       timestamp with time zone not null,
+    picked               boolean                  not null,
+    picked_by            text,
+    last_success         timestamp with time zone,
+    last_failure         timestamp with time zone,
+    consecutive_failures int,
+    last_heartbeat       timestamp with time zone,
+    version              bigint                   not null,
+    primary key (task_name, task_instance)
+);
+
+create index execution_time_idx on scheduled_tasks (execution_time);
+create index last_heartbeat_idx on scheduled_tasks (last_heartbeat);

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
@@ -3,6 +3,7 @@ package no.nav.mulighetsrommet.api
 import io.ktor.server.testing.*
 import no.nav.mulighetsrommet.api.producers.TiltaksgjennomforingKafkaProducer
 import no.nav.mulighetsrommet.api.producers.TiltakstypeKafkaProducer
+import no.nav.mulighetsrommet.api.tasks.SynchronizeNorgEnheter
 import no.nav.mulighetsrommet.database.kotest.extensions.createApiDatabaseTestSchema
 import no.nav.security.mock.oauth2.MockOAuth2Server
 
@@ -32,7 +33,12 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     poaoTilgang = createServiceClientConfig("poaotilgang"),
     amtEnhetsregister = createServiceClientConfig("amtenhetsregister"),
     msGraphConfig = createServiceClientConfig("ms-graph"),
-    arenaAdapter = createServiceClientConfig("arena-adapter")
+    arenaAdapter = createServiceClientConfig("arena-adapter"),
+    tasks = TaskConfig(
+        synchronizeNorgEnheter = SynchronizeNorgEnheter.Config(
+            delayOfMinutes = 10
+        )
+    )
 )
 
 fun createKafkaConfig(): KafkaConfig {

--- a/mulighetsrommet-arena-adapter/build.gradle.kts
+++ b/mulighetsrommet-arena-adapter/build.gradle.kts
@@ -91,5 +91,5 @@ dependencies {
     implementation("org.slf4j:slf4j-api:2.0.5")
 
     implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc:4.41.0")
-    implementation("com.github.kagkarlsson:db-scheduler:11.5")
+    implementation("com.github.kagkarlsson:db-scheduler:11.6")
 }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepositoryTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepositoryTest.kt
@@ -66,7 +66,7 @@ class ArenaEventRepositoryTest : FunSpec({
     }
 
     test("update events consumption status specified by table and consumption status") {
-        val events = repository.updateStatus(table = "table", oldStatus = Processed, newStatus = Replay)
+        repository.updateStatus(table = "table", oldStatus = Processed, newStatus = Replay)
 
         repository.getAll(status = Replay) shouldHaveSize 5
         repository.getAll(status = Pending) shouldHaveSize 5


### PR DESCRIPTION
Legger til db-scheduler som en avhengighet for mulighetsrommet-api. Db-scheduler lar oss sette opp jobber som skal kjøre på et eller annet intervall på en enkel og oversiktlig måte. 