### PR TITLE
:sparkles: Filtrer avtaler på tiltakstype

### DIFF
--- a/frontend/mr-admin-flate/cypress/e2e/mr-admin-flate.cy.js
+++ b/frontend/mr-admin-flate/cypress/e2e/mr-admin-flate.cy.js
@@ -88,6 +88,13 @@ describe("Avtaler", () => {
       cy.checkPageA11y();
     });
   });
+
+  context("Oversikt over avtaler", () => {
+    it("Skal finnes et filter for tiltakstype for avtaler", () => {
+      cy.visit("/avtaler");
+      cy.getByTestId("filter_avtale_tiltakstype").should("exist");
+    });
+  });
 });
 
 describe("Tiltaksgjennomføringer", () => {

--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -62,6 +62,7 @@ const avtaleFilter = atomWithHash<{
   sok: string;
   status: Avtalestatus;
   enhet: string;
+  tiltakstype: string;
   sortering: SorteringAvtaler;
 }>(
   "avtalefilter",
@@ -69,6 +70,7 @@ const avtaleFilter = atomWithHash<{
     sok: "",
     status: Avtalestatus.AKTIV,
     enhet: "",
+    tiltakstype: "",
     sortering: SorteringAvtaler.NAVN_ASCENDING,
   },
   { setHash: "replaceState" }

--- a/frontend/mr-admin-flate/src/api/avtaler/useAvtaler.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useAvtaler.ts
@@ -1,21 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useDebounce } from "mulighetsrommet-frontend-common";
-import { useParams } from "react-router-dom";
 import { AVTALE_PAGE_SIZE } from "../../constants";
 import { avtaleFilter, avtalePaginationAtom } from "../atoms";
 import { mulighetsrommetClient } from "../clients";
 import { QueryKeys } from "../QueryKeys";
 
 export function useAvtaler() {
-  const { tiltakstypeId } = useParams<{ tiltakstypeId: string | undefined }>();
   const [page] = useAtom(avtalePaginationAtom);
   const [filter] = useAtom(avtaleFilter);
   const debouncedSok = useDebounce(filter.sok, 300);
 
   return useQuery(
     QueryKeys.avtaler(
-      tiltakstypeId || "",
+      filter.tiltakstype,
       debouncedSok,
       filter.status,
       filter.enhet,
@@ -24,7 +22,7 @@ export function useAvtaler() {
     ),
     () => {
       return mulighetsrommetClient.avtaler.getAvtaler({
-        tiltakstypeId,
+        tiltakstypeId: filter.tiltakstype || undefined,
         search: debouncedSok || undefined,
         avtalestatus: filter.status ? filter.status : undefined,
         enhet: filter.enhet ? filter.enhet : undefined,

--- a/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstypeById.ts
+++ b/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstypeById.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
+import { useGetTiltakstypeIdFromUrl } from "../../hooks/useGetTiltakstypeIdFromUrl";
 import { mulighetsrommetClient } from "../clients";
 import { QueryKeys } from "../QueryKeys";
 
 export function useTiltakstypeById() {
-  const { tiltakstypeId } = useParams<{ tiltakstypeId: string }>();
+  const tiltakstypeId = useGetTiltakstypeIdFromUrl();
 
   if (!tiltakstypeId) {
     throw new Error("Fant ingen tiltakstype-id i URL");

--- a/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstyper.ts
+++ b/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstyper.ts
@@ -6,7 +6,11 @@ import { PAGE_SIZE } from "../../constants";
 import { paginationAtom, tiltakstypefilter } from "../atoms";
 import { useDebounce } from "mulighetsrommet-frontend-common";
 
-export function useTiltakstyper() {
+interface Options {
+  size: number;
+}
+
+export function useTiltakstyper({ size }: Options = { size: PAGE_SIZE }) {
   const [page] = useAtom(paginationAtom);
   const [sokefilter] = useAtom(tiltakstypefilter);
   const debouncedSok = useDebounce(sokefilter.sok, 300);
@@ -26,7 +30,7 @@ export function useTiltakstyper() {
         tiltakstypekategori: sokefilter.kategori ?? undefined,
         sort: sokefilter.sortering ?? undefined,
         page,
-        size: PAGE_SIZE,
+        size,
       })
   );
 }

--- a/frontend/mr-admin-flate/src/components/filter/Avtalefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/Avtalefilter.tsx
@@ -7,10 +7,18 @@ import { useAvtaler } from "../../api/avtaler/useAvtaler";
 import { useEnheter } from "../../api/enhet/useEnheter";
 import styles from "./Filter.module.scss";
 import { resetPaginering } from "../../utils/Utils";
+import { useTiltakstyper } from "../../api/tiltakstyper/useTiltakstyper";
 
-export function Avtalefilter() {
+type Filters = "tiltakstype";
+
+interface Props {
+  skjulFilter?: Record<Filters, boolean>;
+}
+
+export function Avtalefilter(props: Props) {
   const [filter, setFilter] = useAtom(avtaleFilter);
   const { data: enheter } = useEnheter();
+  const { data: tiltakstyper } = useTiltakstyper();
   const { data } = useAvtaler();
   const [, setPage] = useAtom(avtalePaginationAtom);
   const searchRef = useRef<HTMLDivElement | null>(null);
@@ -77,6 +85,26 @@ export function Avtalefilter() {
               </option>
             ))}
           </Select>
+          {props.skjulFilter?.tiltakstype ? null : (
+            <Select
+              label="Filtrer på tiltakstype"
+              hideLabel
+              size="small"
+              value={filter.tiltakstype}
+              data-testid="filter_avtale_tiltakstype"
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+                resetPaginering(setPage);
+                setFilter({ ...filter, tiltakstype: e.currentTarget.value });
+              }}
+            >
+              <option value="">Alle tiltakstyper</option>
+              {tiltakstyper?.data?.map((tiltakstype) => (
+                <option key={tiltakstype.id} value={tiltakstype.id}>
+                  {tiltakstype.navn}
+                </option>
+              ))}
+            </Select>
+          )}
         </div>
         <div>
           <Select

--- a/frontend/mr-admin-flate/src/components/filter/Avtalefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/Avtalefilter.tsx
@@ -18,7 +18,7 @@ interface Props {
 export function Avtalefilter(props: Props) {
   const [filter, setFilter] = useAtom(avtaleFilter);
   const { data: enheter } = useEnheter();
-  const { data: tiltakstyper } = useTiltakstyper();
+  const { data: tiltakstyper } = useTiltakstyper({ size: 200 });
   const { data } = useAvtaler();
   const [, setPage] = useAtom(avtalePaginationAtom);
   const searchRef = useRef<HTMLDivElement | null>(null);

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingsRad.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingsRad.tsx
@@ -46,10 +46,12 @@ export function TiltaksgjennomforingsRad({ tiltaksgjennomforing }: Props) {
         {formaterDato(tiltaksgjennomforing.startDato)}
       </BodyShort>
       <BodyShort
-        title={`Sluttdato ${formaterDato(tiltaksgjennomforing.sluttDato)}`}
-        aria-label={`Sluttdato: ${formaterDato(
+        title={`Sluttdato ${formaterDato(tiltaksgjennomforing.sluttDato)}, "-"`}
+        aria-label={
           tiltaksgjennomforing.sluttDato
-        )}`}
+            ? `Sluttdato: ${formaterDato(tiltaksgjennomforing.sluttDato, "-")}`
+            : undefined // Noen gjennomføringer har ikke sluttdato så da setter vi heller ikke aria-label for da klager reactA11y
+        }
       >
         {formaterDato(tiltaksgjennomforing.sluttDato)}
       </BodyShort>

--- a/frontend/mr-admin-flate/src/hooks/useGetTiltakstypeIdFromUrl.ts
+++ b/frontend/mr-admin-flate/src/hooks/useGetTiltakstypeIdFromUrl.ts
@@ -1,0 +1,6 @@
+import { useParams } from "react-router-dom";
+
+export function useGetTiltakstypeIdFromUrl() {
+  const { tiltakstypeId } = useParams<{ tiltakstypeId: string }>();
+  return tiltakstypeId;
+}

--- a/frontend/mr-admin-flate/src/pages/avtaler/DetaljerAvtalePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/DetaljerAvtalePage.tsx
@@ -18,7 +18,11 @@ export function DetaljerAvtalePage() {
   const { data } = useFeatureToggles();
 
   if (!avtale && isLoading) {
-    return <Laster tekst="Laster avtale" />;
+    return (
+      <main>
+        <Laster tekst="Laster avtale" />
+      </main>
+    );
   }
 
   if (!avtale) {

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/avtaler/AvtalerForTiltakstype.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/avtaler/AvtalerForTiltakstype.tsx
@@ -1,17 +1,28 @@
 import { Pagination } from "@navikt/ds-react";
 import { useAtom } from "jotai";
-import { avtalePaginationAtom } from "../../../api/atoms";
+import { useEffect } from "react";
+import { avtaleFilter, avtalePaginationAtom } from "../../../api/atoms";
 import { useAvtaler } from "../../../api/avtaler/useAvtaler";
 import { Avtalefilter } from "../../../components/filter/Avtalefilter";
 import { PagineringContainer } from "../../../components/paginering/PagineringContainer";
 import { PagineringsOversikt } from "../../../components/paginering/PagineringOversikt";
 import { AVTALE_PAGE_SIZE } from "../../../constants";
-import { AvtaleTabell } from "./AvtaleTabell";
+import { useGetTiltakstypeIdFromUrl } from "../../../hooks/useGetTiltakstypeIdFromUrl";
 import pageStyles from "../../Page.module.scss";
+import { AvtaleTabell } from "./AvtaleTabell";
 
 export function AvtalerForTiltakstype() {
+  const tiltakstypeId = useGetTiltakstypeIdFromUrl();
   const [page, setPage] = useAtom(avtalePaginationAtom);
   const { data } = useAvtaler();
+  const [filter, setFilter] = useAtom(avtaleFilter);
+
+  useEffect(() => {
+    if (tiltakstypeId) {
+      // For å filtrere på avtaler for den spesifikke tiltakstypen
+      setFilter({ ...filter, tiltakstype: tiltakstypeId });
+    }
+  }, [tiltakstypeId]);
 
   if (!data) {
     return null;
@@ -21,7 +32,7 @@ export function AvtalerForTiltakstype() {
 
   return (
     <div>
-      <Avtalefilter />
+      <Avtalefilter skjulFilter={{ tiltakstype: true }} />
       <PagineringsOversikt
         page={page}
         antall={avtaler.length}


### PR DESCRIPTION
Man kan nå filtrere avtaler på en spesifikk tiltakstype

![image](https://user-images.githubusercontent.com/9053627/227519194-770e78f6-75bb-4f26-b9a7-b577bc1d6be4.png)

![image](https://user-images.githubusercontent.com/9053627/227519246-fc9ed0d8-d4bf-4036-a72d-68dcda2f00f0.png)

Hvis bruker har navigert til en tiltakstype får de ikke filter for tiltakstype på avtaler
![image](https://user-images.githubusercontent.com/9053627/227519353-fab3aaca-8aa9-4567-8abe-3974674f1850.png)

