### PR TITLE
Cacher i hver client istedenfor i brukerservice

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
@@ -1,16 +1,22 @@
 package no.nav.mulighetsrommet.api.clients.oppfolging
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import no.nav.mulighetsrommet.api.domain.ManuellStatusDTO
 import no.nav.mulighetsrommet.api.domain.Oppfolgingsstatus
 import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.plugins.Metrikker
 import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.utils.CacheUtils
 import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
 
 class VeilarboppfolgingClientImpl(
     private val baseUrl: String,
@@ -23,42 +29,65 @@ class VeilarboppfolgingClientImpl(
         install(HttpCache)
     }
 
-    override suspend fun hentOppfolgingsstatus(fnr: String, accessToken: String): Oppfolgingsstatus? {
-        return try {
-            val response = client.get("$baseUrl/person/$fnr/oppfolgingsstatus") {
-                bearerAuth(tokenProvider.invoke(accessToken))
-            }
+    private val veilarboppfolgingCache: Cache<String, Oppfolgingsstatus> = Caffeine.newBuilder()
+        .expireAfterWrite(30, TimeUnit.MINUTES)
+        .maximumSize(500)
+        .recordStats()
+        .build()
 
-            if (response.status == HttpStatusCode.NotFound || response.status == HttpStatusCode.NoContent) {
-                log.info("Fant ikke oppfølgingsstatus for bruker. Det kan være fordi bruker ikke er under oppfølging eller ikke finnes i Arena")
+    private val manuellStatusCache: Cache<String, ManuellStatusDTO> = Caffeine.newBuilder()
+        .expireAfterWrite(30, TimeUnit.MINUTES)
+        .maximumSize(500)
+        .recordStats()
+        .build()
+
+    init {
+        val cacheMetrics: CacheMetricsCollector =
+            CacheMetricsCollector().register(Metrikker.appMicrometerRegistry.prometheusRegistry)
+        cacheMetrics.addCache("veilarboppfolgingCache", veilarboppfolgingCache)
+        cacheMetrics.addCache("manuellStatusCache", manuellStatusCache)
+    }
+
+    override suspend fun hentOppfolgingsstatus(fnr: String, accessToken: String): Oppfolgingsstatus? {
+        return CacheUtils.tryCacheFirstNotNull(veilarboppfolgingCache, fnr) {
+            try {
+                val response = client.get("$baseUrl/person/$fnr/oppfolgingsstatus") {
+                    bearerAuth(tokenProvider.invoke(accessToken))
+                }
+
+                if (response.status == HttpStatusCode.NotFound || response.status == HttpStatusCode.NoContent) {
+                    log.info("Fant ikke oppfølgingsstatus for bruker. Det kan være fordi bruker ikke er under oppfølging eller ikke finnes i Arena")
+                    return null
+                }
+
+                response.body()
+            } catch (exe: Exception) {
+                SecureLog.logger.error("Klarte ikke hente oppfølgingsstatus for bruker med fnr: $fnr")
+                log.error("Klarte ikke hente oppfølgingsstatus. Se secureLogs for detaljer.")
                 return null
             }
-
-            response.body<Oppfolgingsstatus>()
-        } catch (exe: Exception) {
-            SecureLog.logger.error("Klarte ikke hente oppfølgingsstatus for bruker med fnr: $fnr")
-            log.error("Klarte ikke hente oppfølgingsstatus. Se secureLogs for detaljer.")
-            null
         }
     }
 
     override suspend fun hentManuellStatus(fnr: String, accessToken: String): ManuellStatusDTO? {
-        return try {
-            val response = client.get("$baseUrl/v2/manuell/status?fnr=$fnr") {
-                bearerAuth(tokenProvider.invoke(accessToken))
-            }
+        return CacheUtils.tryCacheFirstNotNull(manuellStatusCache, fnr) {
+            try {
+                val response = client.get("$baseUrl/v2/manuell/status?fnr=$fnr") {
+                    bearerAuth(tokenProvider.invoke(accessToken))
+                }
 
-            if (response.status == HttpStatusCode.NotFound || response.status == HttpStatusCode.NoContent) {
-                log.info("Fant ikke manuell status for bruker.")
+                if (response.status == HttpStatusCode.NotFound || response.status == HttpStatusCode.NoContent) {
+                    log.info("Fant ikke manuell status for bruker.")
+                    return null
+                }
+
+                val body = response.body<ManuellStatusDTO>()
+                body
+            } catch (exe: Exception) {
+                SecureLog.logger.error("Klarte ikke hente manuell status for bruker med fnr: $fnr", exe)
+                log.error("Klarte ikke hente manuell status. Se detaljer i secureLogs.")
                 return null
             }
-
-            val body = response.body<ManuellStatusDTO>()
-            body
-        } catch (exe: Exception) {
-            SecureLog.logger.error("Klarte ikke hente manuell status for bruker med fnr: $fnr", exe)
-            log.error("Klarte ikke hente manuell status. Se detaljer i secureLogs.")
-            null
         }
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/person/VeilarbpersonClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/person/VeilarbpersonClientImpl.kt
@@ -1,14 +1,20 @@
 package no.nav.mulighetsrommet.api.clients.person
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
+import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import no.nav.mulighetsrommet.api.domain.PersonDTO
 import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.plugins.Metrikker
 import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.utils.CacheUtils
 import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
 
 class VeilarbpersonClientImpl(
     private val baseUrl: String,
@@ -21,15 +27,29 @@ class VeilarbpersonClientImpl(
         install(HttpCache)
     }
 
+    private val personInfoCache: Cache<String, PersonDTO> = Caffeine.newBuilder()
+        .expireAfterWrite(30, TimeUnit.MINUTES)
+        .maximumSize(500)
+        .recordStats()
+        .build()
+
+    init {
+        val cacheMetrics: CacheMetricsCollector =
+            CacheMetricsCollector().register(Metrikker.appMicrometerRegistry.prometheusRegistry)
+        cacheMetrics.addCache("personInfoCache", personInfoCache)
+    }
+
     override suspend fun hentPersonInfo(fnr: String, accessToken: String): PersonDTO? {
-        return try {
-            client.get("$baseUrl/v2/person?fnr=$fnr") {
-                bearerAuth(tokenProvider.invoke(accessToken))
-            }.body()
-        } catch (exe: Exception) {
-            SecureLog.logger.error("Klarte ikke hente fornavn for bruker med fnr: $fnr")
-            log.error("Klarte ikke hente fornavn. Se detaljer i secureLog.")
-            null
+        return CacheUtils.tryCacheFirstNotNull(personInfoCache, fnr) {
+            return try {
+                client.get("$baseUrl/v2/person?fnr=$fnr") {
+                    bearerAuth(tokenProvider.invoke(accessToken))
+                }.body()
+            } catch (exe: Exception) {
+                SecureLog.logger.error("Klarte ikke hente fornavn for bruker med fnr: $fnr")
+                log.error("Klarte ikke hente fornavn. Se detaljer i secureLog.")
+                return null
+            }
         }
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VeilarbvedtaksstotteClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VeilarbvedtaksstotteClientImpl.kt
@@ -1,15 +1,22 @@
 package no.nav.mulighetsrommet.api.clients.vedtak
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import io.ktor.server.plugins.*
+import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import no.nav.mulighetsrommet.api.domain.VedtakDTO
 import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.plugins.Metrikker
 import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.utils.CacheUtils
 import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
 
 class VeilarbvedtaksstotteClientImpl(
     private val baseUrl: String,
@@ -22,22 +29,36 @@ class VeilarbvedtaksstotteClientImpl(
         install(HttpCache)
     }
 
-    override suspend fun hentSiste14AVedtak(fnr: String, accessToken: String): VedtakDTO? {
-        return try {
-            val response = client.get("$baseUrl/siste-14a-vedtak?fnr=$fnr") {
-                bearerAuth(tokenProvider.invoke(accessToken))
-            }
+    private val siste14aVedtakCache: Cache<String, VedtakDTO> = Caffeine.newBuilder()
+        .expireAfterWrite(30, TimeUnit.MINUTES)
+        .maximumSize(500)
+        .recordStats()
+        .build()
 
-            if (response.status == HttpStatusCode.NotFound || response.status == HttpStatusCode.NoContent) {
-                log.info("Fant ikke siste 14A-vedtak for bruker")
+    init {
+        val cacheMetrics: CacheMetricsCollector =
+            CacheMetricsCollector().register(Metrikker.appMicrometerRegistry.prometheusRegistry)
+        cacheMetrics.addCache("siste14aVedtakCache", siste14aVedtakCache)
+    }
+
+    override suspend fun hentSiste14AVedtak(fnr: String, accessToken: String): VedtakDTO? {
+        return CacheUtils.tryCacheFirstNotNull(siste14aVedtakCache, fnr) {
+            return try {
+                val response = client.get("$baseUrl/siste-14a-vedtak?fnr=$fnr") {
+                    bearerAuth(tokenProvider.invoke(accessToken))
+                }
+
+                if (response.status == HttpStatusCode.NotFound || response.status == HttpStatusCode.NoContent) {
+                    log.info("Fant ikke siste 14A-vedtak for bruker")
+                    return null
+                }
+
+                response.body()
+            } catch (exe: Exception) {
+                SecureLog.logger.error("Klarte ikke hente siste 14A-vedtak for bruker med fnr: $fnr", exe)
+                log.error("Klarte ikke hente siste 14A-vedtak. Se detaljer i secureLogs.")
                 return null
             }
-
-            response.body<VedtakDTO>()
-        } catch (exe: Exception) {
-            SecureLog.logger.error("Klarte ikke hente siste 14A-vedtak for bruker med fnr: $fnr", exe)
-            log.error("Klarte ikke hente siste 14A-vedtak. Se detaljer i secureLogs.")
-            null
         }
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
@@ -1,8 +1,5 @@
 package no.nav.mulighetsrommet.api.services
 
-import com.github.benmanes.caffeine.cache.Cache
-import com.github.benmanes.caffeine.cache.Caffeine
-import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClient
 import no.nav.mulighetsrommet.api.clients.person.VeilarbpersonClient
@@ -10,9 +7,6 @@ import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClient
 import no.nav.mulighetsrommet.api.domain.Innsatsgruppe
 import no.nav.mulighetsrommet.api.domain.ManuellStatusDTO
 import no.nav.mulighetsrommet.api.domain.Oppfolgingsenhet
-import no.nav.mulighetsrommet.ktor.plugins.Metrikker
-import no.nav.mulighetsrommet.utils.CacheUtils
-import java.util.concurrent.TimeUnit
 
 class BrukerService(
     private val veilarboppfolgingClient: VeilarboppfolgingClient,
@@ -20,34 +14,20 @@ class BrukerService(
     private val veilarbpersonClient: VeilarbpersonClient
 ) {
 
-    private val brukerCache: Cache<String, Brukerdata> = Caffeine.newBuilder()
-        .expireAfterWrite(30, TimeUnit.MINUTES)
-        .maximumSize(500)
-        .recordStats()
-        .build()
-
-    init {
-        val cacheMetrics: CacheMetricsCollector =
-            CacheMetricsCollector().register(Metrikker.appMicrometerRegistry.prometheusRegistry)
-        cacheMetrics.addCache("brukerCache", brukerCache)
-    }
-
     suspend fun hentBrukerdata(fnr: String, accessToken: String): Brukerdata {
-        return CacheUtils.tryCacheFirstNotNull(brukerCache, fnr) {
-            val oppfolgingsstatus = veilarboppfolgingClient.hentOppfolgingsstatus(fnr, accessToken)
-            val manuellStatus = veilarboppfolgingClient.hentManuellStatus(fnr, accessToken)
-            val sisteVedtak = veilarbvedtaksstotteClient.hentSiste14AVedtak(fnr, accessToken)
-            val personInfo = veilarbpersonClient.hentPersonInfo(fnr, accessToken)
+        val oppfolgingsstatus = veilarboppfolgingClient.hentOppfolgingsstatus(fnr, accessToken)
+        val manuellStatus = veilarboppfolgingClient.hentManuellStatus(fnr, accessToken)
+        val sisteVedtak = veilarbvedtaksstotteClient.hentSiste14AVedtak(fnr, accessToken)
+        val personInfo = veilarbpersonClient.hentPersonInfo(fnr, accessToken)
 
-            Brukerdata(
-                fnr = fnr,
-                oppfolgingsenhet = oppfolgingsstatus?.oppfolgingsenhet,
-                servicegruppe = oppfolgingsstatus?.servicegruppe,
-                innsatsgruppe = sisteVedtak?.innsatsgruppe,
-                fornavn = personInfo?.fornavn,
-                manuellStatus = manuellStatus
-            )
-        }
+        return Brukerdata(
+            fnr = fnr,
+            oppfolgingsenhet = oppfolgingsstatus?.oppfolgingsenhet,
+            servicegruppe = oppfolgingsstatus?.servicegruppe,
+            innsatsgruppe = sisteVedtak?.innsatsgruppe,
+            fornavn = personInfo?.fornavn,
+            manuellStatus = manuellStatus
+        )
     }
 
     @Serializable

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -30,6 +30,7 @@ app:
   sanity:
     dataset: test
     projectId: xegcworx
+    authToken: ${SANITY_AUTH_TOKEN:-""}
 
   swagger:
     enable: true

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/BrukerServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/BrukerServiceTest.kt
@@ -3,7 +3,6 @@ package no.nav.mulighetsrommet.api.services
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClient
 import no.nav.mulighetsrommet.api.clients.person.VeilarbpersonClient
@@ -60,18 +59,6 @@ class BrukerServiceTest : FunSpec({
         brukerService.hentBrukerdata(FNR, "").manuellStatus?.krrStatus?.kanVarsles shouldBe true
         brukerService.hentBrukerdata(FNR, "").oppfolgingsenhet?.navn shouldBe "NAV Fredrikstad"
         brukerService.hentBrukerdata(FNR, "").oppfolgingsenhet?.enhetId shouldBe "0116"
-    }
-
-    test("Henting av brukerdata blir cachet basert på fnr") {
-        brukerService.hentBrukerdata(FNR, "")
-        brukerService.hentBrukerdata(FNR, "")
-        brukerService.hentBrukerdata(FNR, "")
-        brukerService.hentBrukerdata(FNR_2, "")
-
-        coVerify(exactly = 2) { veilarboppfolgingClient.hentManuellStatus(any(), any()) }
-        coVerify(exactly = 2) { veilarboppfolgingClient.hentOppfolgingsstatus(any(), any()) }
-        coVerify(exactly = 2) { veilarbpersonClient.hentPersonInfo(any(), any()) }
-        coVerify(exactly = 2) { veilarbvedtaksstotteClient.hentSiste14AVedtak(any(), any()) }
     }
 })
 


### PR DESCRIPTION
Flytter cache ut fra brukerservice og inn i hver client istedenfor. På den måten cacher vi ikke null-verdier dersom en av integrasjonene feiler.