### PR TITLE
:sparkles: Valider orgnr for leverandør på avtaler

### DIFF
--- a/frontend/mr-admin-flate/cypress/e2e/mr-admin-flate.cy.js
+++ b/frontend/mr-admin-flate/cypress/e2e/mr-admin-flate.cy.js
@@ -108,6 +108,13 @@ describe("Avtaler", () => {
       cy.getByTestId("registrer-ny-avtale").should("exist").click();
       cy.getByTestId("avtale_modal_header").contains("Registrer ny avtale");
     });
+
+    it("Skal validere organisasjonsnummer for leverandør på avtale", () => {
+      cy.visit("/avtaler");
+      cy.getByTestId("registrer-ny-avtale").should("exist").click();
+      cy.getByTestId("leverandor-input").type("123456789");
+      cy.getByTestId("leverandor-validert-navn").contains("Joblearn As");
+    });
   });
 });
 

--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.module.scss
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.module.scss
@@ -33,3 +33,12 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+.icon_text_align {
+  display: flex;
+  align-items: center;
+}
+
+.virksomhet {
+  margin-top: 0.5rem;
+}

--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.module.scss
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.module.scss
@@ -33,12 +33,3 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
-
-.icon_text_align {
-  display: flex;
-  align-items: center;
-}
-
-.virksomhet {
-  margin-top: 0.5rem;
-}

--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
@@ -121,6 +121,7 @@ export function OpprettAvtaleContainer({
     handleSubmit,
     formState: { errors },
     setError,
+    clearErrors,
   } = form;
 
   const postData: SubmitHandler<inferredSchema> = async (
@@ -169,6 +170,7 @@ export function OpprettAvtaleContainer({
           });
 
         virksomhetDispatcher({ type: "Data hentet", payload: response });
+        clearErrors("leverandor");
       } catch (error) {
         virksomhetDispatcher({ type: "Reset" });
         setError("leverandor", {

--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
@@ -162,14 +162,14 @@ export function OpprettAvtaleContainer({
     virksomhetDispatcher({ type: "Reset" });
     if (orgnr.trim().length === 9) {
       virksomhetDispatcher({ type: "Hent data" });
-      const response =
-        await mulighetsrommetClient.hentVirksomhet.hentVirksomhetMedOrgnr({
-          orgnr: orgnr.trim(),
-        });
+      try {
+        const response =
+          await mulighetsrommetClient.hentVirksomhet.hentVirksomhetMedOrgnr({
+            orgnr: orgnr.trim(),
+          });
 
-      if (response) {
         virksomhetDispatcher({ type: "Data hentet", payload: response });
-      } else {
+      } catch (error) {
         setError("leverandor", {
           message: `Fant ikke leverandør med nummer: ${orgnr}`,
         });

--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
@@ -170,6 +170,7 @@ export function OpprettAvtaleContainer({
 
         virksomhetDispatcher({ type: "Data hentet", payload: response });
       } catch (error) {
+        virksomhetDispatcher({ type: "Reset" });
         setError("leverandor", {
           message: `Fant ikke leverandør med nummer: ${orgnr}`,
         });

--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/virksomhetReducer.ts
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/virksomhetReducer.ts
@@ -1,8 +1,8 @@
-import { AmtVirksomhet } from "mulighetsrommet-api-client";
+import { Virksomhet } from "mulighetsrommet-api-client";
 
 interface State {
   status: "idle" | "fetching" | "fetched";
-  data: AmtVirksomhet | null;
+  data: Virksomhet | null;
 }
 
 type resetAction = {
@@ -15,7 +15,7 @@ type hentDataAction = {
 
 type dataHentetAction = {
   type: "Data hentet";
-  payload: AmtVirksomhet;
+  payload: Virksomhet;
 };
 
 type Actions = hentDataAction | dataHentetAction | resetAction;

--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/virksomhetReducer.ts
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/virksomhetReducer.ts
@@ -1,0 +1,37 @@
+import { AmtVirksomhet } from "mulighetsrommet-api-client";
+
+interface State {
+  status: "idle" | "fetching" | "fetched";
+  data: AmtVirksomhet | null;
+}
+
+type resetAction = {
+  type: "Reset";
+};
+
+type hentDataAction = {
+  type: "Hent data";
+};
+
+type dataHentetAction = {
+  type: "Data hentet";
+  payload: AmtVirksomhet;
+};
+
+type Actions = hentDataAction | dataHentetAction | resetAction;
+
+export const initialState: State = {
+  status: "idle",
+  data: null,
+};
+
+export function reducer(state: State, action: Actions): State {
+  switch (action.type) {
+    case "Reset":
+      return { ...state, status: "idle", data: null };
+    case "Hent data":
+      return { ...state, status: "fetching", data: null };
+    case "Data hentet":
+      return { ...state, status: "fetched", data: action.payload };
+  }
+}

--- a/frontend/mr-admin-flate/src/components/laster/Laster.module.scss
+++ b/frontend/mr-admin-flate/src/components/laster/Laster.module.scss
@@ -4,3 +4,10 @@
   align-items: center;
   flex-direction: column;
 }
+
+.laster_inline {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+}

--- a/frontend/mr-admin-flate/src/components/laster/Laster.tsx
+++ b/frontend/mr-admin-flate/src/components/laster/Laster.tsx
@@ -22,6 +22,13 @@ export function Laster({ tekst, sentrert = true, ...rest }: Props) {
         <BodyShort>{tekst}</BodyShort>
       </div>
     );
+  } else if (!sentrert && tekst) {
+    return (
+      <div className={styles.laster_inline}>
+        <Loader {...rest} />
+        <span>{tekst}</span>
+      </div>
+    );
   }
 
   return (

--- a/frontend/mr-admin-flate/src/components/virksomhet/VirksomhetInput.module.scss
+++ b/frontend/mr-admin-flate/src/components/virksomhet/VirksomhetInput.module.scss
@@ -1,0 +1,8 @@
+.icon_text_align {
+  display: flex;
+  align-items: center;
+}
+
+.virksomhet {
+  margin-top: 0.5rem;
+}

--- a/frontend/mr-admin-flate/src/components/virksomhet/VirksomhetInput.tsx
+++ b/frontend/mr-admin-flate/src/components/virksomhet/VirksomhetInput.tsx
@@ -63,6 +63,7 @@ export function VirksomhetInput({ avtale }: Props) {
           onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
             sjekkOrgnr(e.currentTarget.value),
         })}
+        data-testid="leverandor-input"
       />
       <div className={styles.virksomhet}>
         {virksomhetState.status === "fetching" ? (
@@ -70,6 +71,7 @@ export function VirksomhetInput({ avtale }: Props) {
         ) : null}
         {virksomhetState.status === "fetched" ? (
           <span
+            data-testid="leverandor-validert-navn"
             className={styles.icon_text_align}
             aria-label={`Fant virksomhet for orgnr: ${virksomhetState.data?.organisasjonsnummer} med navn ${virksomhetState.data?.navn}`}
           >

--- a/frontend/mr-admin-flate/src/components/virksomhet/VirksomhetInput.tsx
+++ b/frontend/mr-admin-flate/src/components/virksomhet/VirksomhetInput.tsx
@@ -1,0 +1,83 @@
+import { TextField } from "@navikt/ds-react";
+import { useFormContext } from "react-hook-form";
+import { inferredSchema } from "../avtaler/opprett/OpprettAvtaleContainer";
+import { CheckmarkIcon } from "@navikt/aksel-icons";
+import { useEffect, useReducer } from "react";
+import { mulighetsrommetClient } from "../../api/clients";
+import { capitalizeEveryWord } from "../../utils/Utils";
+import { reducer, initialState } from "../avtaler/opprett/virksomhetReducer";
+import { Laster } from "../laster/Laster";
+import { Avtale } from "mulighetsrommet-api-client";
+import styles from "./VirksomhetInput.module.scss";
+
+interface Props {
+  avtale?: Avtale;
+}
+
+export function VirksomhetInput({ avtale }: Props) {
+  const {
+    register,
+    formState: { errors },
+    setError,
+    clearErrors,
+  } = useFormContext<inferredSchema>();
+
+  useEffect(() => {
+    if (avtale?.leverandor?.organisasjonsnummer?.length === 9) {
+      sjekkOrgnr(avtale.leverandor.organisasjonsnummer);
+    }
+  }, [avtale?.leverandor]);
+
+  const [virksomhetState, virksomhetDispatcher] = useReducer(
+    reducer,
+    initialState
+  );
+
+  const sjekkOrgnr = async (orgnr: string) => {
+    virksomhetDispatcher({ type: "Reset" });
+    if (orgnr.trim().length === 9) {
+      virksomhetDispatcher({ type: "Hent data" });
+      try {
+        const response =
+          await mulighetsrommetClient.hentVirksomhet.hentVirksomhetMedOrgnr({
+            orgnr: orgnr.trim(),
+          });
+
+        virksomhetDispatcher({ type: "Data hentet", payload: response });
+        clearErrors("leverandor");
+      } catch (error) {
+        virksomhetDispatcher({ type: "Reset" });
+        setError("leverandor", {
+          message: `Fant ikke leverandør med nummer: ${orgnr}`,
+        });
+      }
+    }
+  };
+
+  return (
+    <div>
+      <TextField
+        error={errors.leverandor?.message}
+        label={"Leverandør"}
+        {...register("leverandor", {
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+            sjekkOrgnr(e.currentTarget.value),
+        })}
+      />
+      <div className={styles.virksomhet}>
+        {virksomhetState.status === "fetching" ? (
+          <Laster tekst="Henter virksomhet" sentrert={false} />
+        ) : null}
+        {virksomhetState.status === "fetched" ? (
+          <span
+            className={styles.icon_text_align}
+            aria-label={`Fant virksomhet for orgnr: ${virksomhetState.data?.organisasjonsnummer} med navn ${virksomhetState.data?.navn}`}
+          >
+            <CheckmarkIcon color="green" title="Fant virksomhet" />{" "}
+            {capitalizeEveryWord(virksomhetState.data?.navn)}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
+++ b/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
@@ -12,6 +12,7 @@ import {
   TiltaksgjennomforingNokkeltall,
   Tiltakstype,
   TiltakstypeNokkeltall,
+  Virksomhet,
 } from "mulighetsrommet-api-client";
 import { mockBetabruker } from "./fixtures/mock_ansatt";
 import { mockAvtaler } from "./fixtures/mock_avtaler";
@@ -21,6 +22,7 @@ import { mockTiltaksgjennomforinger } from "./fixtures/mock_tiltaksgjennomforing
 import { mockTiltakstyper } from "./fixtures/mock_tiltakstyper";
 import { mockTiltakstyperNokkeltall } from "./fixtures/mock_tiltakstyper_nokkeltall";
 import { mockTiltaksgjennomforingerNokkeltall } from "./fixtures/mock_tiltaksgjennomforinger_nokkeltall";
+import { mockVirksomhet } from "./fixtures/mock_virksomhet";
 
 export const apiHandlers = [
   rest.get<any, any, PaginertTiltakstype>(
@@ -235,4 +237,11 @@ export const apiHandlers = [
       ctx.json({ id: "d1f163b7-1a41-4547-af16-03fd4492b7ba" })
     );
   }),
+
+  rest.get<any, any, Virksomhet>(
+    "*/api/v1/internal/virksomhet/:orgnr",
+    (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(mockVirksomhet));
+    }
+  ),
 ];

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_virksomhet.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_virksomhet.ts
@@ -1,0 +1,8 @@
+import { Virksomhet } from "mulighetsrommet-api-client";
+
+export const mockVirksomhet: Virksomhet = {
+  navn: "Joblearn AS - Avd. Bergen",
+  organisasjonsnummer: "876456342",
+  overordnetEnhetNavn: "Joblearn AS",
+  overordnetEnhetOrganisasjonsnummer: "876456344",
+};

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -50,6 +50,7 @@ fun Application.configure(config: AppConfig) {
             dialogRoutes()
             delMedBrukerRoutes()
             enhetRoutes()
+            virksomhetRoutes()
         }
         authenticate(AuthProvider.AzureAdDefaultApp.name) {
             arenaAdapterRoutes()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/AmtEnhetsregisterClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/AmtEnhetsregisterClient.kt
@@ -1,5 +1,5 @@
 package no.nav.mulighetsrommet.api.clients.enhetsregister
 
 interface AmtEnhetsregisterClient {
-    suspend fun hentVirksomhet(virksomhetsnummer: Int): VirksomhetDto?
+    suspend fun hentVirksomhet(virksomhetsnummer: String): VirksomhetDto?
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/AmtEnhetsregisterClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/AmtEnhetsregisterClientImpl.kt
@@ -22,7 +22,7 @@ class AmtEnhetsregisterClientImpl(
         install(HttpCache)
     }
 
-    override suspend fun hentVirksomhet(virksomhetsnummer: Int): VirksomhetDto? {
+    override suspend fun hentVirksomhet(virksomhetsnummer: String): VirksomhetDto? {
         val response = client.get("$baseUrl/api/enhet/$virksomhetsnummer") {
             bearerAuth(tokenProvider.invoke())
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -211,7 +211,7 @@ private fun services(appConfig: AppConfig) = module {
         )
     }
     single { ArenaAdapterService(get(), get(), get(), get(), get(), get(), get()) }
-    single { AvtaleService(get(), get(), get(), get()) }
+    single { AvtaleService(get(), get(), get(), get(), get()) }
     single { TiltakshistorikkService(get(), get()) }
     single { SanityService(appConfig.sanity, get()) }
     single { ArrangorService(get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
@@ -1,0 +1,27 @@
+package no.nav.mulighetsrommet.api.routes.v1
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.mulighetsrommet.api.clients.enhetsregister.AmtEnhetsregisterClient
+import org.koin.ktor.ext.inject
+
+fun Route.virksomhetRoutes() {
+    val amtEnhetsregisterClientImpl: AmtEnhetsregisterClient by inject()
+    route("api/v1/internal/virksomhet") {
+        get("{orgnr}") {
+            val orgnr = call.parameters["orgnr"]?.toInt() ?: return@get call.respondText(
+                text = "Mangler eller ugyldig organisasjonsnummer",
+                status = HttpStatusCode.BadRequest,
+            )
+
+            val enhet = amtEnhetsregisterClientImpl.hentVirksomhet(orgnr) ?: return@get call.respondText(
+                text = "Fant ingen enhet med orgnr: $orgnr",
+                status = HttpStatusCode.NotFound
+            )
+
+            call.respond(enhet)
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
@@ -11,7 +11,7 @@ fun Route.virksomhetRoutes() {
     val amtEnhetsregisterClientImpl: AmtEnhetsregisterClient by inject()
     route("api/v1/internal/virksomhet") {
         get("{orgnr}") {
-            val orgnr = call.parameters["orgnr"]?.toInt() ?: return@get call.respondText(
+            val orgnr = call.parameters["orgnr"] ?: return@get call.respondText(
                 text = "Mangler eller ugyldig organisasjonsnummer",
                 status = HttpStatusCode.BadRequest,
             )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArrangorService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArrangorService.kt
@@ -27,7 +27,7 @@ class ArrangorService(
     suspend fun hentVirksomhet(virksomhetsnummer: String): VirksomhetDto? {
         return CacheUtils
             .tryCacheFirstNullable(cache, virksomhetsnummer) {
-                val virksomhet: VirksomhetDto? = virksomhetsnummer.let { amtEnhetsregisterClient.hentVirksomhet(it.toInt()) }
+                val virksomhet: VirksomhetDto? = virksomhetsnummer.let { amtEnhetsregisterClient.hentVirksomhet(it) }
                 virksomhet
             }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
@@ -30,11 +30,11 @@ class AvtaleService(
 
     suspend fun upsert(avtale: AvtaleRequest): QueryResult<AvtaleDbo> {
         val avtaleDbo = avtale.toDbo()
-        validerOrganisasjonsnummerForLeverandor(avtale.leverandorOrganisasjonsnummer.toInt())
+        validerOrganisasjonsnummerForLeverandor(avtale.leverandorOrganisasjonsnummer)
         return avtaler.upsert(avtaleDbo)
     }
 
-    private suspend fun validerOrganisasjonsnummerForLeverandor(leverandorOrganisasjonsnummer: Int) {
+    private suspend fun validerOrganisasjonsnummerForLeverandor(leverandorOrganisasjonsnummer: String) {
         amtEnhetsregisterClient.hentVirksomhet(leverandorOrganisasjonsnummer)
             ?: throw BadRequestException("Fant ikke virksomhet med organisasjonsnummer $leverandorOrganisasjonsnummer. Kan derfor ikke lagre avtalen.")
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
@@ -1,5 +1,7 @@
 package no.nav.mulighetsrommet.api.services
 
+import io.ktor.server.plugins.*
+import no.nav.mulighetsrommet.api.clients.enhetsregister.AmtEnhetsregisterClient
 import no.nav.mulighetsrommet.api.domain.dto.AvtaleNokkeltallDto
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
@@ -18,6 +20,7 @@ class AvtaleService(
     private val arrangorService: ArrangorService,
     private val navEnhetService: NavEnhetService,
     private val tiltaksgjennomforinger: TiltaksgjennomforingRepository,
+    private val amtEnhetsregisterClient: AmtEnhetsregisterClient
 ) {
     suspend fun get(id: UUID): AvtaleAdminDto? {
         return avtaler.get(id)
@@ -25,10 +28,15 @@ class AvtaleService(
             ?.hentVirksomhetsnavnForAvtale()
     }
 
-    fun upsert(avtale: AvtaleRequest): QueryResult<AvtaleDbo> {
+    suspend fun upsert(avtale: AvtaleRequest): QueryResult<AvtaleDbo> {
         val avtaleDbo = avtale.toDbo()
-        val result = avtaler.upsert(avtaleDbo)
-        return result
+        validerOrganisasjonsnummerForLeverandor(avtale.leverandorOrganisasjonsnummer.toInt())
+        return avtaler.upsert(avtaleDbo)
+    }
+
+    private suspend fun validerOrganisasjonsnummerForLeverandor(leverandorOrganisasjonsnummer: Int) {
+        amtEnhetsregisterClient.hentVirksomhet(leverandorOrganisasjonsnummer)
+            ?: throw BadRequestException("Fant ikke virksomhet med organisasjonsnummer $leverandorOrganisasjonsnummer. Kan derfor ikke lagre avtalen.")
     }
 
     fun delete(id: UUID): QueryResult<Int> {

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -800,7 +800,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/AmtVirksomhet"
+                  $ref: "#/components/schemas/Virksomhet"
 
 components:
   securitySchemes:
@@ -1624,7 +1624,7 @@ components:
         - FYLKE
         - TILTAK
 
-    AmtVirksomhet:
+    Virksomhet:
       type: object
       properties:
         organisasjonsnummer:

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -783,6 +783,25 @@ paths:
                 items:
                   $ref: "#/components/schemas/NavEnhet"
 
+  /api/v1/internal/virksomhet/{orgnr}:
+    get:
+      tags:
+        - Hent virksomhet
+      operationId: hentVirksomhetMedOrgnr
+      parameters:
+        - in: path
+          name: orgnr
+          schema:
+            type: string
+          description: Hvilket organisasjonsnummer tilhører virksomheten
+      responses:
+        200:
+          description: Virksomhet som matcher organisasjonsnummeret
+          content:
+            application/json:
+              schema:
+                  $ref: "#/components/schemas/AmtVirksomhet"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1604,3 +1623,18 @@ components:
         - LOKAL
         - FYLKE
         - TILTAK
+
+    AmtVirksomhet:
+      type: object
+      properties:
+        organisasjonsnummer:
+          type: string
+        navn:
+          type: string
+        overordnetEnhetOrganisasjonsnummer:
+          type: string
+        overordnetEnhetNavn:
+          type: string
+      required:
+        - organisasjonsnummer
+        - navn

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArrangorServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArrangorServiceTest.kt
@@ -15,13 +15,13 @@ class ArrangorServiceTest : FunSpec({
     val arrangorService = ArrangorService(amtEnhetsregister)
 
     beforeSpec {
-        coEvery { amtEnhetsregister.hentVirksomhet(111) } returns VirksomhetDto(
+        coEvery { amtEnhetsregister.hentVirksomhet("111") } returns VirksomhetDto(
             organisasjonsnummer = "789",
             navn = "Bedrift 1",
             overordnetEnhetOrganisasjonsnummer = "1011",
             overordnetEnhetNavn = "Overordnetbedrift 1"
         )
-        coEvery { amtEnhetsregister.hentVirksomhet(222) } returns VirksomhetDto(
+        coEvery { amtEnhetsregister.hentVirksomhet("222") } returns VirksomhetDto(
             organisasjonsnummer = "7891",
             navn = "Bedrift 2",
             overordnetEnhetOrganisasjonsnummer = "1011",


### PR DESCRIPTION
Validerer at nummeret bruker skriver inn for leverandør får treff i amt-enhet, så vi ikke lagrer virksomhetsnumre som ikke eksisterer. 

Viser en feilmelding og godkjenner ikke skjema for opprettelse og redigering av avtale dersom vi ikke finner virksomheten.
Validerer også data i backend.

![image](https://user-images.githubusercontent.com/9053627/232457859-b058f0ce-840e-4671-aa37-eb6d87d639f5.png)
