### PR TITLE
Henter detaljer om tiltaksgjennomføringer i backend

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforingById.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforingById.ts
@@ -1,55 +1,20 @@
-import groq from 'groq';
-import { useGetTiltaksgjennomforingIdFraUrl } from './useGetTiltaksgjennomforingIdFraUrl';
-import { useSanity } from './useSanity';
-import { erPreview } from '../../../utils/Utils';
 import { SanityTiltaksgjennomforing } from 'mulighetsrommet-api-client';
+import { useQuery } from 'react-query';
+import { erPreview } from '../../../utils/Utils';
+import { mulighetsrommetClient } from '../clients';
+import { QueryKeys } from '../query-keys';
+import { useGetTiltaksgjennomforingIdFraUrl } from './useGetTiltaksgjennomforingIdFraUrl';
 
 export default function useTiltaksgjennomforingById() {
   const tiltaksgjennomforingId = useGetTiltaksgjennomforingIdFraUrl().replace('drafts.', '');
-  const preview = erPreview;
-  const matchIdForProdEllerDrafts = `(_id == '${tiltaksgjennomforingId}' || _id == 'drafts.${tiltaksgjennomforingId}')`;
-  const response = useSanity<SanityTiltaksgjennomforing>(
-    groq`*[_type == "tiltaksgjennomforing" && ${matchIdForProdEllerDrafts}] {
-    _id,
-    tiltaksgjennomforingNavn,
-    beskrivelse,
-    "tiltaksnummer": tiltaksnummer.current,
-    tilgjengelighetsstatus,
-    estimert_ventetid,
-    lokasjon,
-    oppstart,
-    oppstartsdato,
-    faneinnhold {
-      forHvemInfoboks,
-      forHvem,
-      detaljerOgInnholdInfoboks,
-      detaljerOgInnhold,
-      pameldingOgVarighetInfoboks,
-      pameldingOgVarighet,
-    },
-    kontaktinfoArrangor->,
-    kontaktinfoTiltaksansvarlige[]->,
-    tiltakstype->{
-      ...,
-      regelverkFiler[]-> {
-        _id,
-        "regelverkFilUrl": regelverkFilOpplastning.asset->url,
-        regelverkFilNavn
-      },
-      regelverkLenker[]->,
-      innsatsgruppe->,
-
-    }
-  }`,
-    {
-      includeUserdata: false,
-    }
+  const response = useQuery(QueryKeys.sanity.tiltaksgjennomforing(tiltaksgjennomforingId), () =>
+    mulighetsrommetClient.sanity.getTiltaksgjennomforing({ id: tiltaksgjennomforingId })
   );
 
   if (!response.data) {
     return response;
   }
-  return { ...response, data: filterDataToSingleItem(response.data, preview) };
+  return { ...response, data: filterDataToSingleItem(response.data, erPreview) };
 }
 
 function filterDataToSingleItem(data: SanityTiltaksgjennomforing | SanityTiltaksgjennomforing[], preview: boolean) {

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/query-keys.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/query-keys.ts
@@ -16,5 +16,6 @@ export const QueryKeys = {
       { ...bruker },
       { ...tiltaksgjennomforingsfilter },
     ],
+    tiltaksgjennomforing: (id: string) => ['tiltaksgjennomforing', id],
   },
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -141,6 +141,47 @@ export const apiHandlers: RestHandler[] = [
     return ok(result);
   }),
 
+  rest.get<any, any, any>('*/api/v1/internal/sanity/tiltaksgjennomforing/:id', async req => {
+    const id = req.params.id;
+    const matchIdForProdEllerDrafts = `(_id == '${id}' || _id == 'drafts.${id}')`;
+    const query = groq`*[_type == "tiltaksgjennomforing" && ${matchIdForProdEllerDrafts}] {
+    _id,
+    tiltaksgjennomforingNavn,
+    beskrivelse,
+    "tiltaksnummer": tiltaksnummer.current,
+    tilgjengelighetsstatus,
+    estimert_ventetid,
+    lokasjon,
+    oppstart,
+    oppstartsdato,
+    faneinnhold {
+      forHvemInfoboks,
+      forHvem,
+      detaljerOgInnholdInfoboks,
+      detaljerOgInnhold,
+      pameldingOgVarighetInfoboks,
+      pameldingOgVarighet,
+    },
+    kontaktinfoArrangor->,
+    kontaktinfoTiltaksansvarlige[]->,
+    tiltakstype->{
+      ...,
+      regelverkFiler[]-> {
+        _id,
+        "regelverkFilUrl": regelverkFilOpplastning.asset->url,
+        regelverkFilNavn
+      },
+      regelverkLenker[]->,
+      innsatsgruppe->,
+
+    }
+  }`;
+
+    const client = getSanityClient();
+    const result = await client.fetch(query);
+    return ok(result);
+  }),
+
   rest.get<any, any, HistorikkForBruker[]>('*/api/v1/internal/bruker/historikk', (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(historikk));
   }),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
@@ -63,6 +63,15 @@ fun Route.sanityRoutes() {
                 ).toResponse()
             )
         }
+
+        get("/tiltaksgjennomforing/{id}") {
+            poaoTilgangService.verfiyAccessToModia(getNavAnsattAzureId())
+            val id = call.parameters["id"] ?: return@get call.respondText(
+                text = "Mangler eller ugyldig id",
+                status = HttpStatusCode.BadRequest,
+            )
+            call.respondWithData(sanityService.hentTiltaksgjennomforing(id).toResponse())
+        }
     }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -163,6 +163,45 @@ class SanityService(private val config: Config, private val brukerService: Bruke
         return executeQuery(query)
     }
 
+    suspend fun hentTiltaksgjennomforing(id: String): SanityResponse {
+        val query = """
+            *[_type == "tiltaksgjennomforing" && (_id == '$id' || _id == 'drafts.$id')] {
+                _id,
+                tiltaksgjennomforingNavn,
+                beskrivelse,
+                "tiltaksnummer": tiltaksnummer.current,
+                tilgjengelighetsstatus,
+                estimert_ventetid,
+                lokasjon,
+                oppstart,
+                oppstartsdato,
+                faneinnhold {
+                  forHvemInfoboks,
+                  forHvem,
+                  detaljerOgInnholdInfoboks,
+                  detaljerOgInnhold,
+                  pameldingOgVarighetInfoboks,
+                  pameldingOgVarighet,
+                },
+                kontaktinfoArrangor->,
+                kontaktinfoTiltaksansvarlige[]->,
+                tiltakstype->{
+                  ...,
+                  regelverkFiler[]-> {
+                    _id,
+                    "regelverkFilUrl": regelverkFilOpplastning.asset->url,
+                    regelverkFilNavn
+                  },
+                  regelverkLenker[]->,
+                  innsatsgruppe->,
+
+                }
+              }
+        """.trimIndent()
+
+        return executeQuery(query)
+    }
+
     private suspend fun getFylkeIdBasertPaaEnhetsId(enhetsId: String?): String? {
         if (fylkenummerCache[enhetsId] != null) {
             return fylkenummerCache[enhetsId]

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -465,6 +465,27 @@ paths:
                 items:
                   $ref: "#/components/schemas/SanityTiltaksgjennomforing"
 
+  /api/v1/internal/sanity/tiltaksgjennomforing/{id}:
+    get:
+      tags:
+        - Sanity
+      operationId: getTiltaksgjennomforing
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          description: ID for tiltaksgjennomføring i Sanity
+      responses:
+        200:
+          description: Hent tiltaksgjennomføring for id
+          content:
+            application/json:
+              schema:
+                type: array # Sanity kan returnere prod- og draft-versjon av dokument. Derfor array og ikke enkelt objekt
+                items:
+                  $ref: "#/components/schemas/SanityTiltaksgjennomforing"
+
   /api/v1/internal/dialog:
     post:
       tags:


### PR DESCRIPTION
- Flytter henting av detaljer for en tiltaksgjennomføring fra Groq-spørring i frontend til Groq-spørring i backend
- Jeg skal få fjernet ubrukte `useSanity`-hook og generelt sanity-endepunkt i backend i egen pr 