### PR TITLE
Henter lokasjoner til bruker i backend og ikke frontend

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useLokasjonerForBruker.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useLokasjonerForBruker.ts
@@ -1,22 +1,9 @@
-import { useHentBrukerdata } from './useHentBrukerdata';
-import groq from 'groq';
-import { useSanity } from './useSanity';
+import { useQuery } from 'react-query';
+import { mulighetsrommetClient } from '../clients';
+import { QueryKeys } from '../query-keys';
 
 export default function useLokasjonerForBruker() {
-  const brukerData = useHentBrukerdata();
-
-  const sanityQueryString = groq`array::unique(*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**")) 
-  ${byggEnhetOgFylkeFilter()}
-  ]
-  {
-    lokasjon
-  }.lokasjon)`;
-
-  return useSanity<string[]>(sanityQueryString, {
-    enabled: !!brukerData.data?.oppfolgingsenhet,
-  });
-}
-
-function byggEnhetOgFylkeFilter(): string {
-  return groq`&& ($enhetsId in enheter[]._ref || (enheter[0] == null && $fylkeId == fylke._ref))`;
+  return useQuery(QueryKeys.sanity.lokasjoner, () =>
+    mulighetsrommetClient.sanity.getLokasjonerForBrukersEnhetOgFylke()
+  );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/query-keys.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/query-keys.ts
@@ -7,5 +7,6 @@ export const QueryKeys = {
   sanity: {
     innsatsgrupper: ['innsatsgrupper'],
     tiltakstyper: ['tiltakstyper'],
+    lokasjoner: ['lokasjoner'],
   },
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -81,14 +81,25 @@ export const apiHandlers: RestHandler[] = [
   rest.get<any, any, any>('*/api/v1/internal/sanity/innsatsgrupper', async () => {
     const query = `*[_type == "innsatsgruppe" && !(_id in path("drafts.**"))]`;
     const client = getSanityClient();
-    const result = await client.fetch(query, { enhetsId: 'enhet.lokal.5702', fylkeId: 'enhet.fylke.5700' });
+    const result = await client.fetch(query);
     return ok(result);
   }),
 
   rest.get<any, any, any>('*/api/v1/internal/sanity/tiltakstyper', async () => {
     const query = `*[_type == "tiltakstype" && !(_id in path("drafts.**"))]`;
     const client = getSanityClient();
-    const result = await client.fetch(query, { enhetsId: 'enhet.lokal.5702', fylkeId: 'enhet.fylke.5700' });
+    const result = await client.fetch(query);
+    return ok(result);
+  }),
+
+  rest.get<any, any, any>('*/api/v1/internal/sanity/lokasjoner', async () => {
+    const query = `array::unique(*[_type == "tiltaksgjennomforing" && !(_id in path("drafts.**"))
+    && ('enhet.lokal.5702' in enheter[]._ref || (enheter[0] == null && 'enhet.fylke.5700' == fylke._ref))]
+    {
+      lokasjon
+    }.lokasjon)`;
+    const client = getSanityClient();
+    const result = await client.fetch(query);
     return ok(result);
   }),
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
@@ -5,6 +5,7 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.mulighetsrommet.api.plugins.getNavAnsattAzureId
+import no.nav.mulighetsrommet.api.plugins.getNorskIdent
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
 import no.nav.mulighetsrommet.api.services.SanityResponse
 import no.nav.mulighetsrommet.api.services.SanityService
@@ -39,6 +40,16 @@ fun Route.sanityRoutes() {
         get("/tiltakstyper") {
             poaoTilgangService.verfiyAccessToModia(getNavAnsattAzureId())
             call.respondWithData(sanityService.hentTiltakstyper().toResponse())
+        }
+
+        get("/lokasjoner") {
+            poaoTilgangService.verfiyAccessToModia(getNavAnsattAzureId())
+            call.respondWithData(
+                sanityService.hentLokasjonerForBrukersEnhetOgFylke(
+                    getNorskIdent(),
+                    call.getAccessToken()
+                ).toResponse()
+            )
         }
     }
 }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -410,6 +410,21 @@ paths:
                 items:
                   $ref: "#/components/schemas/SanityTiltakstype"
 
+  /api/v1/internal/sanity/lokasjoner:
+    get:
+      tags:
+        - Sanity
+      operationId: getLokasjonerForBrukersEnhetOgFylke
+      responses:
+        200:
+          description: Lokasjoner fra tiltaksgjennomføringer basert på brukers enhet og fylke
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
   /api/v1/internal/dialog:
     post:
       tags:
@@ -1147,4 +1162,3 @@ components:
           type: string
         pameldingOgVarighet:
           type: object
-


### PR DESCRIPTION
Flytter groq-spørring fra frontend til backend for henting av lokasjoner basert på tiltaksgjennomføringene som bruker i kontekst har tilgang på.