### PR TITLE
ci: only run one workflow per branch

### DIFF
--- a/.github/workflows/mr-admin-flate-container.yaml
+++ b/.github/workflows/mr-admin-flate-container.yaml
@@ -19,7 +19,7 @@ on:
           - dev_and_prod
 
 concurrency:
-  group: mr-admin-frontend-container
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/mr-admin-flate-labs.yaml
+++ b/.github/workflows/mr-admin-flate-labs.yaml
@@ -10,6 +10,10 @@ on:
       - frontend/mr-admin-flate/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE: ghcr.io/navikt/mulighetsrommet/mr-admin-flate-mock:${{ github.sha }}
   CI: true

--- a/.github/workflows/mr-admin-flate.yaml
+++ b/.github/workflows/mr-admin-flate.yaml
@@ -25,6 +25,10 @@ on:
           - dev
           - dev_and_prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: true
   TZ: Europe/Amsterdam

--- a/.github/workflows/mr-api-sanity-sync.yaml
+++ b/.github/workflows/mr-api-sanity-sync.yaml
@@ -19,6 +19,10 @@ on:
           - dev
           - dev_and_prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: true
   TZ: Europe/Amsterdam

--- a/.github/workflows/mr-api.yaml
+++ b/.github/workflows/mr-api.yaml
@@ -19,6 +19,10 @@ on:
           - dev
           - dev_and_prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: true
   TZ: Europe/Amsterdam

--- a/.github/workflows/mr-arena-adapter-manager-container.yaml
+++ b/.github/workflows/mr-arena-adapter-manager-container.yaml
@@ -19,7 +19,7 @@ on:
           - dev_and_prod
 
 concurrency:
-  group: mr_arena_adapter_manager_container
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/mr-arena-adapter-manager.yaml
+++ b/.github/workflows/mr-arena-adapter-manager.yaml
@@ -19,6 +19,10 @@ on:
           - dev
           - dev_and_prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: true
   TZ: Europe/Amsterdam

--- a/.github/workflows/mr-arena-adapter.yaml
+++ b/.github/workflows/mr-arena-adapter.yaml
@@ -19,6 +19,10 @@ on:
           - dev
           - dev_and_prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: true
   TZ: Europe/Amsterdam

--- a/.github/workflows/mr-sanity-studio.yaml
+++ b/.github/workflows/mr-sanity-studio.yaml
@@ -10,6 +10,10 @@ on:
       - frontend/mulighetsrommet-cms/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE: ghcr.io/navikt/mulighetsrommet/mulighetsrommet-cms:${{ github.sha }}
   CI: true

--- a/.github/workflows/mr-veileder-flate-container.yaml
+++ b/.github/workflows/mr-veileder-flate-container.yaml
@@ -19,7 +19,7 @@ on:
           - dev_and_prod
 
 concurrency:
-  group: mr_veileder_flate_container
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/mr-veileder-flate-mock.yaml
+++ b/.github/workflows/mr-veileder-flate-mock.yaml
@@ -18,6 +18,10 @@ on:
         options:
           - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE: ghcr.io/navikt/mulighetsrommet/mulighetsrommet-veileder-flate-mock:${{ github.sha }}
   CI: true

--- a/.github/workflows/mr-veileder-flate.yaml
+++ b/.github/workflows/mr-veileder-flate.yaml
@@ -19,6 +19,10 @@ on:
           - dev
           - dev_and_prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: true
   TZ: Europe/Amsterdam

--- a/.github/workflows/nav-enheter-to-sanity.yaml
+++ b/.github/workflows/nav-enheter-to-sanity.yaml
@@ -19,6 +19,10 @@ on:
           - dev
           - dev_and_prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE: ghcr.io/navikt/mulighetsrommet/nav-enheter-to-sanity:${{ github.sha }}
   CI: true


### PR DESCRIPTION
Concurrency group skal sørge for at vi kun kjører én workflow av gangen for gitt navn.
`group` settes til kombinasjonen av workflow som kjøres og branch den kjører på, som burde sørge for at vi kjører færre workflows ved flere push etter hverandre eller når vi merger flere pull requests til main samtidig.