### PR TITLE
Ikke return verdi innenfor cache

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VeilarbvedtaksstotteClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VeilarbvedtaksstotteClientImpl.kt
@@ -58,14 +58,15 @@ class VeilarbvedtaksstotteClientImpl(
                 return null
             }
 
-            return try {
+            try {
                 JsonIgnoreUnknownKeys.decodeFromString(body)
             } catch (e: Throwable) {
                 SecureLog.logger.error(
-                    "Klarte ikke hente siste 14A-vedtak for bruker med fnr: $fnr, response: $response, body: $body", e
+                    "Klarte ikke hente siste 14A-vedtak for bruker med fnr: $fnr, response: $response, body: $body",
+                    e
                 )
                 log.error("Klarte ikke hente siste 14A-vedtak. Se detaljer i secureLogs.")
-                null
+                return null
             }
         }
     }


### PR DESCRIPTION
Dersom man har en `return try` eller `return JsonIgnoreUnknownKeys.decodeFromString(body)` så blir ikke verdien populert i cachen og man får cache-miss hver gang.

Ved å fjerne return så blir cachen populert og fungerer som forventet.

Jeg oppdaget det i går kveld ved å se på metrikkene
![image](https://user-images.githubusercontent.com/9053627/223639113-5dbbbf2e-19f0-4016-bde3-aa88539492b6.png)
