### PR TITLE
Legger til egne felter for år og løpenummer i Sanity

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -79,10 +79,13 @@ export const tiltaksgjennomforing = defineType({
         "Hvis tiltakstypen gjelder individuelle tiltak skal du ikke fylle inn noe her. Tiltaksnummer utledes fra feltene år og løpenummer over",
       type: "slug",
       options: {
+        slugify: (input) => {
+          return input;
+        },
         source: (doc, _) => {
           const aar = doc.aar as unknown as string;
           const lopenummer = doc.lopenummer as unknown as string;
-          return `${aar ? aar : new Date().getFullYear()}-${
+          return `${aar ? aar : new Date().getFullYear()}#${
             lopenummer ? lopenummer : 0
           }`;
         },

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -58,11 +58,35 @@ export const tiltaksgjennomforing = defineType({
       validation: (rule) => rule.required(),
     }),
     defineField({
+      name: "aar",
+      title: "År",
+      description:
+        "Hvis tiltakstypen gjelder individuelle tiltak skal du ikke fylle inn år.",
+      type: "number",
+      initialValue: () => new Date().getFullYear(),
+    }),
+    defineField({
+      name: "lopenummer",
+      title: "Løpenummer",
+      description:
+        "Hvis tiltakstypen gjelder individuelle tiltak skal du ikke fylle inn løpenummer.",
+      type: "number",
+    }),
+    defineField({
       name: "tiltaksnummer",
       title: "Tiltaksnummer",
       description:
-        "Hvis tiltakstypen gjelder individuelle tiltak skal du ikke fylle inn tiltaksnummer.",
+        "Hvis tiltakstypen gjelder individuelle tiltak skal du ikke fylle inn noe her. Tiltaksnummer utledes fra feltene år og løpenummer over",
       type: "slug",
+      options: {
+        source: (doc, _) => {
+          const aar = doc.aar as unknown as string;
+          const lopenummer = doc.lopenummer as unknown as string;
+          return `${aar ? aar : new Date().getFullYear()}-${
+            lopenummer ? lopenummer : 0
+          }`;
+        },
+      },
     }),
     defineField({
       name: "kontaktinfoArrangor",
@@ -117,7 +141,6 @@ export const tiltaksgjennomforing = defineType({
       description:
         "Hvilke enheter kan benytte seg av dette tiltaket? Hvis det gjelder for hele regionen kan dette feltet stå tomt.",
       type: "array",
-
       hidden: ({ document }) => {
         return !document.fylke;
       },

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -3,7 +3,7 @@ import useTiltaksgjennomforingById from '../../core/api/queries/useTiltaksgjenno
 import Kopiknapp from '../kopiknapp/Kopiknapp';
 import Regelverksinfo from './Regelverksinfo';
 import styles from './Sidemenydetaljer.module.scss';
-import { formaterDato, formaterTiltaksnummer } from '../../utils/Utils';
+import { formaterDato, utledLopenummerFraTiltaksnummer } from '../../utils/Utils';
 import { SanityTiltaksgjennomforing } from 'mulighetsrommet-api-client';
 
 const SidemenyDetaljer = () => {
@@ -22,8 +22,8 @@ const SidemenyDetaljer = () => {
               Tiltaksnummer
             </BodyShort>
             <div className={styles.tiltaksnummer}>
-              <BodyShort size="small">{formaterTiltaksnummer(tiltaksnummer)}</BodyShort>
-              <Kopiknapp kopitekst={formaterTiltaksnummer(tiltaksnummer)} dataTestId="knapp_kopier" />
+              <BodyShort size="small">{utledLopenummerFraTiltaksnummer(tiltaksnummer)}</BodyShort>
+              <Kopiknapp kopitekst={utledLopenummerFraTiltaksnummer(tiltaksnummer)} dataTestId="knapp_kopier" />
             </div>
           </div>
         )}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -3,7 +3,7 @@ import useTiltaksgjennomforingById from '../../core/api/queries/useTiltaksgjenno
 import Kopiknapp from '../kopiknapp/Kopiknapp';
 import Regelverksinfo from './Regelverksinfo';
 import styles from './Sidemenydetaljer.module.scss';
-import { formaterDato } from '../../utils/Utils';
+import { formaterDato, formaterTiltaksnummer } from '../../utils/Utils';
 import { SanityTiltaksgjennomforing } from 'mulighetsrommet-api-client';
 
 const SidemenyDetaljer = () => {
@@ -22,8 +22,8 @@ const SidemenyDetaljer = () => {
               Tiltaksnummer
             </BodyShort>
             <div className={styles.tiltaksnummer}>
-              <BodyShort size="small">{tiltaksnummer}</BodyShort>
-              <Kopiknapp kopitekst={String(tiltaksnummer)} dataTestId="knapp_kopier" />
+              <BodyShort size="small">{formaterTiltaksnummer(tiltaksnummer)}</BodyShort>
+              <Kopiknapp kopitekst={formaterTiltaksnummer(tiltaksnummer)} dataTestId="knapp_kopier" />
             </div>
           </div>
         )}

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/tiltaksgjennomforinger.ts
@@ -25,7 +25,7 @@ export const tiltaksgjennomforinger: SanityTiltaksgjennomforing[] = [
     },
     tiltaksgjennomforingNavn: 'Varig tilrettelagt arbeid - VTA',
     beskrivelse: faker.lorem.paragraph(3),
-    tiltaksnummer: 111111,
+    tiltaksnummer: '111111',
     kontaktinfoArrangor: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       selskapsnavn: 'SoloPolo AS',
@@ -69,7 +69,7 @@ export const tiltaksgjennomforinger: SanityTiltaksgjennomforing[] = [
     },
     tiltaksgjennomforingNavn: 'Varig tilrettelagt arbeid - VTA',
     beskrivelse: faker.lorem.paragraph(3),
-    tiltaksnummer: 123456,
+    tiltaksnummer: '123456',
     kontaktinfoArrangor: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       selskapsnavn: 'SoloPolo AS',
@@ -113,7 +113,7 @@ export const tiltaksgjennomforinger: SanityTiltaksgjennomforing[] = [
     },
     tiltaksgjennomforingNavn: 'Varig tilrettelagt arbeid - VTA',
     beskrivelse: faker.lorem.paragraph(3),
-    tiltaksnummer: 112233,
+    tiltaksnummer: '112233',
     kontaktinfoArrangor: {
       _id: faker.datatype.number({ min: 100000, max: 999999 }).toString(),
       selskapsnavn: 'SoloPolo AS',

--- a/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
@@ -35,7 +35,7 @@ export function formaterDato(dato: string | Date, fallback = ''): string {
 }
 
 export function utledLopenummerFraTiltaksnummer(tiltaksnummer: string): string {
-  const parts = tiltaksnummer.split('-');
+  const parts = tiltaksnummer.split('#');
   if (parts.length >= 2) {
     return parts[1];
   }

--- a/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
@@ -34,7 +34,7 @@ export function formaterDato(dato: string | Date, fallback = ''): string {
   return result;
 }
 
-export function formaterTiltaksnummer(tiltaksnummer: string): string {
+export function utledLopenummerFraTiltaksnummer(tiltaksnummer: string): string {
   const parts = tiltaksnummer.split('-');
   if (parts.length >= 2) {
     return parts[1];

--- a/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
@@ -33,3 +33,12 @@ export function formaterDato(dato: string | Date, fallback = ''): string {
 
   return result;
 }
+
+export function formaterTiltaksnummer(tiltaksnummer: string): string {
+  const parts = tiltaksnummer.split('-');
+  if (parts.length >= 2) {
+    return parts[1];
+  }
+
+  return tiltaksnummer;
+}

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1223,7 +1223,7 @@ components:
         beskrivelse:
           type: string
         tiltaksnummer:
-          type: number
+          type: string
         kontaktinfoArrangor:
           $ref: "#/components/schemas/SanityKontaktinfoArrangor"
         lokasjon:


### PR DESCRIPTION
Gjelder Trello-kort: https://trello.com/c/MQbHblj9/149-nytt-inputfelt-i-sanity-for-%C3%A5r-og-l%C3%B8penummer

Introduserer feltene år og løpenummer som = tiltaksnummer. 
Validerer at tiltaksnummer er unikt, men flyten per nå er ikke helt optimal. Den blir nok bedre når vi får splittet 
gruppetiltak og individuelle tiltak ut i egne skjemaer. 

Beholder feltet tiltaksnummer i dokumenttypen for Tiltaksgjennomføring så ingenting brekker, men legger til feltene år og løpenummer så vi kan oppdatere tiltaksgjennomføringene i prod-datasettet manuelt der det trengs.

Hva bør vi gjøre med de tiltaksgjennomføringene som ikke har årstall i tiltaksnummeret nå? Antar vi at det gjelder 2023?