### PR TITLE
Ikke la sortering falle utenfor skjermen

### DIFF
--- a/frontend/mr-admin-flate/src/components/filter/Filter.module.scss
+++ b/frontend/mr-admin-flate/src/components/filter/Filter.module.scss
@@ -10,6 +10,6 @@
 
 .filter_left {
   display: grid;
-  grid-template-columns: repeat(3, 20rem);
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
 }


### PR DESCRIPTION
Ved å spesifisere faktiske verdier (20rem) så falt sorteringen utenfor containeren på mindre skjermer. 1fr tar heller opp plassen den har til rådighet og gir dermed nok plass til sorterings-selecten.