### PR TITLE
:sparkles: Støtte for helptext-komponent for nøkkeltall

### DIFF
--- a/frontend/mr-admin-flate/src/components/nokkeltall/Nokkeltall.module.scss
+++ b/frontend/mr-admin-flate/src/components/nokkeltall/Nokkeltall.module.scss
@@ -2,6 +2,9 @@
   background-color: white;
   padding: 1rem;
   flex: 1;
+  max-width: 25rem;
+  display: flex;
+  justify-content: space-between;
 }
 
 .heading {

--- a/frontend/mr-admin-flate/src/components/nokkeltall/Nokkeltall.tsx
+++ b/frontend/mr-admin-flate/src/components/nokkeltall/Nokkeltall.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Heading } from "@navikt/ds-react";
+import { BodyShort, Heading, HelpText } from "@navikt/ds-react";
 import classNames from "classnames";
 import styles from "./Nokkeltall.module.scss";
 
@@ -6,18 +6,29 @@ interface Props {
   title: string;
   subtitle: string;
   value: number | string;
+  helptext?: string;
+  helptextTitle?: string;
 }
 
-export function Nokkeltall({ title, subtitle, value }: Props) {
+export function Nokkeltall({
+  title,
+  subtitle,
+  value,
+  helptext,
+  helptextTitle,
+}: Props) {
   return (
-    <div className={classNames(styles.nokkeltall, styles.nokkeltall_container)}>
-      <Heading level="3" size="xsmall" className={styles.heading}>
-        {title}
-      </Heading>
-      <BodyShort className={styles.nokkeltall}>
-        <span className={styles.value}>{value}</span>
-        <span className={styles.muted}>{subtitle}</span>
-      </BodyShort>
+    <div className={classNames(styles.nokkeltall_container)}>
+      <div className={styles.nokkeltall}>
+        <Heading level="3" size="xsmall" className={styles.heading}>
+          {title}
+        </Heading>
+        <BodyShort className={styles.nokkeltall}>
+          <span className={styles.value}>{value}</span>
+          <span className={styles.muted}>{subtitle}</span>
+        </BodyShort>
+      </div>
+      {helptext ? <HelpText title={helptextTitle}>{helptext}</HelpText> : null}
     </div>
   );
 }

--- a/frontend/mr-admin-flate/src/pages/avtaler/nokkeltall/NokkeltallForAvtale.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/nokkeltall/NokkeltallForAvtale.tsx
@@ -22,6 +22,8 @@ export function NokkeltallForAvtale() {
         title="Tiltaksgjennomføringer"
         subtitle="totalt"
         value={formaterTall(data.antallTiltaksgjennomforinger)}
+        helptext="Totalt antall tiltaksgjennomføringer"
+        helptextTitle="Hvor kommer tallene fra?"
       />
     </NokkeltallContainer>
   );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9053627/224980234-861742fa-6446-4de4-82f1-4e5d9f9f56ab.png)

Innhold i HelpText er ikke spesifisert enda.