### PR TITLE
✨ Vis pris- og betalingsbet. for anskaffede tiltak

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
@@ -19,6 +19,7 @@ import {
 import { Datovelger } from "../../skjema/OpprettComponents";
 import { VirksomhetInput } from "../../virksomhet/VirksomhetInput";
 import styles from "./OpprettAvtaleContainer.module.scss";
+import { useNavigerTilAvtale } from "../../../hooks/useNavigerTilAvtale";
 
 interface OpprettAvtaleContainerProps {
   onAvbryt: () => void;

--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Select, TextField } from "@navikt/ds-react";
+import { Button, Select, TextField, Textarea } from "@navikt/ds-react";
 import classNames from "classnames";
 import { Avtale, AvtaleRequest, Avtaletype } from "mulighetsrommet-api-client";
 import { Ansatt } from "mulighetsrommet-api-client/build/models/Ansatt";
@@ -11,7 +11,11 @@ import { Dispatch, ReactNode, SetStateAction, useState } from "react";
 import z from "zod";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { mulighetsrommetClient } from "../../../api/clients";
-import { capitalize, formaterDatoSomYYYYMMDD } from "../../../utils/Utils";
+import {
+  capitalize,
+  formaterDatoSomYYYYMMDD,
+  tiltakstypekodeErAnskaffetTiltak,
+} from "../../../utils/Utils";
 import { Datovelger } from "../../skjema/OpprettComponents";
 import styles from "./OpprettAvtaleContainer.module.scss";
 import { useNavigerTilAvtale } from "../../../hooks/useNavigerTilAvtale";
@@ -57,6 +61,7 @@ const Schema = z.object({
     .nullable(),
   avtaleansvarlig: z.string().min(1, "Du må velge en avtaleansvarlig"),
   url: GyldigUrlHvisVerdi,
+  prisOgBetalingsinfo: z.string().optional(),
 });
 
 export type inferredSchema = z.infer<typeof Schema>;
@@ -89,13 +94,20 @@ export function OpprettAvtaleContainer({
       startDato: avtale?.startDato ? new Date(avtale.startDato) : null,
       sluttDato: avtale?.sluttDato ? new Date(avtale.sluttDato) : null,
       url: avtale?.url || "",
+      prisOgBetalingsinfo: avtale?.prisbetingelser || undefined,
     },
   });
   const {
     register,
     handleSubmit,
     formState: { errors },
+    watch,
   } = form;
+
+  const erAnskaffetTiltak = (tiltakstypeId: string): boolean => {
+    const tiltakstype = tiltakstyper.find((type) => type.id === tiltakstypeId);
+    return tiltakstypekodeErAnskaffetTiltak(tiltakstype?.arenaKode);
+  };
 
   const postData: SubmitHandler<inferredSchema> = async (
     data
@@ -115,6 +127,9 @@ export function OpprettAvtaleContainer({
       url: data.url,
       ansvarlig: data.avtaleansvarlig,
       avtaletype: data.avtaletype,
+      prisOgBetalingsinformasjon: erAnskaffetTiltak(data.tiltakstype)
+        ? data.prisOgBetalingsinfo
+        : undefined,
     };
 
     if (avtale?.id) {
@@ -232,6 +247,16 @@ export function OpprettAvtaleContainer({
             {...register("url")}
           />
         </FormGroup>
+        {erAnskaffetTiltak(watch("tiltakstype")) ? (
+          <FormGroup>
+            <Textarea
+              error={errors.prisOgBetalingsinfo?.message}
+              label="Pris og betalingsinformasjon"
+              {...register("prisOgBetalingsinfo")}
+            />
+          </FormGroup>
+        ) : null}
+
         <FormGroup cols={2}>
           <Select
             error={errors.avtaleansvarlig?.message}

--- a/frontend/mr-admin-flate/src/constants.ts
+++ b/frontend/mr-admin-flate/src/constants.ts
@@ -28,3 +28,13 @@ export const forsideKort: { navn: string; url: string; tekst?: string }[] = [
     tekst: "Her finner du informasjon om tiltaksgjennomføringer",
   },
 ];
+
+export const ANSKAFFEDE_TILTAK = [
+  "ARBRRHDAG",
+  "AVKLARAG",
+  "GRUPPEAMO",
+  "INDOPPFAG",
+  "DIGIOPPARB",
+  "JOBBK",
+  "GRUFAGYRKE",
+];

--- a/frontend/mr-admin-flate/src/pages/avtaler/Avtaleinfo.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/Avtaleinfo.tsx
@@ -4,7 +4,11 @@ import { useAvtale } from "../../api/avtaler/useAvtale";
 import { useFeatureToggles } from "../../api/features/feature-toggles";
 import { Metadata, Separator } from "../../components/detaljside/Metadata";
 import { Laster } from "../../components/laster/Laster";
-import { capitalizeEveryWord, formaterDato } from "../../utils/Utils";
+import {
+  capitalizeEveryWord,
+  formaterDato,
+  tiltakstypekodeErAnskaffetTiltak,
+} from "../../utils/Utils";
 import styles from "../DetaljerInfo.module.scss";
 import { NavLink, useParams } from "react-router-dom";
 import OpprettAvtaleModal from "../../components/avtaler/opprett/OpprettAvtaleModal";
@@ -78,16 +82,21 @@ export function Avtaleinfo() {
           <Metadata header="Avtalenr" verdi={avtale.avtalenummer} />
         </div>
         <Separator />
-        <div>
-          <Metadata
-            header="Pris og betalingsbetingelser"
-            verdi={
-              avtale.prisbetingelser ??
-              "Det eksisterer ikke pris og betalingsbetingelser for denne avtalen"
-            }
-          />
-        </div>
-        <Separator />
+
+        {tiltakstypekodeErAnskaffetTiltak(avtale.tiltakstype.arenaKode) ? (
+          <>
+            <div>
+              <Metadata
+                header="Pris og betalingsbetingelser"
+                verdi={
+                  avtale.prisbetingelser ??
+                  "Det eksisterer ikke pris og betalingsbetingelser for denne avtalen"
+                }
+              />
+            </div>
+            <Separator />
+          </>
+        ) : null}
 
         {avtale.ansvarlig && (
           <div>

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -103,3 +103,19 @@ export const oversettStatusForTiltaksgjennomforing = (
       return "";
   }
 };
+
+export const tiltakstypekodeErAnskaffetTiltak = (
+  tiltakstypekode?: string
+): boolean => {
+  if (!tiltakstypekode) return false;
+
+  return [
+    "ARBRRHDAG",
+    "AVKLARAG",
+    "GRUPPEAMO",
+    "INDOPPFAG",
+    "DIGIOPPARB",
+    "JOBBK",
+    "GRUFAGYRKE",
+  ].includes(tiltakstypekode);
+};

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -1,4 +1,5 @@
 import { TiltaksgjennomforingStatus } from "mulighetsrommet-api-client/build/models/TiltaksgjennomforingStatus";
+import { ANSKAFFEDE_TILTAK } from "../constants";
 
 export function capitalize(text?: string): string {
   return text
@@ -109,13 +110,5 @@ export const tiltakstypekodeErAnskaffetTiltak = (
 ): boolean => {
   if (!tiltakstypekode) return false;
 
-  return [
-    "ARBRRHDAG",
-    "AVKLARAG",
-    "GRUPPEAMO",
-    "INDOPPFAG",
-    "DIGIOPPARB",
-    "JOBBK",
-    "GRUFAGYRKE",
-  ].includes(tiltakstypekode);
+  return ANSKAFFEDE_TILTAK.includes(tiltakstypekode);
 };

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -102,7 +102,8 @@ data class AvtaleRequest(
     val antallPlasser: Int,
     val url: String,
     val ansvarlig: String,
-    val avtaletype: Avtaletype
+    val avtaletype: Avtaletype,
+    val prisOgBetalingsinformasjon: String? = null
 ) {
     fun toDbo(): AvtaleDbo {
         return AvtaleDbo(
@@ -119,7 +120,8 @@ data class AvtaleRequest(
             antallPlasser = antallPlasser,
             url = url,
             opphav = AvtaleDbo.Opphav.MR_ADMIN_FLATE,
-            ansvarlige = listOf(ansvarlig)
+            ansvarlige = listOf(ansvarlig),
+            prisbetingelser = prisOgBetalingsinformasjon
         )
     }
 }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -985,6 +985,8 @@ components:
           type: string
         avtaletype:
           $ref: "#/components/schemas/Avtaletype"
+        prisOgBetalingsinformasjon:
+          type: string
       required:
         - tiltakstypeId
         - navn


### PR DESCRIPTION
Viser bare pris- og betalingsbetingelser for anskaffede tiltak.
Dersom bruker velger en tiltakstype som er anskaffet og så skriver i pris- og betalingsfeltet, for så å velge en tiltakstype som ikke er anskaffet så tar jeg ikke vare på innholdet som er skrevet inn.

**Tiltakstype oppfølging er anskaffet**
![image](https://user-images.githubusercontent.com/9053627/232469347-8f0f8799-490f-425a-bf4c-d43717813709.png)

**AFT er ikke anskaffet**
![image](https://user-images.githubusercontent.com/9053627/232469453-5962e252-744c-49f7-a91b-db926063d5b9.png)
