### PR TITLE
:sparkles: Paginering for avtaler tilknyttet tiltakstyper

### DIFF
--- a/frontend/mr-admin-flate/src/api/QueryKeys.ts
+++ b/frontend/mr-admin-flate/src/api/QueryKeys.ts
@@ -31,7 +31,8 @@ export const QueryKeys = {
     sok: string,
     status: Avtalestatus,
     enhet: string,
-    sortering: string
-  ) => [sok, status, enhet, sortering, tiltakstypeId, "avtaler"],
+    sortering: string,
+    page: number
+  ) => [sok, status, enhet, sortering, tiltakstypeId, page, "avtaler"],
   enheter: () => ["enheter"],
 };

--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -1,4 +1,4 @@
-import { atom, ExtractAtomValue } from "jotai";
+import { ExtractAtomValue } from "jotai";
 import { atomWithHash } from "jotai-location";
 import { atomWithStorage } from "jotai/utils";
 import {
@@ -9,11 +9,17 @@ import {
 } from "mulighetsrommet-api-client";
 import { Rolle } from "../tilgang/tilgang";
 
-export const paginationAtom = atomWithHash("page", 1);
+export const paginationAtom = atomWithHash("page", 1, {
+  setHash: "replaceState",
+});
 export const paginationAtomTiltaksgjennomforingMedTiltakstype = atomWithHash(
   "pageOnGjennomforing",
-  1
+  1,
+  { setHash: "replaceState" }
 );
+export const avtalePaginationAtom = atomWithHash("avtalePage", 1, {
+  setHash: "replaceState",
+});
 
 export const rolleAtom = atomWithStorage<Rolle | undefined>(
   "mr-admin-rolle",
@@ -36,17 +42,21 @@ export const tiltakstypefilter = atomWithHash<{
   }
 );
 
-const avtaleFilter = atom<{
+const avtaleFilter = atomWithHash<{
   sok: string;
   status: Avtalestatus;
   enhet: string;
   sortering: SorteringAvtaler;
-}>({
-  sok: "",
-  status: Avtalestatus.AKTIV,
-  enhet: "",
-  sortering: SorteringAvtaler.NAVN_ASCENDING,
-});
+}>(
+  "avtalefilter",
+  {
+    sok: "",
+    status: Avtalestatus.AKTIV,
+    enhet: "",
+    sortering: SorteringAvtaler.NAVN_ASCENDING,
+  },
+  { setHash: "replaceState" }
+);
 
 export type avtaleFilterType = ExtractAtomValue<typeof avtaleFilter>;
 

--- a/frontend/mr-admin-flate/src/api/avtaler/useAvtalerForTiltakstype.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useAvtalerForTiltakstype.ts
@@ -2,11 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useDebounce } from "mulighetsrommet-frontend-common";
 import { useParams } from "react-router-dom";
-import { avtaleFilter } from "../atoms";
+import { AVTALE_PAGE_SIZE } from "../../constants";
+import { avtaleFilter, avtalePaginationAtom } from "../atoms";
 import { mulighetsrommetClient } from "../clients";
 import { QueryKeys } from "../QueryKeys";
 
 export function useAvtalerForTiltakstype() {
+  const [page] = useAtom(avtalePaginationAtom);
   const { tiltakstypeId } = useParams();
   const [filter] = useAtom(avtaleFilter);
   const debouncedSok = useDebounce(filter.sok, 300);
@@ -19,7 +21,8 @@ export function useAvtalerForTiltakstype() {
       debouncedSok,
       filter.status,
       filter.enhet,
-      filter.sortering
+      filter.sortering,
+      page
     ),
     () =>
       mulighetsrommetClient.avtaler.getAvtalerForTiltakstype({
@@ -28,6 +31,8 @@ export function useAvtalerForTiltakstype() {
         avtalestatus: filter.status ? filter.status : undefined,
         enhet: filter.enhet ? filter.enhet : undefined,
         sort: filter.sortering,
+        page,
+        size: AVTALE_PAGE_SIZE,
       })
   );
 }

--- a/frontend/mr-admin-flate/src/components/paginering/PagineringOversikt.tsx
+++ b/frontend/mr-admin-flate/src/components/paginering/PagineringOversikt.tsx
@@ -5,13 +5,21 @@ interface Props {
   page: number;
   antall: number;
   maksAntall?: number;
+  type: string;
 }
 
-export function PagineringsOversikt({ page, antall, maksAntall = 0 }: Props) {
+export function PagineringsOversikt({
+  page,
+  antall,
+  maksAntall = 0,
+  type,
+}: Props) {
+  if (antall === 0) return null;
+
   return (
     <Heading level="1" size="xsmall" data-testid="antall-tiltak">
       Viser {(page - 1) * PAGE_SIZE + 1}-{antall + (page - 1) * PAGE_SIZE} av{" "}
-      {maksAntall} tiltak
+      {maksAntall} {type}
     </Heading>
   );
 }

--- a/frontend/mr-admin-flate/src/components/tiltakstyper/TiltakstyperOversikt.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltakstyper/TiltakstyperOversikt.tsx
@@ -1,12 +1,13 @@
-import { Alert, Heading, Pagination } from "@navikt/ds-react";
+import { Alert, Pagination } from "@navikt/ds-react";
 import { useAtom } from "jotai";
 import { paginationAtom } from "../../api/atoms";
 import { useTiltakstyper } from "../../api/tiltakstyper/useTiltakstyper";
 import { PAGE_SIZE } from "../../constants";
 import { Laster } from "../Laster";
-import { TiltakstypeRad } from "./TiltakstypeRad";
 import styles from "../listeelementer/Listeelementer.module.scss";
 import { ListeheaderTiltakstyper } from "../listeelementer/Listeheader";
+import { PagineringsOversikt } from "../paginering/PagineringOversikt";
+import { TiltakstypeRad } from "./TiltakstypeRad";
 
 export function TiltakstyperOversikt() {
   const { data, isLoading } = useTiltakstyper();
@@ -20,19 +21,14 @@ export function TiltakstyperOversikt() {
   }
   const { data: tiltakstyper, pagination: paginering } = data;
 
-  const PagineringsOversikt = () => {
-    return (
-      <Heading level="3" size="xsmall" data-testid="antall-tiltak">
-        Viser {(page - 1) * PAGE_SIZE + 1}-
-        {tiltakstyper.length + (page - 1) * PAGE_SIZE} av{" "}
-        {paginering?.totalCount} tiltak
-      </Heading>
-    );
-  };
-
   return (
     <>
-      {tiltakstyper.length > 0 ? <PagineringsOversikt /> : null}
+      <PagineringsOversikt
+        page={page}
+        antall={tiltakstyper.length}
+        maksAntall={paginering.totalCount}
+        type="tiltakstyper"
+      />
       {tiltakstyper.length === 0 ? (
         <Alert variant="info">Vi fant ingen tiltakstyper</Alert>
       ) : (
@@ -46,7 +42,12 @@ export function TiltakstyperOversikt() {
           <div className={styles.under_oversikt}>
             {tiltakstyper.length > 0 && (
               <>
-                <PagineringsOversikt />
+                <PagineringsOversikt
+                  page={page}
+                  antall={tiltakstyper.length}
+                  maksAntall={paginering.totalCount}
+                  type="tiltakstyper"
+                />
                 <Pagination
                   size="small"
                   data-testid="paginering"

--- a/frontend/mr-admin-flate/src/constants.ts
+++ b/frontend/mr-admin-flate/src/constants.ts
@@ -3,6 +3,7 @@ import { Shortcut } from "./components/navbar/Navbar";
 export const APPLICATION_NAME = "mr-admin-flate";
 
 export const PAGE_SIZE = 15;
+export const AVTALE_PAGE_SIZE = 15;
 
 export const shortcuts: Shortcut[] = [
   { url: "/tiltakstyper", navn: "Tiltakstyper" },

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
@@ -12,7 +12,7 @@ import { TiltakstypeDetaljer } from "./Tiltakstypedetaljer";
 
 export function DetaljerTiltakstypePage() {
   const optionalTiltakstype = useTiltakstypeById();
-  const [tabValgt, setTabValgt] = useState("arenaInfo");
+  const [tabValgt, setTabValgt] = useState("avtaler"); // arenaInfo
   const features = useFeatureToggles();
 
   if (optionalTiltakstype.isFetching) {

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/avtaler/AvtalerForTiltakstype.module.scss
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/avtaler/AvtalerForTiltakstype.module.scss
@@ -1,0 +1,5 @@
+.paginering {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1rem;
+}

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/avtaler/AvtalerForTiltakstype.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/avtaler/AvtalerForTiltakstype.tsx
@@ -1,12 +1,53 @@
+import { Pagination } from "@navikt/ds-react";
+import { useAtom } from "jotai";
+import { avtalePaginationAtom } from "../../../api/atoms";
+import { useAvtalerForTiltakstype } from "../../../api/avtaler/useAvtalerForTiltakstype";
 import { Avtalefilter } from "../../../components/avtaler/Avtalefilter";
+import { PagineringsOversikt } from "../../../components/paginering/PagineringOversikt";
+import { AVTALE_PAGE_SIZE } from "../../../constants";
+import styles from "./AvtalerForTiltakstype.module.scss";
 import { AvtaleTabell } from "./AvtaleTabell";
 
 export function AvtalerForTiltakstype() {
+  const [page, setPage] = useAtom(avtalePaginationAtom);
+  const { data } = useAvtalerForTiltakstype();
+
+  if (!data) {
+    return null;
+  }
+
+  const { data: avtaler = [], pagination } = data;
+
   return (
     <>
       <Avtalefilter />
+      <PagineringsOversikt
+        page={page}
+        antall={avtaler.length}
+        maksAntall={pagination.totalCount}
+        type="avtaler"
+      />
       <AvtaleTabell />
-      {/** TODO Her kommer paginering for avtaler */}
+      {avtaler.length > 0 ? (
+        <div className={styles.paginering}>
+          <PagineringsOversikt
+            page={page}
+            antall={avtaler.length}
+            maksAntall={pagination.totalCount}
+            type="avtaler"
+          />
+          <Pagination
+            size="small"
+            data-testid="paginering"
+            page={page}
+            onPageChange={setPage}
+            count={Math.ceil(
+              (pagination?.totalCount ?? AVTALE_PAGE_SIZE) / AVTALE_PAGE_SIZE
+            )}
+            data-version="v1"
+          />
+        </div>
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
Man kan nå navigere via paginering dersom en tiltakstype har mange avtaler tilknyttet seg

![image](https://user-images.githubusercontent.com/9053627/219373727-3ca317a4-a030-4807-9619-17ad19a8f53b.png)
