### PR TITLE
Flytter navigering opp i header

### DIFF
--- a/frontend/mr-admin-flate/package.json
+++ b/frontend/mr-admin-flate/package.json
@@ -22,6 +22,7 @@
     "@navikt/ds-css-internal": "^2.8.1",
     "@navikt/ds-react": "^2.8.1",
     "@navikt/ds-react-internal": "^2.8.1",
+    "@navikt/ds-tokens": "^2.8.11",
     "@tanstack/react-query": "^4.27.0",
     "@tanstack/react-query-devtools": "^4.27.0",
     "classnames": "^2.3.2",

--- a/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.module.scss
+++ b/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.module.scss
@@ -1,7 +1,17 @@
+@use "@navikt/ds-tokens/dist/tokens" as *;
+
+:global(.navdsi-header) {
+  flex-wrap: wrap;
+  justify-items: flex-start;
+}
+
 .link {
   text-decoration: none;
   color: white;
 }
+
 .user {
-  margin-left: auto;
+  @media (min-width: $a-breakpoint-sm) {
+    margin-left: auto;
+  }
 }

--- a/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.tsx
+++ b/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.tsx
@@ -1,11 +1,15 @@
 import { Header } from "@navikt/ds-react-internal";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useHentAnsatt } from "../../api/administrator/useHentAdministrator";
 import { capitalize } from "../../utils/Utils";
 import styles from "./AdministratorHeader.module.scss";
+import { NavigeringHeader } from "../../pages/forside/NavigeringHeader";
 
 export function AdministratorHeader() {
   const response = useHentAnsatt();
+
+  const location = useLocation();
+  const pathErIkkeRoot = location.pathname !== "/";
   const ansattNavn = response.data?.fornavn
     ? [response.data.fornavn, response.data?.etternavn ?? ""]
         .map((it) => capitalize(it))
@@ -19,7 +23,7 @@ export function AdministratorHeader() {
           NAV arbeidsmarkedstiltak
         </Link>
       </Header.Title>
-
+      {pathErIkkeRoot ? <NavigeringHeader /> : null}
       <Header.User
         data-testid="header-navident"
         name={ansattNavn}

--- a/frontend/mr-admin-flate/src/components/navbar/Navbar.module.scss
+++ b/frontend/mr-admin-flate/src/components/navbar/Navbar.module.scss
@@ -1,29 +1,28 @@
 .navlink_container {
   display: flex;
-  justify-content: flex-start;
-  background-color: white;
+  justify-content: center;
   box-shadow: rgba(0, 0, 0, 0.16) 0 1px 4px;
+  margin: 0 0.2rem;
 }
 
 .navlink {
   border-bottom: 1px solid transparent;
-  color: var(--a-surface-neutral);
+  color: white;
   text-decoration: none;
-  margin: 1rem 0.5rem 0;
   padding: 1rem 1rem 0.5rem;
   border-bottom: 4px solid transparent;
+  display: block;
 
   &:hover {
-    border-bottom: 4px solid var(--a-surface-action-active);
-    color: var(--a-surface-neutral-hover);
+    color: white;
+    background-color: var(--a-surface-inverted-hover);
   }
 
   &_active {
     text-decoration: none;
-    color: black;
-    margin: 1rem 0.5rem 0;
+    color: white;
     padding: 1rem 1rem 0.5rem;
-    border-bottom: 4px solid var(--a-surface-action-active);
     cursor: default;
+    background-color: var(--a-surface-inverted-hover);
   }
 }

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
@@ -1,15 +1,13 @@
 import { Heading } from "@navikt/ds-react";
+import { AvtaleOversikt } from "../../components/avtaler/AvtaleOversikt";
 import { Avtalefilter } from "../../components/filter/Avtalefilter";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
 import { MainContainer } from "../../layouts/MainContainer";
-import { NavigeringHeader } from "../forside/NavigeringHeader";
 import styles from "../Page.module.scss";
-import { AvtaleOversikt } from "../../components/avtaler/AvtaleOversikt";
 
 export function AvtalerPage() {
   return (
     <MainContainer>
-      <NavigeringHeader />
       <ContainerLayout>
         <Heading level="2" size="large" className={styles.header_wrapper}>
           Oversikt over avtaler

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
@@ -1,15 +1,13 @@
 import { Heading } from "@navikt/ds-react";
-import { ContainerLayout } from "../../layouts/ContainerLayout";
-import { MainContainer } from "../../layouts/MainContainer";
-import { NavigeringHeader } from "../forside/NavigeringHeader";
-import styles from "../Page.module.scss";
 import { Tiltaksgjennomforingfilter } from "../../components/filter/Tiltaksgjennomforingfilter";
 import { TiltaksgjennomforingOversikt } from "../../components/tiltaksgjennomforinger/TiltaksgjennomforingOversikt";
+import { ContainerLayout } from "../../layouts/ContainerLayout";
+import { MainContainer } from "../../layouts/MainContainer";
+import styles from "../Page.module.scss";
 
 export function TiltaksgjennomforingerPage() {
   return (
     <MainContainer>
-      <NavigeringHeader />
       <ContainerLayout>
         <Heading level="2" size="large" className={styles.header_wrapper}>
           Oversikt over tiltaksgjennomføringer

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/TiltakstyperPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/TiltakstyperPage.tsx
@@ -3,13 +3,11 @@ import { Tiltakstypefilter } from "../../components/filter/Tiltakstypefilter";
 import { TiltakstyperOversikt } from "../../components/tiltakstyper/TiltakstyperOversikt";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
 import { MainContainer } from "../../layouts/MainContainer";
-import { NavigeringHeader } from "../forside/NavigeringHeader";
 import styles from "../Page.module.scss";
 
 export function TiltakstyperPage() {
   return (
     <MainContainer>
-      <NavigeringHeader />
       <ContainerLayout>
         <Heading level="2" size="large" className={styles.header_wrapper}>
           Oversikt over tiltakstyper

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@navikt/ds-css-internal": "^2.8.1",
         "@navikt/ds-react": "^2.8.1",
         "@navikt/ds-react-internal": "^2.8.1",
+        "@navikt/ds-tokens": "^2.8.11",
         "@tanstack/react-query": "^4.27.0",
         "@tanstack/react-query-devtools": "^4.27.0",
         "classnames": "^2.3.2",
@@ -5931,6 +5932,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@navikt/ds-tokens": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-2.8.11.tgz",
+      "integrity": "sha512-8Dln31RNRtSmdOLjNb+ijLdTFfq0pFHfibYzLdwUwP3r1/tRLiMByfqyKcypKdQU7XQyKMatbAseVpAbEbOlQA=="
     },
     "node_modules/@navikt/navspa": {
       "version": "6.0.1",
@@ -27007,6 +27013,11 @@
         "copy-to-clipboard": "^3.3.1"
       }
     },
+    "@navikt/ds-tokens": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-2.8.11.tgz",
+      "integrity": "sha512-8Dln31RNRtSmdOLjNb+ijLdTFfq0pFHfibYzLdwUwP3r1/tRLiMByfqyKcypKdQU7XQyKMatbAseVpAbEbOlQA=="
+    },
     "@navikt/navspa": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@navikt/navspa/-/navspa-6.0.1.tgz",
@@ -35353,6 +35364,7 @@
         "@navikt/ds-css-internal": "^2.8.1",
         "@navikt/ds-react": "^2.8.1",
         "@navikt/ds-react-internal": "^2.8.1",
+        "@navikt/ds-tokens": "*",
         "@tanstack/react-query": "^4.27.0",
         "@tanstack/react-query-devtools": "^4.27.0",
         "@types/react": "^18.0.28",


### PR DESCRIPTION
Flytter navigering opp i header slik at bruker ser hvor i landskapet de er når de trykker seg inn på detaljsider for hhv. tiltakstyper, avtaler og gjennomføringer. Viser ikke navbar'en på forsiden.

**Før**
<img width="875" alt="image" src="https://user-images.githubusercontent.com/9053627/231363881-253232fd-dc89-4850-a2c6-e7b3b292b973.png">

**Etter**
<img width="934" alt="image" src="https://user-images.githubusercontent.com/9053627/231363968-1e82ef49-1de4-4bee-b5d9-b429c2c670cb.png">

**Viser ikke navbar'en på forsiden**
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/9053627/231364134-8456220f-8507-4a91-b5cc-31a6770abc78.png">

