### PR TITLE
Refactor/http clients

### DIFF
--- a/common/ktor-clients/build.gradle.kts
+++ b/common/ktor-clients/build.gradle.kts
@@ -1,0 +1,18 @@
+@Suppress("DSL_SCOPE_VIOLATION")
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ktlint)
+}
+
+ktlint {
+    disabledRules.addAll("no-wildcard-imports")
+}
+
+dependencies {
+    api(libs.ktor.client.cio)
+    api(libs.ktor.client.core)
+    api(libs.ktor.client.contentNegotiation)
+    api(libs.ktor.client.logging)
+    api(libs.ktor.serialization.json)
+}

--- a/common/ktor-clients/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
+++ b/common/ktor-clients/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
@@ -12,7 +12,7 @@ import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 import org.slf4j.MDC
 
-internal fun httpJsonClient(engine: HttpClientEngine = CIO.create()) = HttpClient(engine) {
+fun httpJsonClient(engine: HttpClientEngine = CIO.create()) = HttpClient(engine) {
     expectSuccess = false
 
     install(Logging) {

--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -25,6 +25,7 @@ flyway {
 dependencies {
     implementation(projects.common.domain)
     implementation(projects.common.ktor)
+    implementation(projects.common.ktorClients)
     implementation(projects.common.database)
     implementation(projects.common.slack)
     implementation(projects.common.kafka)

--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -36,9 +36,6 @@ dependencies {
     implementation(libs.arrow.core)
 
     // Ktor
-    implementation(libs.ktor.client.cio)
-    implementation(libs.ktor.client.contentNegotiation)
-    implementation(libs.ktor.client.logging)
     testImplementation(libs.ktor.client.mock)
     implementation(libs.ktor.serialization.json)
     implementation(libs.ktor.server.defaultHeaders)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/arenaadapter/ArenaAdapterClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/arenaadapter/ArenaAdapterClientImpl.kt
@@ -7,7 +7,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.domain.dto.ArenaTiltaksgjennomforingsstatusDto
 import no.nav.mulighetsrommet.domain.dto.ExchangeArenaIdForIdResponse
 import org.slf4j.LoggerFactory

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/arenaadapter/ArenaAdapterClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/arenaadapter/ArenaAdapterClientImpl.kt
@@ -7,9 +7,9 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.domain.dto.ArenaTiltaksgjennomforingsstatusDto
 import no.nav.mulighetsrommet.domain.dto.ExchangeArenaIdForIdResponse
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import org.slf4j.LoggerFactory
 import java.util.*
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/dialog/VeilarbdialogClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/dialog/VeilarbdialogClientImpl.kt
@@ -8,7 +8,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.mulighetsrommet.api.services.DialogRequest
 import no.nav.mulighetsrommet.api.services.DialogResponse
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.secure_log.SecureLog
 import org.slf4j.LoggerFactory
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/AmtEnhetsregisterClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/AmtEnhetsregisterClientImpl.kt
@@ -7,7 +7,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.secure_log.SecureLog
 import org.slf4j.LoggerFactory
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -6,7 +6,7 @@ import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.secure_log.SecureLog
 import org.slf4j.LoggerFactory
 import java.util.*

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2ClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2ClientImpl.kt
@@ -4,7 +4,7 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.request.*
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import org.slf4j.LoggerFactory
 
 class Norg2ClientImpl(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
@@ -9,7 +9,7 @@ import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.prometheus.client.cache.caffeine.CacheMetricsCollector
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
 import no.nav.mulighetsrommet.secure_log.SecureLog
 import no.nav.mulighetsrommet.utils.CacheUtils

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/person/VeilarbpersonClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/person/VeilarbpersonClientImpl.kt
@@ -8,7 +8,7 @@ import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.prometheus.client.cache.caffeine.CacheMetricsCollector
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
 import no.nav.mulighetsrommet.secure_log.SecureLog
 import no.nav.mulighetsrommet.utils.CacheUtils

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VeilarbvedtaksstotteClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VeilarbvedtaksstotteClientImpl.kt
@@ -10,7 +10,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import kotlinx.serialization.decodeFromString
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
 import no.nav.mulighetsrommet.secure_log.SecureLog
 import no.nav.mulighetsrommet.serialization.json.JsonIgnoreUnknownKeys

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import no.nav.mulighetsrommet.api.domain.dto.FylkeResponse
 import no.nav.mulighetsrommet.api.domain.dto.SanityResponse
-import no.nav.mulighetsrommet.api.setup.http.httpJsonClient
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.api.utils.*
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
 import no.nav.mulighetsrommet.serialization.json.JsonIgnoreUnknownKeys

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -12,8 +12,8 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import no.nav.mulighetsrommet.api.domain.dto.FylkeResponse
 import no.nav.mulighetsrommet.api.domain.dto.SanityResponse
-import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.api.utils.*
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
 import no.nav.mulighetsrommet.serialization.json.JsonIgnoreUnknownKeys
 import no.nav.mulighetsrommet.utils.CacheUtils

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
@@ -28,7 +28,9 @@ internal fun httpJsonClient(engine: HttpClientEngine = CIO.create()) = HttpClien
     }
 
     defaultRequest {
-        header("Nav-Consumer-Id", "mulighetsrommet-api")
+        System.getenv("NAIS_APP_NAME")?.let {
+            header("Nav-Consumer-Id", it)
+        }
 
         MDC.get("call-id")?.let {
             header(HttpHeaders.XRequestId, it)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
@@ -1,4 +1,4 @@
-package no.nav.mulighetsrommet.api.setup.http
+package no.nav.mulighetsrommet.ktor.clients
 
 import io.ktor.client.*
 import io.ktor.client.engine.*
@@ -13,6 +13,7 @@ import org.slf4j.MDC
 
 internal fun httpJsonClient(engine: HttpClientEngine = CIO.create()) = HttpClient(engine) {
     expectSuccess = false
+
     install(ContentNegotiation) {
         json(
             Json {
@@ -20,8 +21,12 @@ internal fun httpJsonClient(engine: HttpClientEngine = CIO.create()) = HttpClien
             }
         )
     }
+
     defaultRequest {
         header("Nav-Consumer-Id", "mulighetsrommet-api")
-        MDC.get("call-id")?.let { header(HttpHeaders.XRequestId, it) }
+
+        MDC.get("call-id")?.let {
+            header(HttpHeaders.XRequestId, it)
+        }
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
@@ -5,6 +5,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
@@ -13,6 +14,10 @@ import org.slf4j.MDC
 
 internal fun httpJsonClient(engine: HttpClientEngine = CIO.create()) = HttpClient(engine) {
     expectSuccess = false
+
+    install(Logging) {
+        level = LogLevel.INFO
+    }
 
     install(ContentNegotiation) {
         json(

--- a/mulighetsrommet-arena-adapter/build.gradle.kts
+++ b/mulighetsrommet-arena-adapter/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(projects.common.kafka)
     implementation(projects.common.ktor)
     testImplementation(testFixtures(projects.common.ktor))
+    implementation(projects.common.ktorClients)
     implementation(projects.common.slack)
 
     // Kotlin
@@ -41,10 +42,6 @@ dependencies {
     implementation(libs.arrow.core)
 
     // Ktor
-    implementation(libs.ktor.client.cio)
-    implementation(libs.ktor.client.contentNegotiation)
-    implementation(libs.ktor.client.core)
-    implementation(libs.ktor.client.logging)
     testImplementation(libs.ktor.client.mock)
     implementation(libs.ktor.serialization.json)
     implementation(libs.ktor.server.auth)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/MulighetsrommetApiClient.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/MulighetsrommetApiClient.kt
@@ -5,12 +5,10 @@ import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.serialization.kotlinx.json.*
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import org.slf4j.LoggerFactory
 
 class MulighetsrommetApiClient(
@@ -28,13 +26,7 @@ class MulighetsrommetApiClient(
     private val client: HttpClient
 
     init {
-        client = HttpClient(engine) {
-            install(ContentNegotiation) {
-                json()
-            }
-            install(Logging) {
-                level = LogLevel.INFO
-            }
+        client = httpJsonClient(engine).config {
             install(HttpRequestRetry) {
                 retryIf(config.maxRetries) { _, response ->
                     response.status.value.let { it in 500..599 } || response.status == HttpStatusCode.Conflict
@@ -49,6 +41,7 @@ class MulighetsrommetApiClient(
                     logger.info("Retrying request method=${request.method.value}, url=${request.url.buildString()}")
                 }
             }
+
             defaultRequest {
                 contentType(ContentType.Application.Json)
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/clients/ArenaOrdsProxyClientImpl.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/clients/ArenaOrdsProxyClientImpl.kt
@@ -1,22 +1,17 @@
 package no.nav.mulighetsrommet.arena.adapter.clients
 
 import arrow.core.Either
-import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.cache.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import io.ktor.serialization.kotlinx.json.*
 import no.nav.mulighetsrommet.arena.adapter.models.dto.ArenaOrdsArrangor
 import no.nav.mulighetsrommet.arena.adapter.models.dto.ArenaOrdsFnr
-import no.nav.mulighetsrommet.serialization.json.JsonIgnoreUnknownKeys
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 
 class ArenaOrdsProxyClientImpl(
     engine: HttpClientEngine = CIO.create(),
@@ -26,22 +21,7 @@ class ArenaOrdsProxyClientImpl(
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    val client = HttpClient(engine) {
-        expectSuccess = false
-
-        install(ContentNegotiation) {
-            json(JsonIgnoreUnknownKeys)
-        }
-
-        install(Logging) {
-            level = LogLevel.INFO
-        }
-
-        defaultRequest {
-            header("Nav-Consumer-Id", "mulighetsrommet-arena-adapter")
-            MDC.get("call-id")?.let { header(HttpHeaders.XRequestId, it) }
-        }
-
+    val client = httpJsonClient(engine).config {
         install(HttpCache)
     }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/clients/ArenaOrdsProxyClientImpl.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/clients/ArenaOrdsProxyClientImpl.kt
@@ -8,6 +8,7 @@ import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
@@ -30,6 +31,10 @@ class ArenaOrdsProxyClientImpl(
 
         install(ContentNegotiation) {
             json(JsonIgnoreUnknownKeys)
+        }
+
+        install(Logging) {
+            level = LogLevel.INFO
         }
 
         defaultRequest {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,11 +3,12 @@ rootProject.name = "mulighetsrommet"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(
-    "common:ktor",
     "common:database",
     "common:domain",
-    "common:slack",
     "common:kafka",
+    "common:ktor",
+    "common:ktor-clients",
+    "common:slack",
     "mulighetsrommet-api",
     "mulighetsrommet-api-sanity-sync",
     "mulighetsrommet-arena-adapter",


### PR DESCRIPTION
Drev med litt feilsøking i går som hadde gått litt raskere om request-logging hadde vært konfigurert (i MulighetsrommetApiClient).

Endte opp med å trekke ut httpJsonClient til en fellesmodul slik at alle ktor clients basert på denne has basic request logging og tracing headers implementert by default.