### PR TITLE
Lagrer bare relevante enheter

### DIFF
--- a/common/database/src/main/kotlin/no/nav/mulighetsrommet/database/Database.kt
+++ b/common/database/src/main/kotlin/no/nav/mulighetsrommet/database/Database.kt
@@ -14,6 +14,8 @@ interface Database {
 
     fun createTextArray(list: Collection<String>): Array
 
+    fun createIntArray(list: Collection<Int>): Array
+
     fun <T> run(query: NullableResultQueryAction<T>): T?
 
     fun <T> run(query: ListResultQueryAction<T>): List<T>

--- a/common/database/src/main/kotlin/no/nav/mulighetsrommet/database/DatabaseAdapter.kt
+++ b/common/database/src/main/kotlin/no/nav/mulighetsrommet/database/DatabaseAdapter.kt
@@ -75,6 +75,10 @@ open class DatabaseAdapter(config: DatabaseConfig) : Database {
         return createArrayOf("text", list)
     }
 
+    override fun createIntArray(list: Collection<Int>): Array {
+        return createArrayOf("integer", list)
+    }
+
     override fun <T> run(query: NullableResultQueryAction<T>): T? {
         return using(session) {
             it.run(query)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2EnhetDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2EnhetDto.kt
@@ -2,14 +2,26 @@ package no.nav.mulighetsrommet.api.clients.norg2
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
+import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
 
 @Serializable
 data class Norg2EnhetDto(
     val enhetId: Int,
     val navn: String,
     val enhetNr: String,
-    val status: Norg2EnhetStatus
-)
+    val status: Norg2EnhetStatus,
+    val type: Norg2Type
+) {
+    fun toNavEnhetDbo(): NavEnhetDbo {
+        return NavEnhetDbo(
+            enhetId = enhetId,
+            navn = navn,
+            enhetNr = enhetNr,
+            status = NavEnhetStatus.valueOf(status.name)
+        )
+    }
+}
 
 @Serializable
 enum class Norg2EnhetStatus {
@@ -24,4 +36,38 @@ enum class Norg2EnhetStatus {
 
     @SerialName("Nedlagt")
     NEDLAGT
+}
+
+@Serializable
+enum class Norg2Type {
+    KO,
+    FYLKE,
+    TILTAK,
+    AAREG,
+    ALS,
+    ARK,
+    DIR,
+    DOKSENTER,
+    EKSTERN,
+    FORVALTNING,
+    FPY,
+    HELFO,
+    HMS,
+    INNKREV,
+    INTRO,
+    IT,
+    KLAGE,
+    KONTAKT,
+    KONTROLL,
+    LOKAL,
+    OKONOMI,
+    OTENESTE,
+    OPPFUTLAND,
+    OTENESE,
+    RIKSREV,
+    ROBOT,
+    ROL,
+    TILLIT,
+    UTLAND,
+    YTA
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2EnhetDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2EnhetDto.kt
@@ -18,7 +18,8 @@ data class Norg2EnhetDto(
             enhetId = enhetId,
             navn = navn,
             enhetNr = enhetNr,
-            status = NavEnhetStatus.valueOf(status.name)
+            status = NavEnhetStatus.valueOf(status.name),
+            type = Norg2Type.valueOf(type.name)
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavEnhetDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavEnhetDbo.kt
@@ -1,13 +1,15 @@
 package no.nav.mulighetsrommet.api.domain.dbo
 
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 
 @Serializable
 data class NavEnhetDbo(
     val enhetId: Int,
     val navn: String,
     val enhetNr: String,
-    val status: NavEnhetStatus
+    val status: NavEnhetStatus,
+    val type: Norg2Type
 )
 
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepository.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.repositories
 
 import kotliquery.Row
 import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
 import no.nav.mulighetsrommet.api.utils.DatabaseUtils
@@ -20,12 +21,13 @@ class EnhetRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            insert into enhet(enhet_id, navn, enhetsnummer, status)
-            values (:enhet_id, :navn, :enhetsnummer, :status)
+            insert into enhet(enhet_id, navn, enhetsnummer, status, type)
+            values (:enhet_id, :navn, :enhetsnummer, :status, :type)
             on conflict (enhet_id)
                 do update set   navn            = excluded.navn,
                                 enhetsnummer    = excluded.enhetsnummer,
-                                status          = excluded.status
+                                status          = excluded.status,
+                                type            = excluded.type
             returning *
         """.trimIndent()
 
@@ -125,12 +127,14 @@ private fun NavEnhetDbo.toSqlParameters() = mapOf(
     "enhet_id" to enhetId,
     "navn" to navn,
     "enhetsnummer" to enhetNr,
-    "status" to status.name
+    "status" to status.name,
+    "type" to type.name
 )
 
 private fun Row.toEnhetDbo() = NavEnhetDbo(
     enhetId = int("enhet_id"),
     navn = string("navn"),
     enhetNr = string("enhetsnummer"),
-    status = NavEnhetStatus.valueOf(string("status"))
+    status = NavEnhetStatus.valueOf(string("status")),
+    type = Norg2Type.valueOf(string("type"))
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepository.kt
@@ -50,7 +50,7 @@ class EnhetRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            select distinct e.navn,(e.enhetsnummer), e.enhet_id, e.status
+            select distinct e.navn,(e.enhetsnummer), e.enhet_id, e.status, e.type
             from enhet e
             $where
             order by e.navn asc
@@ -77,7 +77,7 @@ class EnhetRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            select distinct e.navn,(e.enhetsnummer), e.enhet_id, e.status
+            select distinct e.navn,(e.enhetsnummer), e.enhet_id, e.status, e.type
             from enhet e
             join avtale a
             on a.enhet = e.enhetsnummer
@@ -94,7 +94,7 @@ class EnhetRepository(private val db: Database) {
     fun get(enhet: String): NavEnhetDbo? {
         @Language("PostgreSQL")
         val query = """
-            select navn, enhet_id, enhetsnummer, status
+            select navn, enhet_id, enhetsnummer, status, type
             from enhet
             where enhetsnummer = ?
         """.trimIndent()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavEnhetService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavEnhetService.kt
@@ -25,7 +25,7 @@ class NavEnhetService(private val enhetRepository: EnhetRepository) {
     }
 
     fun hentAlleEnheter(filter: EnhetFilter): List<NavEnhetDbo> {
-        return enhetRepository.getAll(filter.copy(enhetMaaHaTiltaksgjennomforing = true))
+        return enhetRepository.getAll(filter)
     }
 
     fun hentEnheterForAvtale(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
@@ -30,7 +30,8 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
                     enhetId = it.enhetId,
                     navn = it.navn,
                     enhetNr = it.enhetNr,
-                    status = NavEnhetStatus.valueOf(it.status.name)
+                    status = NavEnhetStatus.valueOf(it.status.name),
+                    type = Norg2Type.valueOf(it.type.name)
                 )
             )
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
@@ -13,11 +13,10 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
     suspend fun synkroniserEnheter(): List<Norg2EnhetDto> {
         val whitelistTyper = listOf(Norg2Type.FYLKE, Norg2Type.TILTAK, Norg2Type.LOKAL)
         val alleEnheter = norg2Client.hentEnheter()
-        val tilSletting = alleEnheter.filterNot { it.type in whitelistTyper }.map { it.enhetId }
-        val tilLagring = alleEnheter.filter { it.type in whitelistTyper }
+        val (tilLagring, tilSletting) = alleEnheter.partition { it.type in whitelistTyper }
         log.info("Hentet ${alleEnheter.size} enheter fra NORG2. Sletter potensielt ${tilSletting.size} enheter som ikke har en whitelistet type ($whitelistTyper). Lagrer ${tilLagring.size} enheter fra NORG2 med type = $whitelistTyper")
 
-        slettEnheterSomIkkeHarWhitelistetType(tilSletting)
+        slettEnheterSomIkkeHarWhitelistetType(tilSletting.map { it.enhetId })
         lagreEnheter(tilLagring)
 
         return tilLagring

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.services
 
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Client
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetDto
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
 import no.nav.mulighetsrommet.api.repositories.EnhetRepository
@@ -10,8 +11,19 @@ import org.slf4j.LoggerFactory
 class Norg2Service(private val norg2Client: Norg2Client, private val enhetRepository: EnhetRepository) {
     private val log = LoggerFactory.getLogger(javaClass)
     suspend fun synkroniserEnheter(): List<Norg2EnhetDto> {
-        val enheter = norg2Client.hentEnheter()
-        log.info("Hentet ${enheter.size} enheter fra NORG2")
+        val whitelistTyper = listOf(Norg2Type.FYLKE, Norg2Type.TILTAK, Norg2Type.LOKAL)
+        val alleEnheter = norg2Client.hentEnheter()
+        val tilSletting = alleEnheter.filterNot { it.type in whitelistTyper }.map { it.enhetId }
+        val tilLagring = alleEnheter.filter { it.type in whitelistTyper }
+        log.info("Hentet ${alleEnheter.size} enheter fra NORG2. Sletter potensielt ${tilSletting.size} enheter som ikke har en whitelistet type ($whitelistTyper). Lagrer ${tilLagring.size} enheter fra NORG2 med type = $whitelistTyper")
+
+        slettEnheterSomIkkeHarWhitelistetType(tilSletting)
+        lagreEnheter(tilLagring)
+
+        return tilLagring
+    }
+
+    private fun lagreEnheter(enheter: List<Norg2EnhetDto>) {
         enheter.forEach {
             enhetRepository.upsert(
                 NavEnhetDbo(
@@ -22,6 +34,9 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
                 )
             )
         }
-        return enheter
+    }
+
+    private fun slettEnheterSomIkkeHarWhitelistetType(ider: List<Int>) {
+        enhetRepository.deleteWhereIds(ider)
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -42,7 +42,6 @@ data class EnhetFilter(
         NavEnhetStatus.UNDER_ETABLERING
     ),
     val tiltakstypeId: String? = null,
-    val enhetMaaHaTiltaksgjennomforing: Boolean? = true
 )
 
 data class TiltaksgjennomforingFilter(

--- a/mulighetsrommet-api/src/main/resources/db/migration/V41__add_columns_for_type_enhet.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V41__add_columns_for_type_enhet.sql
@@ -1,0 +1,9 @@
+alter table enhet
+    add column type text;
+
+update enhet
+    set type = 'LOKAL';
+
+alter table enhet
+    alter column type set not null;
+

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1271,6 +1271,8 @@ components:
           type: string
         status:
           $ref: "#/components/schemas/NavEnhetStatus"
+        type:
+          $ref: "#/components/schemas/Norg2Type"
 
     Leverandor:
       type: object
@@ -1523,3 +1525,10 @@ components:
         - AKTIV
         - UNDER_AVVIKLING
         - NEDLAGT
+
+    Norg2Type:
+      type: string
+      enum:
+        - LOKAL
+        - FYLKE
+        - TILTAK

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/Norg2EnhetFixture.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/Norg2EnhetFixture.kt
@@ -1,0 +1,15 @@
+package no.nav.mulighetsrommet.api.fixtures
+
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetDto
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetStatus
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
+
+object Norg2EnhetFixture {
+    val enhet = Norg2EnhetDto(
+        enhetId = Math.random().toInt(),
+        enhetNr = "1000",
+        navn = "Enhet X",
+        status = Norg2EnhetStatus.AKTIV,
+        type = Norg2Type.LOKAL
+    )
+}

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/DeltakerRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/DeltakerRepositoryTest.kt
@@ -1,7 +1,6 @@
 package no.nav.mulighetsrommet.api.repositories
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.core.test.TestCaseOrder
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
@@ -18,8 +17,6 @@ import java.time.LocalDateTime
 import java.util.*
 
 class DeltakerRepositoryTest : FunSpec({
-
-    testOrder = TestCaseOrder.Sequential
 
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepositoryTest.kt
@@ -1,0 +1,43 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.mulighetsrommet.api.createDatabaseTestConfig
+import no.nav.mulighetsrommet.api.fixtures.Norg2EnhetFixture
+import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.database.utils.getOrThrow
+
+class EnhetRepositoryTest : FunSpec({
+    val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
+
+    beforeEach {
+        database.db.clean()
+        database.db.migrate()
+    }
+
+    context("Synkronisering av enheter") {
+        val enheter = EnhetRepository(database.db)
+
+        test("Skal slette enheter fra liste med id'er") {
+            val enhetSomSkalSlettes1 = Norg2EnhetFixture.enhet.copy(enhetId = 1).toNavEnhetDbo()
+            val enhetSomSkalSlettes2 = Norg2EnhetFixture.enhet.copy(enhetId = 2).toNavEnhetDbo()
+            val enhetSomSkalSlettes3 = Norg2EnhetFixture.enhet.copy(enhetId = 3).toNavEnhetDbo()
+            val enhetSomSkalBeholdes1 = Norg2EnhetFixture.enhet.copy(enhetId = 4).toNavEnhetDbo()
+            val enhetSomSkalBeholdes2 = Norg2EnhetFixture.enhet.copy(enhetId = 5).toNavEnhetDbo()
+
+            enheter.upsert(enhetSomSkalSlettes1).getOrThrow()
+            enheter.upsert(enhetSomSkalSlettes2).getOrThrow()
+            enheter.upsert(enhetSomSkalSlettes3).getOrThrow()
+            enheter.upsert(enhetSomSkalBeholdes1).getOrThrow()
+            enheter.upsert(enhetSomSkalBeholdes2).getOrThrow()
+
+            val count = enheter.getAll().size
+            count shouldBe 5
+
+            val idErForSletting = listOf(1, 2, 3)
+            enheter.deleteWhereIds(idErForSletting)
+            val countAfterDeletion = enheter.getAll().size
+            countAfterDeletion shouldBe 2
+        }
+    }
+})

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/Norg2ServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/Norg2ServiceTest.kt
@@ -1,0 +1,33 @@
+package no.nav.mulighetsrommet.api.services
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Client
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
+import no.nav.mulighetsrommet.api.fixtures.Norg2EnhetFixture
+import no.nav.mulighetsrommet.api.repositories.EnhetRepository
+
+class Norg2ServiceTest : FunSpec({
+    val norg2Client: Norg2Client = mockk()
+    val enheter: EnhetRepository = mockk(relaxed = true)
+    val norg2Service = Norg2Service(norg2Client, enheter)
+
+    test("Synkroniser enheter skal slette enheter som ikke tilfredstiller whitelist") {
+        val mockEnheter = listOf(
+            Norg2EnhetFixture.enhet.copy(enhetId = 1, type = Norg2Type.AAREG),
+            Norg2EnhetFixture.enhet.copy(enhetId = 2),
+            Norg2EnhetFixture.enhet.copy(enhetId = 3)
+        )
+
+        coEvery {
+            norg2Client.hentEnheter()
+        } returns mockEnheter
+
+        val tilLagring = norg2Service.synkroniserEnheter()
+        tilLagring.size shouldBe 2
+        tilLagring[0].enhetId shouldBe 2
+        tilLagring[1].enhetId shouldBe 3
+    }
+})


### PR DESCRIPTION
- Henter alle enheter fra NORG2
- Sletter fra database de som ikke har type `LOKAL, TILTAK, FYLKE`
- Upserter de som har type `LOKAL, TILTAK, TYPE`
- Fjerner unødvendig filter for enheter (må ha tiltaksgjennomføring)
- Legger til kolonne type på enhet-tabellen