### PR TITLE
:sparkles: Filtrer på enhet for avtaler

### DIFF
--- a/frontend/mr-admin-flate/src/api/QueryKeys.ts
+++ b/frontend/mr-admin-flate/src/api/QueryKeys.ts
@@ -33,4 +33,5 @@ export const QueryKeys = {
     enhet: string,
     sortering: string
   ) => [sok, status, enhet, sortering, tiltakstypeId, "avtaler"],
+  enheter: () => ["enheter"],
 };

--- a/frontend/mr-admin-flate/src/api/avtaler/useAvtalerForTiltakstype.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useAvtalerForTiltakstype.ts
@@ -24,9 +24,9 @@ export function useAvtalerForTiltakstype() {
     () =>
       mulighetsrommetClient.avtaler.getAvtalerForTiltakstype({
         id: tiltakstypeId,
-        search: debouncedSok ?? "",
-        avtalestatus: filter.status,
-        enhet: filter.enhet ?? "",
+        search: debouncedSok || undefined,
+        avtalestatus: filter.status ? filter.status : undefined,
+        enhet: filter.enhet ? filter.enhet : undefined,
       })
   );
 }

--- a/frontend/mr-admin-flate/src/api/enhet/useEnheter.ts
+++ b/frontend/mr-admin-flate/src/api/enhet/useEnheter.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+import { mulighetsrommetClient } from "../clients";
+import { QueryKeys } from "../QueryKeys";
+
+export function useEnheter() {
+  const { tiltakstypeId } = useParams<{ tiltakstypeId: string }>();
+
+  if (!tiltakstypeId) {
+    throw new Error("Fant ingen tiltakstype-id i URL");
+  }
+  return useQuery(QueryKeys.enheter(), () =>
+    mulighetsrommetClient.hentEnheter.hentEnheter({ tiltakstypeId })
+  );
+}

--- a/frontend/mr-admin-flate/src/components/avtaler/Avtalefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/Avtalefilter.tsx
@@ -3,10 +3,12 @@ import { useAtom } from "jotai";
 import { Avtalestatus } from "mulighetsrommet-api-client";
 import { ChangeEvent } from "react";
 import { avtaleFilter } from "../../api/atoms";
+import { useEnheter } from "../../api/enhet/useEnheter";
 import styles from "./Avtalefilter.module.scss";
 
 export function Avtalefilter() {
   const [filter, setFilter] = useAtom(avtaleFilter);
+  const { data: enheter } = useEnheter();
   return (
     <>
       <div className={styles.filter_container}>
@@ -38,6 +40,7 @@ export function Avtalefilter() {
             <option value="Planlagt">Planlagt</option>
             <option value="Avsluttet">Avsluttet</option>
             <option value="Avbrutt">Avbrutt</option>
+            <option value="">Alle</option>
           </Select>
           <Select
             label="Enhet"
@@ -49,7 +52,12 @@ export function Avtalefilter() {
               setFilter({ ...filter, enhet: e.currentTarget.value });
             }}
           >
-            <option value="ALLE">Alle</option>
+            <option value="">Alle</option>
+            {enheter?.map((enhet) => (
+              <option key={enhet.enhetId} value={enhet.enhetNr}>
+                {enhet.navn} - {enhet.enhetNr}
+              </option>
+            ))}
           </Select>
         </div>
         <div>

--- a/frontend/mr-admin-flate/src/components/statuselementer/Avtalestatus.tsx
+++ b/frontend/mr-admin-flate/src/components/statuselementer/Avtalestatus.tsx
@@ -1,27 +1,23 @@
 import { Tag } from "@navikt/ds-react";
 import { Avtale } from "mulighetsrommet-api-client";
-import { kalkulerStatusBasertPaaFraOgTilDato } from "../../utils/Utils";
 
 interface Props {
   avtale: Avtale;
 }
 
 export function Avtalestatus({ avtale }: Props) {
-  const status = kalkulerStatusBasertPaaFraOgTilDato({
-    fraDato: avtale.startDato,
-    tilDato: avtale.sluttDato,
-  });
+  const { avtalestatus } = avtale;
   return (
     <Tag
       variant={
-        status === "Aktiv"
+        avtalestatus === "Aktiv"
           ? "success"
-          : status === "Planlagt"
+          : avtalestatus === "Planlagt"
           ? "info"
           : "neutral"
       }
     >
-      {status}
+      {avtalestatus}
     </Tag>
   );
 }

--- a/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
+++ b/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
@@ -1,6 +1,7 @@
 import { rest } from "msw";
 import {
   Ansatt,
+  Enhet,
   PaginertAvtale,
   PaginertTiltaksgjennomforing,
   PaginertTiltakstype,
@@ -9,6 +10,7 @@ import {
 } from "mulighetsrommet-api-client";
 import { mockFagansvarlig, mockTiltaksansvarlig } from "./fixtures/mock_ansatt";
 import { mockAvtaler } from "./fixtures/mock_avtaler";
+import { mockEnheter } from "./fixtures/mock_enheter";
 import { mockTiltaksgjennomforinger } from "./fixtures/mock_tiltaksgjennomforinger";
 import { mockTiltaksgjennomforingerKobletTilAnsatt } from "./fixtures/mock_tiltaksgjennomforinger_koblet_til_ansatt";
 import { mockTiltakstyper } from "./fixtures/mock_tiltakstyper";
@@ -53,6 +55,11 @@ export const apiHandlers = [
       );
     }
   ),
+
+  rest.get<any, any, Enhet[]>("*/api/v1/internal/enheter", (req, res, ctx) => {
+    const enheter = mockEnheter;
+    return res(ctx.status(200), ctx.json(enheter));
+  }),
 
   rest.get<any, any, PaginertTiltaksgjennomforing>(
     "*/api/v1/internal/tiltaksgjennomforinger",

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_enheter.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_enheter.ts
@@ -1,0 +1,28 @@
+import { Enhet } from "mulighetsrommet-api-client";
+
+export const mockEnheter: Enhet[] = [
+  {
+    enhetId: 100000027,
+    navn: "NAV Bærum",
+    enhetNr: "0219",
+    status: Enhet.status.AKTIV,
+  },
+  {
+    enhetId: 100000238,
+    navn: "NAV Hillevåg og Hinna",
+    enhetNr: "1164",
+    status: Enhet.status.AKTIV,
+  },
+  {
+    enhetId: 100000005,
+    navn: "NAV Hvaler",
+    enhetNr: "0111",
+    status: Enhet.status.AKTIV,
+  },
+  {
+    enhetId: 100000058,
+    navn: "NAV Nordre Aker",
+    enhetNr: "0331",
+    status: Enhet.status.AKTIV,
+  },
+];

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -50,6 +50,7 @@ fun Application.configure(config: AppConfig) {
             frontendLoggerRoutes()
             dialogRoutes()
             delMedBrukerRoutes()
+            enhetRoutes()
         }
         authenticate(AuthProvider.AzureAdDefaultApp.name) {
             arenaRoutes()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -196,6 +196,7 @@ private fun services(appConfig: AppConfig) = module {
     single { TiltaksgjennomforingService(get(), get()) }
     single { TiltakstypeService(get()) }
     single { Norg2Service(get(), get()) }
+    single { EnhetService(get()) }
 }
 
 private fun tasks(config: TaskConfig) = module {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -149,7 +149,7 @@ class AvtaleRepository(private val db: Database) {
         val parameters = mapOf(
             "tiltakstype_id" to tiltakstypeId,
             "search" to "%${filter.search}%",
-            "avtalestatus" to filter.avtalestatus.name,
+            "avtalestatus" to filter.avtalestatus?.name,
             "enhet" to filter.enhet,
             "limit" to pagination.limit,
             "offset" to pagination.offset

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/EnhetRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/EnhetRoutes.kt
@@ -1,0 +1,19 @@
+package no.nav.mulighetsrommet.api.routes.v1
+
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.mulighetsrommet.api.services.EnhetService
+import no.nav.mulighetsrommet.api.utils.getEnhetFilter
+import org.koin.ktor.ext.inject
+
+fun Route.enhetRoutes() {
+    val enhetService: EnhetService by inject()
+
+    route("api/v1/internal/enheter") {
+        get {
+            val filter = getEnhetFilter()
+            call.respond(enhetService.hentEnheter(filter))
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/EnhetService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/EnhetService.kt
@@ -1,0 +1,13 @@
+package no.nav.mulighetsrommet.api.services
+
+import no.nav.mulighetsrommet.api.domain.Norg2Enhet
+import no.nav.mulighetsrommet.api.repositories.EnhetRepository
+import no.nav.mulighetsrommet.api.utils.EnhetFilter
+
+class EnhetService(private val enhetRepository: EnhetRepository) {
+    fun hentEnheter(
+        filter: EnhetFilter
+    ): List<Norg2Enhet> {
+        return enhetRepository.getAll(filter)
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
@@ -10,7 +10,7 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
     private val log = LoggerFactory.getLogger(javaClass)
     suspend fun synkroniserEnheter() {
         val enheter = norg2Client.hentEnheter()
-        log.info("Hentet ${enheter.size} fra NORG2")
+        log.info("Hentet ${enheter.size} enheter fra NORG2")
         enheter.forEach {
             enhetRepository.upsert(
                 Norg2EnhetDbo(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.utils
 
 import io.ktor.server.application.*
 import io.ktor.util.pipeline.*
+import no.nav.mulighetsrommet.api.domain.EnhetStatus
 import no.nav.mulighetsrommet.domain.dto.Avtalestatus
 
 data class TiltakstypeFilter(
@@ -12,8 +13,17 @@ data class TiltakstypeFilter(
 
 data class AvtaleFilter(
     val search: String?,
-    val avtalestatus: Avtalestatus,
-    val enhet: String?
+    val avtalestatus: Avtalestatus? = null,
+    val enhet: String? = null
+)
+
+data class EnhetFilter(
+    val statuser: List<EnhetStatus> = listOf(
+        EnhetStatus.AKTIV,
+        EnhetStatus.UNDER_AVVIKLING,
+        EnhetStatus.UNDER_ETABLERING
+    ),
+    val tiltakstypeId: String
 )
 
 enum class Status {
@@ -23,22 +33,29 @@ enum class Status {
 enum class Tiltakstypekategori {
     INDIVIDUELL, GRUPPE
 }
+
 fun <T : Any> PipelineContext<T, ApplicationCall>.getTiltakstypeFilter(): TiltakstypeFilter {
     val search = call.request.queryParameters["search"]
     val status =
         call.request.queryParameters["tiltakstypestatus"]?.let { status -> Status.valueOf(status) } ?: Status.AKTIV
-    val kategori = call.request.queryParameters["tiltakstypekategori"]?.let { kategori -> Tiltakstypekategori.valueOf(kategori) }
+    val kategori =
+        call.request.queryParameters["tiltakstypekategori"]?.let { kategori -> Tiltakstypekategori.valueOf(kategori) }
     return TiltakstypeFilter(search, status, kategori)
 }
 
 fun <T : Any> PipelineContext<T, ApplicationCall>.getAvtaleFilter(): AvtaleFilter {
     val search = call.request.queryParameters["search"]
     val avtalestatus =
-        call.request.queryParameters["avtalestatus"]?.let { status -> Avtalestatus.valueOf(status) } ?: Avtalestatus.Aktiv
+        call.request.queryParameters["avtalestatus"]?.let { status -> Avtalestatus.valueOf(status) }
     val enhet = call.request.queryParameters["enhet"]
     return AvtaleFilter(
         search = search,
         avtalestatus = avtalestatus,
         enhet = enhet
     )
+}
+
+fun <T : Any> PipelineContext<T, ApplicationCall>.getEnhetFilter(): EnhetFilter {
+    val tiltakstypeId = call.request.queryParameters["tiltakstypeId"] ?: ""
+    return EnhetFilter(tiltakstypeId = tiltakstypeId)
 }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -543,6 +543,27 @@ paths:
               schema:
                 type: string
 
+  /api/v1/internal/enheter:
+    get:
+      tags:
+        - Hent enheter
+      operationId: hentEnheter
+      parameters:
+        - in: query
+          name: tiltakstypeId
+          schema:
+            type: string
+          description: ID for tiltakstypen knyttet til avtaler med enheter
+      responses:
+        200:
+          description: "Enheter knyttet til avtaler"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Enhet"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -937,3 +958,21 @@ components:
           type: string
         updated_by:
           type: string
+
+    Enhet:
+      type: object
+      properties:
+        enhetId:
+          type: number
+        enhetNr:
+          type: string
+        navn:
+          type: string
+        status:
+          type: string
+          enum:
+            - UNDER_ETABLERING
+            - AKTIV
+            - UNDER_AVVIKLING
+            - NEDLAGT
+


### PR DESCRIPTION
Nå kan man filtrere på avtaler for en gitt tiltakstype basert på en enhet.
Når bruker går inn på en tiltakstype og ser på avtaler så henter vi enhetene som har avtaler tilknyttet den tiltakstypen. Bruker kan velge en av enhetene for å filtrere, eller velge alle. Da ser man alle avtaler, uavhengig av enhet.

![image](https://user-images.githubusercontent.com/9053627/219351919-6f1bdd0a-8d3d-45ff-9fc8-7ab9b885bb9a.png)
