### PR TITLE
Melding om feil i nøkkeltall for avtaler

### DIFF
--- a/frontend/mr-admin-flate/src/pages/avtaler/nokkeltall/NokkeltallForAvtale.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/nokkeltall/NokkeltallForAvtale.tsx
@@ -1,4 +1,4 @@
-import { Alert } from "@navikt/ds-react";
+import { Alert, BodyShort } from "@navikt/ds-react";
 import { useNokkeltallForAvtale } from "../../../api/avtaler/useNokkeltallForAvtale";
 import { Laster } from "../../../components/laster/Laster";
 import { Nokkeltall } from "../../../components/nokkeltall/Nokkeltall";
@@ -17,14 +17,22 @@ export function NokkeltallForAvtale() {
   }
 
   return (
-    <NokkeltallContainer>
-      <Nokkeltall
-        title="Tiltaksgjennomføringer"
-        subtitle="hittil i år"
-        value={formaterTall(data.antallTiltaksgjennomforinger)}
-        helptext="Sum av alle tiltaksgjennomføringer for valgt avtale, som er aktive innenfor budsjettåret (1. januar -> 31. desember)"
-        helptextTitle="Hvor kommer tallene fra?"
-      />
-    </NokkeltallContainer>
+    <>
+      <Alert style={{ marginBottom: "1rem" }} variant="info">
+        <BodyShort>
+          Nøkkeltall for avtaler er ikke 100% korrekt under pilotering pga. en
+          svakhet i tallgrunnlaget. Teamet jobber med å fikse tallgrunnlaget.
+        </BodyShort>
+      </Alert>
+      <NokkeltallContainer>
+        <Nokkeltall
+          title="Tiltaksgjennomføringer"
+          subtitle="hittil i år"
+          value={formaterTall(data.antallTiltaksgjennomforinger)}
+          helptext="Sum av alle tiltaksgjennomføringer for valgt avtale, som er aktive innenfor budsjettåret (1. januar -> 31. desember)"
+          helptextTitle="Hvor kommer tallene fra?"
+        />
+      </NokkeltallContainer>
+    </>
   );
 }

--- a/frontend/mr-admin-flate/src/pages/avtaler/nokkeltall/NokkeltallForAvtale.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/nokkeltall/NokkeltallForAvtale.tsx
@@ -18,10 +18,10 @@ export function NokkeltallForAvtale() {
 
   return (
     <>
-      <Alert style={{ marginBottom: "1rem" }} variant="info">
+      <Alert style={{ marginBottom: "1rem" }} variant="warning">
         <BodyShort>
-          Nøkkeltall for avtaler er ikke 100% korrekt under pilotering pga. en
-          svakhet i tallgrunnlaget. Teamet jobber med å fikse tallgrunnlaget.
+          Tjenesten er under utvikling og tallene som vises her under nøkkeltall
+          kan være feil eller misvisende pga. feil eller for dårlig datagrunnlag
         </BodyShort>
       </Alert>
       <NokkeltallContainer>


### PR DESCRIPTION
Vi ønsker å vise nøkkeltall for pilot-gjengen, men vi vil gi de beskjed om at tallene for avtaler ikke er 100% til å stole på enda. Legger derfor på en melding som sier at tallgrunnlaget er litt off for øyeblikket.

![image](https://user-images.githubusercontent.com/9053627/226274311-09397e6d-dc23-46f7-b9d7-06c0145b4558.png)
