### PR TITLE
Fjerner feltet 'varighet' fra dokumenttypen Tiltakstype i Sanity

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/tiltakstype.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltakstype.ts
@@ -66,12 +66,6 @@ export const tiltakstype = defineType({
       to: [{ type: "innsatsgruppe" }],
     }),
     defineField({
-      name: "varighet",
-      title: "Varighet",
-      description: "Her kan du legge til hvor lang varighet tiltakstypen har.",
-      type: "string",
-    }),
-    defineField({
       name: "regelverkLenker",
       title: "Regelverkslenker",
       type: "array",


### PR DESCRIPTION
Avklart med Tom Stian at vi fjerner feltet `varighet` siden 1) det brukes ikke i frontend foreløpig og 2) de kan skrive om varighet i fanen `Påmelding og varighet`.