### PR TITLE
:sparkles: Sorter på navn eller status for avtaler

### DIFF
--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -3,6 +3,7 @@ import { atomWithHash } from "jotai-location";
 import { atomWithStorage } from "jotai/utils";
 import {
   Avtalestatus,
+  SorteringAvtaler,
   Tiltakstypekategori,
   Tiltakstypestatus,
 } from "mulighetsrommet-api-client";
@@ -39,12 +40,12 @@ const avtaleFilter = atom<{
   sok: string;
   status: Avtalestatus;
   enhet: string;
-  sortering: string;
+  sortering: SorteringAvtaler;
 }>({
   sok: "",
   status: Avtalestatus.AKTIV,
   enhet: "",
-  sortering: "",
+  sortering: SorteringAvtaler.NAVN_ASCENDING,
 });
 
 export type avtaleFilterType = ExtractAtomValue<typeof avtaleFilter>;

--- a/frontend/mr-admin-flate/src/api/avtaler/useAvtalerForTiltakstype.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useAvtalerForTiltakstype.ts
@@ -27,6 +27,7 @@ export function useAvtalerForTiltakstype() {
         search: debouncedSok || undefined,
         avtalestatus: filter.status ? filter.status : undefined,
         enhet: filter.enhet ? filter.enhet : undefined,
+        sort: filter.sortering,
       })
   );
 }

--- a/frontend/mr-admin-flate/src/components/avtaler/Avtalefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/Avtalefilter.tsx
@@ -1,6 +1,6 @@
 import { Search, Select } from "@navikt/ds-react";
 import { useAtom } from "jotai";
-import { Avtalestatus } from "mulighetsrommet-api-client";
+import { Avtalestatus, SorteringAvtaler } from "mulighetsrommet-api-client";
 import { ChangeEvent } from "react";
 import { avtaleFilter } from "../../api/atoms";
 import { useEnheter } from "../../api/enhet/useEnheter";
@@ -68,10 +68,17 @@ export function Avtalefilter() {
             value={filter.sortering}
             data-testid="filter_avtale_enhet"
             onChange={(e: ChangeEvent<HTMLSelectElement>) => {
-              setFilter({ ...filter, sortering: e.currentTarget.value });
+              setFilter({
+                ...filter,
+                sortering: e.currentTarget.value as SorteringAvtaler,
+              });
             }}
           >
-            <option value="">Sorter</option>
+            <option value="navn-ascending">Sorter</option>
+            <option value="navn-ascending">Navn A-Å</option>
+            <option value="navn-descending">Navn Å-A</option>
+            <option value="status-ascending">Status A-Å</option>
+            <option value="status-descending">Status Å-A</option>
           </Select>
         </div>
       </div>

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -162,6 +162,14 @@ class AvtaleRepository(private val db: Database) {
             filter.enhet to "lower(a.enhet) = lower(:enhet)"
         )
 
+        val order = when (filter.sortering) {
+            "navn-ascending" -> "a.navn asc"
+            "navn-descending" -> "a.navn desc"
+            "status-ascending" -> "a.avtalestatus asc"
+            "status-descending" -> "a.avtalestatus desc"
+            else -> "a.navn asc"
+        }
+
         @Language("PostgreSQL")
         val query = """
            select a.id,
@@ -181,7 +189,7 @@ class AvtaleRepository(private val db: Database) {
             from avtale a
                      join tiltakstype t on a.tiltakstype_id = t.id
             $where
-            order by a.navn
+            order by $order
             limit :limit
             offset :offset
         """.trimIndent()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -14,7 +14,8 @@ data class TiltakstypeFilter(
 data class AvtaleFilter(
     val search: String?,
     val avtalestatus: Avtalestatus? = null,
-    val enhet: String? = null
+    val enhet: String? = null,
+    val sortering: String? = null
 )
 
 data class EnhetFilter(
@@ -48,10 +49,12 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getAvtaleFilter(): AvtaleFilte
     val avtalestatus =
         call.request.queryParameters["avtalestatus"]?.let { status -> Avtalestatus.valueOf(status) }
     val enhet = call.request.queryParameters["enhet"]
+    val sortering = call.request.queryParameters["sort"]
     return AvtaleFilter(
         search = search,
         avtalestatus = avtalestatus,
-        enhet = enhet
+        enhet = enhet,
+        sortering = sortering
     )
 }
 

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -107,6 +107,10 @@ paths:
           schema:
             type: number
           description: Page size, default 50
+        - in: query
+          name: sort
+          schema:
+            $ref: "#/components/schemas/SorteringAvtaler"
       responses:
         200:
           description: Object of paginated avtaler connected to specified tiltakstype-id.
@@ -752,6 +756,14 @@ components:
         - Aktiv
         - Avsluttet
         - Avbrutt
+
+    SorteringAvtaler:
+        type: string
+        enum:
+          - navn-ascending
+          - navn-descending
+          - status-ascending
+          - status-descending
 
     Tiltaksgjennomforing:
       type: object


### PR DESCRIPTION
Nå kan man sortere på avtalenavn eller avtalestatus

Jeg vet ikke hvilke felter som vil gi mest verdi å sortere på så jeg legger inn navn og status i første omgang, så legger vi til flere ved behov senere.

![image](https://user-images.githubusercontent.com/9053627/219365020-51b674d2-8866-4941-8e61-aaa2e5370aef.png)
