### PR TITLE
Test/assert error messages for event processors

### DIFF
--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
@@ -92,30 +92,6 @@ class AvtaleInfoEventProcessor(
         return ArenaAvtaleCutoffDate.isBefore(ArenaUtils.parseTimestamp(avtale.DATO_TIL))
     }
 
-    private fun ArenaAvtaleInfo.toAvtale(id: UUID) = Either
-        .catch {
-            requireNotNull(AVTALENAVN)
-            requireNotNull(DATO_FRA)
-            requireNotNull(DATO_TIL)
-            requireNotNull(ARBGIV_ID_LEVERANDOR)
-
-            Avtale(
-                id = id,
-                aar = AAR,
-                lopenr = LOPENRAVTALE,
-                tiltakskode = TILTAKSKODE,
-                navn = AVTALENAVN,
-                leverandorId = ARBGIV_ID_LEVERANDOR,
-                fraDato = ArenaUtils.parseTimestamp(DATO_FRA),
-                tilDato = ArenaUtils.parseTimestamp(DATO_TIL),
-                ansvarligEnhet = ORGENHET_ANSVARLIG,
-                rammeavtale = AVTALEKODE == Avtalekode.Rammeavtale,
-                status = Avtale.Status.fromArenaAvtalestatuskode(AVTALESTATUSKODE),
-                prisbetingelser = PRIS_BETBETINGELSER,
-            )
-        }
-        .mapLeft { ProcessingError.InvalidPayload(it.localizedMessage) }
-
     private suspend fun toAvtaleDbo(avtale: Avtale): Either<ProcessingError, AvtaleDbo> = either {
         val tiltakstypeMapping = entities
             .getMapping(ArenaTable.Tiltakstype, avtale.tiltakskode)
@@ -155,3 +131,28 @@ class AvtaleInfoEventProcessor(
         )
     }
 }
+
+fun ArenaAvtaleInfo.toAvtale(id: UUID) = Either
+    .catch {
+        requireNotNull(AVTALENAVN)
+        requireNotNull(DATO_FRA)
+        requireNotNull(DATO_TIL)
+        requireNotNull(ARBGIV_ID_LEVERANDOR)
+
+        Avtale(
+            id = id,
+            avtaleId = AVTALE_ID,
+            aar = AAR,
+            lopenr = LOPENRAVTALE,
+            tiltakskode = TILTAKSKODE,
+            navn = AVTALENAVN,
+            leverandorId = ARBGIV_ID_LEVERANDOR,
+            fraDato = ArenaUtils.parseTimestamp(DATO_FRA),
+            tilDato = ArenaUtils.parseTimestamp(DATO_TIL),
+            ansvarligEnhet = ORGENHET_ANSVARLIG,
+            rammeavtale = AVTALEKODE == Avtalekode.Rammeavtale,
+            status = Avtale.Status.fromArenaAvtalestatuskode(AVTALESTATUSKODE),
+            prisbetingelser = PRIS_BETBETINGELSER,
+        )
+    }
+    .mapLeft { ProcessingError.InvalidPayload(it.localizedMessage) }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Avtale.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Avtale.kt
@@ -6,6 +6,7 @@ import java.util.*
 
 data class Avtale(
     val id: UUID,
+    val avtaleId: Int,
     val aar: Int,
     val lopenr: Int,
     val tiltakskode: String,

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/AvtaleRepository.kt
@@ -13,10 +13,11 @@ class AvtaleRepository(private val db: Database) {
     fun upsert(avtale: Avtale) = query {
         @Language("PostgreSQL")
         val query = """
-            insert into avtale(id, aar, lopenr, tiltakskode, leverandor_id, navn, fra_dato, til_dato, ansvarlig_enhet, rammeavtale, status, prisbetingelser)
-            values (:id::uuid, :aar, :lopenr, :tiltakskode, :leverandor_id, :navn, :fra_dato, :til_dato, :ansvarlig_enhet, :rammeavtale, :status, :prisbetingelser)
+            insert into avtale(id, avtale_id, aar, lopenr, tiltakskode, leverandor_id, navn, fra_dato, til_dato, ansvarlig_enhet, rammeavtale, status, prisbetingelser)
+            values (:id::uuid, :avtale_id, :aar, :lopenr, :tiltakskode, :leverandor_id, :navn, :fra_dato, :til_dato, :ansvarlig_enhet, :rammeavtale, :status, :prisbetingelser)
             on conflict (id)
-                do update set aar             = excluded.aar,
+                do update set avtale_id       = excluded.avtale_id,
+                              aar             = excluded.aar,
                               lopenr          = excluded.lopenr,
                               tiltakskode     = excluded.tiltakskode,
                               leverandor_id   = excluded.leverandor_id,
@@ -39,7 +40,7 @@ class AvtaleRepository(private val db: Database) {
     fun get(id: UUID): Avtale? {
         @Language("PostgreSQL")
         val query = """
-            select id, aar, lopenr, tiltakskode, leverandor_id, navn, fra_dato, til_dato, ansvarlig_enhet, rammeavtale, status, prisbetingelser
+            select id, avtale_id, aar, lopenr, tiltakskode, leverandor_id, navn, fra_dato, til_dato, ansvarlig_enhet, rammeavtale, status, prisbetingelser
             from avtale
             where id = ?::uuid
         """.trimIndent()
@@ -64,6 +65,7 @@ class AvtaleRepository(private val db: Database) {
 
     private fun Avtale.toSqlParameters() = mapOf(
         "id" to id,
+        "avtale_id" to avtaleId,
         "aar" to aar,
         "lopenr" to lopenr,
         "tiltakskode" to tiltakskode,
@@ -79,6 +81,7 @@ class AvtaleRepository(private val db: Database) {
 
     private fun Row.toAvtale() = Avtale(
         id = uuid("id"),
+        avtaleId = int("avtale_id"),
         aar = int("aar"),
         lopenr = int("lopenr"),
         tiltakskode = string("tiltakskode"),

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventService.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventService.kt
@@ -10,6 +10,8 @@ import no.nav.mulighetsrommet.arena.adapter.metrics.Metrics
 import no.nav.mulighetsrommet.arena.adapter.metrics.recordSuspend
 import no.nav.mulighetsrommet.arena.adapter.models.arena.ArenaTable
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Handled
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Ignored
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.repositories.ArenaEventRepository
 import org.slf4j.LoggerFactory
@@ -83,12 +85,12 @@ class ArenaEventService(
                     val mapping = entities.getOrCreateMapping(event)
 
                     processor.handleEvent(event)
-                        .flatMap { processingResult ->
-                            if (processingResult.status == ArenaEntityMapping.Status.Ignored && mapping.status == ArenaEntityMapping.Status.Handled) {
+                        .flatMap { result ->
+                            if (mapping.status == Handled && result.status == Ignored) {
                                 logger.info("Sletter entity som tidligere var håndtert men nå skal ignoreres: table=${event.arenaTable}, id=${event.arenaId}")
-                                processor.deleteEntity(event).map { processingResult }
+                                processor.deleteEntity(event).map { result }
                             } else {
-                                processingResult.right()
+                                result.right()
                             }
                         }.onRight {
                             entities.upsertMapping(mapping.copy(status = it.status, message = it.message))

--- a/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V35__reference_avtale_from_gjennomforing.sql
+++ b/mulighetsrommet-arena-adapter/src/main/resources/db/migration/V35__reference_avtale_from_gjennomforing.sql
@@ -1,0 +1,13 @@
+alter table avtale
+    add constraint avtale_avtale_id_key unique (avtale_id);
+
+update avtale
+set avtale_id = arena_id::int
+from arena_entity_mapping aem
+where aem.entity_id = avtale.id;
+
+alter table avtale
+    alter column avtale_id set not null;
+
+alter table tiltaksgjennomforing
+    add constraint tiltaksgjennomforing_avtale_id_fkey foreign key (avtale_id) references avtale (avtale_id);

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessorTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.engine.*
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
@@ -19,6 +20,7 @@ import no.nav.mulighetsrommet.arena.adapter.models.arena.Avtalestatuskode
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Handled
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Ignored
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.Operation.*
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.ProcessingStatus.Failed
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.ProcessingStatus.Invalid
@@ -26,7 +28,6 @@ import no.nav.mulighetsrommet.arena.adapter.models.db.Avtale
 import no.nav.mulighetsrommet.arena.adapter.models.dto.ArenaOrdsArrangor
 import no.nav.mulighetsrommet.arena.adapter.repositories.*
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
-import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.AvtaleDbo
@@ -35,7 +36,6 @@ import no.nav.mulighetsrommet.ktor.createMockEngine
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
 import no.nav.mulighetsrommet.ktor.getLastPathParameterAsUUID
 import no.nav.mulighetsrommet.ktor.respondJson
-import java.util.*
 
 class AvtaleInfoEventProcessorTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
@@ -48,196 +48,225 @@ class AvtaleInfoEventProcessorTest : FunSpec({
         database.db.clean()
     }
 
-    context("when dependent events has not been processed") {
-        test("should save the event with status Failed when dependent tiltakstype is missing") {
-            val consumer = createConsumer(database.db)
+    context("handleEvent") {
+        val entities = ArenaEntityService(
+            mappings = ArenaEntityMappingRepository(database.db),
+            tiltakstyper = TiltakstypeRepository(database.db),
+            saker = SakRepository(database.db),
+            tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db),
+            deltakere = DeltakerRepository(database.db),
+            avtaler = AvtaleRepository(database.db),
+        )
 
-            val result = consumer.handleEvent(createArenaAvtaleInfoEvent(Insert))
-
-            result.shouldBeLeft().should { it.status shouldBe Failed }
-            database.assertThat("avtale").isEmpty
-        }
-    }
-
-    context("when dependent tiltakstype has been processed") {
-        val tiltakstype = TiltakstypeFixtures.Gruppe
-
-        beforeEach {
-            val tiltakstyper = TiltakstypeRepository(database.db)
-            tiltakstyper.upsert(tiltakstype)
-
-            val mappings = ArenaEntityMappingRepository(database.db)
-            mappings.upsert(ArenaEntityMapping(ArenaTable.Tiltakstype, tiltakstype.tiltakskode, tiltakstype.id, Handled))
-        }
-
-        test("ignore avtaler when required fields are missing") {
-            val consumer = createConsumer(database.db)
-
-            val events = listOf(
-                createArenaAvtaleInfoEvent(Insert) {
-                    it.copy(DATO_FRA = null)
-                },
-                createArenaAvtaleInfoEvent(Insert) {
-                    it.copy(DATO_TIL = null)
-                },
-                createArenaAvtaleInfoEvent(Insert) {
-                    it.copy(ARBGIV_ID_LEVERANDOR = null)
-                },
-            )
-
-            events.forEach { event ->
-                consumer.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
-            }
-            database.assertThat("avtale").isEmpty
-        }
-
-        test("ignore avtaler ended before 2023") {
-            val consumer = createConsumer(database.db)
-
-            val event = createArenaAvtaleInfoEvent(Insert) {
-                it.copy(DATO_TIL = "2022-12-31 00:00:00")
+        fun createProcessor(engine: HttpClientEngine = MockEngine { respondOk() }): AvtaleInfoEventProcessor {
+            val client = MulighetsrommetApiClient(engine, baseUri = "api") {
+                "Bearer token"
             }
 
-            consumer.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
-            database.assertThat("avtale").isEmpty
+            val ords = ArenaOrdsProxyClientImpl(engine, baseUrl = "") {
+                "Bearer token"
+            }
+
+            return AvtaleInfoEventProcessor(entities, client, ords)
         }
 
-        test("should treat all operations as upserts") {
-            val engine = createMockEngine(
-                "/ords/arbeidsgiver" to {
-                    respondJson(ArenaOrdsArrangor("123456", "1000000"))
-                },
-                "/api/v1/internal/arena/avtale.*" to { respondOk() }
-            )
-            val consumer = createConsumer(database.db, engine)
-            val entities = ArenaEntityMappingRepository(database.db)
-
-            val e1 = createArenaAvtaleInfoEvent(Insert)
-            entities.upsert(ArenaEntityMapping(e1.arenaTable, e1.arenaId, UUID.randomUUID(), ArenaEntityMapping.Status.Unhandled))
-            consumer.handleEvent(e1) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("avtale").row().value("status").isEqualTo(Avtale.Status.Aktiv.name)
-
-            val e2 = createArenaAvtaleInfoEvent(Update) {
-                it.copy(AVTALESTATUSKODE = Avtalestatuskode.Planlagt)
-            }
-            consumer.handleEvent(e2) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("avtale").row().value("status").isEqualTo(Avtale.Status.Planlagt.name)
-
-            val e3 = createArenaAvtaleInfoEvent(Update) {
-                it.copy(AVTALESTATUSKODE = Avtalestatuskode.Avsluttet)
-            }
-            consumer.handleEvent(e3) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("avtale").row().value("status").isEqualTo(Avtale.Status.Avsluttet.name)
+        fun prepareEvent(event: ArenaEvent): Pair<ArenaEvent, ArenaEntityMapping> {
+            val mapping = entities.getOrCreateMapping(event)
+            return Pair(event, mapping)
         }
 
-        context("api responses") {
-            test("should mark the event as Failed when arena ords proxy responds with an error") {
-                val engine = createMockEngine(
-                    "/ords/arbeidsgiver" to {
-                        respondError(HttpStatusCode.InternalServerError)
-                    }
+        context("when dependent events has not been processed") {
+            test("should save the event with status Failed when dependent tiltakstype is missing") {
+                val processor = createProcessor()
+
+                val (event) = prepareEvent(createArenaAvtaleInfoEvent(Insert))
+                val result = processor.handleEvent(event)
+
+                result.shouldBeLeft().should {
+                    it.status shouldBe Failed
+                    it.message shouldContain "Key (tiltakskode)=(INDOPPFAG) is not present in table \"tiltakstype\""
+                }
+                database.assertThat("avtale").isEmpty
+            }
+        }
+
+        context("when dependent tiltakstype has been processed") {
+            val tiltakstype = TiltakstypeFixtures.Gruppe
+
+            beforeEach {
+                val tiltakstyper = TiltakstypeRepository(database.db)
+                tiltakstyper.upsert(tiltakstype)
+
+                val mappings = ArenaEntityMappingRepository(database.db)
+                mappings.upsert(
+                    ArenaEntityMapping(
+                        ArenaTable.Tiltakstype,
+                        tiltakstype.tiltakskode,
+                        tiltakstype.id,
+                        Handled
+                    )
                 )
-
-                val consumer = createConsumer(database.db, engine)
-                val result = consumer.handleEvent(createArenaAvtaleInfoEvent(Insert))
-
-                result.shouldBeLeft().should { it.status shouldBe Failed }
             }
 
-            // TODO: burde manglende data i ords ha en annen semantikk enn Invalid?
-            test("should mark the event as Invalid when arena ords proxy responds with NotFound") {
-                val engine = createMockEngine(
-                    "/ords/arbeidsgiver" to {
-                        respondError(HttpStatusCode.NotFound)
-                    }
-                )
-                val entities = ArenaEntityMappingRepository(database.db)
-                val event = createArenaAvtaleInfoEvent(Insert)
-                entities.upsert(ArenaEntityMapping(event.arenaTable, event.arenaId, UUID.randomUUID(), ArenaEntityMapping.Status.Unhandled))
-                val consumer = createConsumer(database.db, engine)
-                val result = consumer.handleEvent(event)
+            test("ignore avtaler when required fields are missing") {
+                val processor = createProcessor()
 
-                result.shouldBeLeft().should { it.status shouldBe Invalid }
-            }
-
-            test("should mark the event as Failed when api responds with an error") {
-                val engine = createMockEngine(
-                    "/ords/arbeidsgiver" to {
-                        respondJson(
-                            ArenaOrdsArrangor("123456", "100000")
-                        )
+                val events = listOf(
+                    createArenaAvtaleInfoEvent(Insert) {
+                        it.copy(AVTALENAVN = null)
                     },
-                    "/api/v1/internal/arena/avtale" to {
-                        respondError(HttpStatusCode.InternalServerError)
-                    }
+                    createArenaAvtaleInfoEvent(Insert) {
+                        it.copy(DATO_FRA = null)
+                    },
+                    createArenaAvtaleInfoEvent(Insert) {
+                        it.copy(DATO_TIL = null)
+                    },
+                    createArenaAvtaleInfoEvent(Insert) {
+                        it.copy(ARBGIV_ID_LEVERANDOR = null)
+                    },
                 )
 
-                val consumer = createConsumer(database.db, engine)
-                val result = consumer.handleEvent(createArenaAvtaleInfoEvent(Insert))
-
-                result.shouldBeLeft().should { it.status shouldBe Failed }
+                events.forEach { event ->
+                    processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
+                }
+                database.assertThat("avtale").isEmpty
             }
 
-            test("should call api with mapped event payload when all services responds with success") {
+            test("ignore avtaler ended before 2023") {
+                val processor = createProcessor()
+
+                val event = createArenaAvtaleInfoEvent(Insert) {
+                    it.copy(DATO_TIL = "2022-12-31 00:00:00")
+                }
+
+                processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
+                database.assertThat("avtale").isEmpty
+            }
+
+            test("should treat all operations as upserts") {
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondJson(ArenaOrdsArrangor("123456", "1000000"))
                     },
                     "/api/v1/internal/arena/avtale.*" to { respondOk() }
                 )
+                val processor = createProcessor(engine)
 
-                val consumer = createConsumer(database.db, engine)
-                val entities = ArenaEntityMappingRepository(database.db)
+                val (e1, mapping) = prepareEvent(createArenaAvtaleInfoEvent(Insert))
+                processor.handleEvent(e1) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("avtale").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("status").isEqualTo(Avtale.Status.Aktiv.name)
 
-                val event = createArenaAvtaleInfoEvent(Insert)
-                entities.upsert(ArenaEntityMapping(event.arenaTable, event.arenaId, UUID.randomUUID(), ArenaEntityMapping.Status.Unhandled))
-                consumer.handleEvent(event).shouldBeRight()
+                val e2 = createArenaAvtaleInfoEvent(Update) {
+                    it.copy(AVTALESTATUSKODE = Avtalestatuskode.Planlagt)
+                }
+                processor.handleEvent(e2) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("avtale").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("status").isEqualTo(Avtale.Status.Planlagt.name)
 
-                val generatedId = engine.requestHistory.last().run {
-                    method shouldBe HttpMethod.Put
+                val e3 = createArenaAvtaleInfoEvent(Update) {
+                    it.copy(AVTALESTATUSKODE = Avtalestatuskode.Avsluttet)
+                }
+                processor.handleEvent(e3) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("avtale").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("status").isEqualTo(Avtale.Status.Avsluttet.name)
+            }
 
-                    val avtale = decodeRequestBody<AvtaleDbo>().apply {
-                        tiltakstypeId shouldBe tiltakstype.id
-                        avtalenummer shouldBe "2022#2000"
-                        leverandorOrganisasjonsnummer shouldBe "1000000"
-                        avtaletype shouldBe Avtaletype.Rammeavtale
-                        avslutningsstatus shouldBe Avslutningsstatus.IKKE_AVSLUTTET
+            context("api responses") {
+                test("should mark the event as Failed when arena ords proxy responds with an error") {
+                    val engine = createMockEngine(
+                        "/ords/arbeidsgiver" to {
+                            respondError(HttpStatusCode.InternalServerError)
+                        }
+                    )
+                    val processor = createProcessor(engine)
+
+                    val (event) = prepareEvent(createArenaAvtaleInfoEvent(Insert))
+                    val result = processor.handleEvent(event)
+
+                    result.shouldBeLeft().should {
+                        it.status shouldBe Failed
+                        it.message shouldContain "Unexpected response from arena-ords-proxy"
                     }
-
-                    avtale.id
                 }
 
-                consumer.handleEvent(createArenaAvtaleInfoEvent(Delete)).shouldBeRight()
+                // TODO: burde manglende data i ords ha en annen semantikk enn Invalid?
+                test("should mark the event as Invalid when arena ords proxy responds with NotFound") {
+                    val engine = createMockEngine(
+                        "/ords/arbeidsgiver" to {
+                            respondError(HttpStatusCode.NotFound)
+                        }
+                    )
+                    val processor = createProcessor(engine)
 
-                engine.requestHistory.last().run {
-                    method shouldBe HttpMethod.Delete
+                    val (event) = prepareEvent(createArenaAvtaleInfoEvent(Insert))
+                    val result = processor.handleEvent(event)
 
-                    url.getLastPathParameterAsUUID() shouldBe generatedId
+                    result.shouldBeLeft().should {
+                        it.status shouldBe Invalid
+                        it.message shouldContain "Fant ikke leverandør i Arena ORDS"
+                    }
+                }
+
+                test("should mark the event as Failed when api responds with an error") {
+                    val engine = createMockEngine(
+                        "/ords/arbeidsgiver" to {
+                            respondJson(
+                                ArenaOrdsArrangor("123456", "100000")
+                            )
+                        },
+                        "/api/v1/internal/arena/avtale" to {
+                            respondError(HttpStatusCode.InternalServerError)
+                        }
+                    )
+                    val processor = createProcessor(engine)
+
+                    val (event) = prepareEvent(createArenaAvtaleInfoEvent(Insert))
+                    val result = processor.handleEvent(event)
+
+                    result.shouldBeLeft().should {
+                        it.status shouldBe Failed
+                        it.message shouldContain "Internal Server Error"
+                    }
+                }
+
+                test("should call api with mapped event payload when all services responds with success") {
+                    val engine = createMockEngine(
+                        "/ords/arbeidsgiver" to {
+                            respondJson(ArenaOrdsArrangor("123456", "1000000"))
+                        },
+                        "/api/v1/internal/arena/avtale.*" to { respondOk() }
+                    )
+                    val processor = createProcessor(engine)
+
+                    val (event, mapping) = prepareEvent(createArenaAvtaleInfoEvent(Insert))
+                    processor.handleEvent(event).shouldBeRight()
+
+                    engine.requestHistory.last().apply {
+                        method shouldBe HttpMethod.Put
+
+                        decodeRequestBody<AvtaleDbo>().apply {
+                            id shouldBe mapping.entityId
+                            tiltakstypeId shouldBe tiltakstype.id
+                            avtalenummer shouldBe "2022#2000"
+                            leverandorOrganisasjonsnummer shouldBe "1000000"
+                            avtaletype shouldBe Avtaletype.Rammeavtale
+                            avslutningsstatus shouldBe Avslutningsstatus.IKKE_AVSLUTTET
+                        }
+                    }
+
+                    processor.handleEvent(createArenaAvtaleInfoEvent(Delete)).shouldBeRight()
+
+                    engine.requestHistory.last().run {
+                        method shouldBe HttpMethod.Delete
+
+                        url.getLastPathParameterAsUUID() shouldBe mapping.entityId
+                    }
                 }
             }
         }
     }
 })
-
-private fun createConsumer(
-    db: Database,
-    engine: HttpClientEngine = MockEngine { respondOk() }
-): AvtaleInfoEventProcessor {
-    val client = MulighetsrommetApiClient(engine, baseUri = "api") {
-        "Bearer token"
-    }
-
-    val ords = ArenaOrdsProxyClientImpl(engine, baseUrl = "") {
-        "Bearer token"
-    }
-    val entities = ArenaEntityService(
-        mappings = ArenaEntityMappingRepository(db),
-        tiltakstyper = TiltakstypeRepository(db),
-        saker = SakRepository(db),
-        tiltaksgjennomforinger = TiltaksgjennomforingRepository(db),
-        deltakere = DeltakerRepository(db),
-        avtaler = AvtaleRepository(db),
-    )
-
-    return AvtaleInfoEventProcessor(entities, client, ords)
-}

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakEventProcessorTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.engine.*
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
@@ -14,18 +15,17 @@ import no.nav.mulighetsrommet.arena.adapter.fixtures.createArenaTiltakEvent
 import no.nav.mulighetsrommet.arena.adapter.models.ProcessingResult
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Handled
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.Operation.*
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.ProcessingStatus.Failed
 import no.nav.mulighetsrommet.arena.adapter.repositories.*
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
-import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
 import no.nav.mulighetsrommet.ktor.getLastPathParameterAsUUID
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
 
 class TiltakEventProcessorTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
@@ -38,107 +38,119 @@ class TiltakEventProcessorTest : FunSpec({
         database.db.clean()
     }
 
-    test("should treat all operations as upserts") {
-        val consumer = createConsumer(database.db, MockEngine { respondOk() })
-        val entities = ArenaEntityMappingRepository(database.db)
+    context("handleEvent") {
+        val entities = ArenaEntityService(
+            mappings = ArenaEntityMappingRepository(database.db),
+            tiltakstyper = TiltakstypeRepository(database.db),
+            saker = SakRepository(database.db),
+            tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db),
+            deltakere = DeltakerRepository(database.db),
+            avtaler = AvtaleRepository(database.db),
+        )
 
-        val e1 = createArenaTiltakEvent(Insert) { it.copy(TILTAKSNAVN = "Oppfølging 1") }
-        entities.upsert(ArenaEntityMapping(e1.arenaTable, e1.arenaId, UUID.randomUUID(), ArenaEntityMapping.Status.Unhandled))
-        consumer.handleEvent(e1) shouldBeRight ProcessingResult(Handled)
-        database.assertThat("tiltakstype").row().value("navn").isEqualTo("Oppfølging 1")
-
-        val e2 = createArenaTiltakEvent(Update) { it.copy(TILTAKSNAVN = "Oppfølging 2") }
-        consumer.handleEvent(e2) shouldBeRight ProcessingResult(Handled)
-        database.assertThat("tiltakstype").row().value("navn").isEqualTo("Oppfølging 2")
-
-        val e3 = createArenaTiltakEvent(Delete) { it.copy(TILTAKSNAVN = "Oppfølging 1") }
-        consumer.handleEvent(e3) shouldBeRight ProcessingResult(Handled)
-        database.assertThat("tiltakstype").row()
-            .value("navn").isEqualTo("Oppfølging 1")
-            .value("rett_paa_tiltakspenger").isTrue
-            .value("registrert_dato_i_arena").isEqualTo(LocalDateTime.of(2010, 1, 11, 0, 0, 0, 0))
-            .value("sist_endret_dato_i_arena").isEqualTo(LocalDateTime.of(2022, 1, 11, 0, 0, 0))
-            .value("fra_dato").isEqualTo(LocalDate.of(2022, 1, 11))
-            .value("fra_dato").isEqualTo(LocalDate.of(2022, 1, 11))
-            .value("til_dato").isEqualTo(LocalDate.of(2022, 1, 15))
-            .value("tiltaksgruppekode").isEqualTo("UTFAS")
-            .value("administrasjonskode").isEqualTo("IND")
-            .value("send_tilsagnsbrev_til_deltaker").isTrue
-            .value("skal_ha_anskaffelsesprosess").isFalse
-            .value("maks_antall_plasser").isNull
-            .value("maks_antall_sokere").isEqualTo(10)
-            .value("har_fast_antall_plasser").isNull
-            .value("skal_sjekke_antall_deltakere").isTrue
-            .value("vis_lonnstilskuddskalkulator").isFalse
-            .value("rammeavtale").isEqualTo("IKKE")
-            .value("opplaeringsgruppe").isNull
-            .value("handlingsplan").isEqualTo("TIL")
-            .value("tiltaksgjennomforing_krever_sluttdato").isFalse
-            .value("maks_periode_i_mnd").isEqualTo(6)
-            .value("tiltaksgjennomforing_krever_meldeplikt").isNull
-            .value("tiltaksgjennomforing_krever_vedtak").isFalse
-            .value("tiltaksgjennomforing_reservert_for_ia_bedrift").isFalse
-            .value("har_rett_paa_tilleggsstonader").isFalse
-            .value("har_rett_paa_utdanning").isFalse
-            .value("tiltaksgjennomforing_genererer_tilsagnsbrev_automatisk").isFalse
-            .value("vis_begrunnelse_for_innsoking").isTrue
-            .value("henvisningsbrev_og_hovedbrev_til_arbeidsgiver").isFalse
-            .value("kopibrev_og_hovedbrev_til_arbeidsgiver").isFalse
-    }
-
-    context("api responses") {
-        test("should call api with mapped event payload") {
-            val engine = MockEngine { respondOk() }
-            val consumer = createConsumer(database.db, engine)
-            val entities = ArenaEntityMappingRepository(database.db)
-
-            val e1 = createArenaTiltakEvent(Insert)
-            entities.upsert(ArenaEntityMapping(e1.arenaTable, e1.arenaId, UUID.randomUUID(), ArenaEntityMapping.Status.Unhandled))
-
-            consumer.handleEvent(e1).shouldBeRight()
-
-            val generatedId = engine.requestHistory.last().run {
-                method shouldBe HttpMethod.Put
-
-                val tiltakstype = decodeRequestBody<TiltakstypeDbo>().apply {
-                    navn shouldBe "Oppfølging"
-                    rettPaaTiltakspenger shouldBe true
-                }
-
-                tiltakstype.id
+        fun createProcessor(engine: HttpClientEngine = MockEngine { respondOk() }): TiltakEventProcessor {
+            val client = MulighetsrommetApiClient(engine, baseUri = "api") {
+                "Bearer token"
             }
-
-            consumer.handleEvent(createArenaTiltakEvent(Delete)).shouldBeRight()
-
-            engine.requestHistory.last().run {
-                method shouldBe HttpMethod.Delete
-
-                url.getLastPathParameterAsUUID() shouldBe generatedId
-            }
+            return TiltakEventProcessor(entities, client)
         }
 
-        test("should treat a 500 response as error") {
-            val consumer = createConsumer(database.db, MockEngine { respondError(HttpStatusCode.InternalServerError) })
-            val event = createArenaTiltakEvent(Insert)
+        fun prepareEvent(event: ArenaEvent): Pair<ArenaEvent, ArenaEntityMapping> {
+            val mapping = entities.getOrCreateMapping(event)
+            return Pair(event, mapping)
+        }
 
-            consumer.handleEvent(event).shouldBeLeft().should { it.status shouldBe Failed }
+        test("should treat all operations as upserts") {
+            val processor = createProcessor()
+
+            val (e1, mapping) = prepareEvent(createArenaTiltakEvent(Insert) { it.copy(TILTAKSNAVN = "Oppfølging 1") })
+            processor.handleEvent(e1) shouldBeRight ProcessingResult(Handled)
+            database.assertThat("tiltakstype").row()
+                .value("id").isEqualTo(mapping.entityId)
+                .value("navn").isEqualTo("Oppfølging 1")
+
+            val e2 = createArenaTiltakEvent(Update) { it.copy(TILTAKSNAVN = "Oppfølging 2") }
+            processor.handleEvent(e2) shouldBeRight ProcessingResult(Handled)
+            database.assertThat("tiltakstype").row()
+                .value("id").isEqualTo(mapping.entityId)
+                .value("navn").isEqualTo("Oppfølging 2")
+
+            val e3 = createArenaTiltakEvent(Delete) { it.copy(TILTAKSNAVN = "Oppfølging 1") }
+            processor.handleEvent(e3) shouldBeRight ProcessingResult(Handled)
+            database.assertThat("tiltakstype").row()
+                .value("id").isEqualTo(mapping.entityId)
+                .value("navn").isEqualTo("Oppfølging 1")
+                .value("rett_paa_tiltakspenger").isTrue
+                .value("registrert_dato_i_arena").isEqualTo(LocalDateTime.of(2010, 1, 11, 0, 0, 0, 0))
+                .value("sist_endret_dato_i_arena").isEqualTo(LocalDateTime.of(2022, 1, 11, 0, 0, 0))
+                .value("fra_dato").isEqualTo(LocalDate.of(2022, 1, 11))
+                .value("fra_dato").isEqualTo(LocalDate.of(2022, 1, 11))
+                .value("til_dato").isEqualTo(LocalDate.of(2022, 1, 15))
+                .value("tiltaksgruppekode").isEqualTo("UTFAS")
+                .value("administrasjonskode").isEqualTo("IND")
+                .value("send_tilsagnsbrev_til_deltaker").isTrue
+                .value("skal_ha_anskaffelsesprosess").isFalse
+                .value("maks_antall_plasser").isNull
+                .value("maks_antall_sokere").isEqualTo(10)
+                .value("har_fast_antall_plasser").isNull
+                .value("skal_sjekke_antall_deltakere").isTrue
+                .value("vis_lonnstilskuddskalkulator").isFalse
+                .value("rammeavtale").isEqualTo("IKKE")
+                .value("opplaeringsgruppe").isNull
+                .value("handlingsplan").isEqualTo("TIL")
+                .value("tiltaksgjennomforing_krever_sluttdato").isFalse
+                .value("maks_periode_i_mnd").isEqualTo(6)
+                .value("tiltaksgjennomforing_krever_meldeplikt").isNull
+                .value("tiltaksgjennomforing_krever_vedtak").isFalse
+                .value("tiltaksgjennomforing_reservert_for_ia_bedrift").isFalse
+                .value("har_rett_paa_tilleggsstonader").isFalse
+                .value("har_rett_paa_utdanning").isFalse
+                .value("tiltaksgjennomforing_genererer_tilsagnsbrev_automatisk").isFalse
+                .value("vis_begrunnelse_for_innsoking").isTrue
+                .value("henvisningsbrev_og_hovedbrev_til_arbeidsgiver").isFalse
+                .value("kopibrev_og_hovedbrev_til_arbeidsgiver").isFalse
+        }
+
+        context("api responses") {
+            test("should call api with mapped event payload") {
+                val engine = MockEngine { respondOk() }
+                val processor = createProcessor(engine)
+
+                val (event, mapping) = prepareEvent(createArenaTiltakEvent(Insert))
+
+                processor.handleEvent(event).shouldBeRight()
+
+                engine.requestHistory.last().apply {
+                    method shouldBe HttpMethod.Put
+
+                    decodeRequestBody<TiltakstypeDbo>().apply {
+                        id shouldBe mapping.entityId
+                        navn shouldBe "Oppfølging"
+                        rettPaaTiltakspenger shouldBe true
+                    }
+                }
+
+                processor.handleEvent(createArenaTiltakEvent(Delete)).shouldBeRight()
+
+                engine.requestHistory.last().apply {
+                    method shouldBe HttpMethod.Delete
+
+                    url.getLastPathParameterAsUUID() shouldBe mapping.entityId
+                }
+            }
+
+            test("should treat a 500 response as error") {
+                val engine = MockEngine {
+                    respondError(HttpStatusCode.InternalServerError)
+                }
+                val processor = createProcessor(engine)
+
+                val (event) = prepareEvent(createArenaTiltakEvent(Insert))
+                processor.handleEvent(event).shouldBeLeft().should {
+                    it.status shouldBe Failed
+                    it.message shouldContain "Internal Server Error"
+                }
+            }
         }
     }
 })
-
-private fun createConsumer(db: Database, engine: HttpClientEngine): TiltakEventProcessor {
-    val client = MulighetsrommetApiClient(engine, baseUri = "api") {
-        "Bearer token"
-    }
-
-    val entities = ArenaEntityService(
-        mappings = ArenaEntityMappingRepository(db),
-        tiltakstyper = TiltakstypeRepository(db),
-        saker = SakRepository(db),
-        tiltaksgjennomforinger = TiltaksgjennomforingRepository(db),
-        deltakere = DeltakerRepository(db),
-        avtaler = AvtaleRepository(db),
-    )
-
-    return TiltakEventProcessor(entities, client)
-}

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessorTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.engine.*
 import io.ktor.client.engine.mock.*
@@ -18,7 +19,9 @@ import no.nav.mulighetsrommet.arena.adapter.fixtures.createArenaTiltakdeltakerEv
 import no.nav.mulighetsrommet.arena.adapter.models.ProcessingResult
 import no.nav.mulighetsrommet.arena.adapter.models.arena.ArenaTable
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping
-import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.*
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Handled
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Ignored
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.Operation.*
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.ProcessingStatus.Failed
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.ProcessingStatus.Invalid
@@ -30,7 +33,6 @@ import no.nav.mulighetsrommet.arena.adapter.repositories.*
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
 import no.nav.mulighetsrommet.arena.adapter.utils.AktivitetsplanenLaunchDate
 import no.nav.mulighetsrommet.arena.adapter.utils.ArenaUtils
-import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.utils.getOrThrow
 import no.nav.mulighetsrommet.domain.Tiltakskoder
@@ -58,341 +60,321 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
         .minusDays(1)
         .format(ArenaUtils.TimestampFormatter)
 
-    context("when dependent events has not been processed") {
-        test("should save the event with status Failed when the dependent tiltaksgjennomføring is missing") {
-            val processor = createProcessor(database.db, MockEngine { respondOk() })
+    context("handleEvent") {
+        val entities = ArenaEntityService(
+            mappings = ArenaEntityMappingRepository(database.db),
+            tiltakstyper = TiltakstypeRepository(database.db),
+            saker = SakRepository(database.db),
+            tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db),
+            deltakere = DeltakerRepository(database.db),
+            avtaler = AvtaleRepository(database.db),
+        )
 
-            val result = processor.handleEvent(createArenaTiltakdeltakerEvent(Insert))
+        fun createProcessor(engine: HttpClientEngine = MockEngine { respondOk() }): TiltakdeltakerEventProcessor {
+            val client = MulighetsrommetApiClient(engine, baseUri = "api") {
+                "Bearer token"
+            }
 
-            result.shouldBeLeft().should { it.status shouldBe Failed }
-            database.assertThat("deltaker").isEmpty
+            val ords = ArenaOrdsProxyClientImpl(engine, baseUrl = "") {
+                "Bearer token"
+            }
+
+            return TiltakdeltakerEventProcessor(entities, client, ords)
         }
-    }
 
-    context("when dependent events has been processed") {
-        val tiltakstypeGruppe = TiltakstypeFixtures.Gruppe
-        val sak = Sak(sakId = 1, lopenummer = 1, aar = 2022, enhet = "2990")
-        val tiltaksgjennomforing = Tiltaksgjennomforing(
-            id = UUID.randomUUID(),
-            tiltaksgjennomforingId = 3,
-            sakId = 1,
-            tiltakskode = "INDOPPFAG",
-            arrangorId = 123,
-            navn = "Gjennomføring gruppe",
-            status = "GJENNOMFOR",
-            fraDato = LocalDateTime.of(2023, 1, 1, 0, 0),
-            avtaleId = 1000
-        )
+        fun prepareEvent(event: ArenaEvent): Pair<ArenaEvent, ArenaEntityMapping> {
+            val mapping = entities.getOrCreateMapping(event)
+            return Pair(event, mapping)
+        }
 
-        val tiltakstypeIndividuell = TiltakstypeFixtures.Individuell
-        val sakIndividuell = Sak(sakId = 2, lopenummer = 2, aar = 2022, enhet = "2990")
-        val tiltaksgjennomforingIndividuell = Tiltaksgjennomforing(
-            id = UUID.randomUUID(),
-            tiltaksgjennomforingId = 4,
-            sakId = 2,
-            tiltakskode = "AMO",
-            arrangorId = 123,
-            navn = "Gjennomføring individuell",
-            status = "GJENNOMFOR",
-            fraDato = LocalDateTime.of(2023, 1, 1, 0, 0),
-            avtaleId = 1000
-        )
+        context("when dependent events has not been processed") {
+            test("should save the event with status Failed when the dependent tiltaksgjennomføring is missing") {
+                val processor = createProcessor()
 
-        /**
-         * Tiltakskode er ikke en del av av [Tiltakskoder.AmtTiltak] og opphav på deltakelser for denne tiltakstypen
-         * er dermed Arena (og ikke Komet)
-         */
-        val tiltakstypeGruppeOpphavArena = TiltakstypeFixtures.Gruppe.copy(
-            id = UUID.randomUUID(),
-            tiltakskode = "IPSUNG"
-        )
-        val sakOpphavArena = Sak(sakId = 3, lopenummer = 3, aar = 2022, enhet = "2990")
-        val tiltaksgjennomforingOpphavArena = tiltaksgjennomforing.copy(
-            id = UUID.randomUUID(),
-            tiltaksgjennomforingId = 5,
-            sakId = 3,
-            tiltakskode = tiltakstypeGruppeOpphavArena.tiltakskode,
-            navn = "Gjennomføring opphav Arena",
-        )
+                val (event) = prepareEvent(createArenaTiltakdeltakerEvent(Insert))
+                val result = processor.handleEvent(event)
 
-        beforeEach {
-            val mappings = ArenaEntityMappingRepository(database.db)
+                result.shouldBeLeft().should {
+                    it.status shouldBe Failed
+                    it.message shouldContain "ArenaEntityMapping mangler for arenaTable=Tiltaksgjennomforing og arenaId=3"
+                }
+                database.assertThat("deltaker").isEmpty
+            }
+        }
 
-            val tiltakstyper = TiltakstypeRepository(database.db)
-            listOf(tiltakstypeGruppe, tiltakstypeIndividuell, tiltakstypeGruppeOpphavArena).forEach {
-                tiltakstyper.upsert(it).getOrThrow()
-                mappings.upsert(
-                    ArenaEntityMapping(ArenaTable.Tiltakstype, it.tiltakskode, it.id, Handled)
-                )
+        context("when dependent events has been processed") {
+            val tiltakstypeGruppe = TiltakstypeFixtures.Gruppe
+            val sak = Sak(sakId = 1, lopenummer = 1, aar = 2022, enhet = "2990")
+            val tiltaksgjennomforing = Tiltaksgjennomforing(
+                id = UUID.randomUUID(),
+                tiltaksgjennomforingId = 3,
+                sakId = 1,
+                tiltakskode = "INDOPPFAG",
+                arrangorId = 123,
+                navn = "Gjennomføring gruppe",
+                status = "GJENNOMFOR",
+                fraDato = LocalDateTime.of(2023, 1, 1, 0, 0),
+                avtaleId = null,
+            )
+
+            val tiltakstypeIndividuell = TiltakstypeFixtures.Individuell
+            val sakIndividuell = Sak(sakId = 2, lopenummer = 2, aar = 2022, enhet = "2990")
+            val tiltaksgjennomforingIndividuell = Tiltaksgjennomforing(
+                id = UUID.randomUUID(),
+                tiltaksgjennomforingId = 4,
+                sakId = 2,
+                tiltakskode = "AMO",
+                arrangorId = 123,
+                navn = "Gjennomføring individuell",
+                status = "GJENNOMFOR",
+                fraDato = LocalDateTime.of(2023, 1, 1, 0, 0),
+                avtaleId = null,
+            )
+
+            /**
+             * Tiltakskode er ikke en del av av [Tiltakskoder.AmtTiltak] og opphav på deltakelser for denne tiltakstypen
+             * er dermed Arena (og ikke Komet)
+             */
+            val tiltakstypeGruppeOpphavArena = TiltakstypeFixtures.Gruppe.copy(
+                id = UUID.randomUUID(),
+                tiltakskode = "IPSUNG"
+            )
+            val sakOpphavArena = Sak(sakId = 3, lopenummer = 3, aar = 2022, enhet = "2990")
+            val tiltaksgjennomforingOpphavArena = tiltaksgjennomforing.copy(
+                id = UUID.randomUUID(),
+                tiltaksgjennomforingId = 5,
+                sakId = 3,
+                tiltakskode = tiltakstypeGruppeOpphavArena.tiltakskode,
+                navn = "Gjennomføring opphav Arena",
+            )
+
+            beforeEach {
+                val mappings = ArenaEntityMappingRepository(database.db)
+
+                val tiltakstyper = TiltakstypeRepository(database.db)
+                listOf(tiltakstypeGruppe, tiltakstypeIndividuell, tiltakstypeGruppeOpphavArena).forEach {
+                    tiltakstyper.upsert(it).getOrThrow()
+                    mappings.upsert(
+                        ArenaEntityMapping(ArenaTable.Tiltakstype, it.tiltakskode, it.id, Handled)
+                    )
+                }
+
+                val saker = SakRepository(database.db)
+                listOf(sak, sakIndividuell, sakOpphavArena).forEach {
+                    saker.upsert(it).getOrThrow()
+                }
+
+                val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
+                listOf(tiltaksgjennomforing, tiltaksgjennomforingIndividuell, tiltaksgjennomforingOpphavArena).forEach {
+                    tiltaksgjennomforinger.upsert(it).getOrThrow()
+                    mappings.upsert(
+                        ArenaEntityMapping(
+                            ArenaTable.Tiltaksgjennomforing,
+                            it.tiltaksgjennomforingId.toString(),
+                            it.id,
+                            Handled
+                        )
+                    )
+                }
             }
 
-            val saker = SakRepository(database.db)
-            listOf(sak, sakIndividuell, sakOpphavArena).forEach {
-                saker.upsert(it).getOrThrow()
+            test("should be ignored when REG_DATO is before aktivitetsplanen") {
+                val processor = createProcessor()
+
+                val event = createArenaTiltakdeltakerEvent(Insert) {
+                    it.copy(REG_DATO = regDatoBeforeAktivitetsplanen)
+                }
+
+                processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
             }
 
-            val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
-            listOf(tiltaksgjennomforing, tiltaksgjennomforingIndividuell, tiltaksgjennomforingOpphavArena).forEach {
-                tiltaksgjennomforinger.upsert(it).getOrThrow()
-                mappings.upsert(
+            test("should be ignored when dependent tiltaksgjennomforing is ignored") {
+                entities.upsertMapping(
                     ArenaEntityMapping(
                         ArenaTable.Tiltaksgjennomforing,
-                        it.tiltaksgjennomforingId.toString(),
-                        it.id,
-                        Handled
-                    )
-                )
-            }
-        }
-
-        test("should be ignored when REG_DATO is before aktivitetsplanen") {
-            val processor = createProcessor(database.db, MockEngine { respondOk() })
-
-            val event = createArenaTiltakdeltakerEvent(Insert) { it.copy(REG_DATO = regDatoBeforeAktivitetsplanen) }
-
-            processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
-        }
-
-        test("should be ignored when dependent tiltaksgjennomforing is ignored") {
-            val entities = ArenaEntityMappingRepository(database.db)
-            entities.upsert(
-                ArenaEntityMapping(
-                    ArenaTable.Tiltaksgjennomforing,
-                    tiltaksgjennomforing.tiltaksgjennomforingId.toString(),
-                    UUID.randomUUID(),
-                    Ignored
-                )
-            )
-            val processor = createProcessor(database.db, MockEngine { respondOk() })
-            val event = createArenaTiltakdeltakerEvent(Insert) { it.copy(DELTAKERSTATUSKODE = "FULLF") }
-
-            processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
-        }
-
-        test("should treat all operations as upserts") {
-            val engine = createMockEngine(
-                "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
-                "/api/v1/internal/arena/tiltakshistorikk.*" to { respondOk() }
-            )
-            val processor = createProcessor(database.db, engine)
-            val entities = ArenaEntityMappingRepository(database.db)
-
-            val e1 = createArenaTiltakdeltakerEvent(Insert) { it.copy(DELTAKERSTATUSKODE = "GJENN") }
-            entities.upsert(
-                ArenaEntityMapping(
-                    e1.arenaTable,
-                    e1.arenaId,
-                    UUID.randomUUID(),
-                    Unhandled
-                )
-            )
-            processor.handleEvent(e1) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("deltaker").row().value("status").isEqualTo("DELTAR")
-
-            val e2 = createArenaTiltakdeltakerEvent(Update) { it.copy(DELTAKERSTATUSKODE = "FULLF") }
-            processor.handleEvent(e2) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("deltaker")
-                .row().value("status").isEqualTo("AVSLUTTET")
-
-            val e3 = createArenaTiltakdeltakerEvent(Delete) { it.copy(DELTAKERSTATUSKODE = "FULLF") }
-            processor.handleEvent(e3) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("deltaker").row().value("status").isEqualTo("AVSLUTTET")
-        }
-
-        context("api responses") {
-            test("should mark the event as Failed when arena ords proxy responds with an error") {
-                val engine = createMockEngine(
-                    "/ords/fnr" to { respondError(HttpStatusCode.InternalServerError) },
-                    "/api/v1/internal/arena/deltaker" to { respondOk() }
-                )
-
-                val processor = createProcessor(database.db, engine)
-                val event = createArenaTiltakdeltakerEvent(Insert)
-
-                processor.handleEvent(event).shouldBeLeft().should { it.status shouldBe Failed }
-            }
-
-            // TODO: burde manglende data i ords ha en annen semantikk enn Invalid?
-            test("should mark the event as Invalid when arena ords proxy responds with NotFound") {
-                val engine = createMockEngine(
-                    "/ords/fnr" to { respondError(HttpStatusCode.NotFound) },
-                    "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() }
-                )
-
-                val processor = createProcessor(database.db, engine)
-                val entities = ArenaEntityMappingRepository(database.db)
-                val event = createArenaTiltakdeltakerEvent(Insert)
-                entities.upsert(
-                    ArenaEntityMapping(
-                        event.arenaTable,
-                        event.arenaId,
+                        tiltaksgjennomforing.tiltaksgjennomforingId.toString(),
                         UUID.randomUUID(),
-                        Unhandled
+                        Ignored
                     )
                 )
-                processor.handleEvent(event).shouldBeLeft().should { it.status shouldBe Invalid }
+                val processor = createProcessor()
+                val event = createArenaTiltakdeltakerEvent(Insert) { it.copy(DELTAKERSTATUSKODE = "FULLF") }
+
+                processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
             }
 
-            test("should mark the event as Failed when api responds with an error") {
+            test("should treat all operations as upserts") {
                 val engine = createMockEngine(
                     "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
-                    "/api/v1/internal/arena/tiltakshistorikk" to {
-                        respondError(
-                            HttpStatusCode.InternalServerError
-                        )
-                    }
+                    "/api/v1/internal/arena/tiltakshistorikk.*" to { respondOk() }
                 )
+                val processor = createProcessor(engine)
 
-                val consumer = createProcessor(database.db, engine)
-                val event = createArenaTiltakdeltakerEvent(Insert)
+                val (e1, mapping) = prepareEvent(createArenaTiltakdeltakerEvent(Insert) { it.copy(DELTAKERSTATUSKODE = "GJENN") })
+                processor.handleEvent(e1) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("deltaker").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("status").isEqualTo("DELTAR")
 
-                consumer.handleEvent(event).shouldBeLeft().should { it.status shouldBe Failed }
+                val e2 = createArenaTiltakdeltakerEvent(Update) { it.copy(DELTAKERSTATUSKODE = "FULLF") }
+                processor.handleEvent(e2) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("deltaker").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("status").isEqualTo("AVSLUTTET")
+
+                val e3 = createArenaTiltakdeltakerEvent(Delete) { it.copy(DELTAKERSTATUSKODE = "FULLF") }
+                processor.handleEvent(e3) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("deltaker").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("status").isEqualTo("AVSLUTTET")
             }
 
-            test("should call api with tiltakshistorikk when all services responds with success") {
-                val engine = createMockEngine(
-                    "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
-                    "/api/v1/internal/arena/tiltakshistorikk.*" to { respondOk() },
-                )
-
-                val consumer = createProcessor(database.db, engine)
-                val entities = ArenaEntityMappingRepository(database.db)
-
-                val event = createArenaTiltakdeltakerEvent(Insert)
-
-                val mapping = entities.upsert(
-                    ArenaEntityMapping(
-                        event.arenaTable,
-                        event.arenaId,
-                        UUID.randomUUID(),
-                        Unhandled
+            context("api responses") {
+                test("should mark the event as Failed when arena ords proxy responds with an error") {
+                    val engine = createMockEngine(
+                        "/ords/fnr" to { respondError(HttpStatusCode.InternalServerError) },
+                        "/api/v1/internal/arena/deltaker" to { respondOk() }
                     )
-                )
+                    val processor = createProcessor(engine)
 
-                consumer.handleEvent(event).shouldBeRight()
+                    val (event) = prepareEvent(createArenaTiltakdeltakerEvent(Insert))
 
-                engine.requestHistory.last().apply {
-                    method shouldBe HttpMethod.Put
-
-                    decodeRequestBody<TiltakshistorikkDbo>().apply {
-                        shouldBeInstanceOf<TiltakshistorikkDbo.Gruppetiltak>()
-                        id shouldBe mapping.entityId
-                        tiltaksgjennomforingId shouldBe tiltaksgjennomforing.id
-                        norskIdent shouldBe "12345678910"
+                    processor.handleEvent(event).shouldBeLeft().should {
+                        it.status shouldBe Failed
+                        it.message shouldContain "Internal Server Error"
                     }
                 }
 
-                consumer.handleEvent(createArenaTiltakdeltakerEvent(Delete)).shouldBeRight()
-
-                engine.requestHistory.last().apply {
-                    method shouldBe HttpMethod.Delete
-
-                    url.getLastPathParameterAsUUID() shouldBe mapping.entityId
-                }
-            }
-
-            test("should include arbeidsgiver from ORDS when deltakelse is individuelt tiltak") {
-                val engine = createMockEngine(
-                    "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
-                    "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() },
-                    "/ords/arbeidsgiver" to {
-                        respondJson(
-                            ArenaOrdsArrangor("123456", "000000")
-                        )
-                    }
-                )
-
-                val entities = ArenaEntityMappingRepository(database.db)
-                val processor = createProcessor(database.db, engine)
-
-                val event = createArenaTiltakdeltakerEvent(Insert) {
-                    it.copy(
-                        TILTAKDELTAKER_ID = 2,
-                        TILTAKGJENNOMFORING_ID = tiltaksgjennomforingIndividuell.tiltaksgjennomforingId
+                // TODO: burde manglende data i ords ha en annen semantikk enn Invalid?
+                test("should mark the event as Invalid when arena ords proxy responds with NotFound") {
+                    val engine = createMockEngine(
+                        "/ords/fnr" to { respondError(HttpStatusCode.NotFound) },
+                        "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() }
                     )
-                }
-                val mapping = entities.upsert(
-                    ArenaEntityMapping(
-                        event.arenaTable,
-                        event.arenaId,
-                        UUID.randomUUID(),
-                        Unhandled
-                    )
-                )
 
-                processor.handleEvent(event).shouldBeRight()
-
-                engine.requestHistory.last().apply {
-                    method shouldBe HttpMethod.Put
-
-                    decodeRequestBody<TiltakshistorikkDbo>().apply {
-                        shouldBeInstanceOf<TiltakshistorikkDbo.IndividueltTiltak>()
-                        id shouldBe mapping.entityId
-                        beskrivelse shouldBe tiltaksgjennomforingIndividuell.navn
-                        virksomhetsnummer shouldBe "123456"
-                        tiltakstypeId shouldBe tiltakstypeIndividuell.id
-                        norskIdent shouldBe "12345678910"
+                    val processor = createProcessor(engine)
+                    val (event) = prepareEvent(createArenaTiltakdeltakerEvent(Insert))
+                    processor.handleEvent(event).shouldBeLeft().should {
+                        it.status shouldBe Invalid
+                        it.message shouldContain "Fant ikke norsk ident i Arena ORDS"
                     }
                 }
-            }
 
-            test("should call api with deltaker when deltakelse has opphav=Arena") {
-                val engine = createMockEngine(
-                    "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
-                    "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() },
-                    "/api/v1/internal/arena/deltaker" to { respondOk() },
-                )
-
-                val entities = ArenaEntityMappingRepository(database.db)
-                val processor = createProcessor(database.db, engine)
-
-                val event = createArenaTiltakdeltakerEvent(Insert) {
-                    it.copy(TILTAKGJENNOMFORING_ID = tiltaksgjennomforingOpphavArena.tiltaksgjennomforingId)
-                }
-                val mapping = entities.upsert(
-                    ArenaEntityMapping(
-                        event.arenaTable,
-                        event.arenaId,
-                        UUID.randomUUID(),
-                        Unhandled
+                test("should mark the event as Failed when api responds with an error") {
+                    val engine = createMockEngine(
+                        "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
+                        "/api/v1/internal/arena/tiltakshistorikk" to {
+                            respondError(
+                                HttpStatusCode.InternalServerError
+                            )
+                        }
                     )
-                )
+                    val processor = createProcessor(engine)
 
-                processor.handleEvent(event).shouldBeRight()
+                    val (event) = prepareEvent(createArenaTiltakdeltakerEvent(Insert))
 
-                engine.requestHistory shouldHaveSingleElement {
-                    it.method == HttpMethod.Put &&
-                        it.url.encodedPath == "/api/v1/internal/arena/tiltakshistorikk" &&
-                        it.decodeRequestBody<TiltakshistorikkDbo>().id == mapping.entityId
+                    processor.handleEvent(event).shouldBeLeft().should {
+                        it.status shouldBe Failed
+                        it.message shouldContain "Internal Server Error"
+                    }
                 }
 
-                engine.requestHistory shouldHaveSingleElement {
-                    it.method == HttpMethod.Put &&
-                        it.url.encodedPath == "/api/v1/internal/arena/deltaker" &&
-                        it.decodeRequestBody<DeltakerDbo>().id == mapping.entityId
+                test("should call api with tiltakshistorikk when all services responds with success") {
+                    val engine = createMockEngine(
+                        "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
+                        "/api/v1/internal/arena/tiltakshistorikk.*" to { respondOk() },
+                    )
+                    val processor = createProcessor(engine)
+
+                    val (event, mapping) = prepareEvent(createArenaTiltakdeltakerEvent(Insert))
+                    processor.handleEvent(event).shouldBeRight()
+
+                    engine.requestHistory.last().apply {
+                        method shouldBe HttpMethod.Put
+
+                        decodeRequestBody<TiltakshistorikkDbo>().apply {
+                            shouldBeInstanceOf<TiltakshistorikkDbo.Gruppetiltak>()
+                            id shouldBe mapping.entityId
+                            tiltaksgjennomforingId shouldBe tiltaksgjennomforing.id
+                            norskIdent shouldBe "12345678910"
+                        }
+                    }
+
+                    processor.handleEvent(createArenaTiltakdeltakerEvent(Delete)).shouldBeRight()
+
+                    engine.requestHistory.last().apply {
+                        method shouldBe HttpMethod.Delete
+
+                        url.getLastPathParameterAsUUID() shouldBe mapping.entityId
+                    }
+                }
+
+                test("should include arbeidsgiver from ORDS when deltakelse is individuelt tiltak") {
+                    val engine = createMockEngine(
+                        "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
+                        "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() },
+                        "/ords/arbeidsgiver" to {
+                            respondJson(
+                                ArenaOrdsArrangor("123456", "000000")
+                            )
+                        }
+                    )
+                    val processor = createProcessor(engine)
+
+                    val (event, mapping) = prepareEvent(
+                        createArenaTiltakdeltakerEvent(Insert) {
+                            it.copy(
+                                TILTAKDELTAKER_ID = 2,
+                                TILTAKGJENNOMFORING_ID = tiltaksgjennomforingIndividuell.tiltaksgjennomforingId
+                            )
+                        }
+                    )
+
+                    processor.handleEvent(event).shouldBeRight()
+
+                    engine.requestHistory.last().apply {
+                        method shouldBe HttpMethod.Put
+
+                        decodeRequestBody<TiltakshistorikkDbo>().apply {
+                            shouldBeInstanceOf<TiltakshistorikkDbo.IndividueltTiltak>()
+                            id shouldBe mapping.entityId
+                            beskrivelse shouldBe tiltaksgjennomforingIndividuell.navn
+                            virksomhetsnummer shouldBe "123456"
+                            tiltakstypeId shouldBe tiltakstypeIndividuell.id
+                            norskIdent shouldBe "12345678910"
+                        }
+                    }
+                }
+
+                test("should call api with deltaker when deltakelse has opphav=Arena") {
+                    val engine = createMockEngine(
+                        "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
+                        "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() },
+                        "/api/v1/internal/arena/deltaker" to { respondOk() },
+                    )
+                    val processor = createProcessor(engine)
+
+                    val (event, mapping) = prepareEvent(
+                        createArenaTiltakdeltakerEvent(Insert) {
+                            it.copy(TILTAKGJENNOMFORING_ID = tiltaksgjennomforingOpphavArena.tiltaksgjennomforingId)
+                        }
+                    )
+
+                    processor.handleEvent(event).shouldBeRight()
+
+                    engine.requestHistory shouldHaveSingleElement {
+                        it.method == HttpMethod.Put &&
+                            it.url.encodedPath == "/api/v1/internal/arena/tiltakshistorikk" &&
+                            it.decodeRequestBody<TiltakshistorikkDbo>().id == mapping.entityId
+                    }
+
+                    engine.requestHistory shouldHaveSingleElement {
+                        it.method == HttpMethod.Put &&
+                            it.url.encodedPath == "/api/v1/internal/arena/deltaker" &&
+                            it.decodeRequestBody<DeltakerDbo>().id == mapping.entityId
+                    }
                 }
             }
         }
     }
 })
-
-private fun createProcessor(db: Database, engine: HttpClientEngine): TiltakdeltakerEventProcessor {
-    val client = MulighetsrommetApiClient(engine, baseUri = "api") {
-        "Bearer token"
-    }
-
-    val ords = ArenaOrdsProxyClientImpl(engine, baseUrl = "") {
-        "Bearer token"
-    }
-
-    val entities = ArenaEntityService(
-        mappings = ArenaEntityMappingRepository(db),
-        tiltakstyper = TiltakstypeRepository(db),
-        saker = SakRepository(db),
-        tiltaksgjennomforinger = TiltaksgjennomforingRepository(db),
-        deltakere = DeltakerRepository(db),
-        avtaler = AvtaleRepository(db),
-    )
-
-    return TiltakdeltakerEventProcessor(entities, client, ords)
-}

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessorTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.engine.*
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
@@ -14,12 +15,13 @@ import no.nav.mulighetsrommet.arena.adapter.clients.ArenaOrdsProxyClientImpl
 import no.nav.mulighetsrommet.arena.adapter.createDatabaseTestConfig
 import no.nav.mulighetsrommet.arena.adapter.fixtures.TiltaksgjennomforingFixtures
 import no.nav.mulighetsrommet.arena.adapter.fixtures.TiltakstypeFixtures
-import no.nav.mulighetsrommet.arena.adapter.fixtures.createArenaAvtaleInfoEvent
 import no.nav.mulighetsrommet.arena.adapter.fixtures.createArenaTiltakgjennomforingEvent
 import no.nav.mulighetsrommet.arena.adapter.models.ProcessingResult
 import no.nav.mulighetsrommet.arena.adapter.models.arena.ArenaTable
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Handled
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Ignored
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.Operation.*
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.ProcessingStatus.Failed
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent.ProcessingStatus.Invalid
@@ -29,7 +31,6 @@ import no.nav.mulighetsrommet.arena.adapter.repositories.*
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
 import no.nav.mulighetsrommet.arena.adapter.utils.AktivitetsplanenLaunchDate
 import no.nav.mulighetsrommet.arena.adapter.utils.ArenaUtils
-import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
@@ -38,7 +39,6 @@ import no.nav.mulighetsrommet.ktor.decodeRequestBody
 import no.nav.mulighetsrommet.ktor.getLastPathParameterAsUUID
 import no.nav.mulighetsrommet.ktor.respondJson
 import java.time.LocalDate
-import java.util.*
 
 class TiltakgjennomforingEventProcessorTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
@@ -58,394 +58,322 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
     val regDatoAfterAktivitetsplanen = AktivitetsplanenLaunchDate
         .format(ArenaUtils.TimestampFormatter)
 
-    context("when dependent events has not been processed") {
-        test("should save the event with status Failed when dependent tiltakstype is missing") {
-            val tiltakstyper = TiltakstypeRepository(database.db)
-            tiltakstyper.upsert(TiltakstypeFixtures.Gruppe)
+    context("handleEvent") {
+        val entities = ArenaEntityService(
+            mappings = ArenaEntityMappingRepository(database.db),
+            tiltakstyper = TiltakstypeRepository(database.db),
+            saker = SakRepository(database.db),
+            tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db),
+            deltakere = DeltakerRepository(database.db),
+            avtaler = AvtaleRepository(database.db),
+        )
 
-            val consumer = createConsumer(database.db, MockEngine { respondOk() })
-            val event = createArenaTiltakgjennomforingEvent(Insert)
-
-            consumer.handleEvent(event).shouldBeLeft().should { it.status shouldBe Failed }
-            database.assertThat("tiltaksgjennomforing").isEmpty
-        }
-
-        test("should save the event with status Failed when dependent sak is missing") {
-            val saker = SakRepository(database.db)
-            saker.upsert(
-                Sak(
-                    sakId = 13572352,
-                    lopenummer = 123,
-                    aar = 2022,
-                    enhet = "2990"
-                )
-            )
-
-            val consumer = createConsumer(database.db, MockEngine { respondOk() })
-            val event = createArenaTiltakgjennomforingEvent(Insert)
-
-            consumer.handleEvent(event).shouldBeLeft().should { it.status shouldBe Failed }
-            database.assertThat("tiltaksgjennomforing").isEmpty
-        }
-    }
-
-    context("when tiltaksgjennomføring is individuell") {
-        val tiltakstype = TiltakstypeFixtures.Individuell
-
-        beforeEach {
-            val saker = SakRepository(database.db)
-            saker.upsert(
-                Sak(
-                    sakId = 13572352,
-                    lopenummer = 123,
-                    aar = 2022,
-                    enhet = "2990"
-                )
-            )
-
-            val tiltakstyper = TiltakstypeRepository(database.db)
-            tiltakstyper.upsert(tiltakstype)
-
-            val mappings = ArenaEntityMappingRepository(database.db)
-            mappings.upsert(
-                ArenaEntityMapping(
-                    ArenaTable.Tiltakstype,
-                    tiltakstype.tiltakskode,
-                    tiltakstype.id,
-                    Handled
-                )
-            )
-        }
-
-        test("should ignore individuelle tiltaksgjennomføringer created before Aktivitetsplanen") {
-            val engine = MockEngine { respondOk() }
-            val consumer = createConsumer(database.db, engine)
-
-            val event = createArenaTiltakgjennomforingEvent(
-                Insert,
-                TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
-            ) {
-                it.copy(REG_DATO = regDatoBeforeAktivitetsplanen)
+        fun createProcessor(engine: HttpClientEngine = MockEngine { respondOk() }): TiltakgjennomforingEventProcessor {
+            val client = MulighetsrommetApiClient(engine, baseUri = "api") {
+                "Bearer token"
             }
 
-            consumer.handleEvent(event).shouldBeRight().should { it.status shouldBe ArenaEntityMapping.Status.Ignored }
-            database.assertThat("tiltaksgjennomforing").isEmpty
-            engine.requestHistory.shouldBeEmpty()
-        }
-
-        test("should ignore if DATO_FRA is null") {
-            val engine = MockEngine { respondOk() }
-            val consumer = createConsumer(database.db, engine)
-
-            val event = createArenaTiltakgjennomforingEvent(
-                Insert,
-                TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
-            ) {
-                it.copy(DATO_FRA = null)
+            val ords = ArenaOrdsProxyClientImpl(engine, baseUrl = "") {
+                "Bearer token"
             }
 
-            consumer.handleEvent(event).shouldBeRight().should { it.status shouldBe ArenaEntityMapping.Status.Ignored }
-            database.assertThat("tiltaksgjennomforing").isEmpty
-            engine.requestHistory.shouldBeEmpty()
+            return TiltakgjennomforingEventProcessor(entities, client, ords)
         }
 
-        test("should upsert individuelle tiltaksgjennomføringer created after Aktivitetsplanen") {
-            val engine = MockEngine { respondOk() }
-            val consumer = createConsumer(database.db, engine)
-            val entities = ArenaEntityMappingRepository(database.db)
+        fun prepareEvent(event: ArenaEvent): Pair<ArenaEvent, ArenaEntityMapping> {
+            val mapping = entities.getOrCreateMapping(event)
+            return Pair(event, mapping)
+        }
 
-            val event = createArenaTiltakgjennomforingEvent(
-                Insert,
-                TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
-            ) {
-                it.copy(REG_DATO = regDatoAfterAktivitetsplanen)
+        context("when dependent events has not been processed") {
+            test("should save the event with status Failed when dependent sak is missing") {
+                val tiltakstyper = TiltakstypeRepository(database.db)
+                tiltakstyper.upsert(TiltakstypeFixtures.Gruppe)
+
+                val processor = createProcessor()
+
+                val (event) = prepareEvent(createArenaTiltakgjennomforingEvent(Insert))
+                processor.handleEvent(event).shouldBeLeft().should {
+                    it.status shouldBe Failed
+                    it.message shouldContain "insert or update on table \"tiltaksgjennomforing\" violates foreign key constraint \"tiltaksgjennomforing_sak_id_fkey\""
+                }
+                database.assertThat("tiltaksgjennomforing").isEmpty
             }
 
-            val avtaleEvent = createArenaAvtaleInfoEvent(Insert)
-            val generatedAvtaleId = UUID.randomUUID()
-            entities.upsert(
-                ArenaEntityMapping(
-                    avtaleEvent.arenaTable,
-                    avtaleEvent.arenaId,
-                    generatedAvtaleId,
-                    ArenaEntityMapping.Status.Handled
-                )
-            )
-
-            entities.upsert(
-                ArenaEntityMapping(
-                    event.arenaTable,
-                    event.arenaId,
-                    UUID.randomUUID(),
-                    ArenaEntityMapping.Status.Unhandled
-                )
-            )
-
-            consumer.handleEvent(event) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("tiltaksgjennomforing").row()
-                .value("tiltakskode").isEqualTo("AMO")
-            engine.requestHistory.shouldBeEmpty()
-        }
-    }
-
-    context("when tiltaksgjennomføring is gruppetiltak") {
-        val tiltakstype = TiltakstypeFixtures.Gruppe
-
-        beforeEach {
-            val saker = SakRepository(database.db)
-            saker.upsert(
-                Sak(
-                    sakId = 13572352,
-                    lopenummer = 123,
-                    aar = 2022,
-                    enhet = "2990"
-                )
-            )
-
-            val tiltakstyper = TiltakstypeRepository(database.db)
-            tiltakstyper.upsert(tiltakstype)
-
-            val mappings = ArenaEntityMappingRepository(database.db)
-            mappings.upsert(
-                ArenaEntityMapping(
-                    ArenaTable.Tiltakstype,
-                    tiltakstype.tiltakskode,
-                    tiltakstype.id,
-                    Handled
-                )
-            )
-        }
-
-        test("should treat all operations on gruppetiltak as upserts") {
-            val engine = createMockEngine(
-                "/ords/arbeidsgiver" to {
-                    respondJson(ArenaOrdsArrangor("123456", "000000"))
-                },
-                "/api/v1/internal/arena/tiltaksgjennomforing.*" to { respondOk() }
-            )
-
-            val entities = ArenaEntityMappingRepository(database.db)
-
-            val consumer = createConsumer(database.db, engine)
-
-            val e1 = createArenaTiltakgjennomforingEvent(Insert) {
-                it.copy(
-                    REG_DATO = regDatoBeforeAktivitetsplanen,
-                    LOKALTNAVN = "Navn 1"
-                )
-            }
-
-            val avtaleEvent = createArenaAvtaleInfoEvent(Insert)
-            val generatedAvtaleId = UUID.randomUUID()
-            entities.upsert(
-                ArenaEntityMapping(
-                    avtaleEvent.arenaTable,
-                    avtaleEvent.arenaId,
-                    generatedAvtaleId,
-                    ArenaEntityMapping.Status.Handled
-                )
-            )
-
-            entities.upsert(
-                ArenaEntityMapping(
-                    e1.arenaTable,
-                    e1.arenaId,
-                    UUID.randomUUID(),
-                    ArenaEntityMapping.Status.Unhandled
-                )
-            )
-            consumer.handleEvent(e1) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("tiltaksgjennomforing").row().value("navn").isEqualTo("Navn 1")
-
-            val e2 = createArenaTiltakgjennomforingEvent(Update) {
-                it.copy(
-                    REG_DATO = regDatoAfterAktivitetsplanen,
-                    LOKALTNAVN = "Navn 2"
-                )
-            }
-            consumer.handleEvent(e2) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("tiltaksgjennomforing").row().value("navn").isEqualTo("Navn 2")
-
-            val e3 = createArenaTiltakgjennomforingEvent(Delete) { it.copy(LOKALTNAVN = "Navn 1") }
-            consumer.handleEvent(e3) shouldBeRight ProcessingResult(Handled)
-            database.assertThat("tiltaksgjennomforing").row().value("navn").isEqualTo("Navn 1")
-        }
-
-        context("api responses") {
-            test("should mark the event as Failed when arena ords proxy responds with an error") {
-                val engine = createMockEngine(
-                    "/ords/arbeidsgiver" to {
-                        respondError(
-                            HttpStatusCode.InternalServerError
-                        )
-                    }
-                )
-
-                val entities = ArenaEntityMappingRepository(database.db)
-
-                val consumer = createConsumer(database.db, engine)
-                val event = createArenaTiltakgjennomforingEvent(Insert)
-
-                entities.upsert(
-                    ArenaEntityMapping(
-                        event.arenaTable,
-                        event.arenaId,
-                        UUID.randomUUID(),
-                        ArenaEntityMapping.Status.Unhandled
+            test("should save the event with status Failed when dependent tiltakstype is missing") {
+                val saker = SakRepository(database.db)
+                saker.upsert(
+                    Sak(
+                        sakId = 13572352,
+                        lopenummer = 123,
+                        aar = 2022,
+                        enhet = "2990"
                     )
                 )
 
-                consumer.handleEvent(event).shouldBeLeft().should { it.status shouldBe Failed }
+                val processor = createProcessor()
+                val (event) = prepareEvent(createArenaTiltakgjennomforingEvent(Insert))
+
+                processor.handleEvent(event).shouldBeLeft().should {
+                    it.status shouldBe Failed
+                    it.message shouldContain "insert or update on table \"tiltaksgjennomforing\" violates foreign key constraint \"tiltaksgjennomforing_tiltakskode_fkey\""
+                }
+                database.assertThat("tiltaksgjennomforing").isEmpty
+            }
+        }
+
+        context("when tiltaksgjennomføring is individuell") {
+            val tiltakstype = TiltakstypeFixtures.Individuell
+
+            beforeEach {
+                val saker = SakRepository(database.db)
+                saker.upsert(Sak(sakId = 13572352, lopenummer = 123, aar = 2022, enhet = "2990"))
+
+                val tiltakstyper = TiltakstypeRepository(database.db)
+                tiltakstyper.upsert(tiltakstype)
+                entities.upsertMapping(
+                    ArenaEntityMapping(ArenaTable.Tiltakstype, tiltakstype.tiltakskode, tiltakstype.id, Handled)
+                )
             }
 
-            // TODO: burde manglende data i ords ha en annen semantikk enn Invalid?
-            test("should mark the event as Invalid when arena ords proxy responds with NotFound") {
-                val engine = createMockEngine(
-                    "/ords/arbeidsgiver" to {
-                        respondError(
-                            HttpStatusCode.NotFound
-                        )
-                    }
-                )
-                val entities = ArenaEntityMappingRepository(database.db)
-                val consumer = createConsumer(database.db, engine)
+            test("should ignore if DATO_FRA is null") {
+                val processor = createProcessor()
 
-                val avtaleEvent = createArenaAvtaleInfoEvent(Insert)
-                val generatedAvtaleId = UUID.randomUUID()
-                entities.upsert(
-                    ArenaEntityMapping(
-                        avtaleEvent.arenaTable,
-                        avtaleEvent.arenaId,
-                        generatedAvtaleId,
-                        ArenaEntityMapping.Status.Handled
-                    )
-                )
-
-                val event = createArenaTiltakgjennomforingEvent(Insert)
-                entities.upsert(
-                    ArenaEntityMapping(
-                        event.arenaTable,
-                        event.arenaId,
-                        UUID.randomUUID(),
-                        ArenaEntityMapping.Status.Unhandled
-                    )
-                )
-
-                consumer.handleEvent(event).shouldBeLeft().should { it.status shouldBe Invalid }
-            }
-
-            test("should mark the event as Failed when api responds with an error") {
-                val engine = createMockEngine(
-                    "/ords/arbeidsgiver" to {
-                        respondJson(
-                            ArenaOrdsArrangor(
-                                "123456",
-                                "000000"
-                            )
-                        )
-                    },
-                    "/api/v1/internal/arena/tiltaksgjennomforing" to {
-                        respondError(
-                            HttpStatusCode.InternalServerError
-                        )
+                val (event) = prepareEvent(
+                    createArenaTiltakgjennomforingEvent(
+                        Insert,
+                        TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
+                    ) {
+                        it.copy(DATO_FRA = null)
                     }
                 )
 
-                val consumer = createConsumer(database.db, engine)
-                val event = createArenaTiltakgjennomforingEvent(Insert)
-
-                consumer.handleEvent(event).shouldBeLeft().should { it.status shouldBe Failed }
+                processor.handleEvent(event).shouldBeRight().should {
+                    it.status shouldBe Ignored
+                }
+                database.assertThat("tiltaksgjennomforing").isEmpty
             }
 
-            test("should call api with mapped event payload when all services responds with success") {
+            context("when tiltaksgjennomføring is individuelt tiltak") {
+                test("should ignore gjennomføringer created before Aktivitetsplanen") {
+                    val processor = createProcessor()
+
+                    val (event) = prepareEvent(
+                        createArenaTiltakgjennomforingEvent(
+                            Insert,
+                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
+                        ) {
+                            it.copy(REG_DATO = regDatoBeforeAktivitetsplanen)
+                        }
+                    )
+
+                    processor.handleEvent(event).shouldBeRight().should {
+                        it.status shouldBe Ignored
+                    }
+                    database.assertThat("tiltaksgjennomforing").isEmpty
+                }
+
+                test("should upsert gjennomføringer created after Aktivitetsplanen") {
+                    val processor = createProcessor()
+
+                    val (event) = prepareEvent(
+                        createArenaTiltakgjennomforingEvent(
+                            Insert,
+                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
+                        ) {
+                            it.copy(REG_DATO = regDatoAfterAktivitetsplanen)
+                        }
+                    )
+
+                    processor.handleEvent(event) shouldBeRight ProcessingResult(Handled)
+                    database.assertThat("tiltaksgjennomforing").row()
+                        .value("tiltakskode").isEqualTo("AMO")
+                }
+
+                test("should not send gjennomføringer to mr-api") {
+                    val engine = MockEngine { respondOk() }
+                    val processor = createProcessor()
+
+                    val (event) = prepareEvent(
+                        createArenaTiltakgjennomforingEvent(
+                            Insert,
+                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
+                        )
+                    )
+
+                    processor.handleEvent(event).shouldBeRight()
+                    engine.requestHistory.shouldBeEmpty()
+                }
+            }
+        }
+
+        context("when tiltaksgjennomføring is gruppetiltak") {
+            val tiltakstype = TiltakstypeFixtures.Gruppe
+
+            beforeEach {
+                val saker = SakRepository(database.db)
+                saker.upsert(Sak(sakId = 13572352, lopenummer = 123, aar = 2022, enhet = "2990"))
+
+                val tiltakstyper = TiltakstypeRepository(database.db)
+                tiltakstyper.upsert(tiltakstype)
+                entities.upsertMapping(
+                    ArenaEntityMapping(ArenaTable.Tiltakstype, tiltakstype.tiltakskode, tiltakstype.id, Handled)
+                )
+            }
+
+            test("should treat all operations on gruppetiltak as upserts") {
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
-                        respondJson(
-                            ArenaOrdsArrangor(
-                                "123456",
-                                "000000"
-                            )
-                        )
+                        respondJson(ArenaOrdsArrangor("123456", "000000"))
                     },
                     "/api/v1/internal/arena/tiltaksgjennomforing.*" to { respondOk() }
                 )
+                val processor = createProcessor(engine)
 
-                val consumer = createConsumer(database.db, engine)
-                val entities = ArenaEntityMappingRepository(database.db)
+                val (e1, mapping) = prepareEvent(
+                    createArenaTiltakgjennomforingEvent(Insert) {
+                        it.copy(
+                            REG_DATO = regDatoBeforeAktivitetsplanen,
+                            LOKALTNAVN = "Navn 1"
+                        )
+                    }
+                )
+                processor.handleEvent(e1) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("tiltaksgjennomforing").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("navn").isEqualTo("Navn 1")
 
-                val event = createArenaTiltakgjennomforingEvent(Insert) {
+                val e2 = createArenaTiltakgjennomforingEvent(Update) {
                     it.copy(
-                        DATO_FRA = "2022-11-11 00:00:00",
-                        DATO_TIL = "2023-11-11 00:00:00"
+                        REG_DATO = regDatoAfterAktivitetsplanen,
+                        LOKALTNAVN = "Navn 2"
                     )
                 }
-                val avtaleEvent = createArenaAvtaleInfoEvent(Insert)
+                processor.handleEvent(e2) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("tiltaksgjennomforing").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("navn").isEqualTo("Navn 2")
 
-                val generatedId = UUID.randomUUID()
-                val generatedAvtaleId = UUID.randomUUID()
+                val e3 = createArenaTiltakgjennomforingEvent(Delete) {
+                    it.copy(LOKALTNAVN = "Navn 1")
+                }
+                processor.handleEvent(e3) shouldBeRight ProcessingResult(Handled)
+                database.assertThat("tiltaksgjennomforing").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("navn").isEqualTo("Navn 1")
+            }
 
-                entities.upsert(
-                    ArenaEntityMapping(
-                        avtaleEvent.arenaTable,
-                        avtaleEvent.arenaId,
-                        generatedAvtaleId,
-                        ArenaEntityMapping.Status.Handled
+            context("api responses") {
+                test("should mark the event as Failed when arena ords proxy responds with an error") {
+                    val engine = createMockEngine(
+                        "/ords/arbeidsgiver" to {
+                            respondError(
+                                HttpStatusCode.InternalServerError
+                            )
+                        }
                     )
-                )
-                entities.upsert(
-                    ArenaEntityMapping(
-                        event.arenaTable,
-                        event.arenaId,
-                        generatedId,
-                        ArenaEntityMapping.Status.Unhandled
-                    )
-                )
+                    val processor = createProcessor(engine)
 
-                consumer.handleEvent(event).shouldBeRight()
+                    val (event) = prepareEvent(createArenaTiltakgjennomforingEvent(Insert))
 
-                engine.requestHistory.last().run {
-                    method shouldBe HttpMethod.Put
-
-                    decodeRequestBody<TiltaksgjennomforingDbo>().apply {
-                        tiltakstypeId shouldBe tiltakstype.id
-                        tiltaksnummer shouldBe "2022#123"
-                        virksomhetsnummer shouldBe "123456"
-                        startDato shouldBe LocalDate.of(2022, 11, 11)
-                        sluttDato shouldBe LocalDate.of(2023, 11, 11)
-                        avslutningsstatus shouldBe Avslutningsstatus.IKKE_AVSLUTTET
-                        avtaleId shouldBe generatedAvtaleId
+                    processor.handleEvent(event).shouldBeLeft().should {
+                        it.status shouldBe Failed
+                        it.message shouldContain "Internal Server Error"
                     }
                 }
 
-                consumer.handleEvent(createArenaTiltakgjennomforingEvent(Delete)).shouldBeRight()
+                // TODO: burde manglende data i ords ha en annen semantikk enn Invalid?
+                test("should mark the event as Invalid when arena ords proxy responds with NotFound") {
+                    val engine = createMockEngine(
+                        "/ords/arbeidsgiver" to {
+                            respondError(
+                                HttpStatusCode.NotFound
+                            )
+                        }
+                    )
+                    val processor = createProcessor(engine)
+                    val (event) = prepareEvent(createArenaTiltakgjennomforingEvent(Insert))
 
-                engine.requestHistory.last().run {
-                    method shouldBe HttpMethod.Delete
+                    processor.handleEvent(event).shouldBeLeft().should {
+                        it.status shouldBe Invalid
+                        it.message shouldContain "Fant ikke arrangør i Arena ORDS"
+                    }
+                }
 
-                    url.getLastPathParameterAsUUID() shouldBe generatedId
+                test("should mark the event as Failed when api responds with an error") {
+                    val engine = createMockEngine(
+                        "/ords/arbeidsgiver" to {
+                            respondJson(
+                                ArenaOrdsArrangor(
+                                    "123456",
+                                    "000000"
+                                )
+                            )
+                        },
+                        "/api/v1/internal/arena/tiltaksgjennomforing" to {
+                            respondError(
+                                HttpStatusCode.InternalServerError
+                            )
+                        }
+                    )
+                    val processor = createProcessor(engine)
+
+                    val (event) = prepareEvent(createArenaTiltakgjennomforingEvent(Insert))
+
+                    processor.handleEvent(event).shouldBeLeft().should {
+                        it.status shouldBe Failed
+                        it.message shouldContain "Internal Server Error"
+                    }
+                }
+
+                test("should call api with mapped event payload when all services responds with success") {
+                    val engine = createMockEngine(
+                        "/ords/arbeidsgiver" to {
+                            respondJson(
+                                ArenaOrdsArrangor(
+                                    "123456",
+                                    "000000"
+                                )
+                            )
+                        },
+                        "/api/v1/internal/arena/tiltaksgjennomforing.*" to { respondOk() }
+                    )
+                    val processor = createProcessor(engine)
+
+                    val (event, mapping) = prepareEvent(
+                        createArenaTiltakgjennomforingEvent(Insert) {
+                            it.copy(
+                                DATO_FRA = "2022-11-11 00:00:00",
+                                DATO_TIL = "2023-11-11 00:00:00"
+                            )
+                        }
+                    )
+
+                    processor.handleEvent(event).shouldBeRight()
+
+                    engine.requestHistory.last().apply {
+                        method shouldBe HttpMethod.Put
+
+                        decodeRequestBody<TiltaksgjennomforingDbo>().apply {
+                            id shouldBe mapping.entityId
+                            tiltakstypeId shouldBe tiltakstype.id
+                            tiltaksnummer shouldBe "2022#123"
+                            virksomhetsnummer shouldBe "123456"
+                            startDato shouldBe LocalDate.of(2022, 11, 11)
+                            sluttDato shouldBe LocalDate.of(2023, 11, 11)
+                            avslutningsstatus shouldBe Avslutningsstatus.IKKE_AVSLUTTET
+                        }
+                    }
+
+                    processor.handleEvent(createArenaTiltakgjennomforingEvent(Delete)).shouldBeRight()
+
+                    engine.requestHistory.last().apply {
+                        method shouldBe HttpMethod.Delete
+
+                        url.getLastPathParameterAsUUID() shouldBe mapping.entityId
+                    }
                 }
             }
         }
     }
 })
-
-private fun createConsumer(db: Database, engine: HttpClientEngine): TiltakgjennomforingEventProcessor {
-    val client = MulighetsrommetApiClient(engine, baseUri = "api") {
-        "Bearer token"
-    }
-
-    val ords = ArenaOrdsProxyClientImpl(engine, baseUrl = "") {
-        "Bearer token"
-    }
-
-    val entities = ArenaEntityService(
-        mappings = ArenaEntityMappingRepository(db),
-        tiltakstyper = TiltakstypeRepository(db),
-        saker = SakRepository(db),
-        tiltaksgjennomforinger = TiltaksgjennomforingRepository(db),
-        deltakere = DeltakerRepository(db),
-        avtaler = AvtaleRepository(db),
-    )
-
-    return TiltakgjennomforingEventProcessor(entities, client, ords)
-}

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/ArenaEventFixtures.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/ArenaEventFixtures.kt
@@ -8,52 +8,60 @@ import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 fun createArenaAvtaleInfoEvent(
     operation: ArenaEvent.Operation,
     avtale: ArenaAvtaleInfo = AvtaleFixtures.ArenaAvtaleInfo,
+    status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
     modify: (avtale: ArenaAvtaleInfo) -> ArenaAvtaleInfo = { it }
 ): ArenaEvent = modify(avtale).let {
     createArenaEvent(
         ArenaTable.AvtaleInfo,
         it.AVTALE_ID.toString(),
         operation,
-        Json.encodeToJsonElement(it).toString()
+        Json.encodeToJsonElement(it).toString(),
+        status,
     )
 }
 
 fun createArenaSakEvent(
     operation: ArenaEvent.Operation,
     sak: ArenaSak = SakFixtures.ArenaTiltakSak,
+    status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
     modify: (sak: ArenaSak) -> ArenaSak = { it }
 ): ArenaEvent = modify(sak).let {
     createArenaEvent(
         ArenaTable.Sak,
         it.SAK_ID.toString(),
         operation,
-        Json.encodeToJsonElement(it).toString()
+        Json.encodeToJsonElement(it).toString(),
+        status,
     )
 }
 
 fun createArenaTiltakdeltakerEvent(
     operation: ArenaEvent.Operation,
     deltaker: ArenaTiltakdeltaker = DeltakerFixtures.ArenaTiltakdeltaker,
+    status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
     modify: (deltaker: ArenaTiltakdeltaker) -> ArenaTiltakdeltaker = { it }
 ): ArenaEvent = modify(deltaker).let {
     createArenaEvent(
         ArenaTable.Deltaker,
         it.TILTAKDELTAKER_ID.toString(),
         operation,
-        Json.encodeToJsonElement(it).toString()
+        Json.encodeToJsonElement(it).toString(),
+        status,
     )
 }
 
 fun createArenaTiltakEvent(
     operation: ArenaEvent.Operation,
     tiltak: ArenaTiltak = TiltakstypeFixtures.ArenaGruppetiltak,
+    status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
     modify: (tiltak: ArenaTiltak) -> ArenaTiltak = { it }
 ): ArenaEvent = modify(tiltak).let {
     createArenaEvent(
         ArenaTable.Tiltakstype,
         it.TILTAKSKODE,
         operation,
-        Json.encodeToJsonElement(it).toString()
+        Json.encodeToJsonElement(it).toString(),
+        status,
     )
 }
 
@@ -77,7 +85,7 @@ private fun createArenaEvent(
     id: String,
     operation: ArenaEvent.Operation,
     data: String,
-    status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending
+    status: ArenaEvent.ProcessingStatus,
 ): ArenaEvent {
     val before = if (operation == ArenaEvent.Operation.Delete) {
         data

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/TiltaksgjennomforingFixtures.kt
@@ -16,7 +16,7 @@ object TiltaksgjennomforingFixtures {
         STATUS_TREVERDIKODE_INNSOKNING = JaNeiStatus.Ja,
         ANTALL_DELTAKERE = 5,
         TILTAKSTATUSKODE = "GJENNOMFOR",
-        AVTALE_ID = 1000
+        AVTALE_ID = null,
     )
 
     val ArenaTiltaksgjennomforingIndividuell = ArenaTiltaksgjennomforing(
@@ -31,6 +31,6 @@ object TiltaksgjennomforingFixtures {
         STATUS_TREVERDIKODE_INNSOKNING = JaNeiStatus.Ja,
         ANTALL_DELTAKERE = 5,
         TILTAKSTATUSKODE = "GJENNOMFOR",
-        AVTALE_ID = 1000
+        AVTALE_ID = null,
     )
 }


### PR DESCRIPTION
- lagrer avtale_id på avtaler i arena-adapter og håndhever relasjon mellom avtaler og gjennomføringer
- oppdaterer tester med assertions på feilmeldinger
    - dette er potensielt litt kjipt mtp. endringer, men resultatet nå var at flere tester hadde assertions på feil grunnlag