### PR TITLE
Stor forbokstav for alle virksomhetsnavn

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/Avtalerad.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/Avtalerad.tsx
@@ -1,6 +1,6 @@
 import { BodyShort } from "@navikt/ds-react";
 import { Avtale } from "mulighetsrommet-api-client";
-import { formaterDato } from "../../utils/Utils";
+import { capitalizeEveryWord, formaterDato } from "../../utils/Utils";
 import styles from "../listeelementer/Listeelementer.module.scss";
 import { ListeRad } from "../listeelementer/ListeRad";
 import { Avtalestatus } from "../statuselementer/Avtalestatus";
@@ -10,14 +10,15 @@ interface Props {
 }
 
 export function Avtalerad({ avtale }: Props) {
-  // TODO Fiks korrekt url for avtaler
   return (
     <ListeRad
       linkTo={`/avtaler/${avtale.id}`}
       classname={styles.listerad_avtale}
     >
       <BodyShort size="medium">{avtale.navn}</BodyShort>
-      <BodyShort size="medium">{avtale.leverandor?.navn || ""}</BodyShort>
+      <BodyShort size="medium">
+        {capitalizeEveryWord(avtale.leverandor?.navn, ["og"]) || ""}
+      </BodyShort>
       <BodyShort size="medium">
         {avtale.navEnhet?.navn || avtale?.navEnhet?.enhetsnummer}
       </BodyShort>

--- a/frontend/mr-admin-flate/src/utils/Utils.test.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { kalkulerStatusBasertPaaFraOgTilDato } from "./Utils";
+import {
+  capitalizeEveryWord,
+  kalkulerStatusBasertPaaFraOgTilDato,
+} from "./Utils";
 
 describe("Utils - kalkulerStatusBasertPaaFraOgTilDato", () => {
   test("Skal returnere status 'Aktiv' når nå er større eller lik fra-dato og nå er mindre eller lik til-dato", () => {
@@ -48,5 +51,27 @@ describe("Utils - kalkulerStatusBasertPaaFraOgTilDato", () => {
     );
 
     expect(result).toEqual("Avsluttet");
+  });
+});
+
+describe("Utils - capitalizeEveryWord", () => {
+  test("Skal legge på stor forbokstav for alle ord", () => {
+    const tekst = "EN TEKST MED STORE BOKSTAVER";
+    const result = capitalizeEveryWord(tekst);
+    expect(result).toEqual("En Tekst Med Store Bokstaver");
+  });
+
+  test("Skal legge på stor forbokstav for alle ord bortsatt fra ignorerte ord", () => {
+    const tekst = "EN TEKST MED STORE BOKSTAVER OG noen små bokstaver";
+    const result = capitalizeEveryWord(tekst, ["og"]);
+    expect(result).toEqual(
+      "En Tekst Med Store Bokstaver og Noen Små Bokstaver"
+    );
+  });
+
+  test("Skal ikke krasje ved tom streng", () => {
+    const tekst = "";
+    const result = capitalizeEveryWord(tekst);
+    expect(result).toEqual("");
   });
 });

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -4,6 +4,21 @@ export function capitalize(text?: string): string {
     : "";
 }
 
+export function capitalizeEveryWord(
+  text: string = "",
+  ignoreWords: string[] = []
+): string {
+  return text
+    .split(" ")
+    .map((it) => {
+      if (ignoreWords.includes(it.toLowerCase())) {
+        return it.toLowerCase();
+      }
+      return capitalize(it);
+    })
+    .join(" ");
+}
+
 export function formaterDato(dato?: string | Date, fallback = ""): string {
   if (!dato) return fallback;
 


### PR DESCRIPTION
Vi får virksomhetsnavn returnert fra backend i STORE BOKSTAVER. Vi ønsker å vise de i små, så denne tar hvert ord og legger på stor bokstav, bortsett fra ordet `og` i første omgang. Det blir aldri helt korrekt, men bedre enn at alt er all caps hele tiden.