### PR TITLE
Slacknotify events med retry > 4

### DIFF
--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.arena.adapter
 
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
+import no.nav.mulighetsrommet.arena.adapter.tasks.NotifyFailedEvents
 import no.nav.mulighetsrommet.arena.adapter.tasks.RetryFailedEvents
 import no.nav.mulighetsrommet.database.FlywayDatabaseConfig
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
@@ -22,7 +23,8 @@ data class AppConfig(
 )
 
 data class TaskConfig(
-    val retryFailedEvents: RetryFailedEvents.Config
+    val retryFailedEvents: RetryFailedEvents.Config,
+    val notifyFailedEvents: NotifyFailedEvents.Config
 )
 
 data class ServiceConfig(

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
@@ -16,6 +16,7 @@ import no.nav.mulighetsrommet.arena.adapter.events.processors.*
 import no.nav.mulighetsrommet.arena.adapter.repositories.*
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
+import no.nav.mulighetsrommet.arena.adapter.tasks.NotifyTeamStaleRetries
 import no.nav.mulighetsrommet.arena.adapter.tasks.ReplayEvents
 import no.nav.mulighetsrommet.arena.adapter.tasks.RetryFailedEvents
 import no.nav.mulighetsrommet.database.Database
@@ -65,13 +66,14 @@ private fun tasks(tasks: TaskConfig) = module {
     }
     single {
         val retryFailedEvents = RetryFailedEvents(tasks.retryFailedEvents, get(), get())
+        val notifyTeamStaleRetries = NotifyTeamStaleRetries(get(), get(), get())
         val replayEvents: ReplayEvents = get()
 
         val db: Database by inject()
 
         Scheduler
             .create(db.getDatasource(), replayEvents.task)
-            .startTasks(retryFailedEvents.task)
+            .startTasks(retryFailedEvents.task, notifyTeamStaleRetries.task)
             .registerShutdownHook()
             .build()
     }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepository.kt
@@ -80,15 +80,17 @@ class ArenaEventRepository(private val db: Database) {
         idGreaterThan: String? = null,
         status: ArenaEvent.ProcessingStatus? = null,
         maxRetries: Int? = null,
+        retriesGreaterThan: Int? = null,
         limit: Int = 1000,
     ): List<ArenaEvent> {
-        logger.info("Getting events table=$table, idGreaterThan=$idGreaterThan, status=$status, maxRetries=$maxRetries, limit=$limit")
+        logger.info("Getting events table=$table, idGreaterThan=$idGreaterThan, status=$status, maxRetries=$maxRetries, retriesGreaterThan=$retriesGreaterThan, limit=$limit")
 
         val where = andWhereParameterNotNull(
             table to "arena_table = :arena_table",
             idGreaterThan to "arena_id > :arena_id",
             status to "processing_status= :status::processing_status",
             maxRetries to "retries < :max_retries",
+            retriesGreaterThan to "retries > :retriesGreaterThan"
         )
 
         @Language("PostgreSQL")
@@ -107,6 +109,7 @@ class ArenaEventRepository(private val db: Database) {
                 "arena_id" to idGreaterThan,
                 "status" to status?.name,
                 "max_retries" to maxRetries,
+                "retriesGreaterThan" to retriesGreaterThan,
                 "limit" to limit,
             )
         )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepository.kt
@@ -79,18 +79,18 @@ class ArenaEventRepository(private val db: Database) {
         table: ArenaTable? = null,
         idGreaterThan: String? = null,
         status: ArenaEvent.ProcessingStatus? = null,
-        maxRetries: Int? = null,
-        retriesGreaterThan: Int? = null,
+        retriesLessThan: Int? = null,
+        retriesGreaterThanOrEqual: Int? = null,
         limit: Int = 1000,
     ): List<ArenaEvent> {
-        logger.info("Getting events table=$table, idGreaterThan=$idGreaterThan, status=$status, maxRetries=$maxRetries, retriesGreaterThan=$retriesGreaterThan, limit=$limit")
+        logger.info("Getting events table=$table, idGreaterThan=$idGreaterThan, status=$status, maxRetries=$retriesLessThan, retriesGreaterThanOrEqual=$retriesGreaterThanOrEqual, limit=$limit")
 
         val where = andWhereParameterNotNull(
             table to "arena_table = :arena_table",
             idGreaterThan to "arena_id > :arena_id",
             status to "processing_status= :status::processing_status",
-            maxRetries to "retries < :max_retries",
-            retriesGreaterThan to "retries > :retriesGreaterThan"
+            retriesLessThan to "retries < :max_retries",
+            retriesGreaterThanOrEqual to "retries >= :retriesGreaterThanOrEqual"
         )
 
         @Language("PostgreSQL")
@@ -108,8 +108,8 @@ class ArenaEventRepository(private val db: Database) {
                 "arena_table" to table?.table,
                 "arena_id" to idGreaterThan,
                 "status" to status?.name,
-                "max_retries" to maxRetries,
-                "retriesGreaterThan" to retriesGreaterThan,
+                "max_retries" to retriesLessThan,
+                "retriesGreaterThanOrEqual" to retriesGreaterThanOrEqual,
                 "limit" to limit,
             )
         )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventService.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventService.kt
@@ -135,7 +135,7 @@ class ArenaEventService(
                     table = table,
                     idGreaterThan = prevId,
                     status = status,
-                    maxRetries = maxRetries,
+                    retriesLessThan = maxRetries,
                     limit = config.channelCapacity
                 )
 
@@ -165,7 +165,7 @@ class ArenaEventService(
         logger.info("Consumed $count events in $time")
     }
 
-    fun getStaleEvents(retriesGreaterThan: Int): List<ArenaEvent> {
-        return events.getAll(retriesGreaterThan = retriesGreaterThan)
+    fun getStaleEvents(retriesGreaterThanOrEqual: Int): List<ArenaEvent> {
+        return events.getAll(retriesGreaterThanOrEqual = retriesGreaterThanOrEqual)
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventService.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventService.kt
@@ -164,4 +164,8 @@ class ArenaEventService(
 
         logger.info("Consumed $count events in $time")
     }
+
+    fun getStaleEvents(retriesGreaterThan: Int): List<ArenaEvent> {
+        return events.getAll(retriesGreaterThan = retriesGreaterThan)
+    }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/NotifyFailedEvents.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/NotifyFailedEvents.kt
@@ -9,19 +9,24 @@ import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
 import org.slf4j.LoggerFactory
-import java.time.LocalTime
 
-class NotifyTeamStaleRetries(
+class NotifyFailedEvents(
     private val arenaEventService: ArenaEventService,
     val database: Database,
-    private val slackNotifier: SlackNotifier
+    private val slackNotifier: SlackNotifier,
+    private val config: Config
 ) {
+
+    data class Config(
+        val cron: String,
+        val maxRetries: Int
+    )
 
     private val logger = LoggerFactory.getLogger(javaClass)
     private val taskName = "notify-team-stale-retries"
 
     val task: RecurringTask<Void> = Tasks
-        .recurring(taskName, Schedules.daily(LocalTime.of(7, 0)))
+        .recurring(taskName, Schedules.cron(config.cron))
         .onFailure { _, _ ->
             slackNotifier.sendMessage("Klarte ikke kjøre task '$taskName'. Konsekvensen er at man ikke får gitt beskjed på Slack dersom det finnes events som er stale etter for mange retries.")
         }
@@ -29,11 +34,12 @@ class NotifyTeamStaleRetries(
             logger.info("Running task ${instance.taskName}")
 
             runBlocking {
-                val retries = 4
-                val staleEvents: List<ArenaEvent> = arenaEventService.getStaleEvents(retriesGreaterThan = retries)
+                val retries = config.maxRetries
+                val staleEvents: List<ArenaEvent> =
+                    arenaEventService.getStaleEvents(retriesGreaterThanOrEqual = retries)
                 if (staleEvents.isNotEmpty()) {
                     val message = """
-                        Det finnes ${staleEvents.size} rader i tabellen 'arena_events' som har retries > $retries.
+                        Det finnes ${staleEvents.size} rader i tabellen 'arena_events' som har retries >= $retries.
                         Det gjelder følgende rader: \n
                         ${staleEvents.formaterSlackMeldingForEvents()}
                     """.trimIndent()
@@ -45,7 +51,7 @@ class NotifyTeamStaleRetries(
     private fun List<ArenaEvent>.formaterSlackMeldingForEvents(): String {
         return this.joinToString("\n") {
             """
-                arena-table: ${it.arenaTable}, arena_id: ${it.arenaId}, processing_status: ${it.status.name}, retries: ${it.retries}, message: ${it.message}, operation: ${it.operation.name}
+                arena-table: ${it.arenaTable}, arena_id: ${it.arenaId}
             """.trimIndent()
         }
     }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/NotifyTeamStaleRetries.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/NotifyTeamStaleRetries.kt
@@ -1,0 +1,52 @@
+package no.nav.mulighetsrommet.arena.adapter.tasks
+
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask
+import com.github.kagkarlsson.scheduler.task.helper.Tasks
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules
+import kotlinx.coroutines.runBlocking
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
+import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
+import no.nav.mulighetsrommet.database.Database
+import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
+import org.slf4j.LoggerFactory
+import java.time.LocalTime
+
+class NotifyTeamStaleRetries(
+    private val arenaEventService: ArenaEventService,
+    val database: Database,
+    private val slackNotifier: SlackNotifier
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val taskName = "notify-team-stale-retries"
+
+    val task: RecurringTask<Void> = Tasks
+        .recurring(taskName, Schedules.daily(LocalTime.of(7, 0)))
+        .onFailure { _, _ ->
+            slackNotifier.sendMessage("Klarte ikke kjøre task '$taskName'. Konsekvensen er at man ikke får gitt beskjed på Slack dersom det finnes events som er stale etter for mange retries.")
+        }
+        .execute { instance, _ ->
+            logger.info("Running task ${instance.taskName}")
+
+            runBlocking {
+                val retries = 4
+                val staleEvents: List<ArenaEvent> = arenaEventService.getStaleEvents(retriesGreaterThan = retries)
+                if (staleEvents.isNotEmpty()) {
+                    val message = """
+                        Det finnes ${staleEvents.size} rader i tabellen 'arena_events' som har retries > $retries.
+                        Det gjelder følgende rader: \n
+                        ${staleEvents.formaterSlackMeldingForEvents()}
+                    """.trimIndent()
+                    slackNotifier.sendMessage(message)
+                }
+            }
+        }
+
+    private fun List<ArenaEvent>.formaterSlackMeldingForEvents(): String {
+        return this.joinToString("\n") {
+            """
+                arena-table: ${it.arenaTable}, arena_id: ${it.arenaId}, processing_status: ${it.status.name}, retries: ${it.retries}, message: ${it.message}, operation: ${it.operation.name}
+            """.trimIndent()
+        }
+    }
+}

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
@@ -29,6 +29,10 @@ app:
     retryFailedEvents:
       delayOfMinutes: 5
 
+    notifyFailedEvents:
+      maxRetries: 5
+      cron: '0 0 7 * * MON-FRI'
+
   enableFailedRecordProcessor: true
 
   auth:

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
@@ -27,6 +27,10 @@ app:
     retryFailedEvents:
       delayOfMinutes: 1
 
+    notifyFailedEvents:
+      maxRetries: 5
+      cron: '0 0 7 * * MON-FRI'
+
   enableFailedRecordProcessor: true
 
   auth:
@@ -59,4 +63,4 @@ app:
   slack:
     token: ${SLACK_TOKEN:-""}
     channel: "#team-valp-monitoring"
-    enable: true
+    enable: false

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
@@ -59,4 +59,4 @@ app:
   slack:
     token: ${SLACK_TOKEN:-""}
     channel: "#team-valp-monitoring"
-    enable: false
+    enable: true

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
@@ -29,6 +29,10 @@ app:
     retryFailedEvents:
       delayOfMinutes: 15
 
+    notifyFailedEvents:
+      maxRetries: 5
+      cron: '0 0 7 * * MON-FRI'
+
   enableFailedRecordProcessor: true
 
   auth:

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationTestConfig.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationTestConfig.kt
@@ -46,7 +46,7 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
         ),
         notifyFailedEvents = NotifyFailedEvents.Config(
             maxRetries = 5,
-            cron = ""
+            cron = "0 0 0 1 1 0"
         )
     ),
     services = ServiceConfig(

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationTestConfig.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationTestConfig.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.arena.adapter
 
 import io.ktor.server.testing.*
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
+import no.nav.mulighetsrommet.arena.adapter.tasks.NotifyFailedEvents
 import no.nav.mulighetsrommet.arena.adapter.tasks.RetryFailedEvents
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
@@ -42,6 +43,10 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     tasks = TaskConfig(
         retryFailedEvents = RetryFailedEvents.Config(
             delayOfMinutes = 1
+        ),
+        notifyFailedEvents = NotifyFailedEvents.Config(
+            maxRetries = 5,
+            cron = ""
         )
     ),
     services = ServiceConfig(


### PR DESCRIPTION
Legger til en task som kjøres kl. 07.00 og melder på Slack dersom vi har events i arena_event som har `retries > 4`.