### PR TITLE
Modia støtter ikke ny url enda - fallback til gammel

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/.nais/nais-dev.yaml
+++ b/frontend/mulighetsrommet-veileder-flate/.nais/nais-dev.yaml
@@ -10,6 +10,7 @@ spec:
   port: 8080
   ingresses:
     - https://mulighetsrommet-veileder-flate.intern.dev.nav.no
+    - https://mulighetsrommet-veileder-flate.dev.intern.nav.no
   liveness:
     path: /internal/alive
     initialDelay: 10


### PR DESCRIPTION
Jeg har opprettet en tråd i #poao-tech https://nav-it.slack.com/archives/CQ2H1AY3Z/p1678095853805939 angående resolving av ny dev-url for Modia

Mens vi venter på svar der så kan vi enten A) leve med at dev er utilgjengelig for oss for veilederflate, eller B) legge tilbake gammel dev-ingress og så fjerne den når vi, og Modia (veilarbpersonflatefs), er klare for det.