### PR TITLE
:wheelchair: Bedre aria-labels for rader i admin-flate

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/Avtalerad.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/Avtalerad.tsx
@@ -16,23 +16,35 @@ export function Avtalerad({ avtale }: Props) {
       classname={styles.listerad_avtale}
       testId="avtalerad"
     >
-      <BodyShort size="medium">{avtale.navn}</BodyShort>
-      <BodyShort size="medium">
+      <BodyShort aria-label={`Avtalenavn: ${avtale.navn}`} size="medium">
+        {avtale.navn}
+      </BodyShort>
+      <BodyShort
+        aria-label={`Leverandør: ${avtale.leverandor?.navn}`}
+        size="medium"
+      >
         {capitalizeEveryWord(avtale.leverandor?.navn, ["og", "i"]) || ""}
       </BodyShort>
-      <BodyShort size="medium">
+      <BodyShort
+        aria-label={`NAV-enhet: ${
+          avtale.navEnhet?.navn || avtale.navEnhet?.enhetsnummer
+        }`}
+        size="medium"
+      >
         {avtale.navEnhet?.navn || avtale?.navEnhet?.enhetsnummer}
       </BodyShort>
 
       <BodyShort
         size="small"
         title={`Startdato ${formaterDato(avtale.startDato)}`}
+        aria-label={`Startdato ${formaterDato(avtale.startDato)}`}
       >
         {formaterDato(avtale.startDato)}
       </BodyShort>
       <BodyShort
         size="small"
         title={`Sluttdato ${formaterDato(avtale.sluttDato)}`}
+        aria-label={`Sluttdato ${formaterDato(avtale.sluttDato)}`}
       >
         {formaterDato(avtale.sluttDato)}
       </BodyShort>

--- a/frontend/mr-admin-flate/src/components/avtaler/Avtalerad.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/Avtalerad.tsx
@@ -37,14 +37,14 @@ export function Avtalerad({ avtale }: Props) {
       <BodyShort
         size="small"
         title={`Startdato ${formaterDato(avtale.startDato)}`}
-        aria-label={`Startdato ${formaterDato(avtale.startDato)}`}
+        aria-label={`Startdato: ${formaterDato(avtale.startDato)}`}
       >
         {formaterDato(avtale.startDato)}
       </BodyShort>
       <BodyShort
         size="small"
         title={`Sluttdato ${formaterDato(avtale.sluttDato)}`}
-        aria-label={`Sluttdato ${formaterDato(avtale.sluttDato)}`}
+        aria-label={`Sluttdato: ${formaterDato(avtale.sluttDato)}`}
       >
         {formaterDato(avtale.sluttDato)}
       </BodyShort>

--- a/frontend/mr-admin-flate/src/components/listeelementer/Listeheader.tsx
+++ b/frontend/mr-admin-flate/src/components/listeelementer/Listeheader.tsx
@@ -30,8 +30,8 @@ export function ListeheaderAvtaler() {
       <BodyShort size="medium">Tittel</BodyShort>
       <BodyShort size="medium">Leverandør</BodyShort>
       <BodyShort size="medium">Enhet</BodyShort>
-      <BodyShort size="medium">Dato fra</BodyShort>
-      <BodyShort size="medium">Dato til</BodyShort>
+      <BodyShort size="medium">Startdato</BodyShort>
+      <BodyShort size="medium">Sluttdato</BodyShort>
       <BodyShort size="medium">Status</BodyShort>
     </Listeheader>
   );

--- a/frontend/mr-admin-flate/src/components/statuselementer/Avtalestatus.tsx
+++ b/frontend/mr-admin-flate/src/components/statuselementer/Avtalestatus.tsx
@@ -9,6 +9,7 @@ export function Avtalestatus({ avtale }: Props) {
   const { avtalestatus } = avtale;
   return (
     <Tag
+      aria-label={`Avtalestatus: ${avtalestatus}`}
       variant={
         avtalestatus === "Aktiv"
           ? "success"

--- a/frontend/mr-admin-flate/src/components/statuselementer/Tiltakstypestatus.tsx
+++ b/frontend/mr-admin-flate/src/components/statuselementer/Tiltakstypestatus.tsx
@@ -10,6 +10,7 @@ export function Tiltakstypestatus({ tiltakstype }: Props) {
 
   return (
     <Tag
+      aria-label={`Status for tiltakstype: ${status}`}
       variant={
         status === "Aktiv"
           ? "success"

--- a/frontend/mr-admin-flate/src/components/tiltakstyper/TiltakstypeRad.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltakstyper/TiltakstypeRad.tsx
@@ -28,14 +28,14 @@ export function TiltakstypeRad({ tiltakstype }: Props) {
       <BodyShort
         size="small"
         title={`Startdato ${formaterDato(tiltakstype.fraDato)}`}
-        aria-label={`Startdato ${formaterDato(tiltakstype.fraDato)}`}
+        aria-label={`Startdato: ${formaterDato(tiltakstype.fraDato)}`}
       >
         {formaterDato(tiltakstype.fraDato)}
       </BodyShort>
       <BodyShort
         size="small"
         title={`Sluttdato ${formaterDato(tiltakstype.tilDato)}`}
-        aria-label={`Sluttdato ${formaterDato(tiltakstype.tilDato)}`}
+        aria-label={`Sluttdato: ${formaterDato(tiltakstype.tilDato)}`}
       >
         {formaterDato(tiltakstype.tilDato)}
       </BodyShort>

--- a/frontend/mr-admin-flate/src/components/tiltakstyper/TiltakstypeRad.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltakstyper/TiltakstypeRad.tsx
@@ -16,19 +16,26 @@ export function TiltakstypeRad({ tiltakstype }: Props) {
       classname={styles.listerad_tiltakstype}
       testId="tiltakstyperad"
     >
-      <BodyShort size="medium">{tiltakstype.navn}</BodyShort>
+      <BodyShort
+        aria-label={`Navn på tiltakstype: ${tiltakstype.navn}`}
+        size="medium"
+      >
+        {tiltakstype.navn}
+      </BodyShort>
       <BodyShort size="medium">
         <Tiltakstypestatus tiltakstype={tiltakstype} />
       </BodyShort>
       <BodyShort
         size="small"
         title={`Startdato ${formaterDato(tiltakstype.fraDato)}`}
+        aria-label={`Startdato ${formaterDato(tiltakstype.fraDato)}`}
       >
         {formaterDato(tiltakstype.fraDato)}
       </BodyShort>
       <BodyShort
         size="small"
         title={`Sluttdato ${formaterDato(tiltakstype.tilDato)}`}
+        aria-label={`Sluttdato ${formaterDato(tiltakstype.tilDato)}`}
       >
         {formaterDato(tiltakstype.tilDato)}
       </BodyShort>

--- a/frontend/mr-admin-flate/src/pages/avtaler/Avtaleinfo.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/Avtaleinfo.tsx
@@ -6,7 +6,7 @@ import {
   Separator,
 } from "../../components/detaljside/Metadata";
 import { Laster } from "../../components/Laster";
-import { formaterDato } from "../../utils/Utils";
+import { capitalizeEveryWord, formaterDato } from "../../utils/Utils";
 import styles from "./Avtaleinfo.module.scss";
 
 export function Avtaleinfo() {
@@ -39,7 +39,8 @@ export function Avtaleinfo() {
         <Metadata
           header="Leverandør"
           verdi={
-            avtale.leverandor?.navn || avtale.leverandor?.organisasjonsnummer
+            capitalizeEveryWord(avtale.leverandor?.navn) ||
+            avtale.leverandor?.organisasjonsnummer
           }
         />
       </Grid>


### PR DESCRIPTION
I forbindelse med en workshop med Bekk testet jeg admin-flate med voiceover på Mac og fant at vi har godt av noen eksplisitt aria-labels for radene for tiltakstyper og avtaler.