### PR TITLE
Mapper virksomhetsnummer til arrangørnavn on the fly

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/AvtaleAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/AvtaleAdminDto.kt
@@ -14,6 +14,7 @@ data class AvtaleAdminDto(
     val navn: String,
     val avtalenummer: String,
     val leverandorOrganisasjonsnummer: String,
+    val leverandornavn: String? = null,
     @Serializable(with = LocalDateSerializer::class)
     val startDato: LocalDate,
     @Serializable(with = LocalDateSerializer::class)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -196,7 +196,7 @@ private fun services(appConfig: AppConfig) = module {
     }
     single { ArenaAdapterService(get()) }
     single { ArenaService(get(), get(), get(), get(), get(), get()) }
-    single { AvtaleService(get()) }
+    single { AvtaleService(get(), get()) }
     single { HistorikkService(get(), get()) }
     single { SanityService(appConfig.sanity, get()) }
     single { ArrangorService(get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArrangorService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArrangorService.kt
@@ -3,6 +3,7 @@ package no.nav.mulighetsrommet.api.services
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import no.nav.mulighetsrommet.api.clients.enhetsregister.AmtEnhetsregisterClient
+import no.nav.mulighetsrommet.api.domain.VirksomhetDTO
 import no.nav.mulighetsrommet.utils.CacheUtils
 import java.util.concurrent.TimeUnit
 
@@ -10,17 +11,20 @@ class ArrangorService(
     private val amtEnhetsregisterClient: AmtEnhetsregisterClient
 ) {
 
-    val cache: Cache<String, String> = Caffeine.newBuilder()
+    val cache: Cache<String, VirksomhetDTO> = Caffeine.newBuilder()
         .expireAfterWrite(12, TimeUnit.HOURS)
         .maximumSize(10000)
         .build()
 
-    suspend fun hentArrangornavn(virksomhetsnummer: String): String? {
+    suspend fun hentVirksomhet(virksomhetsnummer: String): VirksomhetDTO? {
         return CacheUtils
-            .tryCacheFirstNotNull(cache, virksomhetsnummer) {
-                val virksomhet = virksomhetsnummer.let { amtEnhetsregisterClient.hentVirksomhet(it.toInt()) }
-                virksomhet?.overordnetEnhetNavn ?: ""
+            .tryCacheFirstNullable(cache, virksomhetsnummer) {
+                val virksomhet: VirksomhetDTO? = virksomhetsnummer.let { amtEnhetsregisterClient.hentVirksomhet(it.toInt()) }
+                virksomhet
             }
-            .ifEmpty { null }
+    }
+
+    suspend fun hentArrangornavn(virksomhetsnummer: String): String {
+        return hentVirksomhet(virksomhetsnummer)?.overordnetEnhetNavn ?: ""
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
@@ -8,17 +8,17 @@ import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.domain.dto.AvtaleAdminDto
 import java.util.*
 
-class AvtaleService(private val avtaler: AvtaleRepository) {
+class AvtaleService(private val avtaler: AvtaleRepository, private val arrangorService: ArrangorService) {
 
     fun get(id: UUID): AvtaleAdminDto? {
         return avtaler.get(id)
     }
 
-    fun getAll(pagination: PaginationParams): PaginatedResponse<AvtaleAdminDto> {
+    suspend fun getAll(pagination: PaginationParams): PaginatedResponse<AvtaleAdminDto> {
         val (totalCount, items) = avtaler.getAll(pagination)
 
         return PaginatedResponse(
-            data = items,
+            data = items.hentVirksomhetsnavnForAvtaler(),
             pagination = Pagination(
                 totalCount = totalCount,
                 currentPage = pagination.page,
@@ -27,16 +27,29 @@ class AvtaleService(private val avtaler: AvtaleRepository) {
         )
     }
 
-    fun getAvtalerForTiltakstype(tiltakstypeId: UUID, filter: AvtaleFilter, pagination: PaginationParams = PaginationParams()): PaginatedResponse<AvtaleAdminDto> {
+    suspend fun getAvtalerForTiltakstype(
+        tiltakstypeId: UUID,
+        filter: AvtaleFilter,
+        pagination: PaginationParams = PaginationParams()
+    ): PaginatedResponse<AvtaleAdminDto> {
         val (totalCount, items) = avtaler.getAvtalerForTiltakstype(tiltakstypeId, filter, pagination)
 
+        val avtalerMedLeverandorNavn = items.hentVirksomhetsnavnForAvtaler()
+
         return PaginatedResponse(
-            data = items,
+            data = avtalerMedLeverandorNavn,
             pagination = Pagination(
                 totalCount = totalCount,
                 currentPage = pagination.page,
                 pageSize = pagination.limit
             )
         )
+    }
+
+    private suspend fun List<AvtaleAdminDto>.hentVirksomhetsnavnForAvtaler(): List<AvtaleAdminDto> {
+        return this.map {
+            val virksomhet = arrangorService.hentVirksomhet(it.leverandorOrganisasjonsnummer)
+            it.copy(leverandornavn = virksomhet?.navn ?: "")
+        }
     }
 }


### PR DESCRIPTION
Når vi skal vise tabell med avtaler tilknyttet en tiltakstype så ønsker vi å vise navnet på virksomheten, ikke bare virksomhetsnummeret. Denne PRen viser et minimalt eksempel på hvordan vi kan gjøre det. Det vil være flere behov knyttet til virksomhetsnummer og bedriftsnavn, men litt usikker på hvor mye vi skal legge til rette for det, før vi helt vet hva vi skal implementere.