### PR TITLE
Henter ut overordnet enhet fra NORG og lagrer på enhet-tabell

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2Client.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2Client.kt
@@ -1,5 +1,5 @@
 package no.nav.mulighetsrommet.api.clients.norg2
 
 interface Norg2Client {
-    suspend fun hentEnheter(): List<Norg2EnhetDto>
+    suspend fun hentEnheter(): List<Norg2Response>
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2ClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2ClientImpl.kt
@@ -13,9 +13,13 @@ class Norg2ClientImpl(
 ) : Norg2Client {
     private val log = LoggerFactory.getLogger(javaClass)
     private val client = httpJsonClient(clientEngine)
-    override suspend fun hentEnheter(): List<Norg2EnhetDto> {
+    override suspend fun hentEnheter(): List<Norg2Response> {
         return try {
-            val response = client.get("$baseUrl/enhet")
+            val response = client.get("$baseUrl/enhet/kontaktinformasjon/organisering/all") {
+                headers {
+                    this.append("consumerId", "team-mulighetsrommet-enhet-sync")
+                }
+            }
             response.body()
         } catch (exe: Exception) {
             log.error("Klarte ikke hente enheter fra NORG2. Konsekvensen er at oppdatering av enheter mot database ikke blir kjørt")

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2EnhetDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2EnhetDto.kt
@@ -2,8 +2,12 @@ package no.nav.mulighetsrommet.api.clients.norg2
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
-import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
+
+@Serializable
+data class Norg2Response(
+    val enhet: Norg2EnhetDto,
+    val overordnetEnhet: String?
+)
 
 @Serializable
 data class Norg2EnhetDto(
@@ -12,17 +16,7 @@ data class Norg2EnhetDto(
     val enhetNr: String,
     val status: Norg2EnhetStatus,
     val type: Norg2Type
-) {
-    fun toNavEnhetDbo(): NavEnhetDbo {
-        return NavEnhetDbo(
-            enhetId = enhetId,
-            navn = navn,
-            enhetNr = enhetNr,
-            status = NavEnhetStatus.valueOf(status.name),
-            type = Norg2Type.valueOf(type.name)
-        )
-    }
-}
+)
 
 @Serializable
 enum class Norg2EnhetStatus {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavEnhetDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavEnhetDbo.kt
@@ -5,7 +5,6 @@ import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 
 @Serializable
 data class NavEnhetDbo(
-    val enhetId: Int,
     val navn: String,
     val enhetNr: String,
     val status: NavEnhetStatus,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavEnhetDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavEnhetDbo.kt
@@ -9,7 +9,8 @@ data class NavEnhetDbo(
     val navn: String,
     val enhetNr: String,
     val status: NavEnhetStatus,
-    val type: Norg2Type
+    val type: Norg2Type,
+    val overordnetEnhet: String?
 )
 
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepository.kt
@@ -21,13 +21,14 @@ class EnhetRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            insert into enhet(enhet_id, navn, enhetsnummer, status, type)
-            values (:enhet_id, :navn, :enhetsnummer, :status, :type)
+            insert into enhet(enhet_id, navn, enhetsnummer, status, type, overordnet_enhet)
+            values (:enhet_id, :navn, :enhetsnummer, :status, :type, :overordnet_enhet)
             on conflict (enhet_id)
                 do update set   navn            = excluded.navn,
                                 enhetsnummer    = excluded.enhetsnummer,
                                 status          = excluded.status,
-                                type            = excluded.type
+                                type            = excluded.type,
+                                overordnet_enhet = excluded.overordnet_enhet
             returning *
         """.trimIndent()
 
@@ -50,7 +51,7 @@ class EnhetRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            select distinct e.navn,(e.enhetsnummer), e.enhet_id, e.status, e.type
+            select distinct e.navn,(e.enhetsnummer), e.enhet_id, e.status, e.type, e.overordnet_enhet
             from enhet e
             $where
             order by e.navn asc
@@ -77,7 +78,7 @@ class EnhetRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            select distinct e.navn,(e.enhetsnummer), e.enhet_id, e.status, e.type
+            select distinct e.navn,(e.enhetsnummer), e.enhet_id, e.status, e.type, e.overordnet_enhet
             from enhet e
             join avtale a
             on a.enhet = e.enhetsnummer
@@ -94,7 +95,7 @@ class EnhetRepository(private val db: Database) {
     fun get(enhet: String): NavEnhetDbo? {
         @Language("PostgreSQL")
         val query = """
-            select navn, enhet_id, enhetsnummer, status, type
+            select navn, enhet_id, enhetsnummer, status, type, overordnet_enhet
             from enhet
             where enhetsnummer = ?
         """.trimIndent()
@@ -128,7 +129,8 @@ private fun NavEnhetDbo.toSqlParameters() = mapOf(
     "navn" to navn,
     "enhetsnummer" to enhetNr,
     "status" to status.name,
-    "type" to type.name
+    "type" to type.name,
+    "overordnet_enhet" to overordnetEnhet
 )
 
 private fun Row.toEnhetDbo() = NavEnhetDbo(
@@ -136,5 +138,6 @@ private fun Row.toEnhetDbo() = NavEnhetDbo(
     navn = string("navn"),
     enhetNr = string("enhetsnummer"),
     status = NavEnhetStatus.valueOf(string("status")),
-    type = Norg2Type.valueOf(string("type"))
+    type = Norg2Type.valueOf(string("type")),
+    overordnetEnhet = stringOrNull("overordnet_enhet")
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
@@ -1,7 +1,8 @@
 package no.nav.mulighetsrommet.api.services
 
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Client
-import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetDto
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetStatus
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Response
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
@@ -10,27 +11,29 @@ import org.slf4j.LoggerFactory
 
 class Norg2Service(private val norg2Client: Norg2Client, private val enhetRepository: EnhetRepository) {
     private val log = LoggerFactory.getLogger(javaClass)
-    suspend fun synkroniserEnheter(): List<Norg2EnhetDto> {
+    suspend fun synkroniserEnheter(): List<Norg2Response> {
         val whitelistTyper = listOf(Norg2Type.FYLKE, Norg2Type.TILTAK, Norg2Type.LOKAL)
+        val whitelistStatus = listOf(Norg2EnhetStatus.AKTIV, Norg2EnhetStatus.UNDER_AVVIKLING, Norg2EnhetStatus.UNDER_ETABLERING)
         val alleEnheter = norg2Client.hentEnheter()
-        val (tilLagring, tilSletting) = alleEnheter.partition { it.type in whitelistTyper }
+        val (tilLagring, tilSletting) = alleEnheter.partition { it.enhet.type in whitelistTyper && it.enhet.status in whitelistStatus }
         log.info("Hentet ${alleEnheter.size} enheter fra NORG2. Sletter potensielt ${tilSletting.size} enheter som ikke har en whitelistet type ($whitelistTyper). Lagrer ${tilLagring.size} enheter fra NORG2 med type = $whitelistTyper")
 
-        slettEnheterSomIkkeHarWhitelistetType(tilSletting.map { it.enhetId })
+        slettEnheterSomIkkeHarWhitelistetType(tilSletting.map { it.enhet.enhetId })
         lagreEnheter(tilLagring)
 
         return tilLagring
     }
 
-    private fun lagreEnheter(enheter: List<Norg2EnhetDto>) {
+    private fun lagreEnheter(enheter: List<Norg2Response>) {
         enheter.forEach {
             enhetRepository.upsert(
                 NavEnhetDbo(
-                    enhetId = it.enhetId,
-                    navn = it.navn,
-                    enhetNr = it.enhetNr,
-                    status = NavEnhetStatus.valueOf(it.status.name),
-                    type = Norg2Type.valueOf(it.type.name)
+                    enhetId = it.enhet.enhetId,
+                    navn = it.enhet.navn,
+                    enhetNr = it.enhet.enhetNr,
+                    status = NavEnhetStatus.valueOf(it.enhet.status.name),
+                    type = Norg2Type.valueOf(it.enhet.type.name),
+                    overordnetEnhet = it.overordnetEnhet
                 )
             )
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
@@ -18,7 +18,7 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
         val (tilLagring, tilSletting) = alleEnheter.partition { it.enhet.type in whitelistTyper && it.enhet.status in whitelistStatus }
         log.info("Hentet ${alleEnheter.size} enheter fra NORG2. Sletter potensielt ${tilSletting.size} enheter som ikke har en whitelistet type ($whitelistTyper). Lagrer ${tilLagring.size} enheter fra NORG2 med type = $whitelistTyper")
 
-        slettEnheterSomIkkeHarWhitelistetType(tilSletting.map { it.enhet.enhetId })
+        slettEnheterSomIkkeHarWhitelistetType(tilSletting.map { it.enhet.enhetNr })
         lagreEnheter(tilLagring)
 
         return tilLagring
@@ -28,7 +28,6 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
         enheter.forEach {
             enhetRepository.upsert(
                 NavEnhetDbo(
-                    enhetId = it.enhet.enhetId,
                     navn = it.enhet.navn,
                     enhetNr = it.enhet.enhetNr,
                     status = NavEnhetStatus.valueOf(it.enhet.status.name),
@@ -39,7 +38,7 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
         }
     }
 
-    private fun slettEnheterSomIkkeHarWhitelistetType(ider: List<Int>) {
-        enhetRepository.deleteWhereIds(ider)
+    private fun slettEnheterSomIkkeHarWhitelistetType(ider: List<String>) {
+        enhetRepository.deleteWhereEnhetsnummer(ider)
     }
 }

--- a/mulighetsrommet-api/src/main/resources/db/migration/V47__overordnet_enhet_for_enhet_tabell.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V47__overordnet_enhet_for_enhet_tabell.sql
@@ -1,4 +1,10 @@
 alter table enhet
-    add column overordnet_enhet text;
+    drop column enhet_id;
+
+alter table enhet
+    add constraint enhetsnummer_pk primary key (enhetsnummer);
+
+alter table enhet
+    add column overordnet_enhet text references enhet(enhetsnummer);
 
 create index enhet_overordnet_enhet_idx on enhet(overordnet_enhet);

--- a/mulighetsrommet-api/src/main/resources/db/migration/V47__overordnet_enhet_for_enhet_tabell.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V47__overordnet_enhet_for_enhet_tabell.sql
@@ -1,0 +1,4 @@
+alter table enhet
+    add column overordnet_enhet text;
+
+create index enhet_overordnet_enhet_idx on enhet(overordnet_enhet);

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/Norg2Fixture.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/Norg2Fixture.kt
@@ -18,7 +18,6 @@ object Norg2EnhetFixture {
 
 object NavEnhetDboFixture {
     val enhetDbo = NavEnhetDbo(
-        enhetId = Math.random().toInt(),
         enhetNr = "1000",
         navn = "Enhet X",
         status = NavEnhetStatus.AKTIV,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/Norg2Fixture.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/Norg2Fixture.kt
@@ -3,6 +3,8 @@ package no.nav.mulighetsrommet.api.fixtures
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetDto
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetStatus
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
+import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
+import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
 
 object Norg2EnhetFixture {
     val enhet = Norg2EnhetDto(
@@ -10,6 +12,17 @@ object Norg2EnhetFixture {
         enhetNr = "1000",
         navn = "Enhet X",
         status = Norg2EnhetStatus.AKTIV,
-        type = Norg2Type.LOKAL
+        type = Norg2Type.LOKAL,
+    )
+}
+
+object NavEnhetDboFixture {
+    val enhetDbo = NavEnhetDbo(
+        enhetId = Math.random().toInt(),
+        enhetNr = "1000",
+        navn = "Enhet X",
+        status = NavEnhetStatus.AKTIV,
+        type = Norg2Type.LOKAL,
+        overordnetEnhet = "1200"
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepositoryTest.kt
@@ -3,7 +3,7 @@ package no.nav.mulighetsrommet.api.repositories
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
-import no.nav.mulighetsrommet.api.fixtures.Norg2EnhetFixture
+import no.nav.mulighetsrommet.api.fixtures.NavEnhetDboFixture
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.utils.getOrThrow
 
@@ -19,11 +19,11 @@ class EnhetRepositoryTest : FunSpec({
         val enheter = EnhetRepository(database.db)
 
         test("Skal slette enheter fra liste med id'er") {
-            val enhetSomSkalSlettes1 = Norg2EnhetFixture.enhet.copy(enhetId = 1).toNavEnhetDbo()
-            val enhetSomSkalSlettes2 = Norg2EnhetFixture.enhet.copy(enhetId = 2).toNavEnhetDbo()
-            val enhetSomSkalSlettes3 = Norg2EnhetFixture.enhet.copy(enhetId = 3).toNavEnhetDbo()
-            val enhetSomSkalBeholdes1 = Norg2EnhetFixture.enhet.copy(enhetId = 4).toNavEnhetDbo()
-            val enhetSomSkalBeholdes2 = Norg2EnhetFixture.enhet.copy(enhetId = 5).toNavEnhetDbo()
+            val enhetSomSkalSlettes1 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 1)
+            val enhetSomSkalSlettes2 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 2)
+            val enhetSomSkalSlettes3 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 3)
+            val enhetSomSkalBeholdes1 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 4)
+            val enhetSomSkalBeholdes2 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 5)
 
             enheter.upsert(enhetSomSkalSlettes1).getOrThrow()
             enheter.upsert(enhetSomSkalSlettes2).getOrThrow()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepositoryTest.kt
@@ -19,12 +19,14 @@ class EnhetRepositoryTest : FunSpec({
         val enheter = EnhetRepository(database.db)
 
         test("Skal slette enheter fra liste med id'er") {
-            val enhetSomSkalSlettes1 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 1)
-            val enhetSomSkalSlettes2 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 2)
-            val enhetSomSkalSlettes3 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 3)
-            val enhetSomSkalBeholdes1 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 4)
-            val enhetSomSkalBeholdes2 = NavEnhetDboFixture.enhetDbo.copy(enhetId = 5)
+            val enhetSomSkalSlettes1 = NavEnhetDboFixture.enhetDbo.copy(enhetNr = "1")
+            val enhetSomSkalSlettes2 = NavEnhetDboFixture.enhetDbo.copy(enhetNr = "2")
+            val enhetSomSkalSlettes3 = NavEnhetDboFixture.enhetDbo.copy(enhetNr = "3")
+            val enhetSomSkalBeholdes1 = NavEnhetDboFixture.enhetDbo.copy(enhetNr = "4")
+            val enhetSomSkalBeholdes2 = NavEnhetDboFixture.enhetDbo.copy(enhetNr = "5")
+            val overordnetEnhet = NavEnhetDboFixture.enhetDbo.copy(enhetNr = "1200")
 
+            enheter.upsert(overordnetEnhet).getOrThrow()
             enheter.upsert(enhetSomSkalSlettes1).getOrThrow()
             enheter.upsert(enhetSomSkalSlettes2).getOrThrow()
             enheter.upsert(enhetSomSkalSlettes3).getOrThrow()
@@ -32,12 +34,12 @@ class EnhetRepositoryTest : FunSpec({
             enheter.upsert(enhetSomSkalBeholdes2).getOrThrow()
 
             val count = enheter.getAll().size
-            count shouldBe 5
+            count shouldBe 6
 
-            val idErForSletting = listOf(1, 2, 3)
-            enheter.deleteWhereIds(idErForSletting)
+            val idErForSletting = listOf("1", "2", "3")
+            enheter.deleteWhereEnhetsnummer(idErForSletting)
             val countAfterDeletion = enheter.getAll().size
-            countAfterDeletion shouldBe 2
+            countAfterDeletion shouldBe 3
         }
     }
 })

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/Norg2ServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/Norg2ServiceTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Client
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Response
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.fixtures.Norg2EnhetFixture
 import no.nav.mulighetsrommet.api.repositories.EnhetRepository
@@ -16,9 +17,18 @@ class Norg2ServiceTest : FunSpec({
 
     test("Synkroniser enheter skal slette enheter som ikke tilfredstiller whitelist") {
         val mockEnheter = listOf(
-            Norg2EnhetFixture.enhet.copy(enhetId = 1, type = Norg2Type.AAREG),
-            Norg2EnhetFixture.enhet.copy(enhetId = 2),
-            Norg2EnhetFixture.enhet.copy(enhetId = 3)
+            Norg2Response(
+                enhet = Norg2EnhetFixture.enhet.copy(enhetId = 1, type = Norg2Type.AAREG),
+                overordnetEnhet = "1200"
+            ),
+            Norg2Response(
+                enhet = Norg2EnhetFixture.enhet.copy(enhetId = 2),
+                overordnetEnhet = "1200"
+            ),
+            Norg2Response(
+                enhet = Norg2EnhetFixture.enhet.copy(enhetId = 3),
+                overordnetEnhet = "1400"
+            ),
         )
 
         coEvery {
@@ -27,7 +37,9 @@ class Norg2ServiceTest : FunSpec({
 
         val tilLagring = norg2Service.synkroniserEnheter()
         tilLagring.size shouldBe 2
-        tilLagring[0].enhetId shouldBe 2
-        tilLagring[1].enhetId shouldBe 3
+        tilLagring[0].enhet.enhetId shouldBe 2
+        tilLagring[0].overordnetEnhet shouldBe "1200"
+        tilLagring[1].enhet.enhetId shouldBe 3
+        tilLagring[1].overordnetEnhet shouldBe "1400"
     }
 })


### PR DESCRIPTION
Vi trenger overordnet enhet for å kunne hente ut underenheter til en hovedenhet for videre utvikling av admin-flate. 
Tar også og fjerner nedlagte nav-kontorer. 