### PR TITLE
Endrer fra dev.intern.nav.no -> intern.dev.nav.no

### DIFF
--- a/.github/workflows/mr-admin-flate-pr-comment-link.yaml
+++ b/.github/workflows/mr-admin-flate-pr-comment-link.yaml
@@ -17,4 +17,4 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            URL for testing: https://mulighetsrommet-admin-flate.dev.intern.nav.no/pr-${{ github.event.number }}/index.html
+            URL for testing: https://mulighetsrommet-admin-flate.intern.dev.nav.no/pr-${{ github.event.number }}/index.html

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ løsningen: [https://unleash.nais.io/#/features](https://unleash.nais.io/#/featu
 
 ### `mulighetsrommet-veileder-flate`
 
-| | |
+| |                                                                                                         |
 |------------------|---------------------------------------------------------------------------------------------------------|
 | Kildekode        | <https://github.com/navikt/mulighetsrommet/tree/main/frontend/mulighetsrommet-veileder-flate>           |
 | README           | <https://github.com/navikt/mulighetsrommet/blob/main/frontend/mulighetsrommet-veileder-flate/README.md> |
-| Url (dev-miljø)  | <https://veilarbpersonflate.dev.intern.nav.no/12118323058>                                              |
+| Url (dev-miljø)  | <https://veilarbpersonflate.intern.dev.nav.no/12118323058>                                              |
 | Url (labs-miljø) | <https://mulighetsrommet-veileder-flate.labs.nais.no/>                                                  |
 
 ### `mulighetsrommet-api-client`
@@ -77,33 +77,33 @@ Sanity Studio til forvaltning av informasjon for veiledere.
 
 ### `mulighetsrommet-api`
 
-| | |
+| |                                                                                     |
 |-----------------|-------------------------------------------------------------------------------------|
 | Kildekode       | <https://github.com/navikt/mulighetsrommet/tree/main/mulighetsrommet-api>           |
 | README          | <https://github.com/navikt/mulighetsrommet/blob/main/mulighetsrommet-api/README.md> |
-| Url (dev-miljø) | <https://mulighetsrommet-api.dev.intern.nav.no/>                                    |
-| API             | <https://mulighetsrommet-api.dev.intern.nav.no/swagger-ui>                          |
+| Url (dev-miljø) | <https://mulighetsrommet-api.intern.dev.nav.no/>                                    |
+| API             | <https://mulighetsrommet-api.intern.dev.nav.no/swagger-ui>                          |
 
 ### `mulighetsrommet-kafka-manager`
 
 Applikasjon som gir oversikt over kafka-topics relevante for dette prosjektet.
 
-| | |
-| --------------- | ----------------------------------------------------------------------------------- |
-| README | <https://github.com/navikt/kafka-manager> |
+| |                                                                         |
+| --------------- |-------------------------------------------------------------------------|
+| README | <https://github.com/navikt/kafka-manager>                               |
 | Kildekode | <https://github.com/navikt/mulighetsrommet/tree/main/iac/kafka-manager> |
-| Url (dev-miljø) | <https://mulighetsrommet-kafka-manager.dev.intern.nav.no> |
-| Url (prod-miljø | <https://mulighetsrommet-kafka-manager.intern.nav.no> |
+| Url (dev-miljø) | <https://mulighetsrommet-kafka-manager.intern.dev.nav.no>               |
+| Url (prod-miljø | <https://mulighetsrommet-kafka-manager.intern.nav.no>                   |
 
 ### `mr-admin-flate`
 
 Administrasjonsflate for tiltak- og fagansvarlige i NAV som jobber med tiltakstyper og tiltaksgjennomføringer.
 
-| | |
+| |                                                                                         |
 |------------------|-----------------------------------------------------------------------------------------|
 | README           | <https://github.com/navikt/mulighetsrommet/blob/main/frontend/mr-admin-flate/README.md> |
 | Demo-miljø       | <https://mulighetsrommet-admin-flate.labs.nais.io>                                      |
-| Url (dev-miljø)  | <https://mulighetsrommet-admin-flate.dev.intern.nav.no>                                 |
+| Url (dev-miljø)  | <https://mulighetsrommet-admin-flate.intern.dev.nav.no>                                 |
 | Url (prod-miljø) | <https://mulighetsrommet-admin-flate.intern.nav.no>                                     |
 
 ## Overvåking av automatiske jobber

--- a/frontend/arena-adapter-manager/.nais/nais-dev.yaml
+++ b/frontend/arena-adapter-manager/.nais/nais-dev.yaml
@@ -9,7 +9,7 @@ spec:
   image: ghcr.io/navikt/poao-frontend/poao-frontend:2023.02.20_10.11-47a91300306e
   port: 8080
   ingresses:
-    - https://mulighetsrommet-arena-adapter-manager.dev.intern.nav.no
+    - https://mulighetsrommet-arena-adapter-manager.intern.dev.nav.no
   liveness:
     path: /internal/alive
     initialDelay: 10

--- a/frontend/mr-admin-flate/.nais/nais-dev.yaml
+++ b/frontend/mr-admin-flate/.nais/nais-dev.yaml
@@ -9,7 +9,7 @@ spec:
   image: ghcr.io/navikt/poao-frontend/poao-frontend:2023.02.20_10.11-47a91300306e
   port: 8080
   ingresses:
-    - https://mulighetsrommet-admin-flate.dev.intern.nav.no
+    - https://mulighetsrommet-admin-flate.intern.dev.nav.no
   liveness:
     path: /internal/alive
     initialDelay: 10

--- a/frontend/mulighetsrommet-veileder-flate/.nais/nais-dev.yaml
+++ b/frontend/mulighetsrommet-veileder-flate/.nais/nais-dev.yaml
@@ -9,7 +9,7 @@ spec:
   image: ghcr.io/navikt/poao-frontend/poao-frontend:2023.02.20_10.11-47a91300306e
   port: 8080
   ingresses:
-    - https://mulighetsrommet-veileder-flate.dev.intern.nav.no
+    - https://mulighetsrommet-veileder-flate.intern.dev.nav.no
   liveness:
     path: /internal/alive
     initialDelay: 10

--- a/iac/README.md
+++ b/iac/README.md
@@ -37,7 +37,7 @@ Deployment av topic skjer automatisk via Github Actions når man merger kode rel
 ## Kafka manager
 Kafka manager er en applikasjon som kan nås på følgende url'er:
 
-**Dev**: https://mulighetsrommet-kafka-manager.dev.intern.nav.no
+**Dev**: https://mulighetsrommet-kafka-manager.intern.dev.nav.no
 **Prod**: https://mulighetsrommet-kafka-manager.intern.nav.no
 
 Man kan bruke manageren for å lese meldinger på topics som er definert i konfigurasjonen.

--- a/iac/kafka-manager/dev/kafka-manager-dev.yaml
+++ b/iac/kafka-manager/dev/kafka-manager-dev.yaml
@@ -10,7 +10,7 @@ spec:
   port: 8080
   webproxy: true
   ingresses:
-    - https://mulighetsrommet-kafka-manager.dev.intern.nav.no
+    - https://mulighetsrommet-kafka-manager.intern.dev.nav.no
   prometheus:
     enabled: true
     path: /internal/prometheus

--- a/mulighetsrommet-api/.nais/nais-dev.yaml
+++ b/mulighetsrommet-api/.nais/nais-dev.yaml
@@ -9,7 +9,7 @@ spec:
   image: {{image}}
   port: 8080
   ingresses:
-    - https://mulighetsrommet-api.dev.intern.nav.no
+    - https://mulighetsrommet-api.intern.dev.nav.no
   secureLogs:
     enabled: true
   prometheus:

--- a/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
@@ -9,7 +9,7 @@ spec:
   image: {{image}}
   port: 8084
   ingresses:
-    - https://mulighetsrommet-arena-adapter.dev.intern.nav.no
+    - https://mulighetsrommet-arena-adapter.intern.dev.nav.no
   secureLogs:
     enabled: true
   prometheus:


### PR DESCRIPTION
Ref. https://nav-it.slack.com/archives/C01DE3M9YBV/p1677747333208699 så endrer vi fra dev.intern.nav.no til intern.dev.nav.no for dev-ingresser.