### PR TITLE
Bump deps og fjern hardkodet høyde for search

### DIFF
--- a/frontend/mr-admin-flate/package.json
+++ b/frontend/mr-admin-flate/package.json
@@ -16,17 +16,17 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@navikt/ds-css": "^2.1.7",
-    "@navikt/ds-css-internal": "^2.1.7",
-    "@navikt/ds-icons": "^2.1.7",
-    "@navikt/ds-react": "^2.1.7",
-    "@navikt/ds-react-internal": "^2.1.7",
-    "@tanstack/react-query": "^4.24.6",
-    "@tanstack/react-query-devtools": "^4.24.6",
+    "@navikt/ds-css": "^2.3.0",
+    "@navikt/ds-css-internal": "^2.3.0",
+    "@navikt/ds-icons": "^2.3.0",
+    "@navikt/ds-react": "^2.3.0",
+    "@navikt/ds-react-internal": "^2.3.0",
+    "@tanstack/react-query": "^4.24.10",
+    "@tanstack/react-query-devtools": "^4.24.10",
     "classnames": "^2.3.2",
     "eslint": "8.34.0",
     "formik": "^2.2.9",
-    "jotai": "^2.0.1",
+    "jotai": "^2.0.2",
     "jotai-location": "^0.4.0",
     "mulighetsrommet-api-client": "*",
     "mulighetsrommet-frontend-common": "*",
@@ -40,14 +40,14 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.28",
-    "@types/react-dom": "^18.0.10",
+    "@types/react-dom": "^18.0.11",
     "axe-core": "^4.6.3",
     "cross-env": "^7.0.3",
-    "cypress": "^12.5.1",
+    "cypress": "^12.6.0",
     "cypress-axe": "^1.3.0",
     "msw": "^1.0.1",
     "typescript": "^4.9.5",
-    "vite": "^4.1.1"
+    "vite": "^4.1.4"
   },
   "msw": {
     "workerDirectory": "public"

--- a/frontend/mr-admin-flate/src/components/avtaler/Avtalefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/Avtalefilter.tsx
@@ -31,7 +31,6 @@ export function Avtalefilter() {
         <div className={styles.filter_left}>
           <Search
             ref={searchRef}
-            style={{ height: "34px" }} // Samme høyde som select-komponentene under
             label="Søk etter avtale"
             hideLabel
             variant="simple"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,17 +40,17 @@
     "frontend/mr-admin-flate": {
       "version": "0.0.0",
       "dependencies": {
-        "@navikt/ds-css": "^2.1.7",
-        "@navikt/ds-css-internal": "^2.1.7",
-        "@navikt/ds-icons": "^2.1.7",
-        "@navikt/ds-react": "^2.1.7",
-        "@navikt/ds-react-internal": "^2.1.7",
-        "@tanstack/react-query": "^4.24.6",
-        "@tanstack/react-query-devtools": "^4.24.6",
+        "@navikt/ds-css": "^2.3.0",
+        "@navikt/ds-css-internal": "^2.3.0",
+        "@navikt/ds-icons": "^2.3.0",
+        "@navikt/ds-react": "^2.3.0",
+        "@navikt/ds-react-internal": "^2.3.0",
+        "@tanstack/react-query": "^4.24.10",
+        "@tanstack/react-query-devtools": "^4.24.10",
         "classnames": "^2.3.2",
         "eslint": "8.34.0",
         "formik": "^2.2.9",
-        "jotai": "^2.0.1",
+        "jotai": "^2.0.2",
         "jotai-location": "^0.4.0",
         "mulighetsrommet-api-client": "*",
         "mulighetsrommet-frontend-common": "*",
@@ -64,14 +64,14 @@
       },
       "devDependencies": {
         "@types/react": "^18.0.28",
-        "@types/react-dom": "^18.0.10",
+        "@types/react-dom": "^18.0.11",
         "axe-core": "^4.6.3",
         "cross-env": "^7.0.3",
-        "cypress": "^12.5.1",
+        "cypress": "^12.6.0",
         "cypress-axe": "^1.3.0",
         "msw": "^1.0.1",
         "typescript": "^4.9.5",
-        "vite": "^4.1.1"
+        "vite": "^4.1.4"
       }
     },
     "frontend/mr-admin-flate/node_modules/@esbuild/android-arm": {
@@ -104,60 +104,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "frontend/mr-admin-flate/node_modules/@tanstack/query-core": {
-      "version": "4.24.6",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.24.6.tgz",
-      "integrity": "sha512-Tfru6YTDTCpX7dKVwHp/sosw/dNjEdzrncduUjIkQxn7n7u+74HT2ZrGtwwrU6Orws4x7zp3FKRqBPWVVhpx9w==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "frontend/mr-admin-flate/node_modules/@tanstack/react-query": {
-      "version": "4.24.6",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.24.6.tgz",
-      "integrity": "sha512-pbJUVZCS4pcXS0kZiY+mVJ01ude0GrH5OXT2g9whcqSveRG/YVup/XdA9NdRpSMGkP2HxDRxxRNsTXkniWeIIA==",
-      "dependencies": {
-        "@tanstack/query-core": "4.24.6",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "frontend/mr-admin-flate/node_modules/@tanstack/react-query-devtools": {
-      "version": "4.24.6",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.24.6.tgz",
-      "integrity": "sha512-d8CN4ZTtLkdCNi9x4Hogma0fdhlv7ckknv/RLuV4nbUciUoZEvhg1cI0+vp/1aY4W3jq9vH0BD/eUQKecgY15Q==",
-      "dependencies": {
-        "@tanstack/match-sorter-utils": "^8.7.0",
-        "superjson": "^1.10.0",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "4.24.6",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "frontend/mr-admin-flate/node_modules/ansi-styles": {
@@ -267,9 +213,9 @@
       }
     },
     "frontend/mr-admin-flate/node_modules/jotai": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.0.1.tgz",
-      "integrity": "sha512-b/BpBFkv3nq8HgT6YX5h5/y9VfKIn9OL1dO6gd9bWTgKt6LLe24VIMURTDwSYS888XfubuRQlbepb5IQGAtmcQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.0.2.tgz",
+      "integrity": "sha512-0yOked08Swa84LUbBjtj7ZLZrE05n3u50rHeZ+bsT86thUjcy0kFgQz9GmEWhYbQDFoT1G8Ww6edSj/MBJHO4A==",
       "engines": {
         "node": ">=12.20.0"
       },
@@ -434,9 +380,9 @@
       }
     },
     "frontend/mr-admin-flate/node_modules/vite": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.1.tgz",
-      "integrity": "sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
+      "integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.16.14",
@@ -6080,19 +6026,19 @@
       }
     },
     "node_modules/@navikt/ds-css": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-2.1.7.tgz",
-      "integrity": "sha512-Dq/vFsGqnmVQCRWGLIzOB7XaFWgJRYVnbA2n4lfcnovp+zCwql1NNXKscvVWqaQEbq+2bGR71A5bgrr4NCR14w=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-2.3.0.tgz",
+      "integrity": "sha512-OPboAg87IEm0jbH7R8LUY7/q4ZTKfHJ4OfUDF8ymMPmNJukcGxfPuUgXPRN1RnBWBxaMOMtejHFIc9LvACWirQ=="
     },
     "node_modules/@navikt/ds-css-internal": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-css-internal/-/ds-css-internal-2.1.7.tgz",
-      "integrity": "sha512-SSMkiKW7gTRvk/32fdgoY7JIBA/VaCSbtp91FrZdIMMkQzNtvCJm7ZSTbodEDqnoKm11ybuQJ2fud0M/l3wa3Q=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-css-internal/-/ds-css-internal-2.3.0.tgz",
+      "integrity": "sha512-L3jNNqbk0hMWlKC1tgBdRnRid+rK+oq0+rb6IupDIoGa3pK66uGRFZ+2Lq+kFnELJ0MD5BrSeBHrvVYZTNZdnA=="
     },
     "node_modules/@navikt/ds-icons": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-icons/-/ds-icons-2.1.7.tgz",
-      "integrity": "sha512-1QGVRkkjPeqPRJg3kbO5WcWLIkronMNmz4m1MFC+HPZ4+Dp4WXIHeBUi6b13rrJAXBxb2Dun+gpbXxSzPxx79A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-icons/-/ds-icons-2.3.0.tgz",
+      "integrity": "sha512-YJH5dqSxfJdGJOwj6AABQvcL+w2OHs+HoqqsDlGc1fG8/xP5e620UOIgRLD7HisS+dmE2t9OJESPjuI42agkCw==",
       "peerDependencies": {
         "@types/react": "^17.0.30 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0"
@@ -6104,12 +6050,12 @@
       }
     },
     "node_modules/@navikt/ds-react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-2.1.7.tgz",
-      "integrity": "sha512-3IX4YfCbxS+ZsU/F2e9icIpacGDuZI8GEVFXZexOgWA7LfpK7a4Maif2Xi+pFo6mgmQUV6PJW4XCP417MjVrmQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-2.3.0.tgz",
+      "integrity": "sha512-+Xqnfjx3HygibJznsAu4UKRgDQLxKRS2R+MJrefZBvyKGIr8/v0Nth3tZHy5cjkQVNnUhKxOq8caxfN80JdqgQ==",
       "dependencies": {
         "@floating-ui/react": "0.17.0",
-        "@navikt/ds-icons": "^2.1.7",
+        "@navikt/ds-icons": "^2.3.0",
         "@radix-ui/react-tabs": "1.0.0",
         "@radix-ui/react-toggle-group": "1.0.0",
         "clsx": "^1.2.1",
@@ -6128,12 +6074,12 @@
       }
     },
     "node_modules/@navikt/ds-react-internal": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-react-internal/-/ds-react-internal-2.1.7.tgz",
-      "integrity": "sha512-1aaGBk3Dvvu2pAs6FVFnEsoES8BULEpYQ0Ezp2KorgjQikwAKbq79FZ6cdWUEOLwIVKB1V3987T7Km+xLBpXfQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-react-internal/-/ds-react-internal-2.3.0.tgz",
+      "integrity": "sha512-d3HL1J/6a409TyD2AxssgImypePm0BORTUEZcwBI8xDUZax39EoQxKQJfT790OwwDRvBeajD1iLQg+KeoMO59g==",
       "dependencies": {
-        "@navikt/ds-icons": "^2.1.7",
-        "@navikt/ds-react": "^2.1.7",
+        "@navikt/ds-icons": "^2.3.0",
+        "@navikt/ds-react": "^2.3.0",
         "clsx": "^1.1.1",
         "copy-to-clipboard": "^3.3.1"
       },
@@ -7763,6 +7709,60 @@
         "url": "https://github.com/sponsors/kentcdodds"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.24.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.24.10.tgz",
+      "integrity": "sha512-2QywqXEAGBIUoTdgn1lAB4/C8QEqwXHj2jrCLeYTk2xVGtLiPEUD8jcMoeB2noclbiW2mMt4+Fq7fZStuz3wAQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.24.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.24.10.tgz",
+      "integrity": "sha512-FY1DixytOcNNCydPQXLxuKEV7VSST32CAuJ55BjhDNqASnMLZn+6c30yQBMrODjmWMNwzfjMZnq0Vw7C62Fwow==",
+      "dependencies": {
+        "@tanstack/query-core": "4.24.10",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.24.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.24.10.tgz",
+      "integrity": "sha512-1uzJNLdLjRsNt4O5ldv1SYPevWvSdHtKIyVJeUv4hSERPEhrKKfa8WC3dBOX24CdLEYH2ndLZW4ZiC9nzSKCtg==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "4.24.10",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.0.0-beta.29",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.29.tgz",
@@ -8119,9 +8119,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
-      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -11140,9 +11140,9 @@
       "integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A=="
     },
     "node_modules/cypress": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.5.1.tgz",
-      "integrity": "sha512-ZmCmJ3lsyeOpBfh410m5+AO2CO1AxAzFBt7k6/uVbNcrNZje1vdiwYTpj2ksPKg9mjr9lR6V8tmlDNMvr4H/YQ==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
+      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -11163,7 +11163,7 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -28177,28 +28177,28 @@
       }
     },
     "@navikt/ds-css": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-2.1.7.tgz",
-      "integrity": "sha512-Dq/vFsGqnmVQCRWGLIzOB7XaFWgJRYVnbA2n4lfcnovp+zCwql1NNXKscvVWqaQEbq+2bGR71A5bgrr4NCR14w=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-2.3.0.tgz",
+      "integrity": "sha512-OPboAg87IEm0jbH7R8LUY7/q4ZTKfHJ4OfUDF8ymMPmNJukcGxfPuUgXPRN1RnBWBxaMOMtejHFIc9LvACWirQ=="
     },
     "@navikt/ds-css-internal": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-css-internal/-/ds-css-internal-2.1.7.tgz",
-      "integrity": "sha512-SSMkiKW7gTRvk/32fdgoY7JIBA/VaCSbtp91FrZdIMMkQzNtvCJm7ZSTbodEDqnoKm11ybuQJ2fud0M/l3wa3Q=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-css-internal/-/ds-css-internal-2.3.0.tgz",
+      "integrity": "sha512-L3jNNqbk0hMWlKC1tgBdRnRid+rK+oq0+rb6IupDIoGa3pK66uGRFZ+2Lq+kFnELJ0MD5BrSeBHrvVYZTNZdnA=="
     },
     "@navikt/ds-icons": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-icons/-/ds-icons-2.1.7.tgz",
-      "integrity": "sha512-1QGVRkkjPeqPRJg3kbO5WcWLIkronMNmz4m1MFC+HPZ4+Dp4WXIHeBUi6b13rrJAXBxb2Dun+gpbXxSzPxx79A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-icons/-/ds-icons-2.3.0.tgz",
+      "integrity": "sha512-YJH5dqSxfJdGJOwj6AABQvcL+w2OHs+HoqqsDlGc1fG8/xP5e620UOIgRLD7HisS+dmE2t9OJESPjuI42agkCw==",
       "requires": {}
     },
     "@navikt/ds-react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-2.1.7.tgz",
-      "integrity": "sha512-3IX4YfCbxS+ZsU/F2e9icIpacGDuZI8GEVFXZexOgWA7LfpK7a4Maif2Xi+pFo6mgmQUV6PJW4XCP417MjVrmQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-2.3.0.tgz",
+      "integrity": "sha512-+Xqnfjx3HygibJznsAu4UKRgDQLxKRS2R+MJrefZBvyKGIr8/v0Nth3tZHy5cjkQVNnUhKxOq8caxfN80JdqgQ==",
       "requires": {
         "@floating-ui/react": "0.17.0",
-        "@navikt/ds-icons": "^2.1.7",
+        "@navikt/ds-icons": "^2.3.0",
         "@radix-ui/react-tabs": "1.0.0",
         "@radix-ui/react-toggle-group": "1.0.0",
         "clsx": "^1.2.1",
@@ -28208,12 +28208,12 @@
       }
     },
     "@navikt/ds-react-internal": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@navikt/ds-react-internal/-/ds-react-internal-2.1.7.tgz",
-      "integrity": "sha512-1aaGBk3Dvvu2pAs6FVFnEsoES8BULEpYQ0Ezp2KorgjQikwAKbq79FZ6cdWUEOLwIVKB1V3987T7Km+xLBpXfQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-react-internal/-/ds-react-internal-2.3.0.tgz",
+      "integrity": "sha512-d3HL1J/6a409TyD2AxssgImypePm0BORTUEZcwBI8xDUZax39EoQxKQJfT790OwwDRvBeajD1iLQg+KeoMO59g==",
       "requires": {
-        "@navikt/ds-icons": "^2.1.7",
-        "@navikt/ds-react": "^2.1.7",
+        "@navikt/ds-icons": "^2.3.0",
+        "@navikt/ds-react": "^2.3.0",
         "clsx": "^1.1.1",
         "copy-to-clipboard": "^3.3.1"
       }
@@ -29448,6 +29448,30 @@
         "remove-accents": "0.4.2"
       }
     },
+    "@tanstack/query-core": {
+      "version": "4.24.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.24.10.tgz",
+      "integrity": "sha512-2QywqXEAGBIUoTdgn1lAB4/C8QEqwXHj2jrCLeYTk2xVGtLiPEUD8jcMoeB2noclbiW2mMt4+Fq7fZStuz3wAQ=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.24.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.24.10.tgz",
+      "integrity": "sha512-FY1DixytOcNNCydPQXLxuKEV7VSST32CAuJ55BjhDNqASnMLZn+6c30yQBMrODjmWMNwzfjMZnq0Vw7C62Fwow==",
+      "requires": {
+        "@tanstack/query-core": "4.24.10",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.24.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.24.10.tgz",
+      "integrity": "sha512-1uzJNLdLjRsNt4O5ldv1SYPevWvSdHtKIyVJeUv4hSERPEhrKKfa8WC3dBOX24CdLEYH2ndLZW4ZiC9nzSKCtg==",
+      "requires": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "@tanstack/react-virtual": {
       "version": "3.0.0-beta.29",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.29.tgz",
@@ -29790,9 +29814,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
-      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "requires": {
         "@types/react": "*"
       }
@@ -32104,9 +32128,9 @@
       "integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A=="
     },
     "cypress": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.5.1.tgz",
-      "integrity": "sha512-ZmCmJ3lsyeOpBfh410m5+AO2CO1AxAzFBt7k6/uVbNcrNZje1vdiwYTpj2ksPKg9mjr9lR6V8tmlDNMvr4H/YQ==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
+      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -32126,7 +32150,7 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -37239,33 +37263,33 @@
     "mr-admin-flate": {
       "version": "file:frontend/mr-admin-flate",
       "requires": {
-        "@navikt/ds-css": "^2.1.7",
-        "@navikt/ds-css-internal": "^2.1.7",
-        "@navikt/ds-icons": "^2.1.7",
-        "@navikt/ds-react": "^2.1.7",
-        "@navikt/ds-react-internal": "^2.1.7",
-        "@tanstack/react-query": "^4.24.6",
-        "@tanstack/react-query-devtools": "^4.24.6",
+        "@navikt/ds-css": "^2.3.0",
+        "@navikt/ds-css-internal": "^2.3.0",
+        "@navikt/ds-icons": "^2.3.0",
+        "@navikt/ds-react": "^2.3.0",
+        "@navikt/ds-react-internal": "^2.3.0",
+        "@tanstack/react-query": "^4.24.10",
+        "@tanstack/react-query-devtools": "^4.24.10",
         "@types/react": "^18.0.28",
-        "@types/react-dom": "^18.0.10",
+        "@types/react-dom": "^18.0.11",
         "axe-core": "^4.6.3",
         "classnames": "^2.3.2",
         "cross-env": "^7.0.3",
-        "cypress": "^12.5.1",
+        "cypress": "^12.6.0",
         "cypress-axe": "^1.3.0",
         "eslint": "8.34.0",
         "formik": "^2.2.9",
-        "jotai": "^2.0.1",
+        "jotai": "^2.0.2",
         "jotai-location": "^0.4.0",
         "msw": "^1.0.1",
         "mulighetsrommet-api-client": "*",
         "mulighetsrommet-frontend-common": "*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-error-boundary": "*",
+        "react-error-boundary": "^3.1.4",
         "react-router-dom": "^6.8.1",
         "typescript": "^4.9.5",
-        "vite": "^4.1.1",
+        "vite": "^4.1.4",
         "vite-plugin-require": "^1.1.10",
         "zod": "^3.20.6",
         "zod-formik-adapter": "1.2.0"
@@ -37284,30 +37308,6 @@
           "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
           "dev": true,
           "optional": true
-        },
-        "@tanstack/query-core": {
-          "version": "4.24.6",
-          "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.24.6.tgz",
-          "integrity": "sha512-Tfru6YTDTCpX7dKVwHp/sosw/dNjEdzrncduUjIkQxn7n7u+74HT2ZrGtwwrU6Orws4x7zp3FKRqBPWVVhpx9w=="
-        },
-        "@tanstack/react-query": {
-          "version": "4.24.6",
-          "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.24.6.tgz",
-          "integrity": "sha512-pbJUVZCS4pcXS0kZiY+mVJ01ude0GrH5OXT2g9whcqSveRG/YVup/XdA9NdRpSMGkP2HxDRxxRNsTXkniWeIIA==",
-          "requires": {
-            "@tanstack/query-core": "4.24.6",
-            "use-sync-external-store": "^1.2.0"
-          }
-        },
-        "@tanstack/react-query-devtools": {
-          "version": "4.24.6",
-          "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.24.6.tgz",
-          "integrity": "sha512-d8CN4ZTtLkdCNi9x4Hogma0fdhlv7ckknv/RLuV4nbUciUoZEvhg1cI0+vp/1aY4W3jq9vH0BD/eUQKecgY15Q==",
-          "requires": {
-            "@tanstack/match-sorter-utils": "^8.7.0",
-            "superjson": "^1.10.0",
-            "use-sync-external-store": "^1.2.0"
-          }
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -37393,9 +37393,9 @@
           }
         },
         "jotai": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.0.1.tgz",
-          "integrity": "sha512-b/BpBFkv3nq8HgT6YX5h5/y9VfKIn9OL1dO6gd9bWTgKt6LLe24VIMURTDwSYS888XfubuRQlbepb5IQGAtmcQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.0.2.tgz",
+          "integrity": "sha512-0yOked08Swa84LUbBjtj7ZLZrE05n3u50rHeZ+bsT86thUjcy0kFgQz9GmEWhYbQDFoT1G8Ww6edSj/MBJHO4A==",
           "requires": {}
         },
         "jotai-location": {
@@ -37498,9 +37498,9 @@
           "dev": true
         },
         "vite": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.1.tgz",
-          "integrity": "sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==",
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
+          "integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
           "dev": true,
           "requires": {
             "esbuild": "^0.16.14",


### PR DESCRIPTION
Bumper deps for admin-flate og fjerner hardkodet høyde for search. Search hadde opprinnelig 32px høyde, mens Select-komponenter hadde 34px. Versjon 2.3.0 av designsystemet fikser den lille designbugen.