### PR TITLE
Oppsett for slack-notifikasjoner

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Administrasjonsflate for tiltak- og fagansvarlige i NAV som jobber med tiltaksty
 | Url (dev-miljø)  | <https://mulighetsrommet-admin-flate.dev.intern.nav.no>                                 |
 | Url (prod-miljø) | <https://mulighetsrommet-admin-flate.intern.nav.no>                                     |
 
+## Overvåking av automatiske jobber
+Vi har satt opp to Slack-bots som kan gi beskjed til oss på Slack i kanalen #team-valp-monitoring dersom det oppstår feil under kjøring av de automatiske jobbene.
+
+Botene finner man her:
+- Dev-monitorering: https://api.slack.com/apps/A04PW7S8J94/general
+- Prod-monitorering: https://api.slack.com/apps/A04Q2NNABDZ
+
 ## Henvendelser
 
 Spørsmål knyttet til koden eller prosjektet kan stilles via issues her på GitHub.

--- a/common/ktor/build.gradle.kts
+++ b/common/ktor/build.gradle.kts
@@ -35,6 +35,10 @@ dependencies {
     val navCommonModules = "2.2023.01.02_13.51-1c6adeb1653b"
     implementation("no.nav.common:audit-log:$navCommonModules")
 
+    // Slack-SDK
+    val slackVersion = "1.27.3"
+    implementation("com.slack.api:slack-api-client:$slackVersion")
+
     // Cache
     val caffeineVersion = "3.1.2"
     implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")

--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/slack_notifier/SlackNotifier.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/slack_notifier/SlackNotifier.kt
@@ -1,0 +1,5 @@
+package no.nav.mulighetsrommet.slack_notifier
+
+interface SlackNotifier {
+    fun sendMessage(message: String)
+}

--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/slack_notifier/SlackNotifierImpl.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/slack_notifier/SlackNotifierImpl.kt
@@ -1,0 +1,32 @@
+package no.nav.mulighetsrommet.slack_notifier
+
+import com.slack.api.Slack
+import org.slf4j.LoggerFactory
+
+class SlackNotifierImpl(private val token: String, private val channel: String, private val enabled: Boolean) :
+    SlackNotifier {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val slack = Slack.getInstance()
+
+    init {
+        log.info("Initierer SlackNotifier for kanal: $channel")
+    }
+
+    override fun sendMessage(message: String) {
+        if (!enabled) {
+            log.info("Sending av melding via SlackNotifier er ikke skrudd på. Enabled = $enabled")
+            return
+        }
+
+        val response = slack.methods(token).chatPostMessage {
+            it.channel(channel)
+                .text(message)
+        }
+        if (!response.isOk) {
+            log.warn(
+                "Klarte ikke sende melding til Slack-kanal: $channel. Skulle sendt melding: '$message'",
+                response.errors.joinToString("\n")
+            )
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -27,7 +27,8 @@ data class AppConfig(
     val arenaAdapter: ServiceClientConfig,
     val msGraphConfig: ServiceClientConfig,
     val tasks: TaskConfig,
-    val norg2: Norg2Config
+    val norg2: Norg2Config,
+    val slack: SlackConfig
 )
 
 data class AuthConfig(
@@ -73,4 +74,10 @@ data class TaskConfig(
 
 data class Norg2Config(
     val baseUrl: String
+)
+
+data class SlackConfig(
+    val token: String,
+    val channel: String,
+    val enable: Boolean
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.services
 
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Client
+import no.nav.mulighetsrommet.api.domain.Norg2Enhet
 import no.nav.mulighetsrommet.api.domain.dbo.EnhetStatus
 import no.nav.mulighetsrommet.api.domain.dbo.Norg2EnhetDbo
 import no.nav.mulighetsrommet.api.repositories.EnhetRepository
@@ -8,7 +9,7 @@ import org.slf4j.LoggerFactory
 
 class Norg2Service(private val norg2Client: Norg2Client, private val enhetRepository: EnhetRepository) {
     private val log = LoggerFactory.getLogger(javaClass)
-    suspend fun synkroniserEnheter() {
+    suspend fun synkroniserEnheter(): List<Norg2Enhet> {
         val enheter = norg2Client.hentEnheter()
         log.info("Hentet ${enheter.size} enheter fra NORG2")
         enheter.forEach {
@@ -21,5 +22,6 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
                 )
             )
         }
+        return enheter
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNorgEnheter.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNorgEnheter.kt
@@ -5,9 +5,10 @@ import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay
 import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.api.services.Norg2Service
+import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
 import org.slf4j.LoggerFactory
 
-class SynchronizeNorgEnheter(config: Config, norg2Service: Norg2Service) {
+class SynchronizeNorgEnheter(config: Config, norg2Service: Norg2Service, slackNotifier: SlackNotifier) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     data class Config(
@@ -17,10 +18,15 @@ class SynchronizeNorgEnheter(config: Config, norg2Service: Norg2Service) {
 
     val task: RecurringTask<Void> = Tasks
         .recurring("synchronize-norg2-enheter", FixedDelay.ofMinutes(config.delayOfMinutes))
+        .onFailure { _, _ ->
+            slackNotifier.sendMessage("Klarte ikke synkronisere enheter fra NORG2. Konsekvensen er at ingen enheter blir oppdaterte i databasen og vi kan potensielt vise feil enheter til bruker i admin-flate.")
+        }
         .execute { _, _ ->
             runBlocking {
                 logger.info("Kjører synkronisering av NORG2-enheter")
-                norg2Service.synkroniserEnheter()
+                slackNotifier.sendMessage("Synkroniserer NORG2-enheter...")
+                val enheter = norg2Service.synkroniserEnheter()
+                slackNotifier.sendMessage("Synkroniserte ${enheter.size} enheter fra NORG2")
             }
         }
 }

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -80,6 +80,6 @@ app:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1
 
   slack:
-    token: ${SLACK_DEV_TOKEN}
+    token: ${SLACK_TOKEN}
     channel: "#team-valp-monitoring"
     enable: true

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -78,3 +78,8 @@ app:
 
   norg2:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1
+
+  slack:
+    token: ${SLACK_DEV_TOKEN}
+    channel: "#team-valp-monitoring"
+    enable: true

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -77,3 +77,8 @@ app:
 
   norg2:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1
+
+  slack:
+    token: ${SLACK_DEV_TOKEN}
+    channel: "#team-valp-monitoring"
+    enable: true

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -79,6 +79,6 @@ app:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1
 
   slack:
-    token: ${SLACK_DEV_TOKEN:-""}
+    token: ${SLACK_TOKEN:-""}
     channel: "#team-valp-monitoring"
     enable: false

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -79,6 +79,6 @@ app:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1
 
   slack:
-    token: ${SLACK_DEV_TOKEN}
+    token: ${SLACK_DEV_TOKEN:-""}
     channel: "#team-valp-monitoring"
-    enable: true
+    enable: false

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -75,3 +75,8 @@ app:
 
   norg2:
     baseUrl: https://norg2.prod-fss-pub.nais.io/norg2/api/v1
+
+  slack:
+    token: ${SLACK_PROD_TOKEN}
+    channel: "#team-valp-monitoring"
+    enable: true

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -77,6 +77,6 @@ app:
     baseUrl: https://norg2.prod-fss-pub.nais.io/norg2/api/v1
 
   slack:
-    token: ${SLACK_PROD_TOKEN}
+    token: ${SLACK_TOKEN}
     channel: "#team-valp-monitoring"
     enable: true

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/MulighetsrommetTestConfig.kt
@@ -39,7 +39,12 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
             delayOfMinutes = 10
         ),
     ),
-    norg2 = Norg2Config(baseUrl = "")
+    norg2 = Norg2Config(baseUrl = ""),
+    slack = SlackConfig(
+        token = "",
+        channel = "",
+        enable = false
+    )
 )
 
 fun createKafkaConfig(): KafkaConfig {

--- a/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
@@ -60,3 +60,6 @@ spec:
     outbound:
       rules:
         - application: mulighetsrommet-api
+
+  envFrom:
+    - mulighetsrommet-arena-adapter

--- a/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
@@ -63,3 +63,6 @@ spec:
     outbound:
       rules:
         - application: mulighetsrommet-api
+
+  envFrom:
+    - mulighetsrommet-arena-adapter

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
@@ -16,7 +16,8 @@ data class AppConfig(
     val services: ServiceConfig,
     val database: FlywayDatabaseConfig,
     val kafka: KafkaConfig,
-    val auth: AuthConfig
+    val auth: AuthConfig,
+    val slack: SlackConfig
 )
 
 data class TaskConfig(
@@ -67,4 +68,10 @@ data class ConsumerConfig(
     val id: String,
     val topic: String,
     val initialRunningState: Boolean = false,
+)
+
+data class SlackConfig(
+    val token: String,
+    val channel: String,
+    val enable: Boolean
 )

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
@@ -48,3 +48,8 @@ app:
         tiltakdeltakerendret: teamarenanais.aapen-arena-tiltakdeltakerendret-v1-q2
         sakendret: teamarenanais.aapen-arena-sakendret-v1-q2
         avtaleinfoendret: teamarenanais.aapen-arena-avtaleinfoendret-v1-q2
+
+  slack:
+    token: ${SLACK_DEV_TOKEN}
+    channel: "#team-valp-monitoring"
+    enable: true

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
@@ -50,6 +50,6 @@ app:
         avtaleinfoendret: teamarenanais.aapen-arena-avtaleinfoendret-v1-q2
 
   slack:
-    token: ${SLACK_DEV_TOKEN}
+    token: ${SLACK_TOKEN}
     channel: "#team-valp-monitoring"
     enable: true

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
@@ -49,6 +49,6 @@ app:
         avtaleinfoendret: avtaleinfoendret
 
   slack:
-    token: ${SLACK_DEV_TOKEN:-""}
+    token: ${SLACK_TOKEN:-""}
     channel: "#team-valp-monitoring"
     enable: false

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
@@ -47,3 +47,8 @@ app:
         tiltakdeltakerendret: tiltakdeltakerendret
         sakendret: sakendret
         avtaleinfoendret: avtaleinfoendret
+
+  slack:
+    token: ${SLACK_DEV_TOKEN}
+    channel: "#team-valp-monitoring"
+    enable: true

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
@@ -49,6 +49,6 @@ app:
         avtaleinfoendret: avtaleinfoendret
 
   slack:
-    token: ${SLACK_DEV_TOKEN}
+    token: ${SLACK_DEV_TOKEN:-""}
     channel: "#team-valp-monitoring"
-    enable: true
+    enable: false

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
@@ -48,3 +48,8 @@ app:
         tiltakdeltakerendret: teamarenanais.aapen-arena-tiltakdeltakerendret-v1-p
         sakendret: teamarenanais.aapen-arena-tiltakssakendret-v1-p
         avtaleinfoendret: teamarenanais.aapen-arena-avtaleinfoendret-v1-p
+
+  slack:
+    token: ${SLACK_PROD_TOKEN}
+    channel: "#team-valp-monitoring"
+    enable: true

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
@@ -50,6 +50,6 @@ app:
         avtaleinfoendret: teamarenanais.aapen-arena-avtaleinfoendret-v1-p
 
   slack:
-    token: ${SLACK_PROD_TOKEN}
+    token: ${SLACK_TOKEN}
     channel: "#team-valp-monitoring"
     enable: true

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ArenaAdapterTestConfig.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ArenaAdapterTestConfig.kt
@@ -37,6 +37,11 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
             maxRetries = 0
         ),
         arenaOrdsProxy = ServiceClientConfig(url = "arena-ords-proxy", scope = "")
+    ),
+    slack = SlackConfig(
+        token = "",
+        channel = "",
+        enable = false
     )
 )
 


### PR DESCRIPTION
Minimumsoppsett for notifkasjoner til kanalen `#team-valp-monitoring` på Slack. 

Jeg har opprettet en secret i Secret Manager hos GCP for arena-adapter slik at vi kan legge inn token for dev- og prod. 

Jeg har valgt å opprette to bots, en for dev og en for prod så vi kan skille på navn. Kanskje vi på sikt bare ønsker å kjøre prod-boten også?

Selve meldingen til Slack er bare enkel tekst for øyeblikket, men Slack sitt SDK for Kotlin har støtte for mer rik tekst dersom vi ønsker det. https://slack.dev/java-slack-sdk/guides/composing-messages#block-kit-kotlin-dsl

