### PR TITLE
:bug: collate C for korrekt alfabetisk sortering

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -131,9 +131,10 @@ class AvtaleRepository(private val db: Database) {
             filter.enhet to "lower(a.enhet) = lower(:enhet)"
         )
 
+        // collate "C" gjør at alfabetisk sortering blir korrekt
         val order = when (filter.sortering) {
-            "navn-ascending" -> "a.navn asc"
-            "navn-descending" -> "a.navn desc"
+            "navn-ascending" -> "a.navn collate \"C\" asc"
+            "navn-descending" -> "a.navn collate \"C\" desc"
             "status-ascending" -> "a.avslutningsstatus asc, a.start_dato asc, a.slutt_dato desc"
             "status-descending" -> "a.avslutningsstatus desc, a.slutt_dato asc, a.start_dato desc"
             else -> "a.navn asc"

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
@@ -100,9 +100,10 @@ class TiltakstypeRepository(private val db: Database) {
             }
         )
 
+        // collate "C" gjør at alfabetisk sortering blir korrekt
         val order = when (tiltakstypeFilter.sortering) {
-            "navn-ascending" -> "navn asc"
-            "navn-descending" -> "navn desc"
+            "navn-ascending" -> "navn collate \"C\" asc"
+            "navn-descending" -> "navn collate \"C\" desc"
             else -> "navn asc"
         }
 


### PR DESCRIPTION
Ved å skrive `collate "C"` i order-clausen så får vi korrekt oppførsel på norsk alfabetisk sortering.

Nedsiden er at man må huske på det. Den positive siden er at vi ikke trenger å migrere til ny database. 
Jeg tenker dette er godt nok for nå, og dersom vi oppdager at det blir et stort problem i fremtiden så tar vi og løser det da.