### PR TITLE
Chore/upgrade ktlint gradle plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 root = true
 
 [*]
-disabled_rules = no-wildcard-imports
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
@@ -10,6 +9,9 @@ trim_trailing_whitespace = true
 [*.{kt,kts}]
 indent_size = 4
 indent_style = space
+
+# Custom config to override `ktlint` defaults
+ktlint_standard_no-wildcard-imports = disabled
 
 [*.{js,ts,tsx,json}]
 indent_size = 2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 group = "no.nav.mulighetsrommet"
 version = "0.0.1"
@@ -14,6 +15,13 @@ plugins {
 }
 
 allprojects {
+    // Apply ktlint for all projects
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    configure<KtlintExtension> {
+        version.set("0.48.2")
+    }
+
     tasks.withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "17"
     }

--- a/common/database/build.gradle.kts
+++ b/common/database/build.gradle.kts
@@ -1,11 +1,6 @@
 plugins {
     `java-test-fixtures`
     alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.ktlint)
-}
-
-ktlint {
-    disabledRules.addAll("no-wildcard-imports")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/common/domain/.gitattributes
+++ b/common/domain/.gitattributes
@@ -1,6 +1,0 @@
-#
-# https://help.github.com/articles/dealing-with-line-endings/
-#
-# These are explicitly windows files and should use crlf
-*.bat           text eol=crlf
-

--- a/common/domain/.gitignore
+++ b/common/domain/.gitignore
@@ -1,5 +1,0 @@
-# Ignore Gradle project-specific cache directory
-.gradle
-
-# Ignore Gradle build output directory
-build

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/Avslutningsstatus.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/Avslutningsstatus.kt
@@ -4,7 +4,8 @@ enum class Avslutningsstatus {
     AVLYST,
     AVBRUTT,
     AVSLUTTET,
-    IKKE_AVSLUTTET;
+    IKKE_AVSLUTTET,
+    ;
 
     companion object {
         fun fromArenastatus(arenaStatus: String): Avslutningsstatus {

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakshistorikkDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakshistorikkDbo.kt
@@ -32,7 +32,7 @@ sealed class TiltakshistorikkDbo {
         @Serializable(with = LocalDateTimeSerializer::class)
         override val tilDato: LocalDateTime? = null,
         @Serializable(with = UUIDSerializer::class)
-        val tiltaksgjennomforingId: UUID
+        val tiltaksgjennomforingId: UUID,
     ) : TiltakshistorikkDbo()
 
     @Serializable
@@ -48,6 +48,6 @@ sealed class TiltakshistorikkDbo {
         val beskrivelse: String,
         @Serializable(with = UUIDSerializer::class)
         val tiltakstypeId: UUID,
-        val virksomhetsnummer: String
+        val virksomhetsnummer: String,
     ) : TiltakshistorikkDbo()
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakstypeDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakstypeDbo.kt
@@ -22,5 +22,5 @@ data class TiltakstypeDbo(
     val fraDato: LocalDate,
     @Serializable(with = LocalDateSerializer::class)
     val tilDato: LocalDate,
-    val rettPaaTiltakspenger: Boolean
+    val rettPaaTiltakspenger: Boolean,
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/ArenaTiltaksgjennomforingsstatusDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/ArenaTiltaksgjennomforingsstatusDto.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ArenaTiltaksgjennomforingsstatusDto(
-    val status: String
+    val status: String,
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/AvtaleAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/AvtaleAdminDto.kt
@@ -37,7 +37,7 @@ data class AvtaleAdminDto(
     @Serializable
     data class NavEnhet(
         val enhetsnummer: String,
-        val navn: String? = null
+        val navn: String? = null,
     )
 
     @Serializable

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Avtalestatus.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Avtalestatus.kt
@@ -7,14 +7,15 @@ enum class Avtalestatus {
     Planlagt,
     Aktiv,
     Avsluttet,
-    Avbrutt;
+    Avbrutt,
+    ;
 
     companion object {
         fun resolveFromDatesAndAvslutningsstatus(
             now: LocalDate,
             startDato: LocalDate,
             sluttDato: LocalDate,
-            avslutningsstatus: Avslutningsstatus
+            avslutningsstatus: Avslutningsstatus,
         ): Avtalestatus = when {
             avslutningsstatus == Avslutningsstatus.AVBRUTT -> Avbrutt
             avslutningsstatus == Avslutningsstatus.AVSLUTTET -> Avsluttet

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/ExchangeArenaIdForIdResponse.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/ExchangeArenaIdForIdResponse.kt
@@ -7,6 +7,5 @@ import java.util.*
 @Serializable
 data class ExchangeArenaIdForIdResponse(
     @Serializable(with = UUIDSerializer::class)
-    val id: UUID
+    val id: UUID,
 )
-

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -34,6 +34,6 @@ data class TiltaksgjennomforingAdminDto(
         @Serializable(with = UUIDSerializer::class)
         val id: UUID,
         val navn: String,
-        val arenaKode: String
+        val arenaKode: String,
     )
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
@@ -17,14 +17,14 @@ data class TiltaksgjennomforingDto(
     @Serializable(with = LocalDateSerializer::class)
     val sluttDato: LocalDate? = null,
     val status: Tiltaksgjennomforingsstatus,
-    val virksomhetsnummer: String
+    val virksomhetsnummer: String,
 ) {
     @Serializable
     data class Tiltakstype(
         @Serializable(with = UUIDSerializer::class)
         val id: UUID,
         val navn: String,
-        val arenaKode: String
+        val arenaKode: String,
     )
 
     companion object {
@@ -40,7 +40,7 @@ data class TiltaksgjennomforingDto(
                 startDato = tiltaksgjennomforing.startDato,
                 sluttDato = tiltaksgjennomforing.sluttDato,
                 status = tiltaksgjennomforing.status,
-                virksomhetsnummer = tiltaksgjennomforing.virksomhetsnummer
+                virksomhetsnummer = tiltaksgjennomforing.virksomhetsnummer,
             )
     }
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingsArenadataDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingsArenadataDto.kt
@@ -8,7 +8,7 @@ data class TiltaksgjennomforingsArenadataDto(
     val lopenr: Int?,
     val virksomhetsnummer: String?,
     val ansvarligNavEnhetId: String?,
-    val status: String
+    val status: String,
 ) {
     companion object {
         fun from(tiltaksgjennomforing: TiltaksgjennomforingAdminDto, status: String) = tiltaksgjennomforing.run {
@@ -17,7 +17,7 @@ data class TiltaksgjennomforingsArenadataDto(
                 lopenr = tiltaksnummer?.split("#")?.get(1)?.toInt(),
                 virksomhetsnummer = virksomhetsnummer,
                 ansvarligNavEnhetId = arenaAnsvarligEnhet,
-                status = status
+                status = status,
             )
         }
     }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Tiltaksgjennomforingsstatus.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Tiltaksgjennomforingsstatus.kt
@@ -10,14 +10,15 @@ enum class Tiltaksgjennomforingsstatus {
     AVBRUTT,
     AVLYST,
     AVSLUTTET,
-    APENT_FOR_INNSOK;
+    APENT_FOR_INNSOK,
+    ;
 
     companion object {
         fun fromDbo(
             dagensDato: LocalDate,
             startDato: LocalDate,
             sluttDato: LocalDate?,
-            avslutningsStatus: Avslutningsstatus
+            avslutningsStatus: Avslutningsstatus,
         ): Tiltaksgjennomforingsstatus {
             return when {
                 avslutningsStatus == Avslutningsstatus.AVLYST -> AVLYST
@@ -30,4 +31,3 @@ enum class Tiltaksgjennomforingsstatus {
         }
     }
 }
-

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltakstypeDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltakstypeDto.kt
@@ -24,7 +24,7 @@ data class TiltakstypeDto(
     @Serializable(with = LocalDateSerializer::class)
     val tilDato: LocalDate,
     val rettPaaTiltakspenger: Boolean,
-    val status: Tiltakstypestatus
+    val status: Tiltakstypestatus,
 ) {
     companion object {
         fun from(tiltakstype: TiltakstypeDbo) = tiltakstype.run {
@@ -37,10 +37,8 @@ data class TiltakstypeDto(
                 fraDato = fraDato,
                 tilDato = tilDato,
                 rettPaaTiltakspenger = rettPaaTiltakspenger,
-                status = Tiltakstypestatus.resolveFromDates(LocalDate.now(), fraDato, tilDato)
+                status = Tiltakstypestatus.resolveFromDates(LocalDate.now(), fraDato, tilDato),
             )
         }
     }
 }
-
-

--- a/common/kafka/build.gradle.kts
+++ b/common/kafka/build.gradle.kts
@@ -1,11 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ktlint)
-}
-
-ktlint {
-    disabledRules.addAll("no-wildcard-imports")
 }
 
 dependencies {

--- a/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerRepository.kt
+++ b/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerRepository.kt
@@ -24,7 +24,7 @@ class KafkaConsumerRepository(private val db: Database) : KafkaConsumerRepositor
             record.key,
             record.value,
             record.headersJson,
-            record.timestamp
+            record.timestamp,
         ).asUpdate
         return db.run(queryResult).toLong()
     }
@@ -101,7 +101,7 @@ class KafkaConsumerRepository(private val db: Database) : KafkaConsumerRepositor
             row.stringOrNull("headers_json"),
             row.int("retries"),
             row.sqlTimestampOrNull("last_retry"),
-            row.long("record_timestamp")
+            row.long("record_timestamp"),
         )
     }
 }

--- a/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaTopicConsumer.kt
+++ b/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaTopicConsumer.kt
@@ -1,14 +1,14 @@
 package no.nav.mulighetsrommet.kafka
 
 import kotlinx.coroutines.runBlocking
-import no.nav.common.kafka.consumer.util.KafkaConsumerClientBuilder
+import no.nav.common.kafka.consumer.util.KafkaConsumerClientBuilder.TopicConfig
 import org.apache.kafka.common.serialization.Deserializer
 import java.util.function.Consumer
 
 abstract class KafkaTopicConsumer<K, V>(
     val config: Config,
     private val keyDeserializer: Deserializer<K>,
-    private val valueDeserializer: Deserializer<V>
+    private val valueDeserializer: Deserializer<V>,
 ) {
 
     data class Config(
@@ -17,8 +17,8 @@ abstract class KafkaTopicConsumer<K, V>(
         val initialRunningState: Boolean = false,
     )
 
-    internal fun toTopicConfig(kafkaConsumerRepository: KafkaConsumerRepository): KafkaConsumerClientBuilder.TopicConfig<K, V> {
-        return KafkaConsumerClientBuilder.TopicConfig<K, V>()
+    internal fun toTopicConfig(kafkaConsumerRepository: KafkaConsumerRepository): TopicConfig<K, V> {
+        return TopicConfig<K, V>()
             .withLogging()
             .withStoreOnFailure(kafkaConsumerRepository)
             .withConsumerConfig(
@@ -29,7 +29,7 @@ abstract class KafkaTopicConsumer<K, V>(
                     runBlocking {
                         consume(event.key(), event.value())
                     }
-                }
+                },
             )
     }
 

--- a/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/Topic.kt
+++ b/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/Topic.kt
@@ -7,5 +7,5 @@ data class Topic(
     val id: String,
     val topic: String,
     val type: TopicType,
-    val running: Boolean
+    val running: Boolean,
 )

--- a/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/TopicRepository.kt
+++ b/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/TopicRepository.kt
@@ -74,6 +74,6 @@ class TopicRepository(private val db: Database) {
         id = string("id"),
         topic = string("topic"),
         type = TopicType.valueOf(string("type")),
-        running = boolean("running")
+        running = boolean("running"),
     )
 }

--- a/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerOrchestratorTest.kt
+++ b/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerOrchestratorTest.kt
@@ -24,8 +24,8 @@ import kotlin.time.Duration.Companion.seconds
 class KafkaConsumerOrchestratorTest : FunSpec({
     val kafka = install(
         TestContainerExtension(
-            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
-        )
+            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1")),
+        ),
     ) { withEmbeddedZookeeper() }
 
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
@@ -70,8 +70,8 @@ class KafkaConsumerOrchestratorTest : FunSpec({
                 id = "foo",
                 topic = "foo",
                 type = TopicType.CONSUMER,
-                running = true
-            )
+                running = true,
+            ),
         )
     }
 
@@ -88,7 +88,7 @@ class KafkaConsumerOrchestratorTest : FunSpec({
         orchestrator.getConsumers().first().isRunning shouldBe true
 
         orchestrator.updateRunningTopics(
-            orchestrator.getTopics().map { it.copy(running = false) }
+            orchestrator.getTopics().map { it.copy(running = false) },
         )
 
         eventually(3.seconds) {

--- a/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerRepositoryTest.kt
+++ b/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerRepositoryTest.kt
@@ -25,7 +25,7 @@ class KafkaConsumerRepositoryTest : FunSpec({
                 "key$it".toByteArray(),
                 "value$it".toByteArray(),
                 "{}",
-                LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+                LocalDateTime.now().toEpochSecond(ZoneOffset.UTC),
             )
         }
 
@@ -67,8 +67,8 @@ class KafkaConsumerRepositoryTest : FunSpec({
                 "key1".toByteArray(),
                 "value1".toByteArray(),
                 "{}",
-                LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
-            )
+                LocalDateTime.now().toEpochSecond(ZoneOffset.UTC),
+            ),
         )
 
         val result = kafkaConsumerRepository.getTopicPartitions(mutableListOf("topic1"))

--- a/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/TestConsumer.kt
+++ b/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/TestConsumer.kt
@@ -8,7 +8,9 @@ import no.nav.common.kafka.consumer.util.deserializer.Deserializers.stringDeseri
 import no.nav.mulighetsrommet.kafka.serialization.JsonElementDeserializer
 
 class TestConsumer(name: String) : KafkaTopicConsumer<String?, String?>(
-    Config(name, name, true), stringDeserializer(), stringDeserializer()
+    Config(name, name, true),
+    stringDeserializer(),
+    stringDeserializer(),
 ) {
     override suspend fun consume(key: String?, message: String?) {
         if (message != "true") {
@@ -18,7 +20,9 @@ class TestConsumer(name: String) : KafkaTopicConsumer<String?, String?>(
 }
 
 class JsonTestConsumer(name: String) : KafkaTopicConsumer<String?, JsonElement>(
-    Config(name, name, true), stringDeserializer(), JsonElementDeserializer()
+    Config(name, name, true),
+    stringDeserializer(),
+    JsonElementDeserializer(),
 ) {
     override suspend fun consume(key: String?, message: JsonElement) {
         val success = message.jsonObject.getValue("success").jsonPrimitive.boolean

--- a/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/TopicRepositoryTest.kt
+++ b/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/TopicRepositoryTest.kt
@@ -20,7 +20,7 @@ class TopicRepositoryTest : FunSpec({
 
         val updatedTopics = listOf(
             topic0.copy(running = true),
-            Topic(id = "new-id", topic = "new-topic", type = TopicType.CONSUMER, running = false)
+            Topic(id = "new-id", topic = "new-topic", type = TopicType.CONSUMER, running = false),
         )
 
         repository.setAll(updatedTopics)

--- a/common/ktor-clients/build.gradle.kts
+++ b/common/ktor-clients/build.gradle.kts
@@ -1,11 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ktlint)
-}
-
-ktlint {
-    disabledRules.addAll("no-wildcard-imports")
 }
 
 dependencies {

--- a/common/ktor-clients/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
+++ b/common/ktor-clients/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
@@ -23,7 +23,7 @@ fun httpJsonClient(engine: HttpClientEngine = CIO.create()) = HttpClient(engine)
         json(
             Json {
                 ignoreUnknownKeys = true
-            }
+            },
         )
     }
 

--- a/common/ktor/build.gradle.kts
+++ b/common/ktor/build.gradle.kts
@@ -2,11 +2,6 @@ plugins {
     `java-test-fixtures`
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ktlint)
-}
-
-ktlint {
-    disabledRules.addAll("no-wildcard-imports")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/auditlog/AuditLog.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/auditlog/AuditLog.kt
@@ -1,4 +1,4 @@
-package no.nav.mulighetsrommet.audit_log
+package no.nav.mulighetsrommet.auditlog
 
 import no.nav.common.audit_log.log.AuditLoggerImpl
 

--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/env/NaisEnv.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/env/NaisEnv.kt
@@ -4,7 +4,8 @@ enum class NaisEnv(val clusterName: String) {
 
     Local("local"),
     DevGCP("dev-gcp"),
-    ProdGCP("prod-gcp");
+    ProdGCP("prod-gcp"),
+    ;
 
     companion object {
         fun current(): NaisEnv = when (System.getenv("NAIS_CLUSTER_NAME")) {

--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/ktor/StartKtorApplication.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/ktor/StartKtorApplication.kt
@@ -19,7 +19,7 @@ fun startKtorApplication(config: ServerConfig, configure: Application.() -> Unit
                 port = config.port
                 host = config.host
             }
-        }
+        },
     )
 
     server.start(true)

--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/securelog/SecureLog.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/securelog/SecureLog.kt
@@ -1,4 +1,4 @@
-package no.nav.mulighetsrommet.secure_log
+package no.nav.mulighetsrommet.securelog
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/common/ktor/src/testFixtures/kotlin/no/nav/mulighetsrommet/ktor/TestUtils.kt
+++ b/common/ktor/src/testFixtures/kotlin/no/nav/mulighetsrommet/ktor/TestUtils.kt
@@ -30,7 +30,8 @@ inline fun <reified T : Any> MockRequestHandleScope.respondJson(
     status: HttpStatusCode = HttpStatusCode.OK,
 ): HttpResponseData {
     val headers = headersOf(
-        HttpHeaders.ContentType, ContentType.Application.Json.toString()
+        HttpHeaders.ContentType,
+        ContentType.Application.Json.toString(),
     )
     return respond(JsonIgnoreUnknownKeys.encodeToString(T::class.serializer(), content), status, headers)
 }
@@ -42,7 +43,7 @@ inline fun <reified T : Any> MockRequestHandleScope.respondJson(
  * [IllegalStateException] if it receives an HTTP request without a corresponding handler.
  */
 fun createMockEngine(
-    vararg requestHandlers: Pair<String, suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData>
+    vararg requestHandlers: Pair<String, suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData>,
 ) = MockEngine { request ->
     for ((path, handler) in requestHandlers) {
         if (request.url.encodedPath.matches(path.toRegex())) {

--- a/common/slack/build.gradle.kts
+++ b/common/slack/build.gradle.kts
@@ -1,11 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ktlint)
-}
-
-ktlint {
-    disabledRules.addAll("no-wildcard-imports")
 }
 
 dependencies {

--- a/common/slack/src/main/kotlin/no/nav/mulighetsrommet/slack/SlackNotifier.kt
+++ b/common/slack/src/main/kotlin/no/nav/mulighetsrommet/slack/SlackNotifier.kt
@@ -1,4 +1,4 @@
-package no.nav.mulighetsrommet.slack_notifier
+package no.nav.mulighetsrommet.slack
 
 interface SlackNotifier {
     fun sendMessage(message: String)

--- a/common/slack/src/main/kotlin/no/nav/mulighetsrommet/slack/SlackNotifierImpl.kt
+++ b/common/slack/src/main/kotlin/no/nav/mulighetsrommet/slack/SlackNotifierImpl.kt
@@ -1,4 +1,4 @@
-package no.nav.mulighetsrommet.slack_notifier
+package no.nav.mulighetsrommet.slack
 
 import com.slack.api.Slack
 import org.slf4j.LoggerFactory
@@ -26,7 +26,7 @@ class SlackNotifierImpl(private val token: String, private val channel: String, 
             if (!response.isOk) {
                 log.warn(
                     "Klarte ikke sende melding til Slack-kanal: $channel. Skulle sendt melding: '$message'",
-                    response.errors.joinToString("\n")
+                    response.errors.joinToString("\n"),
                 )
             }
         } catch (ioException: IOException) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ metrics = "4.2.18"
 flyway = { id = "org.flywaydb.flyway", version.ref = "flyway" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-ktlint = "org.jlleitschuh.gradle.ktlint:10.3.0"
+ktlint = "org.jlleitschuh.gradle.ktlint:11.3.1"
 shadow = "com.github.johnrengelman.shadow:8.1.1"
 
 [libraries]

--- a/mulighetsrommet-api-sanity-sync/build.gradle.kts
+++ b/mulighetsrommet-api-sanity-sync/build.gradle.kts
@@ -2,16 +2,11 @@ plugins {
     application
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ktlint)
     alias(libs.plugins.shadow)
 }
 
 application {
     mainClass.set("no.nav.mulighetsrommet.sanity.ApplicationKt")
-}
-
-ktlint {
-    disabledRules.addAll("no-wildcard-imports")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/mulighetsrommet-api-sanity-sync/src/main/kotlin/no/nav/mulighetsrommet/sanity/Application.kt
+++ b/mulighetsrommet-api-sanity-sync/src/main/kotlin/no/nav/mulighetsrommet/sanity/Application.kt
@@ -54,7 +54,7 @@ private fun CoroutineScope.produceTiltak(capacity: Int, sanity: SanityClient): R
               _id,
               "tiltaksnummer": tiltaksnummer.current
             }
-            """.trimIndent()
+            """.trimIndent(),
         )
         tiltak.result.forEach {
             if (it.tiltaksnummer != null) {
@@ -68,7 +68,7 @@ private fun CoroutineScope.produceTiltak(capacity: Int, sanity: SanityClient): R
 private suspend fun writeTilgjengelighetsstatus(
     channel: ReceiveChannel<Tiltak>,
     db: Database,
-    sanity: SanityClient
+    sanity: SanityClient,
 ) {
     channel.consumeEach { tiltak ->
         @Language("PostgreSQL")
@@ -110,7 +110,7 @@ private suspend fun writeTilgjengelighetsstatus(
                         }
                     ]
                 }
-                """.trimIndent()
+                """.trimIndent(),
             )
         }
     }

--- a/mulighetsrommet-api-sanity-sync/src/main/kotlin/no/nav/mulighetsrommet/sanity/SanityClient.kt
+++ b/mulighetsrommet-api-sanity-sync/src/main/kotlin/no/nav/mulighetsrommet/sanity/SanityClient.kt
@@ -49,7 +49,7 @@ class SanityClient(private val config: Config) {
     @Serializable
     data class Operation(
         val id: String? = null,
-        val operation: String
+        val operation: String,
     )
 
     enum class MutationVisibility {
@@ -81,7 +81,7 @@ class SanityClient(private val config: Config) {
             json(
                 Json {
                     ignoreUnknownKeys = true
-                }
+                },
             )
         }
 

--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -2,17 +2,12 @@ plugins {
     application
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ktlint)
     alias(libs.plugins.flyway)
     alias(libs.plugins.shadow)
 }
 
 application {
     mainClass.set("no.nav.mulighetsrommet.api.ApplicationKt")
-}
-
-ktlint {
-    disabledRules.addAll("no-wildcard-imports")
 }
 
 flyway {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -10,7 +10,7 @@ import no.nav.mulighetsrommet.ktor.ServerConfig
 
 data class Config(
     val server: ServerConfig,
-    val app: AppConfig
+    val app: AppConfig,
 )
 
 data class AppConfig(
@@ -30,11 +30,11 @@ data class AppConfig(
     val msGraphConfig: ServiceClientConfig,
     val tasks: TaskConfig,
     val norg2: Norg2Config,
-    val slack: SlackConfig
+    val slack: SlackConfig,
 )
 
 data class AuthConfig(
-    val azure: AuthProvider
+    val azure: AuthProvider,
 )
 
 data class KafkaConfig(
@@ -47,7 +47,7 @@ data class KafkaConfig(
 
 data class KafkaProducers(
     val tiltaksgjennomforinger: TiltaksgjennomforingKafkaProducer.Config,
-    val tiltakstyper: TiltakstypeKafkaProducer.Config
+    val tiltakstyper: TiltakstypeKafkaProducer.Config,
 )
 
 data class KafkaConsumers(
@@ -58,28 +58,28 @@ data class AuthProvider(
     val issuer: String,
     val jwksUri: String,
     val audience: String,
-    val tokenEndpointUrl: String
+    val tokenEndpointUrl: String,
 )
 
 data class SwaggerConfig(
-    val enable: Boolean
+    val enable: Boolean,
 )
 
 data class ServiceClientConfig(
     val url: String,
-    val scope: String
+    val scope: String,
 )
 
 data class TaskConfig(
-    val synchronizeNorgEnheter: SynchronizeNorgEnheter.Config
+    val synchronizeNorgEnheter: SynchronizeNorgEnheter.Config,
 )
 
 data class Norg2Config(
-    val baseUrl: String
+    val baseUrl: String,
 )
 
 data class SlackConfig(
     val token: String,
     val channel: String,
-    val enable: Boolean
+    val enable: Boolean,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/arenaadapter/ArenaAdapterClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/arenaadapter/ArenaAdapterClientImpl.kt
@@ -18,7 +18,7 @@ private val log = LoggerFactory.getLogger(ArenaAdapterClientImpl::class.java)
 class ArenaAdapterClientImpl(
     private val baseUrl: String,
     private val machineToMachineTokenClient: () -> String,
-    clientEngine: HttpClientEngine = CIO.create()
+    clientEngine: HttpClientEngine = CIO.create(),
 ) : ArenaAdapterClient {
     val client = httpJsonClient(clientEngine).config {
         install(HttpCache)
@@ -27,7 +27,7 @@ class ArenaAdapterClientImpl(
     override suspend fun exchangeTiltaksgjennomforingsArenaIdForId(arenaId: String): ExchangeArenaIdForIdResponse? {
         val response = client.get("$baseUrl/api/exchange/$arenaId") {
             bearerAuth(
-                machineToMachineTokenClient.invoke()
+                machineToMachineTokenClient.invoke(),
             )
         }
 
@@ -44,7 +44,7 @@ class ArenaAdapterClientImpl(
     override suspend fun hentTiltaksgjennomforingsstatus(id: UUID): ArenaTiltaksgjennomforingsstatusDto? {
         val response = client.get("$baseUrl/api/status/$id") {
             bearerAuth(
-                machineToMachineTokenClient.invoke()
+                machineToMachineTokenClient.invoke(),
             )
         }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/dialog/VeilarbdialogClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/dialog/VeilarbdialogClientImpl.kt
@@ -9,13 +9,13 @@ import io.ktor.http.*
 import no.nav.mulighetsrommet.api.services.DialogRequest
 import no.nav.mulighetsrommet.api.services.DialogResponse
 import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import org.slf4j.LoggerFactory
 
 class VeilarbdialogClientImpl(
     private val baseUrl: String,
     private val tokenProvider: (accessToken: String) -> String,
-    clientEngine: HttpClientEngine = CIO.create()
+    clientEngine: HttpClientEngine = CIO.create(),
 ) : VeilarbdialogClient {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -26,7 +26,7 @@ class VeilarbdialogClientImpl(
     override suspend fun sendMeldingTilDialogen(
         fnr: String,
         accessToken: String,
-        requestBody: DialogRequest
+        requestBody: DialogRequest,
     ): DialogResponse? {
         return try {
             val response = client.post("$baseUrl/dialog?fnr=$fnr") {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/AmtEnhetsregisterClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/AmtEnhetsregisterClientImpl.kt
@@ -8,13 +8,13 @@ import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import org.slf4j.LoggerFactory
 
 class AmtEnhetsregisterClientImpl(
     private val baseUrl: String,
     private val tokenProvider: () -> String,
-    clientEngine: HttpClientEngine = CIO.create()
+    clientEngine: HttpClientEngine = CIO.create(),
 ) : AmtEnhetsregisterClient {
     private val log = LoggerFactory.getLogger(javaClass)
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/VirksomhetDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/VirksomhetDto.kt
@@ -7,5 +7,5 @@ data class VirksomhetDto(
     val organisasjonsnummer: String,
     val navn: String,
     val overordnetEnhetOrganisasjonsnummer: String? = null,
-    val overordnetEnhetNavn: String? = null
+    val overordnetEnhetNavn: String? = null,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/AnsattDataDTO.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/AnsattDataDTO.kt
@@ -5,5 +5,5 @@ data class AnsattDataDTO(
     val hovedenhetNavn: String,
     val fornavn: String,
     val etternavn: String,
-    val navident: String
+    val navident: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -8,14 +8,14 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import org.slf4j.LoggerFactory
 import java.util.*
 
 class MicrosoftGraphClientImpl(
     private val baseUrl: String,
     private val tokenProvider: (accessToken: String) -> String,
-    clientEngine: HttpClientEngine = CIO.create()
+    clientEngine: HttpClientEngine = CIO.create(),
 ) : MicrosoftGraphClient {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -40,7 +40,7 @@ class MicrosoftGraphClientImpl(
             hovedenhetNavn = user.city,
             fornavn = user.givenName,
             etternavn = user.surname,
-            navident = user.onPremisesSamAccountName
+            navident = user.onPremisesSamAccountName,
         )
     }
 }
@@ -51,5 +51,5 @@ data class MSGraphUser(
     val city: String,
     val givenName: String,
     val surname: String,
-    val onPremisesSamAccountName: String
+    val onPremisesSamAccountName: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2ClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2ClientImpl.kt
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory
 
 class Norg2ClientImpl(
     private val baseUrl: String,
-    clientEngine: HttpClientEngine = CIO.create()
+    clientEngine: HttpClientEngine = CIO.create(),
 ) : Norg2Client {
     private val log = LoggerFactory.getLogger(javaClass)
     private val client = httpJsonClient(clientEngine)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2EnhetDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2EnhetDto.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Norg2Response(
     val enhet: Norg2EnhetDto,
-    val overordnetEnhet: String?
+    val overordnetEnhet: String?,
 )
 
 @Serializable
@@ -15,7 +15,7 @@ data class Norg2EnhetDto(
     val navn: String,
     val enhetNr: String,
     val status: Norg2EnhetStatus,
-    val type: Norg2Type
+    val type: Norg2Type,
 )
 
 @Serializable
@@ -30,7 +30,7 @@ enum class Norg2EnhetStatus {
     UNDER_AVVIKLING,
 
     @SerialName("Nedlagt")
-    NEDLAGT
+    NEDLAGT,
 }
 
 @Serializable
@@ -64,5 +64,5 @@ enum class Norg2Type {
     ROL,
     TILLIT,
     UTLAND,
-    YTA
+    YTA,
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/ManuellStatusDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/ManuellStatusDto.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ManuellStatusDto(
     val erUnderManuellOppfolging: Boolean,
-    val krrStatus: KrrStatus
+    val krrStatus: KrrStatus,
 )
 
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/OppfolgingsstatusDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/OppfolgingsstatusDto.kt
@@ -5,11 +5,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class OppfolgingsstatusDto(
     val oppfolgingsenhet: Oppfolgingsenhet?,
-    val servicegruppe: String?
+    val servicegruppe: String?,
 )
 
 @Serializable
 data class Oppfolgingsenhet(
     val navn: String?,
-    val enhetId: String?
+    val enhetId: String?,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClientImpl.kt
@@ -11,7 +11,7 @@ import io.ktor.http.*
 import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import no.nav.mulighetsrommet.utils.CacheUtils
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
 class VeilarboppfolgingClientImpl(
     private val baseUrl: String,
     private val tokenProvider: (accessToken: String) -> String,
-    clientEngine: HttpClientEngine = CIO.create()
+    clientEngine: HttpClientEngine = CIO.create(),
 ) : VeilarboppfolgingClient {
     private val log = LoggerFactory.getLogger(javaClass)
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/person/PersonDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/person/PersonDto.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PersonDto(
-    val fornavn: String
+    val fornavn: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/person/VeilarbpersonClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/person/VeilarbpersonClientImpl.kt
@@ -10,7 +10,7 @@ import io.ktor.client.request.*
 import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import no.nav.mulighetsrommet.utils.CacheUtils
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit
 class VeilarbpersonClientImpl(
     private val baseUrl: String,
     private val tokenProvider: (accessToken: String) -> String,
-    clientEngine: HttpClientEngine = CIO.create()
+    clientEngine: HttpClientEngine = CIO.create(),
 ) : VeilarbpersonClient {
     private val log = LoggerFactory.getLogger(javaClass)
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VedtakDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VedtakDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class VedtakDto(
-    val innsatsgruppe: Innsatsgruppe?
+    val innsatsgruppe: Innsatsgruppe?,
 )
 
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VeilarbvedtaksstotteClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/vedtak/VeilarbvedtaksstotteClientImpl.kt
@@ -12,7 +12,7 @@ import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import kotlinx.serialization.decodeFromString
 import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import no.nav.mulighetsrommet.serialization.json.JsonIgnoreUnknownKeys
 import no.nav.mulighetsrommet.utils.CacheUtils
 import org.slf4j.LoggerFactory
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 class VeilarbvedtaksstotteClientImpl(
     private val baseUrl: String,
     private val tokenProvider: (accessToken: String) -> String,
-    clientEngine: HttpClientEngine = CIO.create()
+    clientEngine: HttpClientEngine = CIO.create(),
 ) : VeilarbvedtaksstotteClient {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -63,7 +63,7 @@ class VeilarbvedtaksstotteClientImpl(
             } catch (e: Throwable) {
                 SecureLog.logger.error(
                     "Klarte ikke hente siste 14A-vedtak for bruker med fnr: $fnr, response: $response, body: $body",
-                    e
+                    e,
                 )
                 log.error("Klarte ikke hente siste 14A-vedtak. Se detaljer i secureLogs.")
                 return null

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/DelMedBrukerDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/DelMedBrukerDbo.kt
@@ -16,5 +16,5 @@ data class DelMedBrukerDbo(
     @Serializable(with = LocalDateTimeSerializer::class)
     val updatedAt: LocalDateTime? = null,
     val createdBy: String? = null,
-    val updatedBy: String? = null
+    val updatedBy: String? = null,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavEnhetDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavEnhetDbo.kt
@@ -9,7 +9,7 @@ data class NavEnhetDbo(
     val enhetNr: String,
     val status: NavEnhetStatus,
     val type: Norg2Type,
-    val overordnetEnhet: String?
+    val overordnetEnhet: String?,
 )
 
 @Serializable
@@ -17,5 +17,5 @@ enum class NavEnhetStatus {
     UNDER_ETABLERING,
     AKTIV,
     UNDER_AVVIKLING,
-    NEDLAGT
+    NEDLAGT,
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/AvtaleNokkeltallDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/AvtaleNokkeltallDto.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AvtaleNokkeltallDto(
     val antallTiltaksgjennomforinger: Int,
-    val antallDeltakere: Int
+    val antallDeltakere: Int,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/SanityResponseDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/SanityResponseDto.kt
@@ -8,17 +8,17 @@ import kotlinx.serialization.json.jsonObject
 
 @Serializable
 data class FylkeResponse(
-    val fylke: Fylke
+    val fylke: Fylke,
 )
 
 @Serializable
 data class Fylke(
-    val nummer: Slug
+    val nummer: Slug,
 )
 
 @Serializable
 data class Slug(
-    val current: String
+    val current: String,
 )
 
 @Serializable(with = SanityReponseSerializer::class)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltaksgjennomforingNokkeltallDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltaksgjennomforingNokkeltallDto.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class TiltaksgjennomforingNokkeltallDto(
-    val antallDeltakere: Int
+    val antallDeltakere: Int,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltakstypeNokkeltallDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltakstypeNokkeltallDto.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 data class TiltakstypeNokkeltallDto(
     val antallTiltaksgjennomforinger: Int,
     val antallAvtaler: Int,
-    val antallDeltakere: Int
+    val antallDeltakere: Int,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
@@ -25,7 +25,7 @@ object AppRoles {
 }
 
 fun Application.configureAuthentication(
-    auth: AuthConfig
+    auth: AuthConfig,
 ) {
     val (azure) = auth
 
@@ -105,6 +105,6 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getNavAnsattAzureId(): UUID {
 fun <T : Any> PipelineContext<T, ApplicationCall>.getNorskIdent(): String {
     return call.request.header("nav-norskident") ?: throw StatusException(
         HttpStatusCode.BadRequest,
-        "nav-norskident mangler i headers"
+        "nav-norskident mangler i headers",
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Serialization.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Serialization.kt
@@ -10,7 +10,7 @@ fun Application.configureSerialization() {
         json(
             Json {
                 ignoreUnknownKeys = true
-            }
+            },
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/producers/TiltaksgjennomforingKafkaProducer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/producers/TiltaksgjennomforingKafkaProducer.kt
@@ -9,17 +9,17 @@ import java.util.*
 
 class TiltaksgjennomforingKafkaProducer(
     private val kafkaProducerClient: KafkaProducerClient<String, String?>,
-    private val config: Config
+    private val config: Config,
 ) {
     data class Config(
-        val topic: String
+        val topic: String,
     )
 
     fun publish(value: TiltaksgjennomforingDto) {
         val record: ProducerRecord<String, String?> = ProducerRecord(
             config.topic,
             value.id.toString(),
-            Json.encodeToString(value)
+            Json.encodeToString(value),
         )
         kafkaProducerClient.sendSync(record)
     }
@@ -28,7 +28,7 @@ class TiltaksgjennomforingKafkaProducer(
         val record: ProducerRecord<String, String?> = ProducerRecord(
             config.topic,
             id.toString(),
-            null
+            null,
         )
         kafkaProducerClient.sendSync(record)
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/producers/TiltakstypeKafkaProducer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/producers/TiltakstypeKafkaProducer.kt
@@ -9,17 +9,17 @@ import java.util.*
 
 class TiltakstypeKafkaProducer(
     private val kafkaProducerClient: KafkaProducerClient<String, String?>,
-    private val config: Config
+    private val config: Config,
 ) {
     data class Config(
-        val topic: String
+        val topic: String,
     )
 
     fun publish(value: TiltakstypeDto) {
         val record: ProducerRecord<String, String?> = ProducerRecord(
             config.topic,
             value.id.toString(),
-            Json.encodeToString(value)
+            Json.encodeToString(value),
         )
         kafkaProducerClient.sendSync(record)
     }
@@ -28,7 +28,7 @@ class TiltakstypeKafkaProducer(
         val record: ProducerRecord<String, String?> = ProducerRecord(
             config.topic,
             id.toString(),
-            null
+            null,
         )
         kafkaProducerClient.sendSync(record)
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -92,14 +92,14 @@ class AvtaleRepository(private val db: Database) {
                 queryOf(
                     upsertAnsvarlig,
                     avtale.id,
-                    ansvarlig
+                    ansvarlig,
                 ).asExecute.let { tx.run(it) }
             }
 
             queryOf(
                 deleteAnsvarlige,
                 avtale.id,
-                db.createTextArray(avtale.ansvarlige)
+                db.createTextArray(avtale.ansvarlige),
             ).asExecute.let { tx.run(it) }
 
             result
@@ -152,7 +152,7 @@ class AvtaleRepository(private val db: Database) {
 
     fun getAll(
         filter: AvtaleFilter,
-        pagination: PaginationParams = PaginationParams()
+        pagination: PaginationParams = PaginationParams(),
     ): Pair<Int, List<AvtaleAdminDto>> {
         if (filter.tiltakstypeId != null) {
             logger.info("Henter avtaler for tiltakstype med id: '${filter.tiltakstypeId}'")
@@ -165,14 +165,14 @@ class AvtaleRepository(private val db: Database) {
             "enhet" to filter.enhet,
             "limit" to pagination.limit,
             "offset" to pagination.offset,
-            "today" to filter.dagensDato
+            "today" to filter.dagensDato,
         )
 
         val where = DatabaseUtils.andWhereParameterNotNull(
             filter.tiltakstypeId to "a.tiltakstype_id = :tiltakstype_id",
             filter.search to "(lower(a.navn) like lower(:search))",
             filter.avtalestatus to filter.avtalestatus?.toDbStatement(),
-            filter.enhet to "lower(a.enhet) = lower(:enhet)"
+            filter.enhet to "lower(a.enhet) = lower(:enhet)",
         )
 
         val order = when (filter.sortering) {
@@ -239,7 +239,7 @@ class AvtaleRepository(private val db: Database) {
         "prisbetingelser" to prisbetingelser,
         "antall_plasser" to antallPlasser,
         "url" to url,
-        "opphav" to opphav.name
+        "opphav" to opphav.name,
     )
 
     private fun Row.toAvtaleDbo(): AvtaleDbo {
@@ -257,7 +257,7 @@ class AvtaleRepository(private val db: Database) {
             prisbetingelser = stringOrNull("prisbetingelser"),
             antallPlasser = intOrNull("antall_plasser"),
             url = stringOrNull("url"),
-            opphav = AvtaleDbo.Opphav.valueOf(string("opphav"))
+            opphav = AvtaleDbo.Opphav.valueOf(string("opphav")),
         )
     }
 
@@ -270,11 +270,11 @@ class AvtaleRepository(private val db: Database) {
             tiltakstype = AvtaleAdminDto.Tiltakstype(
                 id = uuid("tiltakstype_id"),
                 navn = string("tiltakstype_navn"),
-                arenaKode = string("tiltakskode")
+                arenaKode = string("tiltakskode"),
             ),
             avtalenummer = stringOrNull("avtalenummer"),
             leverandor = AvtaleAdminDto.Leverandor(
-                organisasjonsnummer = string("leverandor_organisasjonsnummer")
+                organisasjonsnummer = string("leverandor_organisasjonsnummer"),
             ),
             startDato = startDato,
             sluttDato = sluttDato,
@@ -286,12 +286,12 @@ class AvtaleRepository(private val db: Database) {
                 LocalDate.now(),
                 startDato,
                 sluttDato,
-                Avslutningsstatus.valueOf(string("avslutningsstatus"))
+                Avslutningsstatus.valueOf(string("avslutningsstatus")),
             ),
             prisbetingelser = stringOrNull("prisbetingelser"),
             ansvarlig = stringOrNull("navident"),
             url = stringOrNull("url"),
-            antallPlasser = intOrNull("antall_plasser")
+            antallPlasser = intOrNull("antall_plasser"),
         )
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/DeltakerRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/DeltakerRepository.kt
@@ -41,7 +41,7 @@ class DeltakerRepository(private val db: Database) {
 
     fun getAll(tiltaksgjennomforingId: UUID? = null): List<DeltakerDbo> {
         val where = DatabaseUtils.andWhereParameterNotNull(
-            tiltaksgjennomforingId to "tiltaksgjennomforing_id = :tiltaksgjennomforing_id::uuid"
+            tiltaksgjennomforingId to "tiltaksgjennomforing_id = :tiltaksgjennomforing_id::uuid",
         )
 
         @Language("PostgreSQL")
@@ -73,11 +73,11 @@ class DeltakerRepository(private val db: Database) {
 
     fun countAntallDeltakereForTiltakstypeWithId(
         tiltakstypeId: UUID,
-        currentDate: LocalDate = LocalDate.now()
+        currentDate: LocalDate = LocalDate.now(),
     ): Int {
         val parameters = mapOf(
             "tiltakstypeId" to tiltakstypeId,
-            "currentDate" to currentDate
+            "currentDate" to currentDate,
         )
 
         val query = """

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/EnhetRepository.kt
@@ -68,12 +68,12 @@ class EnhetRepository(private val db: Database) {
         logger.info("Henter enheter med status: ${statuser.joinToString(", ")}")
         val parameters = mapOf(
             "statuser" to db.createTextArray(statuser.map { it.name }),
-            "tiltakstypeId" to filter.tiltakstypeId
+            "tiltakstypeId" to filter.tiltakstypeId,
         )
 
         val where = DatabaseUtils.andWhereParameterNotNull(
             filter.statuser to "e.status = any(:statuser)",
-            filter.tiltakstypeId to "a.tiltakstype_id = :tiltakstypeId::uuid"
+            filter.tiltakstypeId to "a.tiltakstype_id = :tiltakstypeId::uuid",
         )
 
         @Language("PostgreSQL")
@@ -110,7 +110,7 @@ class EnhetRepository(private val db: Database) {
         logger.info("Sletter enheter med enhetsnummer: $enhetsnummerForSletting")
 
         val parameters = mapOf(
-            "ider" to db.createTextArray(enhetsnummerForSletting)
+            "ider" to db.createTextArray(enhetsnummerForSletting),
         )
 
         @Language("PostgreSQL")
@@ -129,7 +129,7 @@ private fun NavEnhetDbo.toSqlParameters() = mapOf(
     "enhetsnummer" to enhetNr,
     "status" to status.name,
     "type" to type.name,
-    "overordnet_enhet" to overordnetEnhet
+    "overordnet_enhet" to overordnetEnhet,
 )
 
 private fun Row.toEnhetDbo() = NavEnhetDbo(
@@ -137,5 +137,5 @@ private fun Row.toEnhetDbo() = NavEnhetDbo(
     enhetNr = string("enhetsnummer"),
     status = NavEnhetStatus.valueOf(string("status")),
     type = Norg2Type.valueOf(string("type")),
-    overordnetEnhet = stringOrNull("overordnet_enhet")
+    overordnetEnhet = stringOrNull("overordnet_enhet"),
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -77,8 +77,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                     queryOf(
                         upsertAnsvarlig,
                         tiltaksgjennomforing.id,
-                        ansvarlig
-                    ).asExecute
+                        ansvarlig,
+                    ).asExecute,
                 )
             }
 
@@ -86,8 +86,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 queryOf(
                     deleteAnsvarlige,
                     tiltaksgjennomforing.id,
-                    db.createTextArray(tiltaksgjennomforing.ansvarlige)
-                ).asExecute
+                    db.createTextArray(tiltaksgjennomforing.ansvarlige),
+                ).asExecute,
             )
 
             tiltaksgjennomforing.enheter.forEach { enhetId ->
@@ -95,8 +95,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                     queryOf(
                         upsertEnhet,
                         tiltaksgjennomforing.id,
-                        enhetId
-                    ).asExecute
+                        enhetId,
+                    ).asExecute,
                 )
             }
 
@@ -104,8 +104,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 queryOf(
                     deleteEnheter,
                     tiltaksgjennomforing.id,
-                    db.createTextArray(tiltaksgjennomforing.enheter)
-                ).asExecute
+                    db.createTextArray(tiltaksgjennomforing.enheter),
+                ).asExecute,
             )
         }
     }
@@ -145,7 +145,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
 
     fun getAll(
         pagination: PaginationParams = PaginationParams(),
-        filter: AdminTiltaksgjennomforingFilter
+        filter: AdminTiltaksgjennomforingFilter,
     ): QueryResult<Pair<Int, List<TiltaksgjennomforingAdminDto>>> = query {
         val parameters = mapOf(
             "search" to "%${filter.search}%",
@@ -154,7 +154,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             "statuser" to filter.statuser?.let { db.createTextArray(it.map { it.name }) },
             "limit" to pagination.limit,
             "offset" to pagination.offset,
-            "cutoffdato" to filter.sluttDatoCutoff
+            "cutoffdato" to filter.sluttDatoCutoff,
         )
 
         val where = DatabaseUtils.andWhereParameterNotNull(
@@ -217,7 +217,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         dateIntervalStart: LocalDate,
         dateIntervalEnd: LocalDate,
         avslutningsstatus: Avslutningsstatus,
-        pagination: PaginationParams
+        pagination: PaginationParams,
     ): QueryResult<List<TiltaksgjennomforingDbo>> = query {
         logger.info("Henter alle tiltaksgjennomføringer med start- eller sluttdato mellom $dateIntervalStart og $dateIntervalEnd, med avslutningsstatus $avslutningsstatus")
 
@@ -250,8 +250,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 "date_interval_start" to dateIntervalStart,
                 "date_interval_end" to dateIntervalEnd,
                 "limit" to pagination.limit,
-                "offset" to pagination.offset
-            )
+                "offset" to pagination.offset,
+            ),
         )
             .map { it.toTiltaksgjennomforingDbo() }
             .asList
@@ -284,7 +284,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "avslutningsstatus" to avslutningsstatus.name,
         "tilgjengelighet" to tilgjengelighet.name,
         "antall_plasser" to antallPlasser,
-        "avtale_id" to avtaleId
+        "avtale_id" to avtaleId,
     )
 
     private fun Row.toTiltaksgjennomforingDbo() = TiltaksgjennomforingDbo(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepository.kt
@@ -81,16 +81,16 @@ class TiltakshistorikkRepository(private val db: Database) {
             "norsk_ident" to norskIdent,
             "status" to status.name,
             "fra_dato" to fraDato,
-            "til_dato" to tilDato
+            "til_dato" to tilDato,
         ) + when (this) {
             is TiltakshistorikkDbo.Gruppetiltak -> listOfNotNull(
-                "tiltaksgjennomforing_id" to tiltaksgjennomforingId
+                "tiltaksgjennomforing_id" to tiltaksgjennomforingId,
             )
 
             is TiltakshistorikkDbo.IndividueltTiltak -> listOfNotNull(
                 "beskrivelse" to beskrivelse,
                 "virksomhetsnummer" to virksomhetsnummer,
-                "tiltakstypeid" to tiltakstypeId
+                "tiltakstypeid" to tiltakstypeId,
             )
         }
     }
@@ -104,7 +104,7 @@ class TiltakshistorikkRepository(private val db: Database) {
                     norskIdent = string("norsk_ident"),
                     status = Deltakerstatus.valueOf(string("status")),
                     fraDato = localDateTimeOrNull("fra_dato"),
-                    tilDato = localDateTimeOrNull("til_dato")
+                    tilDato = localDateTimeOrNull("til_dato"),
                 )
             }
             ?: TiltakshistorikkDbo.IndividueltTiltak(
@@ -115,7 +115,7 @@ class TiltakshistorikkRepository(private val db: Database) {
                 tilDato = localDateTimeOrNull("til_dato"),
                 beskrivelse = string("beskrivelse"),
                 tiltakstypeId = uuid("tiltakstypeid"),
-                virksomhetsnummer = string("virksomhetsnummer")
+                virksomhetsnummer = string("virksomhetsnummer"),
             )
     }
 
@@ -128,6 +128,6 @@ class TiltakshistorikkRepository(private val db: Database) {
         tiltakstype = string("tiltakstype"),
         arrangor = stringOrNull("virksomhetsnummer")?.let {
             TiltakshistorikkDto.Arrangor(virksomhetsnummer = it, navn = null)
-        }
+        },
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
@@ -55,11 +55,11 @@ class TiltakstypeRepository(private val db: Database) {
     }
 
     fun getAll(
-        paginationParams: PaginationParams = PaginationParams()
+        paginationParams: PaginationParams = PaginationParams(),
     ): Pair<Int, List<TiltakstypeDto>> {
         val parameters = mapOf(
             "limit" to paginationParams.limit,
-            "offset" to paginationParams.offset
+            "offset" to paginationParams.offset,
         )
 
         @Language("PostgreSQL")
@@ -91,7 +91,7 @@ class TiltakstypeRepository(private val db: Database) {
 
     fun getAllSkalMigreres(
         tiltakstypeFilter: TiltakstypeFilter,
-        paginationParams: PaginationParams = PaginationParams()
+        paginationParams: PaginationParams = PaginationParams(),
     ): Pair<Int, List<TiltakstypeDto>> {
         val parameters = mapOf(
             "search" to "%${tiltakstypeFilter.search}%",
@@ -110,7 +110,7 @@ class TiltakstypeRepository(private val db: Database) {
                     Tiltakstypekategori.INDIVIDUELL -> "not(tiltakskode = any(:gruppetiltakskoder))"
                 }
             },
-            true to "skal_migreres = true"
+            true to "skal_migreres = true",
         )
 
         val order = when (tiltakstypeFilter.sortering) {
@@ -150,7 +150,7 @@ class TiltakstypeRepository(private val db: Database) {
     fun getAllByDateInterval(
         dateIntervalStart: LocalDate,
         dateIntervalEnd: LocalDate,
-        pagination: PaginationParams
+        pagination: PaginationParams,
     ): List<TiltakstypeDto> {
         logger.info("Henter alle tiltakstyper med start- eller sluttdato mellom $dateIntervalStart og $dateIntervalEnd")
 
@@ -172,7 +172,7 @@ class TiltakstypeRepository(private val db: Database) {
                 "date_interval_end" to dateIntervalEnd,
                 "limit" to pagination.limit,
                 "offset" to pagination.offset,
-            )
+            ),
         )
             .map { it.toTiltakstypeDto() }
             .asList
@@ -201,7 +201,7 @@ class TiltakstypeRepository(private val db: Database) {
         "sist_endret_dato_i_arena" to sistEndretDatoIArena,
         "fra_dato" to fraDato,
         "til_dato" to tilDato,
-        "rett_paa_tiltakspenger" to rettPaaTiltakspenger
+        "rett_paa_tiltakspenger" to rettPaaTiltakspenger,
     )
 
     private fun Row.toTiltakstypeDbo() = TiltakstypeDbo(
@@ -212,7 +212,7 @@ class TiltakstypeRepository(private val db: Database) {
         sistEndretDatoIArena = localDateTime("sist_endret_dato_i_arena"),
         fraDato = localDate("fra_dato"),
         tilDato = localDate("til_dato"),
-        rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger")
+        rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger"),
     )
 
     private fun Row.toTiltakstypeDto(): TiltakstypeDto {
@@ -227,7 +227,7 @@ class TiltakstypeRepository(private val db: Database) {
             fraDato = fraDato,
             tilDato = tilDato,
             rettPaaTiltakspenger = boolean("rett_paa_tiltakspenger"),
-            status = Tiltakstypestatus.resolveFromDates(LocalDate.now(), fraDato, tilDato)
+            status = Tiltakstypestatus.resolveFromDates(LocalDate.now(), fraDato, tilDato),
         )
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/FrontendLoggerRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/FrontendLoggerRoutes.kt
@@ -28,7 +28,7 @@ fun Route.frontendLoggerRoutes() {
             }.onFailure {
                 logger.error(
                     "Error during at request handler method=${this.context.request.httpMethod} path=${this.context.request.path()}",
-                    it
+                    it,
                 )
             }
         }
@@ -39,5 +39,5 @@ fun Route.frontendLoggerRoutes() {
 data class FrontendEvent(
     var name: String,
     var fields: Map<String, String> = emptyMap(),
-    var tags: Map<String, String> = emptyMap()
+    var tags: Map<String, String> = emptyMap(),
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaAdapterRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaAdapterRoutes.kt
@@ -34,7 +34,7 @@ fun Route.arenaAdapterRoutes() {
         delete("tiltakstype/{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@delete call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
 
             arenaAdapterService.removeTiltakstype(id)
@@ -59,7 +59,7 @@ fun Route.arenaAdapterRoutes() {
         delete("avtale/{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@delete call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
 
             arenaAdapterService.removeAvtale(id)
@@ -84,7 +84,7 @@ fun Route.arenaAdapterRoutes() {
         delete("tiltaksgjennomforing/{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@delete call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
 
             arenaAdapterService.removeTiltaksgjennomforing(id)
@@ -117,7 +117,7 @@ fun Route.arenaAdapterRoutes() {
         delete("tiltakshistorikk/{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@delete call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             arenaAdapterService.removeTiltakshistorikk(id)
                 .map { call.response.status(HttpStatusCode.OK) }
@@ -141,7 +141,7 @@ fun Route.arenaAdapterRoutes() {
         delete("deltaker/{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@delete call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
 
             arenaAdapterService.removeDeltaker(id)
@@ -157,6 +157,6 @@ fun Route.arenaAdapterRoutes() {
 fun PipelineContext<Unit, ApplicationCall>.logError(logger: Logger, error: PSQLException) {
     logger.debug(
         "Error during at request handler method=${this.context.request.httpMethod.value} path=${this.context.request.path()}",
-        error
+        error,
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -72,7 +72,7 @@ fun Route.avtaleRoutes() {
         delete("{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@delete call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
 
             avtaler.delete(id)
@@ -103,7 +103,7 @@ data class AvtaleRequest(
     val url: String,
     val ansvarlig: String,
     val avtaletype: Avtaletype,
-    val prisOgBetalingsinformasjon: String? = null
+    val prisOgBetalingsinformasjon: String? = null,
 ) {
     fun toDbo(): AvtaleDbo {
         return AvtaleDbo(
@@ -121,7 +121,7 @@ data class AvtaleRequest(
             url = url,
             opphav = AvtaleDbo.Opphav.MR_ADMIN_FLATE,
             ansvarlige = listOf(ansvarlig),
-            prisbetingelser = prisOgBetalingsinformasjon
+            prisbetingelser = prisOgBetalingsinformasjon,
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
@@ -15,8 +15,8 @@ import no.nav.mulighetsrommet.api.services.BrukerService
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
 import no.nav.mulighetsrommet.api.services.TiltakshistorikkService
 import no.nav.mulighetsrommet.api.utils.getAccessToken
-import no.nav.mulighetsrommet.audit_log.AuditLog
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.auditlog.AuditLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import org.koin.ktor.ext.inject
 
 fun Route.brukerRoutes() {
@@ -31,7 +31,7 @@ fun Route.brukerRoutes() {
             poaoTilgangService.verifyAccessToUserFromVeileder(getNavAnsattAzureId(), getNorskIdent())
             val fnr = call.request.queryParameters["fnr"] ?: return@get call.respondText(
                 "Mangler eller ugyldig fnr",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             val accessToken = call.getAccessToken()
             call.respond(brukerService.hentBrukerdata(fnr, accessToken))
@@ -63,7 +63,7 @@ private fun PipelineContext<Unit, ApplicationCall>.createAuditMessage(msg: Strin
         .timeEnded(System.currentTimeMillis())
         .extension(
             "msg",
-            msg
+            msg,
         )
         .build()
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DelMedBrukerRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DelMedBrukerRoutes.kt
@@ -11,7 +11,7 @@ import no.nav.mulighetsrommet.api.services.DelMedBrukerService
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
 import no.nav.mulighetsrommet.ktor.extensions.getNonEmptyPathParameter
 import no.nav.mulighetsrommet.ktor.extensions.getNonEmptyQueryParameter
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import org.koin.ktor.ext.inject
 
 fun Route.delMedBrukerRoutes() {
@@ -32,7 +32,7 @@ fun Route.delMedBrukerRoutes() {
                     SecureLog.logger.error("Klarte ikke lagre informasjon om deling med bruker", it.error)
                     call.respondText(
                         "Klarte ikke lagre informasjon om deling med bruker",
-                        status = HttpStatusCode.InternalServerError
+                        status = HttpStatusCode.InternalServerError,
                     )
                 }
         }
@@ -48,7 +48,7 @@ fun Route.delMedBrukerRoutes() {
                     if (it == null) {
                         call.respondText(
                             status = HttpStatusCode.NoContent,
-                            text = "Fant ikke innslag om at veileder har delt tiltak med bruker tidligere"
+                            text = "Fant ikke innslag om at veileder har delt tiltak med bruker tidligere",
                         )
                     } else {
                         call.respond(it)
@@ -57,7 +57,7 @@ fun Route.delMedBrukerRoutes() {
                 .onLeft {
                     call.respondText(
                         status = HttpStatusCode.InternalServerError,
-                        text = "Klarte ikke innslag om at veileder har delt tiltak med bruker tidligere"
+                        text = "Klarte ikke innslag om at veileder har delt tiltak med bruker tidligere",
                     )
                 }
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DialogRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DialogRoutes.kt
@@ -16,7 +16,7 @@ import no.nav.mulighetsrommet.api.services.DialogRequest
 import no.nav.mulighetsrommet.api.services.DialogService
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
 import no.nav.mulighetsrommet.api.utils.getAccessToken
-import no.nav.mulighetsrommet.audit_log.AuditLog
+import no.nav.mulighetsrommet.auditlog.AuditLog
 import org.koin.ktor.ext.inject
 
 fun Route.dialogRoutes() {
@@ -42,7 +42,7 @@ fun Route.dialogRoutes() {
 }
 
 private fun PipelineContext<Unit, ApplicationCall>.createAuditMessage(
-    msg: String
+    msg: String,
 ): CefMessage? {
     return CefMessage.builder()
         .applicationName("mulighetsrommet-api")
@@ -54,7 +54,7 @@ private fun PipelineContext<Unit, ApplicationCall>.createAuditMessage(
         .timeEnded(System.currentTimeMillis())
         .extension(
             "msg",
-            msg
+            msg,
         )
         .build()
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ExternalRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ExternalRoutes.kt
@@ -19,14 +19,14 @@ fun Route.externalRoutes() {
         get("tiltaksgjennomforinger/{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@get call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             tiltaksgjennomforingService.get(id)
                 .onRight {
                     if (it == null) {
                         return@get call.respondText(
                             "Det finnes ikke noe tiltaksgjennomføring med id $id",
-                            status = HttpStatusCode.NotFound
+                            status = HttpStatusCode.NotFound,
                         )
                     }
                     call.respond(TiltaksgjennomforingDto.from(it))
@@ -40,12 +40,12 @@ fun Route.externalRoutes() {
         get("tiltaksgjennomforinger/id/{arenaId}") {
             val arenaId = call.parameters["arenaId"] ?: return@get call.respondText(
                 "Mangler eller ugyldig arenaId",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             val idResponse = arenaAdapterService.exchangeTiltaksgjennomforingsArenaIdForId(arenaId)
                 ?: return@get call.respondText(
                     "Det finnes ikke noe tiltaksgjennomføring med arenaId $arenaId",
-                    status = HttpStatusCode.NotFound
+                    status = HttpStatusCode.NotFound,
                 )
             call.respond(idResponse)
         }
@@ -53,19 +53,19 @@ fun Route.externalRoutes() {
         get("tiltaksgjennomforinger/arenadata/{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@get call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             tiltaksgjennomforingService.get(id)
                 .map {
                     if (it == null) {
                         return@get call.respondText(
                             "Det finnes ikke noe tiltaksgjennomføring med id $id",
-                            status = HttpStatusCode.NotFound
+                            status = HttpStatusCode.NotFound,
                         )
                     }
                     val status = arenaAdapterService.hentTiltaksgjennomforingsstatus(id)?.status ?: return@get call.respondText(
                         "Det finnes ikke noe tiltaksgjennomføring med id $id",
-                        status = HttpStatusCode.NotFound
+                        status = HttpStatusCode.NotFound,
                     )
                     call.respond(TiltaksgjennomforingsArenadataDto.from(it, status))
                 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
@@ -35,8 +35,8 @@ fun Route.sanityRoutes() {
             call.respondWithData(
                 sanityService.hentLokasjonerForBrukersEnhetOgFylke(
                     getNorskIdent(),
-                    call.getAccessToken()
-                ).toResponse()
+                    call.getAccessToken(),
+                ).toResponse(),
             )
         }
 
@@ -46,8 +46,8 @@ fun Route.sanityRoutes() {
                 sanityService.hentTiltaksgjennomforingerForBrukerBasertPaEnhetOgFylke(
                     getNorskIdent(),
                     call.getAccessToken(),
-                    getTiltaksgjennomforingsFilter()
-                ).toResponse()
+                    getTiltaksgjennomforingsFilter(),
+                ).toResponse(),
             )
         }
 
@@ -66,7 +66,7 @@ private suspend fun ApplicationCall.respondWithData(apiResponse: ApiResponse) {
     this.response.call.respondText(
         text = apiResponse.text,
         contentType = apiResponse.contentType,
-        status = apiResponse.status
+        status = apiResponse.status,
     )
 }
 
@@ -80,7 +80,7 @@ private fun SanityResponse.toResponse(): ApiResponse {
             log.warn("Error fra Sanity -> {}", this.error)
             return ApiResponse(
                 text = this.error.toString(),
-                status = HttpStatusCode.InternalServerError
+                status = HttpStatusCode.InternalServerError,
             )
         }
     }
@@ -89,5 +89,5 @@ private fun SanityResponse.toResponse(): ApiResponse {
 data class ApiResponse(
     val text: String,
     val contentType: ContentType? = ContentType.Application.Json,
-    val status: HttpStatusCode? = HttpStatusCode.OK
+    val status: HttpStatusCode? = HttpStatusCode.OK,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -37,10 +37,10 @@ fun Route.tiltaksgjennomforingRoutes() {
                             pagination = Pagination(
                                 totalCount = totalCount,
                                 currentPage = paginationParams.page,
-                                pageSize = paginationParams.limit
+                                pageSize = paginationParams.limit,
                             ),
-                            data = items
-                        )
+                            data = items,
+                        ),
                     )
                 }
                 .onLeft {
@@ -52,7 +52,7 @@ fun Route.tiltaksgjennomforingRoutes() {
         get("{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@get call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             tiltaksgjennomforingService
                 .get(id)
@@ -60,7 +60,7 @@ fun Route.tiltaksgjennomforingRoutes() {
                     if (it == null) {
                         return@get call.respondText(
                             "Det finnes ikke noe tiltaksgjennomføring med id $id",
-                            status = HttpStatusCode.NotFound
+                            status = HttpStatusCode.NotFound,
                         )
                     }
                     return@get call.respond(it)
@@ -89,7 +89,7 @@ fun Route.tiltaksgjennomforingRoutes() {
         get("{id}/nokkeltall") {
             val id = call.parameters["id"]?.toUUID() ?: return@get call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             call.respond(tiltaksgjennomforingService.getNokkeltallForTiltaksgjennomforing(id))
         }
@@ -139,7 +139,7 @@ data class TiltaksgjennomforingRequest(
                 virksomhetsnummer = virksomhetsnummer,
                 ansvarlige = listOf(ansvarlig),
                 enheter = enheter,
-            )
+            ),
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
@@ -21,18 +21,18 @@ fun Route.tiltakstypeRoutes() {
             call.respond(
                 tiltakstypeService.getWithFilter(
                     filter,
-                    paginationParams
-                )
+                    paginationParams,
+                ),
             )
         }
         get("{id}") {
             val id = call.parameters["id"]?.toUUID() ?: return@get call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             val tiltakstype = tiltakstypeService.getById(id) ?: return@get call.respondText(
                 "Det finnes ikke noe tiltakstype med id $id",
-                status = HttpStatusCode.NotFound
+                status = HttpStatusCode.NotFound,
             )
 
             call.respond(tiltakstype)
@@ -41,7 +41,7 @@ fun Route.tiltakstypeRoutes() {
         get("{id}/nokkeltall") {
             val id = call.parameters["id"]?.toUUID() ?: return@get call.respondText(
                 "Mangler eller ugyldig id",
-                status = HttpStatusCode.BadRequest
+                status = HttpStatusCode.BadRequest,
             )
             val nokkeltall = tiltakstypeService.getNokkeltallForTiltakstype(id)
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
@@ -18,7 +18,7 @@ fun Route.virksomhetRoutes() {
 
             val enhet = amtEnhetsregisterClientImpl.hentVirksomhet(orgnr) ?: return@get call.respondText(
                 text = "Fant ingen enhet med orgnr: $orgnr",
-                status = HttpStatusCode.NotFound
+                status = HttpStatusCode.NotFound,
             )
 
             call.respond(enhet)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/responses/PaginatedResponse.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/responses/PaginatedResponse.kt
@@ -5,12 +5,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PaginatedResponse<T>(
     val pagination: Pagination,
-    val data: List<T>
+    val data: List<T>,
 )
 
 @Serializable
 data class Pagination(
     val totalCount: Int,
     val currentPage: Int,
-    val pageSize: Int
+    val pageSize: Int,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AnsattService.kt
@@ -8,7 +8,7 @@ import java.util.*
 
 class AnsattService(
     private val poaoTilgangService: PoaoTilgangService,
-    private val microsoftGraphService: MicrosoftGraphService
+    private val microsoftGraphService: MicrosoftGraphService,
 ) {
     suspend fun hentAnsattData(accessToken: String, navAnsattAzureId: UUID): AnsattData {
         val data = microsoftGraphService.hentAnsattData(accessToken, navAnsattAzureId)
@@ -20,7 +20,7 @@ class AnsattService(
             navn = "${data.fornavn} ${data.etternavn}",
             tilganger = azureAdGrupper.mapNotNull(::mapAdGruppeTilTilgang).toSet(),
             hovedenhet = data.hovedenhetKode,
-            hovedenhetNavn = data.hovedenhetNavn
+            hovedenhetNavn = data.hovedenhetNavn,
         )
     }
 }
@@ -41,11 +41,11 @@ data class AnsattData(
     val navn: String?,
     val tilganger: Set<Tilgang>,
     val hovedenhet: String,
-    val hovedenhetNavn: String
+    val hovedenhetNavn: String,
 )
 
 @Serializable
 enum class Tilgang {
     BETABRUKER,
-    UTVIKLER_VALP
+    UTVIKLER_VALP,
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterService.kt
@@ -18,7 +18,7 @@ class ArenaAdapterService(
     private val tiltakshistorikk: TiltakshistorikkRepository,
     private val deltakere: DeltakerRepository,
     private val tiltaksgjennomforingKafkaProducer: TiltaksgjennomforingKafkaProducer,
-    private val tiltakstypeKafkaProducer: TiltakstypeKafkaProducer
+    private val tiltakstypeKafkaProducer: TiltakstypeKafkaProducer,
 ) {
     fun upsertTiltakstype(tiltakstype: TiltakstypeDbo): QueryResult<TiltakstypeDbo> {
         return tiltakstyper.upsert(tiltakstype).onRight {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArrangorService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArrangorService.kt
@@ -10,7 +10,7 @@ import no.nav.mulighetsrommet.utils.CacheUtils
 import java.util.concurrent.TimeUnit
 
 class ArrangorService(
-    private val amtEnhetsregisterClient: AmtEnhetsregisterClient
+    private val amtEnhetsregisterClient: AmtEnhetsregisterClient,
 ) {
 
     private val cache: Cache<String, VirksomhetDto> = Caffeine.newBuilder()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
@@ -20,7 +20,7 @@ class AvtaleService(
     private val arrangorService: ArrangorService,
     private val navEnhetService: NavEnhetService,
     private val tiltaksgjennomforinger: TiltaksgjennomforingRepository,
-    private val amtEnhetsregisterClient: AmtEnhetsregisterClient
+    private val amtEnhetsregisterClient: AmtEnhetsregisterClient,
 ) {
     suspend fun get(id: UUID): AvtaleAdminDto? {
         return avtaler.get(id)
@@ -45,7 +45,7 @@ class AvtaleService(
 
     suspend fun getAll(
         filter: AvtaleFilter,
-        pagination: PaginationParams = PaginationParams()
+        pagination: PaginationParams = PaginationParams(),
     ): PaginatedResponse<AvtaleAdminDto> {
         val (totalCount, items) = avtaler.getAll(filter, pagination)
 
@@ -58,8 +58,8 @@ class AvtaleService(
             pagination = Pagination(
                 totalCount = totalCount,
                 currentPage = pagination.page,
-                pageSize = pagination.limit
-            )
+                pageSize = pagination.limit,
+            ),
         )
     }
 
@@ -90,7 +90,7 @@ class AvtaleService(
         val antallDeltakereForAvtale = tiltaksgjennomforinger.countDeltakereForAvtaleWithId(id)
         return AvtaleNokkeltallDto(
             antallTiltaksgjennomforinger = antallTiltaksgjennomforinger,
-            antallDeltakere = antallDeltakereForAvtale
+            antallDeltakere = antallDeltakereForAvtale,
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
@@ -11,7 +11,7 @@ import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClient
 class BrukerService(
     private val veilarboppfolgingClient: VeilarboppfolgingClient,
     private val veilarbvedtaksstotteClient: VeilarbvedtaksstotteClient,
-    private val veilarbpersonClient: VeilarbpersonClient
+    private val veilarbpersonClient: VeilarbpersonClient,
 ) {
 
     suspend fun hentBrukerdata(fnr: String, accessToken: String): Brukerdata {
@@ -26,7 +26,7 @@ class BrukerService(
             servicegruppe = oppfolgingsstatus?.servicegruppe,
             innsatsgruppe = sisteVedtak?.innsatsgruppe,
             fornavn = personInfo?.fornavn,
-            manuellStatus = manuellStatus
+            manuellStatus = manuellStatus,
         )
     }
 
@@ -37,6 +37,6 @@ class BrukerService(
         val oppfolgingsenhet: Oppfolgingsenhet?,
         val servicegruppe: String?,
         val fornavn: String?,
-        val manuellStatus: ManuellStatusDto?
+        val manuellStatus: ManuellStatusDto?,
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerService.kt
@@ -7,7 +7,7 @@ import no.nav.mulighetsrommet.api.domain.dbo.DelMedBrukerDbo
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.QueryResult
 import no.nav.mulighetsrommet.database.utils.query
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 
@@ -24,7 +24,7 @@ class DelMedBrukerService(private val db: Database) {
 
         if (data.navident.trim().isEmpty()) {
             SecureLog.logger.warn(
-                "Veileders NAVident er tomt. Kan ikke lagre info om tiltak."
+                "Veileders NAVident er tomt. Kan ikke lagre info om tiltak.",
             )
             throw BadRequestException("Veileders NAVident er ikke 6 tegn")
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DialogService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DialogService.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.clients.dialog.VeilarbdialogClient
 
 class DialogService(
-    private val veilarbdialogClient: VeilarbdialogClient
+    private val veilarbdialogClient: VeilarbdialogClient,
 ) {
     suspend fun sendMeldingTilDialogen(fnr: String, accessToken: String, dialogRequest: DialogRequest): DialogResponse? {
         return veilarbdialogClient.sendMeldingTilDialogen(fnr, accessToken, dialogRequest)
@@ -14,10 +14,10 @@ class DialogService(
 @Serializable
 data class DialogRequest(
     val overskrift: String,
-    val tekst: String
+    val tekst: String,
 )
 
 @Serializable
 data class DialogResponse(
-    val id: String
+    val id: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncService.kt
@@ -15,7 +15,7 @@ class KafkaSyncService(
     private val tiltaksgjennomforingRepository: TiltaksgjennomforingRepository,
     private val tiltakstypeRepository: TiltakstypeRepository,
     private val tiltaksgjennomforingKafkaProducer: TiltaksgjennomforingKafkaProducer,
-    private val tiltakstypeKafkaProducer: TiltakstypeKafkaProducer
+    private val tiltakstypeKafkaProducer: TiltakstypeKafkaProducer,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -27,7 +27,7 @@ class KafkaSyncService(
                 dateIntervalStart = lastSuccessDate,
                 dateIntervalEnd = today,
                 avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
-                pagination = paginationParams
+                pagination = paginationParams,
             ).getOrThrow()
 
             tiltaksgjennomforinger.forEach { it ->
@@ -49,7 +49,7 @@ class KafkaSyncService(
             val tiltakstyper = tiltakstypeRepository.getAllByDateInterval(
                 dateIntervalStart = lastSuccessDate,
                 dateIntervalEnd = today,
-                pagination = paginationParams
+                pagination = paginationParams,
             )
 
             tiltakstyper.forEach { it ->

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavEnhetService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavEnhetService.kt
@@ -29,7 +29,7 @@ class NavEnhetService(private val enhetRepository: EnhetRepository) {
     }
 
     fun hentEnheterForAvtale(
-        filter: EnhetFilter
+        filter: EnhetFilter,
     ): List<NavEnhetDbo> {
         return enhetRepository.getAllEnheterWithAvtale(filter)
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/Norg2Service.kt
@@ -32,8 +32,8 @@ class Norg2Service(private val norg2Client: Norg2Client, private val enhetReposi
                     enhetNr = it.enhet.enhetNr,
                     status = NavEnhetStatus.valueOf(it.enhet.status.name),
                     type = Norg2Type.valueOf(it.enhet.type.name),
-                    overordnetEnhet = it.overordnetEnhet
-                )
+                    overordnetEnhet = it.overordnetEnhet,
+                ),
             )
         }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/PoaoTilgangService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/PoaoTilgangService.kt
@@ -6,14 +6,14 @@ import io.ktor.http.*
 import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import no.nav.mulighetsrommet.ktor.exception.StatusException
 import no.nav.mulighetsrommet.ktor.plugins.Metrikker
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import no.nav.mulighetsrommet.utils.CacheUtils
 import no.nav.poao_tilgang.client.*
 import java.util.*
 import java.util.concurrent.TimeUnit
 
 class PoaoTilgangService(
-    val client: PoaoTilgangClient
+    val client: PoaoTilgangClient,
 ) {
 
     private val tilgangCache: Cache<String, Boolean> = Caffeine.newBuilder()
@@ -40,8 +40,8 @@ class PoaoTilgangService(
                 NavAnsattTilgangTilEksternBrukerPolicyInput(
                     navAnsattAzureId,
                     TilgangType.LESE,
-                    norskIdent
-                )
+                    norskIdent,
+                ),
             )
                 .getOrDefault(Decision.Deny("Veileder har ikke tilgang til bruker", "")).isPermit
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -95,7 +95,7 @@ class SanityService(private val config: Config, private val brukerService: Bruke
             executeQuery(
                 """
             *[_type == "innsatsgruppe" && !(_id in path("drafts.**"))] | order(order asc)
-                """.trimIndent()
+                """.trimIndent(),
             )
         }
     }
@@ -105,7 +105,7 @@ class SanityService(private val config: Config, private val brukerService: Bruke
             executeQuery(
                 """
                 *[_type == "tiltakstype" && !(_id in path("drafts.**"))]
-                """.trimIndent()
+                """.trimIndent(),
             )
         }
     }
@@ -125,7 +125,7 @@ class SanityService(private val config: Config, private val brukerService: Bruke
 
         return CacheUtils.tryCacheFirstNotNull(sanityCache, fnr) {
             executeQuery(
-                query
+                query,
             )
         }
     }
@@ -133,7 +133,7 @@ class SanityService(private val config: Config, private val brukerService: Bruke
     suspend fun hentTiltaksgjennomforingerForBrukerBasertPaEnhetOgFylke(
         fnr: String,
         accessToken: String,
-        filter: TiltaksgjennomforingFilter
+        filter: TiltaksgjennomforingFilter,
     ): SanityResponse {
         val brukerData = brukerService.hentBrukerdata(fnr, accessToken)
         val enhetsId = brukerData.oppfolgingsenhet?.enhetId ?: ""
@@ -214,7 +214,7 @@ class SanityService(private val config: Config, private val brukerService: Bruke
         val fylkeResponse = when (response) {
             is SanityResponse.Result -> response.result?.let {
                 JsonIgnoreUnknownKeys.decodeFromJsonElement<FylkeResponse>(
-                    it
+                    it,
                 )
             }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -16,7 +16,7 @@ import java.util.*
 class TiltaksgjennomforingService(
     private val tiltaksgjennomforingRepository: TiltaksgjennomforingRepository,
     private val arrangorService: ArrangorService,
-    private val deltakerRepository: DeltakerRepository
+    private val deltakerRepository: DeltakerRepository,
 ) {
     private val log = LoggerFactory.getLogger("TiltaksgjennomforingService")
 
@@ -26,7 +26,7 @@ class TiltaksgjennomforingService(
 
     suspend fun getAll(
         paginationParams: PaginationParams,
-        filter: AdminTiltaksgjennomforingFilter
+        filter: AdminTiltaksgjennomforingFilter,
     ): QueryResult<Pair<Int, List<TiltaksgjennomforingAdminDto>>> =
         tiltaksgjennomforingRepository
             .getAll(paginationParams, filter)
@@ -41,7 +41,7 @@ class TiltaksgjennomforingService(
 
     fun getNokkeltallForTiltaksgjennomforing(tiltaksgjennomforingId: UUID): TiltaksgjennomforingNokkeltallDto =
         TiltaksgjennomforingNokkeltallDto(
-            antallDeltakere = deltakerRepository.countAntallDeltakereForTiltakstypeWithId(tiltaksgjennomforingId)
+            antallDeltakere = deltakerRepository.countAntallDeltakereForTiltakstypeWithId(tiltaksgjennomforingId),
         )
 
     private suspend fun TiltaksgjennomforingAdminDto.hentVirksomhetsnavnForTiltaksgjennomforing(): TiltaksgjennomforingAdminDto {
@@ -54,5 +54,5 @@ class TiltaksgjennomforingService(
 }
 
 data class Sokefilter(
-    val tiltaksnummer: String
+    val tiltaksnummer: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkService.kt
@@ -2,13 +2,13 @@ package no.nav.mulighetsrommet.api.services
 
 import no.nav.mulighetsrommet.api.domain.dto.TiltakshistorikkDto
 import no.nav.mulighetsrommet.api.repositories.TiltakshistorikkRepository
-import no.nav.mulighetsrommet.secure_log.SecureLog
+import no.nav.mulighetsrommet.securelog.SecureLog
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class TiltakshistorikkService(
     private val arrangorService: ArrangorService,
-    private val tiltakshistorikkRepository: TiltakshistorikkRepository
+    private val tiltakshistorikkRepository: TiltakshistorikkRepository,
 ) {
     val log: Logger = LoggerFactory.getLogger(javaClass)
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
@@ -16,15 +16,15 @@ class TiltakstypeService(
     private val tiltakstypeRepository: TiltakstypeRepository,
     private val tiltaksgjennomforingRepository: TiltaksgjennomforingRepository,
     private val avtaleRepository: AvtaleRepository,
-    private val deltakerRepository: DeltakerRepository
+    private val deltakerRepository: DeltakerRepository,
 ) {
     fun getWithFilter(
         tiltakstypeFilter: TiltakstypeFilter,
-        paginationParams: PaginationParams
+        paginationParams: PaginationParams,
     ): PaginatedResponse<TiltakstypeDto> {
         val (totalCount, items) = tiltakstypeRepository.getAllSkalMigreres(
             tiltakstypeFilter,
-            paginationParams
+            paginationParams,
         )
 
         return PaginatedResponse(
@@ -32,8 +32,8 @@ class TiltakstypeService(
             pagination = Pagination(
                 totalCount = totalCount,
                 currentPage = paginationParams.page,
-                pageSize = paginationParams.limit
-            )
+                pageSize = paginationParams.limit,
+            ),
         )
     }
 
@@ -48,7 +48,7 @@ class TiltakstypeService(
         return TiltakstypeNokkeltallDto(
             antallTiltaksgjennomforinger = antallGjennomforinger,
             antallAvtaler = antallAvtaler,
-            antallDeltakere = antallDeltakere
+            antallDeltakere = antallDeltakere,
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNorgEnheter.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNorgEnheter.kt
@@ -5,7 +5,7 @@ import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay
 import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.api.services.Norg2Service
-import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
+import no.nav.mulighetsrommet.slack.SlackNotifier
 import org.slf4j.LoggerFactory
 
 class SynchronizeNorgEnheter(config: Config, norg2Service: Norg2Service, slackNotifier: SlackNotifier) {
@@ -13,7 +13,7 @@ class SynchronizeNorgEnheter(config: Config, norg2Service: Norg2Service, slackNo
 
     data class Config(
         val delayOfMinutes: Int,
-        val schedulerStatePollDelay: Long = 1000
+        val schedulerStatePollDelay: Long = 1000,
     )
 
     val task: RecurringTask<Void> = Tasks

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeTiltaksgjennomforingsstatuserToKafka.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeTiltaksgjennomforingsstatuserToKafka.kt
@@ -5,7 +5,7 @@ import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import com.github.kagkarlsson.scheduler.task.schedule.Daily
 import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.api.services.KafkaSyncService
-import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
+import no.nav.mulighetsrommet.slack.SlackNotifier
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalTime
@@ -13,7 +13,7 @@ import java.time.ZoneId
 
 class SynchronizeTiltaksgjennomforingsstatuserToKafka(
     kafkaSyncService: KafkaSyncService,
-    slackNotifier: SlackNotifier
+    slackNotifier: SlackNotifier,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -28,7 +28,7 @@ class SynchronizeTiltaksgjennomforingsstatuserToKafka(
                 kafkaSyncService.oppdaterTiltaksgjennomforingsstatus(
                     LocalDate.now(),
                     context.execution.lastSuccess?.let { LocalDate.ofInstant(it, ZoneId.systemDefault()) }
-                        ?: LocalDate.of(2023, 2, 1)
+                        ?: LocalDate.of(2023, 2, 1),
                 )
             }
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeTiltakstypestatuserToKafka.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeTiltakstypestatuserToKafka.kt
@@ -5,7 +5,7 @@ import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import com.github.kagkarlsson.scheduler.task.schedule.Daily
 import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.api.services.KafkaSyncService
-import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
+import no.nav.mulighetsrommet.slack.SlackNotifier
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalTime
@@ -13,7 +13,7 @@ import java.time.ZoneId
 
 class SynchronizeTiltakstypestatuserToKafka(
     kafkaSyncService: KafkaSyncService,
-    slackNotifier: SlackNotifier
+    slackNotifier: SlackNotifier,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -28,7 +28,7 @@ class SynchronizeTiltakstypestatuserToKafka(
                 kafkaSyncService.oppdaterTiltakstypestatus(
                     LocalDate.now(),
                     context.execution.lastSuccess?.let { LocalDate.ofInstant(it, ZoneId.systemDefault()) }
-                        ?: LocalDate.of(2023, 2, 1)
+                        ?: LocalDate.of(2023, 2, 1),
                 )
             }
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -33,14 +33,14 @@ data class AdminTiltaksgjennomforingFilter(
     val tiltakstypeId: UUID? = null,
     val statuser: List<Avslutningsstatus>? = null,
     val sortering: String? = null,
-    val sluttDatoCutoff: LocalDate? = LocalDate.of(2023, 1, 1)
+    val sluttDatoCutoff: LocalDate? = LocalDate.of(2023, 1, 1),
 )
 
 data class EnhetFilter(
     val statuser: List<NavEnhetStatus>? = listOf(
         NavEnhetStatus.AKTIV,
         NavEnhetStatus.UNDER_AVVIKLING,
-        NavEnhetStatus.UNDER_ETABLERING
+        NavEnhetStatus.UNDER_ETABLERING,
     ),
     val tiltakstypeId: String? = null,
 )
@@ -49,7 +49,7 @@ data class TiltaksgjennomforingFilter(
     val innsatsgruppe: String? = null,
     val tiltakstypeIder: List<String> = emptyList(),
     val sokestreng: String = "",
-    val lokasjoner: List<String> = emptyList()
+    val lokasjoner: List<String> = emptyList(),
 )
 
 enum class Tiltakstypekategori {
@@ -83,7 +83,7 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getAvtaleFilter(): AvtaleFilte
         search = search,
         avtalestatus = avtalestatus,
         enhet = enhet,
-        sortering = sortering
+        sortering = sortering,
     )
 }
 
@@ -98,7 +98,7 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getAdminTiltaksgjennomforingsF
         enhet = enhet,
         tiltakstypeId = tiltakstypeId,
         statuser = statuser,
-        sortering = sortering
+        sortering = sortering,
     )
 }
 
@@ -117,6 +117,6 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getTiltaksgjennomforingsFilter
         innsatsgruppe = innsatsgruppe,
         tiltakstypeIder = tiltakstypeIder,
         sokestreng = sokestreng,
-        lokasjoner = lokasjoner
+        lokasjoner = lokasjoner,
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/PaginationUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/PaginationUtils.kt
@@ -5,7 +5,7 @@ import io.ktor.util.pipeline.*
 
 class PaginationParams(
     private val nullablePage: Int? = null,
-    private val nullableLimit: Int? = null
+    private val nullableLimit: Int? = null,
 ) {
     val page get() = nullablePage ?: 1
     val limit get() = nullableLimit ?: DEFAULT_PAGINATION_LIMIT
@@ -17,6 +17,6 @@ const val DEFAULT_PAGINATION_LIMIT = 50
 fun <T : Any> PipelineContext<T, ApplicationCall>.getPaginationParams(): PaginationParams {
     return PaginationParams(
         nullablePage = call.parameters["page"]?.toIntOrNull(),
-        nullableLimit = call.parameters["size"]?.toIntOrNull()
+        nullableLimit = call.parameters["size"]?.toIntOrNull(),
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityFilters.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityFilters.kt
@@ -49,20 +49,20 @@ fun utledInnsatsgrupper(innsatsgruppe: String): List<String> {
         Innsatsgruppe.STANDARD_INNSATS.name -> listOf(Innsatsgruppe.STANDARD_INNSATS.name)
         Innsatsgruppe.SITUASJONSBESTEMT_INNSATS.name -> listOf(
             Innsatsgruppe.STANDARD_INNSATS.name,
-            Innsatsgruppe.SITUASJONSBESTEMT_INNSATS.name
+            Innsatsgruppe.SITUASJONSBESTEMT_INNSATS.name,
         )
 
         Innsatsgruppe.SPESIELT_TILPASSET_INNSATS.name -> listOf(
             Innsatsgruppe.STANDARD_INNSATS.name,
             Innsatsgruppe.SITUASJONSBESTEMT_INNSATS.name,
-            Innsatsgruppe.SPESIELT_TILPASSET_INNSATS.name
+            Innsatsgruppe.SPESIELT_TILPASSET_INNSATS.name,
         )
 
         Innsatsgruppe.VARIG_TILPASSET_INNSATS.name -> listOf(
             Innsatsgruppe.STANDARD_INNSATS.name,
             Innsatsgruppe.SITUASJONSBESTEMT_INNSATS.name,
             Innsatsgruppe.SPESIELT_TILPASSET_INNSATS.name,
-            Innsatsgruppe.VARIG_TILPASSET_INNSATS.name
+            Innsatsgruppe.VARIG_TILPASSET_INNSATS.name,
         )
 
         else -> emptyList()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/kafka/amt/AmtDeltakerV1TopicConsumer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/kafka/amt/AmtDeltakerV1TopicConsumer.kt
@@ -20,7 +20,7 @@ class AmtDeltakerV1TopicConsumer(
 ) : KafkaTopicConsumer<UUID, JsonElement>(
     config,
     uuidDeserializer(),
-    JsonElementDeserializer()
+    JsonElementDeserializer(),
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -17,7 +17,7 @@ fun createDatabaseTestConfig() = createDatabaseTestSchema("mulighetsrommet-api-d
 fun <R> withTestApplication(
     oauth: MockOAuth2Server = MockOAuth2Server(),
     config: AppConfig = createTestApplicationConfig(oauth),
-    test: suspend ApplicationTestBuilder.() -> R
+    test: suspend ApplicationTestBuilder.() -> R,
 ) {
     var flywayAdapter: FlywayDatabaseAdapter? = null
 
@@ -52,15 +52,15 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     arenaAdapter = createServiceClientConfig("arena-adapter"),
     tasks = TaskConfig(
         synchronizeNorgEnheter = SynchronizeNorgEnheter.Config(
-            delayOfMinutes = 10
+            delayOfMinutes = 10,
         ),
     ),
     norg2 = Norg2Config(baseUrl = ""),
     slack = SlackConfig(
         token = "",
         channel = "",
-        enable = false
-    )
+        enable = false,
+    ),
 )
 
 fun createKafkaConfig(): KafkaConfig {
@@ -69,19 +69,19 @@ fun createKafkaConfig(): KafkaConfig {
         producerId = "mulighetsrommet-api-producer",
         producers = KafkaProducers(
             tiltaksgjennomforinger = TiltaksgjennomforingKafkaProducer.Config(topic = "siste-tiltaksgjennomforinger-v1"),
-            tiltakstyper = TiltakstypeKafkaProducer.Config(topic = "siste-tiltakstyper-v1")
+            tiltakstyper = TiltakstypeKafkaProducer.Config(topic = "siste-tiltakstyper-v1"),
         ),
         consumerGroupId = "mulighetsrommet-api-consumer",
         consumers = KafkaConsumers(
             amtDeltakerV1 = KafkaTopicConsumer.Config(id = "amt-deltaker", topic = "amt-deltaker"),
-        )
+        ),
     )
 }
 
 fun createServiceClientConfig(url: String): ServiceClientConfig {
     return ServiceClientConfig(
         url = url,
-        scope = ""
+        scope = "",
     )
 }
 
@@ -90,14 +90,14 @@ fun createServiceClientConfig(url: String): ServiceClientConfig {
 fun createAuthConfig(
     oauth: MockOAuth2Server,
     issuer: String = "default",
-    audience: String = "default"
+    audience: String = "default",
 ): AuthConfig {
     return AuthConfig(
         azure = AuthProvider(
             issuer = oauth.issuerUrl(issuer).toString(),
             jwksUri = oauth.jwksUrl(issuer).toUri().toString(),
             audience = audience,
-            tokenEndpointUrl = oauth.tokenEndpointUrl(issuer).toString()
-        )
+            tokenEndpointUrl = oauth.tokenEndpointUrl(issuer).toString(),
+        ),
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -30,8 +30,8 @@ class AvtaleFixtures(private val database: FlywayDatabaseTestListener) {
                 registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                 sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                 fraDato = LocalDate.of(2023, 1, 11),
-                tilDato = LocalDate.of(2023, 1, 12)
-            )
+                tilDato = LocalDate.of(2023, 1, 12),
+            ),
         ).getOrThrow()
     }
 
@@ -62,7 +62,7 @@ class AvtaleFixtures(private val database: FlywayDatabaseTestListener) {
         avslutningsstatus: Avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         startDato: LocalDate = LocalDate.of(2023, 1, 11),
         sluttDato: LocalDate = LocalDate.of(2023, 2, 28),
-        ansvarlige: List<String> = emptyList()
+        ansvarlige: List<String> = emptyList(),
     ): AvtaleDbo {
         return AvtaleDbo(
             id = UUID.randomUUID(),
@@ -77,7 +77,7 @@ class AvtaleFixtures(private val database: FlywayDatabaseTestListener) {
             avslutningsstatus = avslutningsstatus,
             prisbetingelser = null,
             opphav = AvtaleDbo.Opphav.MR_ADMIN_FLATE,
-            ansvarlige = ansvarlige
+            ansvarlige = ansvarlige,
         )
     }
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/Norg2Fixture.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/Norg2Fixture.kt
@@ -22,6 +22,6 @@ object NavEnhetDboFixture {
         navn = "Enhet X",
         status = NavEnhetStatus.AKTIV,
         type = Norg2Type.LOKAL,
-        overordnetEnhet = "1200"
+        overordnetEnhet = "1200",
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
@@ -64,7 +64,7 @@ class AvtaleRepositoryTest : FunSpec({
     context("Filter for avtaler") {
 
         val defaultFilter = AvtaleFilter(
-            dagensDato = LocalDate.of(2023, 2, 1)
+            dagensDato = LocalDate.of(2023, 2, 1),
         )
 
         context("Avtalenavn") {
@@ -81,7 +81,7 @@ class AvtaleRepositoryTest : FunSpec({
                     filter = defaultFilter.copy(
                         tiltakstypeId = avtaleFixture.tiltakstypeId,
                         search = "Kroko",
-                    )
+                    ),
                 )
 
                 result.second shouldHaveSize 1
@@ -99,14 +99,14 @@ class AvtaleRepositoryTest : FunSpec({
                 )
                 val avtaleAvsluttetDato = avtaleFixture.createAvtaleForTiltakstype(
                     avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
-                    sluttDato = LocalDate.of(2023, 1, 31)
+                    sluttDato = LocalDate.of(2023, 1, 31),
                 )
                 val avtaleAvbrutt = avtaleFixture.createAvtaleForTiltakstype(
                     avslutningsstatus = Avslutningsstatus.AVBRUTT,
                 )
                 val avtalePlanlagt = avtaleFixture.createAvtaleForTiltakstype(
                     avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
-                    startDato = LocalDate.of(2023, 2, 2)
+                    startDato = LocalDate.of(2023, 2, 2),
                 )
 
                 val avtaleRepository = avtaleFixture.upsertAvtaler(
@@ -115,14 +115,14 @@ class AvtaleRepositoryTest : FunSpec({
                         avtaleAvbrutt,
                         avtalePlanlagt,
                         avtaleAvsluttetDato,
-                        avtaleAvsluttetStatus
-                    )
+                        avtaleAvsluttetStatus,
+                    ),
                 )
                 val result = avtaleRepository.getAll(
                     filter = defaultFilter.copy(
                         tiltakstypeId = avtaleFixture.tiltakstypeId,
                         avtalestatus = Avtalestatus.Avbrutt,
-                    )
+                    ),
                 )
 
                 result.second shouldHaveSize 1
@@ -138,14 +138,14 @@ class AvtaleRepositoryTest : FunSpec({
                 )
                 val avtaleAvsluttetDato = avtaleFixture.createAvtaleForTiltakstype(
                     avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
-                    sluttDato = LocalDate.of(2023, 1, 31)
+                    sluttDato = LocalDate.of(2023, 1, 31),
                 )
                 val avtaleAvbrutt = avtaleFixture.createAvtaleForTiltakstype(
                     avslutningsstatus = Avslutningsstatus.AVBRUTT,
                 )
                 val avtalePlanlagt = avtaleFixture.createAvtaleForTiltakstype(
                     avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
-                    startDato = LocalDate.of(2023, 2, 2)
+                    startDato = LocalDate.of(2023, 2, 2),
                 )
 
                 val avtaleRepository = avtaleFixture.upsertAvtaler(
@@ -154,14 +154,14 @@ class AvtaleRepositoryTest : FunSpec({
                         avtaleAvbrutt,
                         avtalePlanlagt,
                         avtaleAvsluttetDato,
-                        avtaleAvsluttetStatus
-                    )
+                        avtaleAvsluttetStatus,
+                    ),
                 )
                 val result = avtaleRepository.getAll(
                     filter = defaultFilter.copy(
                         tiltakstypeId = avtaleFixture.tiltakstypeId,
                         avtalestatus = Avtalestatus.Avsluttet,
-                    )
+                    ),
                 )
 
                 result.second shouldHaveSize 2
@@ -171,18 +171,18 @@ class AvtaleRepositoryTest : FunSpec({
         context("Enhet") {
             test("Filtrere på enhet returnerer avtaler for gitt enhet") {
                 val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
-                    enhet = "1801"
+                    enhet = "1801",
                 )
                 val avtale2 = avtaleFixture.createAvtaleForTiltakstype(
-                    enhet = "1900"
+                    enhet = "1900",
                 )
                 val avtaleRepository = avtaleFixture.upsertAvtaler(listOf(avtale1, avtale2))
                 val result = avtaleRepository.getAll(
 
                     filter = defaultFilter.copy(
                         tiltakstypeId = avtaleFixture.tiltakstypeId,
-                        enhet = "1801"
-                    )
+                        enhet = "1801",
+                    ),
                 )
                 result.second shouldHaveSize 1
                 result.second[0].navEnhet.enhetsnummer shouldBe "1801"
@@ -193,13 +193,13 @@ class AvtaleRepositoryTest : FunSpec({
             val tiltakstypeId: UUID = avtaleFixture.tiltakstypeId
             val tiltakstypeIdForAvtale3: UUID = UUID.randomUUID()
             val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
-                tiltakstypeId = tiltakstypeId
+                tiltakstypeId = tiltakstypeId,
             )
             val avtale2 = avtaleFixture.createAvtaleForTiltakstype(
-                tiltakstypeId = tiltakstypeId
+                tiltakstypeId = tiltakstypeId,
             )
             val avtale3 = avtaleFixture.createAvtaleForTiltakstype(
-                tiltakstypeId = tiltakstypeIdForAvtale3
+                tiltakstypeId = tiltakstypeIdForAvtale3,
             )
             avtaleFixture.upsertTiltakstype(
                 listOf(
@@ -211,15 +211,15 @@ class AvtaleRepositoryTest : FunSpec({
                         registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                         sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                         fraDato = LocalDate.of(2023, 1, 11),
-                        tilDato = LocalDate.of(2023, 1, 12)
-                    )
-                )
+                        tilDato = LocalDate.of(2023, 1, 12),
+                    ),
+                ),
             )
             val avtaleRepository = avtaleFixture.upsertAvtaler(listOf(avtale1, avtale2, avtale3))
             val result = avtaleRepository.getAll(
                 filter = defaultFilter.copy(
-                    tiltakstypeId = tiltakstypeId
-                )
+                    tiltakstypeId = tiltakstypeId,
+                ),
             )
 
             result.second shouldHaveSize 2
@@ -230,25 +230,25 @@ class AvtaleRepositoryTest : FunSpec({
         context("Sortering") {
             test("Sortering på navn fra a-å sorterer korrekt med æøå til slutt") {
                 val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Anders"
+                    navn = "Avtale hos Anders",
                 )
                 val avtale2 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Åse"
+                    navn = "Avtale hos Åse",
                 )
                 val avtale3 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Øyvind"
+                    navn = "Avtale hos Øyvind",
                 )
                 val avtale4 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Kjetil"
+                    navn = "Avtale hos Kjetil",
                 )
                 val avtale5 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Ærfuglen Ærle"
+                    navn = "Avtale hos Ærfuglen Ærle",
                 )
                 val avtaleRepository = avtaleFixture.upsertAvtaler(listOf(avtale1, avtale2, avtale3, avtale4, avtale5))
                 val result = avtaleRepository.getAll(
                     filter = defaultFilter.copy(
-                        sortering = "navn-ascending"
-                    )
+                        sortering = "navn-ascending",
+                    ),
                 )
 
                 result.second shouldHaveSize 5
@@ -261,25 +261,25 @@ class AvtaleRepositoryTest : FunSpec({
 
             test("Sortering på navn fra å-a sorterer korrekt") {
                 val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Anders"
+                    navn = "Avtale hos Anders",
                 )
                 val avtale2 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Åse"
+                    navn = "Avtale hos Åse",
                 )
                 val avtale3 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Øyvind"
+                    navn = "Avtale hos Øyvind",
                 )
                 val avtale4 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Kjetil"
+                    navn = "Avtale hos Kjetil",
                 )
                 val avtale5 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Ærfuglen Ærle"
+                    navn = "Avtale hos Ærfuglen Ærle",
                 )
                 val avtaleRepository = avtaleFixture.upsertAvtaler(listOf(avtale1, avtale2, avtale3, avtale4, avtale5))
                 val result = avtaleRepository.getAll(
                     filter = defaultFilter.copy(
-                        sortering = "navn-descending"
-                    )
+                        sortering = "navn-descending",
+                    ),
                 )
 
                 result.second shouldHaveSize 5
@@ -292,25 +292,25 @@ class AvtaleRepositoryTest : FunSpec({
 
             test("Sortering på navn fra a-å sorterer korrekt med æøå til slutt") {
                 val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Anders"
+                    navn = "Avtale hos Anders",
                 )
                 val avtale2 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Åse"
+                    navn = "Avtale hos Åse",
                 )
                 val avtale3 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Øyvind"
+                    navn = "Avtale hos Øyvind",
                 )
                 val avtale4 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Kjetil"
+                    navn = "Avtale hos Kjetil",
                 )
                 val avtale5 = avtaleFixture.createAvtaleForTiltakstype(
-                    navn = "Avtale hos Ærfuglen Ærle"
+                    navn = "Avtale hos Ærfuglen Ærle",
                 )
                 val avtaleRepository = avtaleFixture.upsertAvtaler(listOf(avtale1, avtale2, avtale3, avtale4, avtale5))
                 val result = avtaleRepository.getAll(
                     filter = defaultFilter.copy(
-                        sortering = "navn-ascending"
-                    )
+                        sortering = "navn-ascending",
+                    ),
                 )
 
                 result.second shouldHaveSize 5
@@ -324,34 +324,34 @@ class AvtaleRepositoryTest : FunSpec({
             test("Sortering på sluttdato fra a-å sorterer korrekt") {
                 val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2010, 1, 31),
-                    navn = "Avtale hos Anders"
+                    navn = "Avtale hos Anders",
                 )
                 val avtale2 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2009, 1, 1),
-                    navn = "Avtale hos Åse"
+                    navn = "Avtale hos Åse",
                 )
                 val avtale3 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2010, 1, 1),
-                    navn = "Avtale hos Øyvind"
+                    navn = "Avtale hos Øyvind",
                 )
                 val avtale4 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2011, 1, 1),
-                    navn = "Avtale hos Kjetil"
+                    navn = "Avtale hos Kjetil",
                 )
                 val avtale5 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2023, 1, 1),
-                    navn = "Avtale hos Benny"
+                    navn = "Avtale hos Benny",
                 )
                 val avtale6 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2023, 1, 1),
-                    navn = "Avtale hos Christina"
+                    navn = "Avtale hos Christina",
                 )
                 val avtaleRepository =
                     avtaleFixture.upsertAvtaler(listOf(avtale1, avtale2, avtale3, avtale4, avtale5, avtale6))
                 val result = avtaleRepository.getAll(
                     filter = defaultFilter.copy(
-                        sortering = "sluttdato-descending"
-                    )
+                        sortering = "sluttdato-descending",
+                    ),
                 )
 
                 result.second shouldHaveSize 6
@@ -372,34 +372,34 @@ class AvtaleRepositoryTest : FunSpec({
             test("Sortering på sluttdato fra å-a sorterer korrekt") {
                 val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2010, 1, 31),
-                    navn = "Avtale hos Anders"
+                    navn = "Avtale hos Anders",
                 )
                 val avtale2 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2009, 1, 1),
-                    navn = "Avtale hos Åse"
+                    navn = "Avtale hos Åse",
                 )
                 val avtale3 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2010, 1, 1),
-                    navn = "Avtale hos Øyvind"
+                    navn = "Avtale hos Øyvind",
                 )
                 val avtale4 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2011, 1, 1),
-                    navn = "Avtale hos Kjetil"
+                    navn = "Avtale hos Kjetil",
                 )
                 val avtale5 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2023, 1, 1),
-                    navn = "Avtale hos Benny"
+                    navn = "Avtale hos Benny",
                 )
                 val avtale6 = avtaleFixture.createAvtaleForTiltakstype(
                     sluttDato = LocalDate.of(2023, 1, 1),
-                    navn = "Avtale hos Christina"
+                    navn = "Avtale hos Christina",
                 )
                 val avtaleRepository =
                     avtaleFixture.upsertAvtaler(listOf(avtale1, avtale2, avtale3, avtale4, avtale5, avtale6))
                 val result = avtaleRepository.getAll(
                     filter = defaultFilter.copy(
-                        sortering = "sluttdato-ascending"
-                    )
+                        sortering = "sluttdato-ascending",
+                    ),
                 )
 
                 result.second shouldHaveSize 6
@@ -436,26 +436,26 @@ class AvtaleRepositoryTest : FunSpec({
                     id = UUID.randomUUID(),
                     tiltakstypeId = avtaleFixture.tiltakstypeId,
                     startDato = LocalDate.of(2021, 1, 1),
-                    sluttDato = LocalDate.of(2022, 10, 15)
+                    sluttDato = LocalDate.of(2022, 10, 15),
                 )
                 val gjennomforing2 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                     id = UUID.randomUUID(),
                     tiltakstypeId = avtaleFixture.tiltakstypeId,
                     startDato = LocalDate.of(2021, 1, 1),
                     sluttDato = LocalDate.of(2050, 10, 15),
-                    avtaleId = avtale.id
+                    avtaleId = avtale.id,
                 )
                 val gjennomforing3 = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                     id = UUID.randomUUID(),
                     tiltakstypeId = tiltakstypeIdSomIkkeSkalMatche,
                     startDato = LocalDate.of(2021, 1, 1),
-                    sluttDato = LocalDate.of(2050, 10, 15)
+                    sluttDato = LocalDate.of(2050, 10, 15),
                 )
                 val gjennomforing4 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                     id = UUID.randomUUID(),
                     tiltakstypeId = tiltakstypeIdSomIkkeSkalMatche,
                     startDato = LocalDate.of(2021, 1, 1),
-                    sluttDato = LocalDate.of(2050, 10, 15)
+                    sluttDato = LocalDate.of(2050, 10, 15),
                 )
 
                 tiltakstypeRepository.upsert(tiltakstype).getOrThrow()
@@ -484,19 +484,19 @@ class AvtaleRepositoryTest : FunSpec({
 
                 val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
                     startDato = LocalDate.of(2021, 1, 1),
-                    sluttDato = LocalDate.of(2022, 10, 15)
+                    sluttDato = LocalDate.of(2022, 10, 15),
                 )
                 val avtale2 = avtaleFixture.createAvtaleForTiltakstype(
                     startDato = LocalDate.of(2021, 1, 1),
-                    sluttDato = LocalDate.of(2050, 10, 15)
+                    sluttDato = LocalDate.of(2050, 10, 15),
                 )
                 val avtale3 = avtaleFixture.createAvtaleForTiltakstype(
                     startDato = LocalDate.of(2021, 1, 1),
-                    sluttDato = LocalDate.of(2050, 10, 15)
+                    sluttDato = LocalDate.of(2050, 10, 15),
                 )
                 val avtale4 = avtaleFixture.createAvtaleForTiltakstype(
                     startDato = LocalDate.of(2021, 1, 1),
-                    sluttDato = LocalDate.of(2050, 10, 15)
+                    sluttDato = LocalDate.of(2050, 10, 15),
                 )
                 val avtale5 = avtaleFixture.createAvtaleForTiltakstype(tiltakstypeId = tiltakstypeIdSomIkkeSkalMatche)
                 tiltakstypeRepository.upsert(tiltakstype).getOrThrow()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/DeltakerRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/DeltakerRepositoryTest.kt
@@ -122,7 +122,7 @@ class DeltakerRepositoryTest : FunSpec({
 
             val antallDeltakere = deltakerRepository.countAntallDeltakereForTiltakstypeWithId(
                 tiltakstype.id,
-                currentDate = LocalDate.of(2023, 3, 16)
+                currentDate = LocalDate.of(2023, 3, 16),
             )
             antallDeltakere shouldBe 3
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -91,7 +91,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     status = NavEnhetStatus.AKTIV,
                     type = Norg2Type.LOKAL,
                     overordnetEnhet = null,
-                )
+                ),
             ).shouldBeRight()
             enhetRepository.upsert(
                 NavEnhetDbo(
@@ -100,7 +100,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     status = NavEnhetStatus.AKTIV,
                     type = Norg2Type.LOKAL,
                     overordnetEnhet = null,
-                )
+                ),
             ).shouldBeRight()
             enhetRepository.upsert(
                 NavEnhetDbo(
@@ -109,7 +109,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     status = NavEnhetStatus.AKTIV,
                     type = Norg2Type.LOKAL,
                     overordnetEnhet = null,
-                )
+                ),
             ).shouldBeRight()
 
             val gjennomforing = gjennomforing1.copy(enheter = listOf("1", "2"))
@@ -136,8 +136,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             tiltaksgjennomforinger.upsert(
                 gjennomforing1.copy(
                     id = UUID.randomUUID(),
-                    sluttDato = LocalDate.of(2022, 12, 31)
-                )
+                    sluttDato = LocalDate.of(2022, 12, 31),
+                ),
             ).shouldBeRight()
 
             val result =
@@ -194,7 +194,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             opphav = Deltakeropphav.AMT,
             startDato = null,
             sluttDato = null,
-            registrertDato = LocalDateTime.of(2023, 3, 1, 0, 0, 0)
+            registrertDato = LocalDateTime.of(2023, 3, 1, 0, 0, 0),
         )
 
         context("when tilgjengelighet is set to Stengt") {
@@ -202,8 +202,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             beforeAny {
                 tiltaksgjennomforinger.upsert(
                     gjennomforing1.copy(
-                        tilgjengelighet = Tilgjengelighetsstatus.Stengt
-                    )
+                        tilgjengelighet = Tilgjengelighetsstatus.Stengt,
+                    ),
                 ).shouldBeRight()
             }
 
@@ -220,7 +220,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     gjennomforing1.copy(
                         tilgjengelighet = Tilgjengelighetsstatus.Ledig,
                         avslutningsstatus = Avslutningsstatus.AVSLUTTET,
-                    )
+                    ),
                 ).shouldBeRight()
             }
 
@@ -236,8 +236,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 tiltaksgjennomforinger.upsert(
                     gjennomforing1.copy(
                         tilgjengelighet = Tilgjengelighetsstatus.Ledig,
-                        antallPlasser = null
-                    )
+                        antallPlasser = null,
+                    ),
                 ).shouldBeRight()
             }
 
@@ -253,8 +253,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 tiltaksgjennomforinger.upsert(
                     gjennomforing1.copy(
                         tilgjengelighet = Tilgjengelighetsstatus.Ledig,
-                        antallPlasser = 0
-                    )
+                        antallPlasser = 0,
+                    ),
                 ).shouldBeRight()
             }
 
@@ -270,8 +270,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 tiltaksgjennomforinger.upsert(
                     gjennomforing1.copy(
                         tilgjengelighet = Tilgjengelighetsstatus.Ledig,
-                        antallPlasser = 1
-                    )
+                        antallPlasser = 1,
+                    ),
                 ).shouldBeRight()
 
                 deltakere.upsert(deltaker.copy(status = Deltakerstatus.DELTAR))
@@ -289,8 +289,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 tiltaksgjennomforinger.upsert(
                     gjennomforing1.copy(
                         tilgjengelighet = Tilgjengelighetsstatus.Ledig,
-                        antallPlasser = 1
-                    )
+                        antallPlasser = 1,
+                    ),
                 ).shouldBeRight()
 
                 deltakere.upsert(deltaker.copy(status = Deltakerstatus.AVSLUTTET))
@@ -321,7 +321,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                         antallPlasser = null,
                         ansvarlige = emptyList(),
                         enheter = emptyList(),
-                    )
+                    ),
                 )
             }
         }
@@ -343,9 +343,9 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val (totalCount, items) = tiltaksgjennomforinger.getAll(
                 PaginationParams(
                     4,
-                    20
+                    20,
                 ),
-                AdminTiltaksgjennomforingFilter()
+                AdminTiltaksgjennomforingFilter(),
             ).shouldBeRight()
 
             items.size shouldBe 20
@@ -359,9 +359,9 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             val (totalCount, items) = tiltaksgjennomforinger.getAll(
                 PaginationParams(
-                    3
+                    3,
                 ),
-                AdminTiltaksgjennomforingFilter()
+                AdminTiltaksgjennomforingFilter(),
             ).shouldBeRight()
 
             items.size shouldBe 5
@@ -375,9 +375,9 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             val (totalCount, items) = tiltaksgjennomforinger.getAll(
                 PaginationParams(
-                    nullableLimit = 200
+                    nullableLimit = 200,
                 ),
-                AdminTiltaksgjennomforingFilter()
+                AdminTiltaksgjennomforingFilter(),
             ).shouldBeRight()
 
             items.size shouldBe 105

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
@@ -34,8 +34,8 @@ class TiltakstypeRepositoryTest : FunSpec({
                 registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                 sistEndretDatoIArena = LocalDateTime.of(2022, 1, 15, 0, 0, 0),
                 fraDato = LocalDate.of(2023, 1, 11),
-                tilDato = LocalDate.of(2023, 1, 12)
-            )
+                tilDato = LocalDate.of(2023, 1, 12),
+            ),
         )
         tiltakstyper.upsert(
             TiltakstypeDbo(
@@ -46,8 +46,8 @@ class TiltakstypeRepositoryTest : FunSpec({
                 registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                 sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                 fraDato = LocalDate.of(2023, 1, 11),
-                tilDato = LocalDate.of(2023, 1, 12)
-            )
+                tilDato = LocalDate.of(2023, 1, 12),
+            ),
         )
         Query("update tiltakstype set skal_migreres = true").asUpdate.let { database.db.run(it) }
 
@@ -56,8 +56,8 @@ class TiltakstypeRepositoryTest : FunSpec({
             TiltakstypeFilter(
                 search = "Førerhund",
                 status = Tiltakstypestatus.Aktiv,
-                kategori = null
-            )
+                kategori = null,
+            ),
         ).second shouldHaveSize 0
 
         val arbeidstrening =
@@ -65,8 +65,8 @@ class TiltakstypeRepositoryTest : FunSpec({
                 TiltakstypeFilter(
                     search = "Arbeidstrening",
                     status = Tiltakstypestatus.Avsluttet,
-                    kategori = null
-                )
+                    kategori = null,
+                ),
             )
         arbeidstrening.second shouldHaveSize 1
         arbeidstrening.second[0].navn shouldBe "Arbeidstrening"
@@ -92,7 +92,7 @@ class TiltakstypeRepositoryTest : FunSpec({
             registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
             sistEndretDatoIArena = LocalDateTime.of(2022, 1, 15, 0, 0, 0),
             fraDato = LocalDate.of(2023, 1, 13),
-            tilDato = LocalDate.of(2023, 1, 15)
+            tilDato = LocalDate.of(2023, 1, 15),
         )
         val tiltakstypeAktiv = TiltakstypeDbo(
             id = UUID.randomUUID(),
@@ -102,7 +102,7 @@ class TiltakstypeRepositoryTest : FunSpec({
             registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
             sistEndretDatoIArena = LocalDateTime.of(2022, 1, 15, 0, 0, 0),
             fraDato = LocalDate.of(2023, 1, 11),
-            tilDato = LocalDate.of(2023, 1, 15)
+            tilDato = LocalDate.of(2023, 1, 15),
         )
         val tiltakstypeAvsluttet = TiltakstypeDbo(
             id = UUID.randomUUID(),
@@ -112,7 +112,7 @@ class TiltakstypeRepositoryTest : FunSpec({
             registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
             sistEndretDatoIArena = LocalDateTime.of(2022, 1, 15, 0, 0, 0),
             fraDato = LocalDate.of(2023, 1, 9),
-            tilDato = LocalDate.of(2023, 1, 11)
+            tilDato = LocalDate.of(2023, 1, 11),
         )
         val idSkalIkkeMigreres = UUID.randomUUID()
         val tiltakstypeSkalIkkeMigreres = TiltakstypeDbo(
@@ -123,7 +123,7 @@ class TiltakstypeRepositoryTest : FunSpec({
             registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
             sistEndretDatoIArena = LocalDateTime.of(2022, 1, 15, 0, 0, 0),
             fraDato = LocalDate.of(2023, 1, 9),
-            tilDato = LocalDate.of(2023, 1, 11)
+            tilDato = LocalDate.of(2023, 1, 11),
         )
 
         tiltakstyper.upsert(tiltakstypePlanlagt)
@@ -136,8 +136,8 @@ class TiltakstypeRepositoryTest : FunSpec({
             tiltakstyper.getAllSkalMigreres(
                 TiltakstypeFilter(
                     search = null,
-                    kategori = Tiltakstypekategori.GRUPPE
-                )
+                    kategori = Tiltakstypekategori.GRUPPE,
+                ),
             ).second shouldHaveSize 2
         }
 
@@ -145,8 +145,8 @@ class TiltakstypeRepositoryTest : FunSpec({
             tiltakstyper.getAllSkalMigreres(
                 TiltakstypeFilter(
                     search = null,
-                    kategori = Tiltakstypekategori.INDIVIDUELL
-                )
+                    kategori = Tiltakstypekategori.INDIVIDUELL,
+                ),
             ).second shouldHaveSize 1
         }
 
@@ -154,8 +154,8 @@ class TiltakstypeRepositoryTest : FunSpec({
             tiltakstyper.getAllSkalMigreres(
                 TiltakstypeFilter(
                     search = null,
-                    kategori = null
-                )
+                    kategori = null,
+                ),
             ).second shouldHaveSize 3
         }
 
@@ -163,8 +163,8 @@ class TiltakstypeRepositoryTest : FunSpec({
             tiltakstyper.getAllSkalMigreres(
                 TiltakstypeFilter(
                     search = null,
-                    kategori = null
-                )
+                    kategori = null,
+                ),
             ).second shouldHaveSize 3
         }
 
@@ -174,8 +174,8 @@ class TiltakstypeRepositoryTest : FunSpec({
                     search = null,
                     kategori = null,
                     status = Tiltakstypestatus.Planlagt,
-                    dagensDato = dagensDato
-                )
+                    dagensDato = dagensDato,
+                ),
             )
             typer.second shouldHaveSize 1
             typer.second.first().id shouldBe tiltakstypePlanlagt.id
@@ -187,8 +187,8 @@ class TiltakstypeRepositoryTest : FunSpec({
                     search = null,
                     kategori = null,
                     status = Tiltakstypestatus.Aktiv,
-                    dagensDato = dagensDato
-                )
+                    dagensDato = dagensDato,
+                ),
             )
             typer.second shouldHaveSize 1
             typer.second.first().id shouldBe tiltakstypeAktiv.id
@@ -200,8 +200,8 @@ class TiltakstypeRepositoryTest : FunSpec({
                     search = null,
                     kategori = null,
                     status = Tiltakstypestatus.Avsluttet,
-                    dagensDato = dagensDato
-                )
+                    dagensDato = dagensDato,
+                ),
             )
             typer.second shouldHaveSize 1
             typer.second.first().id shouldBe tiltakstypeAvsluttet.id
@@ -224,8 +224,8 @@ class TiltakstypeRepositoryTest : FunSpec({
                     registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                     sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
                     fraDato = LocalDate.of(2023, 1, 11),
-                    tilDato = LocalDate.of(2023, 1, 12)
-                )
+                    tilDato = LocalDate.of(2023, 1, 12),
+                ),
             )
         }
 
@@ -243,8 +243,8 @@ class TiltakstypeRepositoryTest : FunSpec({
             val (totalCount, items) = tiltakstyper.getAll(
                 paginationParams = PaginationParams(
                     4,
-                    20
-                )
+                    20,
+                ),
             )
 
             items.size shouldBe 20
@@ -257,8 +257,8 @@ class TiltakstypeRepositoryTest : FunSpec({
         test("pagination with page 3 default size should give tiltak with id 95-99") {
             val (totalCount, items) = tiltakstyper.getAll(
                 paginationParams = PaginationParams(
-                    3
-                )
+                    3,
+                ),
             )
 
             items.size shouldBe 5
@@ -271,8 +271,8 @@ class TiltakstypeRepositoryTest : FunSpec({
         test("pagination with default page and size 200 should give tiltak with id 1-99") {
             val (totalCount, items) = tiltakstyper.getAll(
                 paginationParams = PaginationParams(
-                    nullableLimit = 200
-                )
+                    nullableLimit = 200,
+                ),
             )
 
             items.size shouldBe 105
@@ -296,25 +296,25 @@ class TiltakstypeRepositoryTest : FunSpec({
                 id = UUID.randomUUID(),
                 tiltakstypeId = tiltaksgjennomforingFixture.Oppfolging1.tiltakstypeId,
                 startDato = LocalDate.of(2021, 1, 1),
-                sluttDato = LocalDate.of(2022, 10, 15)
+                sluttDato = LocalDate.of(2022, 10, 15),
             )
             val gjennomforing2 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                 id = UUID.randomUUID(),
                 tiltakstypeId = tiltaksgjennomforingFixture.Oppfolging2.tiltakstypeId,
                 startDato = LocalDate.of(2021, 1, 1),
-                sluttDato = LocalDate.of(2050, 10, 15)
+                sluttDato = LocalDate.of(2050, 10, 15),
             )
             val gjennomforing3 = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                 id = UUID.randomUUID(),
                 tiltakstypeId = tiltakstypeIdSomIkkeSkalMatche,
                 startDato = LocalDate.of(2021, 1, 1),
-                sluttDato = LocalDate.of(2050, 10, 15)
+                sluttDato = LocalDate.of(2050, 10, 15),
             )
             val gjennomforing4 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                 id = UUID.randomUUID(),
                 tiltakstypeId = tiltakstypeIdSomIkkeSkalMatche,
                 startDato = LocalDate.of(2021, 1, 1),
-                sluttDato = LocalDate.of(2050, 10, 15)
+                sluttDato = LocalDate.of(2050, 10, 15),
             )
 
             val tiltakstype = TiltakstypeFixtures.Oppfolging.copy(id = gjennomforing1.tiltakstypeId)
@@ -347,26 +347,26 @@ class TiltakstypeRepositoryTest : FunSpec({
                 tiltakstypeId = tiltaksgjennomforingFixture.Oppfolging1.tiltakstypeId,
                 startDato = LocalDate.of(2021, 1, 1),
                 sluttDato = LocalDate.of(2022, 10, 15),
-                avtaleId = avtale.id
+                avtaleId = avtale.id,
             )
             val gjennomforing2 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                 id = UUID.randomUUID(),
                 tiltakstypeId = tiltaksgjennomforingFixture.Oppfolging2.tiltakstypeId,
                 startDato = LocalDate.of(2021, 1, 1),
                 sluttDato = LocalDate.of(2050, 10, 15),
-                avtaleId = avtale.id
+                avtaleId = avtale.id,
             )
             val gjennomforing3 = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                 id = UUID.randomUUID(),
                 tiltakstypeId = tiltakstypeIdSomIkkeSkalMatche,
                 startDato = LocalDate.of(2021, 1, 1),
-                sluttDato = LocalDate.of(2050, 10, 15)
+                sluttDato = LocalDate.of(2050, 10, 15),
             )
             val gjennomforing4 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                 id = UUID.randomUUID(),
                 tiltakstypeId = tiltakstypeIdSomIkkeSkalMatche,
                 startDato = LocalDate.of(2021, 1, 1),
-                sluttDato = LocalDate.of(2050, 10, 15)
+                sluttDato = LocalDate.of(2050, 10, 15),
             )
 
             val deltaker1 = DeltakerFixture.Deltaker.copy(tiltaksgjennomforingId = gjennomforing1.id, id = UUID.randomUUID())

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
@@ -36,7 +36,7 @@ class ArenaAdapterServiceTest : FunSpec({
         registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         fraDato = LocalDate.of(2023, 1, 11),
-        tilDato = LocalDate.of(2023, 1, 12)
+        tilDato = LocalDate.of(2023, 1, 12),
     )
 
     val avtale = AvtaleDbo(
@@ -51,7 +51,7 @@ class ArenaAdapterServiceTest : FunSpec({
         avtaletype = Avtaletype.Rammeavtale,
         avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         prisbetingelser = "💸",
-        opphav = AvtaleDbo.Opphav.ARENA
+        opphav = AvtaleDbo.Opphav.ARENA,
     )
 
     val tiltaksgjennomforing = TiltaksgjennomforingDbo(
@@ -76,7 +76,7 @@ class ArenaAdapterServiceTest : FunSpec({
         norskIdent = "12345678910",
         status = Deltakerstatus.VENTER,
         fraDato = LocalDateTime.now(),
-        tilDato = LocalDateTime.now().plusYears(1)
+        tilDato = LocalDateTime.now().plusYears(1),
     )
 
     val tiltakstypeIndividuell = TiltakstypeDbo(
@@ -87,7 +87,7 @@ class ArenaAdapterServiceTest : FunSpec({
         registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         fraDato = LocalDate.of(2023, 1, 11),
-        tilDato = LocalDate.of(2023, 1, 12)
+        tilDato = LocalDate.of(2023, 1, 12),
     )
 
     val tiltakshistorikkIndividuell = TiltakshistorikkDbo.IndividueltTiltak(
@@ -264,7 +264,7 @@ class ArenaAdapterServiceTest : FunSpec({
 
             verify(exactly = 1) {
                 tiltaksgjennomforingKafkaProducer.publish(
-                    TiltaksgjennomforingDto.from(tiltaksgjennomforingDto)
+                    TiltaksgjennomforingDto.from(tiltaksgjennomforingDto),
                 )
             }
 
@@ -272,7 +272,7 @@ class ArenaAdapterServiceTest : FunSpec({
 
             verify(exactly = 1) {
                 tiltaksgjennomforingKafkaProducer.retract(
-                    tiltaksgjennomforing.id
+                    tiltaksgjennomforing.id,
                 )
             }
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArrangorServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArrangorServiceTest.kt
@@ -19,13 +19,13 @@ class ArrangorServiceTest : FunSpec({
             organisasjonsnummer = "789",
             navn = "Bedrift 1",
             overordnetEnhetOrganisasjonsnummer = "1011",
-            overordnetEnhetNavn = "Overordnetbedrift 1"
+            overordnetEnhetNavn = "Overordnetbedrift 1",
         )
         coEvery { amtEnhetsregister.hentVirksomhet("222") } returns VirksomhetDto(
             organisasjonsnummer = "7891",
             navn = "Bedrift 2",
             overordnetEnhetOrganisasjonsnummer = "1011",
-            overordnetEnhetNavn = "Overordnetbedrift 2"
+            overordnetEnhetNavn = "Overordnetbedrift 2",
         )
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/BrukerServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/BrukerServiceTest.kt
@@ -24,32 +24,32 @@ class BrukerServiceTest : FunSpec({
     beforeSpec {
         coEvery { veilarboppfolgingClient.hentOppfolgingsstatus(FNR, any()) } returns OppfolgingsstatusDto(
             oppfolgingsenhet = mockOppfolgingsenhet(),
-            servicegruppe = "IKKE_VURDERT"
+            servicegruppe = "IKKE_VURDERT",
         )
 
         coEvery { veilarboppfolgingClient.hentManuellStatus(FNR, any()) } returns mockManuellStatus()
 
         coEvery { veilarbvedtaksstotteClient.hentSiste14AVedtak(FNR, any()) } returns VedtakDto(
-            innsatsgruppe = Innsatsgruppe.STANDARD_INNSATS
+            innsatsgruppe = Innsatsgruppe.STANDARD_INNSATS,
         )
 
         coEvery { veilarbpersonClient.hentPersonInfo(FNR, any()) } returns PersonDto(
-            fornavn = "Ola"
+            fornavn = "Ola",
         )
 
         coEvery { veilarboppfolgingClient.hentOppfolgingsstatus(FNR_2, any()) } returns OppfolgingsstatusDto(
             oppfolgingsenhet = mockOppfolgingsenhet(),
-            servicegruppe = "IKKE_VURDERT"
+            servicegruppe = "IKKE_VURDERT",
         )
 
         coEvery { veilarboppfolgingClient.hentManuellStatus(FNR_2, any()) } returns mockManuellStatus()
 
         coEvery { veilarbvedtaksstotteClient.hentSiste14AVedtak(FNR_2, any()) } returns VedtakDto(
-            innsatsgruppe = Innsatsgruppe.GRADERT_VARIG_TILPASSET_INNSATS
+            innsatsgruppe = Innsatsgruppe.GRADERT_VARIG_TILPASSET_INNSATS,
         )
 
         coEvery { veilarbpersonClient.hentPersonInfo(FNR_2, any()) } returns PersonDto(
-            fornavn = "Petter"
+            fornavn = "Petter",
         )
     }
 
@@ -70,8 +70,8 @@ fun mockManuellStatus(): ManuellStatusDto {
         erUnderManuellOppfolging = false,
         krrStatus = KrrStatus(
             kanVarsles = true,
-            erReservert = false
-        )
+            erReservert = false,
+        ),
     )
 }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/DelMedBrukerServiceTest.kt
@@ -30,7 +30,7 @@ class DelMedBrukerServiceTest : FunSpec({
             norskIdent = "12345678910",
             navident = "nav123",
             sanityId = "123456",
-            dialogId = "1234"
+            dialogId = "1234",
         )
 
         test("Insert del med bruker-data") {
@@ -45,7 +45,7 @@ class DelMedBrukerServiceTest : FunSpec({
 
         test("Lagre til tabell feiler dersom input for brukers fnr er ulikt 11 tegn") {
             val payloadMedFeilData = payload.copy(
-                norskIdent = "12345678910123"
+                norskIdent = "12345678910123",
             )
             val exception = shouldThrow<BadRequestException> {
                 service.lagreDelMedBruker(payloadMedFeilData)
@@ -59,7 +59,7 @@ class DelMedBrukerServiceTest : FunSpec({
 
             val delMedBruker = service.getDeltMedBruker(
                 fnr = "12345678910",
-                sanityId = "123456"
+                sanityId = "123456",
             )
 
             delMedBruker.shouldBeRight().should {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
@@ -40,13 +40,13 @@ class KafkaSyncServiceTest : FunSpec({
         registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         fraDato = LocalDate.of(2023, 1, 11),
-        tilDato = LocalDate.of(2099, 1, 12)
+        tilDato = LocalDate.of(2099, 1, 12),
     )
 
     fun createTiltaksgjennomforing(
         startDato: LocalDate = LocalDate.of(2023, 2, 15),
         sluttDato: LocalDate = LocalDate.of(2023, 11, 11),
-        avslutningsstatus: Avslutningsstatus = Avslutningsstatus.AVSLUTTET
+        avslutningsstatus: Avslutningsstatus = Avslutningsstatus.AVSLUTTET,
     ): TiltaksgjennomforingDbo {
         return TiltaksgjennomforingDbo(
             id = UUID.randomUUID(),
@@ -77,7 +77,7 @@ class KafkaSyncServiceTest : FunSpec({
             virksomhetsnummer = virksomhetsnummer,
             startDato = startDato,
             sluttDato = sluttDato,
-            status = tiltaksgjennomforingsstatus
+            status = tiltaksgjennomforingsstatus,
         )
     }
 
@@ -91,7 +91,7 @@ class KafkaSyncServiceTest : FunSpec({
             fraDato = fraDato,
             tilDato = tilDato,
             rettPaaTiltakspenger = rettPaaTiltakspenger,
-            status = tiltakstypestatus
+            status = tiltakstypestatus,
         )
     }
 
@@ -104,7 +104,7 @@ class KafkaSyncServiceTest : FunSpec({
                 tiltaksgjennomforingRepository,
                 tiltakstypeRepository,
                 tiltaksgjennomforingKafkaProducer,
-                mockk()
+                mockk(),
             )
 
         val startdatoInnenforMenAvsluttetStatus = createTiltaksgjennomforing()
@@ -113,16 +113,16 @@ class KafkaSyncServiceTest : FunSpec({
         val sluttdatoInnenforMenAvbruttStatus = createTiltaksgjennomforing(
             startDato = lastSuccessDate,
             sluttDato = lastSuccessDate,
-            avslutningsstatus = Avslutningsstatus.AVBRUTT
+            avslutningsstatus = Avslutningsstatus.AVBRUTT,
         )
         val sluttdatoInnenfor = createTiltaksgjennomforing(
             startDato = lastSuccessDate,
             sluttDato = lastSuccessDate,
-            avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET
+            avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         )
         val datoerUtenfor = createTiltaksgjennomforing(
             startDato = lastSuccessDate,
-            avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET
+            avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         )
 
         test("oppdater statuser på kafka på relevante tiltaksgjennomføringer") {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/Norg2ServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/Norg2ServiceTest.kt
@@ -19,15 +19,15 @@ class Norg2ServiceTest : FunSpec({
         val mockEnheter = listOf(
             Norg2Response(
                 enhet = Norg2EnhetFixture.enhet.copy(enhetId = 1, type = Norg2Type.AAREG),
-                overordnetEnhet = "1200"
+                overordnetEnhet = "1200",
             ),
             Norg2Response(
                 enhet = Norg2EnhetFixture.enhet.copy(enhetId = 2),
-                overordnetEnhet = "1200"
+                overordnetEnhet = "1200",
             ),
             Norg2Response(
                 enhet = Norg2EnhetFixture.enhet.copy(enhetId = 3),
-                overordnetEnhet = "1400"
+                overordnetEnhet = "1400",
             ),
         )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/PoaoTilgangServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/PoaoTilgangServiceTest.kt
@@ -24,8 +24,8 @@ class PoaoTilgangServiceTest : FunSpec(
                     throwable = null,
                     result = Decision.Deny(
                         message = "",
-                        reason = ""
-                    )
+                        reason = "",
+                    ),
                 )
 
                 val client: PoaoTilgangClient = mockk()
@@ -34,8 +34,8 @@ class PoaoTilgangServiceTest : FunSpec(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId1,
                             TilgangType.LESE,
-                            "12345678910"
-                        )
+                            "12345678910",
+                        ),
                     )
                 } returns mockResponse
 
@@ -50,8 +50,8 @@ class PoaoTilgangServiceTest : FunSpec(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId1,
                             TilgangType.LESE,
-                            "12345678910"
-                        )
+                            "12345678910",
+                        ),
                     )
                 }
             }
@@ -59,7 +59,7 @@ class PoaoTilgangServiceTest : FunSpec(
             test("should verify access to modia when decision is PERMIT") {
                 val mockResponse = ApiResult<Decision>(
                     throwable = null,
-                    result = Decision.Permit
+                    result = Decision.Permit,
                 )
 
                 val client: PoaoTilgangClient = mockk()
@@ -68,8 +68,8 @@ class PoaoTilgangServiceTest : FunSpec(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId1,
                             TilgangType.LESE,
-                            "12345678910"
-                        )
+                            "12345678910",
+                        ),
                     )
                 } returns mockResponse
 
@@ -82,8 +82,8 @@ class PoaoTilgangServiceTest : FunSpec(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId1,
                             TilgangType.LESE,
-                            "12345678910"
-                        )
+                            "12345678910",
+                        ),
                     )
                 }
             }
@@ -91,7 +91,7 @@ class PoaoTilgangServiceTest : FunSpec(
             test("should cache response based on provided NAVident") {
                 val mockResponse = ApiResult<Decision>(
                     throwable = null,
-                    result = Decision.Permit
+                    result = Decision.Permit,
                 )
 
                 val client: PoaoTilgangClient = mockk()
@@ -100,8 +100,8 @@ class PoaoTilgangServiceTest : FunSpec(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId1,
                             TilgangType.LESE,
-                            "12345678910"
-                        )
+                            "12345678910",
+                        ),
                     )
                 } returns mockResponse
                 every {
@@ -109,8 +109,8 @@ class PoaoTilgangServiceTest : FunSpec(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId2,
                             TilgangType.LESE,
-                            "12345678910"
-                        )
+                            "12345678910",
+                        ),
                     )
                 } returns mockResponse
                 every {
@@ -118,8 +118,8 @@ class PoaoTilgangServiceTest : FunSpec(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId2,
                             TilgangType.LESE,
-                            "10987654321"
-                        )
+                            "10987654321",
+                        ),
                     )
                 } returns mockResponse
 
@@ -137,25 +137,25 @@ class PoaoTilgangServiceTest : FunSpec(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId1,
                             TilgangType.LESE,
-                            "12345678910"
-                        )
+                            "12345678910",
+                        ),
                     )
                     client.evaluatePolicy(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId2,
                             TilgangType.LESE,
-                            "12345678910"
-                        )
+                            "12345678910",
+                        ),
                     )
                     client.evaluatePolicy(
                         NavAnsattTilgangTilEksternBrukerPolicyInput(
                             navAnsattAzureId2,
                             TilgangType.LESE,
-                            "10987654321"
-                        )
+                            "10987654321",
+                        ),
                     )
                 }
             }
         }
-    }
+    },
 )

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
@@ -28,7 +28,7 @@ class TiltakshistorikkServiceTest : FunSpec({
         registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         fraDato = LocalDate.of(2023, 1, 11),
-        tilDato = LocalDate.of(2023, 1, 12)
+        tilDato = LocalDate.of(2023, 1, 12),
     )
 
     val tiltaksgjennomforing = TiltaksgjennomforingDbo(
@@ -52,7 +52,7 @@ class TiltakshistorikkServiceTest : FunSpec({
         norskIdent = "12345678910",
         status = Deltakerstatus.VENTER,
         fraDato = LocalDateTime.of(2018, 12, 3, 0, 0),
-        tilDato = LocalDateTime.of(2019, 12, 3, 0, 0)
+        tilDato = LocalDateTime.of(2019, 12, 3, 0, 0),
     )
 
     val tiltakstypeIndividuell = TiltakstypeDbo(
@@ -63,7 +63,7 @@ class TiltakshistorikkServiceTest : FunSpec({
         registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
         fraDato = LocalDate.of(2023, 1, 11),
-        tilDato = LocalDate.of(2023, 1, 12)
+        tilDato = LocalDate.of(2023, 1, 12),
     )
 
     val tiltakshistorikkIndividuell = TiltakshistorikkDbo.IndividueltTiltak(
@@ -106,7 +106,7 @@ class TiltakshistorikkServiceTest : FunSpec({
                 status = Deltakerstatus.VENTER,
                 tiltaksnavn = "Arbeidstrening",
                 tiltakstype = "Arbeidstrening",
-                arrangor = TiltakshistorikkDto.Arrangor(virksomhetsnummer = "123456789", navn = bedriftsnavn)
+                arrangor = TiltakshistorikkDto.Arrangor(virksomhetsnummer = "123456789", navn = bedriftsnavn),
             ),
             TiltakshistorikkDto(
                 id = tiltakshistorikkIndividuell.id,
@@ -115,8 +115,8 @@ class TiltakshistorikkServiceTest : FunSpec({
                 status = Deltakerstatus.VENTER,
                 tiltaksnavn = "Utdanning",
                 tiltakstype = "Høyere utdanning",
-                arrangor = TiltakshistorikkDto.Arrangor(virksomhetsnummer = "12343", navn = bedriftsnavn2)
-            )
+                arrangor = TiltakshistorikkDto.Arrangor(virksomhetsnummer = "12343", navn = bedriftsnavn2),
+            ),
         )
 
         historikkService.hentHistorikkForBruker("12345678910") shouldBe forventetHistorikk

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityFiltersKtTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityFiltersKtTest.kt
@@ -80,7 +80,7 @@ class SanityFiltersKtTest : FunSpec({
             result shouldBe listOf(
                 Innsatsgruppe.STANDARD_INNSATS.name,
                 Innsatsgruppe.SITUASJONSBESTEMT_INNSATS.name,
-                Innsatsgruppe.SPESIELT_TILPASSET_INNSATS.name
+                Innsatsgruppe.SPESIELT_TILPASSET_INNSATS.name,
             )
         }
 
@@ -91,7 +91,7 @@ class SanityFiltersKtTest : FunSpec({
                 Innsatsgruppe.STANDARD_INNSATS.name,
                 Innsatsgruppe.SITUASJONSBESTEMT_INNSATS.name,
                 Innsatsgruppe.SPESIELT_TILPASSET_INNSATS.name,
-                Innsatsgruppe.VARIG_TILPASSET_INNSATS.name
+                Innsatsgruppe.VARIG_TILPASSET_INNSATS.name,
             )
         }
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/kafka/amt/AmtDeltakerV1TopicConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/kafka/amt/AmtDeltakerV1TopicConsumerTest.kt
@@ -46,7 +46,7 @@ class AmtDeltakerV1TopicConsumerTest : FunSpec({
         val deltakere = DeltakerRepository(database.db)
         val deltakerConsumer = AmtDeltakerV1TopicConsumer(
             config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker"),
-            deltakere
+            deltakere,
         )
 
         val amtDeltaker1 = AmtDeltakerV1Dto(
@@ -58,11 +58,11 @@ class AmtDeltakerV1TopicConsumerTest : FunSpec({
             status = AmtDeltakerV1Dto.Status.VENTER_PA_OPPSTART,
             registrertDato = LocalDateTime.of(2023, 3, 1, 0, 0, 0),
             dagerPerUke = null,
-            prosentStilling = null
+            prosentStilling = null,
         )
         val amtDeltaker2 = amtDeltaker1.copy(
             id = UUID.randomUUID(),
-            personIdent = "10101010101"
+            personIdent = "10101010101",
         )
         val deltaker1Dbo = DeltakerDbo(
             id = amtDeltaker1.id,

--- a/mulighetsrommet-arena-adapter/build.gradle.kts
+++ b/mulighetsrommet-arena-adapter/build.gradle.kts
@@ -2,17 +2,12 @@ plugins {
     application
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ktlint)
     alias(libs.plugins.flyway)
     alias(libs.plugins.shadow)
 }
 
 application {
     mainClass.set("no.nav.mulighetsrommet.arena.adapter.ApplicationKt")
-}
-
-ktlint {
-    disabledRules.addAll("no-wildcard-imports")
 }
 
 flyway {

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Config.kt
@@ -9,7 +9,7 @@ import no.nav.mulighetsrommet.ktor.ServerConfig
 
 data class Config(
     val server: ServerConfig,
-    val app: AppConfig
+    val app: AppConfig,
 )
 
 data class AppConfig(
@@ -19,12 +19,12 @@ data class AppConfig(
     val database: FlywayDatabaseAdapter.Config,
     val kafka: KafkaConfig,
     val auth: AuthConfig,
-    val slack: SlackConfig
+    val slack: SlackConfig,
 )
 
 data class TaskConfig(
     val retryFailedEvents: RetryFailedEvents.Config,
-    val notifyFailedEvents: NotifyFailedEvents.Config
+    val notifyFailedEvents: NotifyFailedEvents.Config,
 )
 
 data class ServiceConfig(
@@ -34,19 +34,19 @@ data class ServiceConfig(
 )
 
 data class AuthConfig(
-    val azure: AuthProvider
+    val azure: AuthProvider,
 )
 
 data class AuthProvider(
     val issuer: String,
     val jwksUri: String,
     val audience: String,
-    val tokenEndpointUrl: String
+    val tokenEndpointUrl: String,
 )
 
 data class ServiceClientConfig(
     val url: String,
-    val scope: String
+    val scope: String,
 )
 
 data class KafkaConfig(
@@ -66,5 +66,5 @@ data class KafkaConsumers(
 data class SlackConfig(
     val token: String,
     val channel: String,
-    val enable: Boolean
+    val enable: Boolean,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/MulighetsrommetApiClient.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/MulighetsrommetApiClient.kt
@@ -48,7 +48,7 @@ class MulighetsrommetApiClient(
                 url.takeFrom(
                     URLBuilder().takeFrom(baseUri).apply {
                         encodedPath += url.encodedPath
-                    }
+                    },
                 )
             }
         }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/ArenaEventConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/ArenaEventConsumer.kt
@@ -43,7 +43,7 @@ internal fun decodeArenaEvent(payload: JsonElement): ArenaEvent {
         arenaId = arenaId,
         operation = operation,
         payload = payload,
-        status = ArenaEvent.ProcessingStatus.Pending
+        status = ArenaEvent.ProcessingStatus.Pending,
     )
 }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
@@ -25,7 +25,7 @@ import java.util.*
 class AvtaleInfoEventProcessor(
     private val entities: ArenaEntityService,
     private val client: MulighetsrommetApiClient,
-    private val ords: ArenaOrdsProxyClient
+    private val ords: ArenaOrdsProxyClient,
 ) : ArenaEventProcessor {
     override val arenaTable: ArenaTable = ArenaTable.AvtaleInfo
 
@@ -128,7 +128,7 @@ class AvtaleInfoEventProcessor(
             avtaletype = avtaletype,
             avslutningsstatus = avslutningsstatus,
             prisbetingelser = avtale.prisbetingelser,
-            opphav = AvtaleDbo.Opphav.ARENA
+            opphav = AvtaleDbo.Opphav.ARENA,
         )
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/SakEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/SakEventProcessor.kt
@@ -14,7 +14,7 @@ import no.nav.mulighetsrommet.arena.adapter.models.db.Sak
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
 
 class SakEventProcessor(
-    private val entities: ArenaEntityService
+    private val entities: ArenaEntityService,
 ) : ArenaEventProcessor {
 
     override val arenaTable: ArenaTable = ArenaTable.Sak
@@ -51,7 +51,7 @@ class SakEventProcessor(
                 sakId = SAK_ID,
                 aar = AAR,
                 lopenummer = LOPENRSAK,
-                enhet = AETATENHET_ANSVARLIG
+                enhet = AETATENHET_ANSVARLIG,
             )
         }
         .mapLeft { ProcessingError.InvalidPayload(it.localizedMessage) }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakEventProcessor.kt
@@ -19,7 +19,7 @@ import java.util.*
 
 class TiltakEventProcessor(
     private val entities: ArenaEntityService,
-    private val client: MulighetsrommetApiClient
+    private val client: MulighetsrommetApiClient,
 ) : ArenaEventProcessor {
     override val arenaTable: ArenaTable = ArenaTable.Tiltakstype
 
@@ -82,7 +82,7 @@ class TiltakEventProcessor(
                 tiltaksgjennomforingGenererTilsagnsbrevAutomatisk = ArenaUtils.parseJaNei(AUTOMATISK_TILSAGNSBREV),
                 visBegrunnelseForInnsoking = ArenaUtils.parseJaNei(STATUS_BEGRUNNELSE_INNSOKT),
                 sendHenvisningsbrevOgHovedbrevTilArbeidsgiver = ArenaUtils.parseJaNei(STATUS_HENVISNING_BREV),
-                sendKopibrevOgHovedbrevTilArbeidsgiver = ArenaUtils.parseJaNei(STATUS_KOPIBREV)
+                sendKopibrevOgHovedbrevTilArbeidsgiver = ArenaUtils.parseJaNei(STATUS_KOPIBREV),
             )
         }
         .mapLeft { ProcessingError.InvalidPayload(it.localizedMessage) }
@@ -95,6 +95,6 @@ class TiltakEventProcessor(
         sistEndretDatoIArena = sistEndretIArenaDato,
         fraDato = fraDato.toLocalDate(),
         tilDato = tilDato.toLocalDate(),
-        rettPaaTiltakspenger = rettPaaTiltakspenger
+        rettPaaTiltakspenger = rettPaaTiltakspenger,
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessor.kt
@@ -29,7 +29,7 @@ import java.util.*
 class TiltakdeltakerEventProcessor(
     private val entities: ArenaEntityService,
     private val client: MulighetsrommetApiClient,
-    private val ords: ArenaOrdsProxyClient
+    private val ords: ArenaOrdsProxyClient,
 ) : ArenaEventProcessor {
     override val arenaTable: ArenaTable = ArenaTable.Deltaker
 
@@ -46,7 +46,7 @@ class TiltakdeltakerEventProcessor(
         if (tiltaksgjennomforingIsIgnored) {
             return@either ProcessingResult(
                 Ignored,
-                "Deltaker ignorert fordi tilhørende tiltaksgjennomføring også er ignorert"
+                "Deltaker ignorert fordi tilhørende tiltaksgjennomføring også er ignorert",
             )
         }
 
@@ -147,7 +147,7 @@ class TiltakdeltakerEventProcessor(
                 fraDato = ArenaUtils.parseNullableTimestamp(DATO_FRA),
                 tilDato = ArenaUtils.parseNullableTimestamp(DATO_TIL),
                 registrertDato = ArenaUtils.parseTimestamp(REG_DATO),
-                status = ArenaUtils.toDeltakerstatus(DELTAKERSTATUSKODE)
+                status = ArenaUtils.toDeltakerstatus(DELTAKERSTATUSKODE),
             )
         }
         .mapLeft { ProcessingError.InvalidPayload(it.localizedMessage) }
@@ -155,7 +155,7 @@ class TiltakdeltakerEventProcessor(
     private suspend fun Deltaker.toTiltakshistorikkDbo(
         tiltakstype: Tiltakstype,
         tiltaksgjennomforing: Tiltaksgjennomforing,
-        norskIdent: String
+        norskIdent: String,
     ) = either<ProcessingError, TiltakshistorikkDbo> {
         if (isGruppetiltak(tiltakstype.tiltakskode)) {
             TiltakshistorikkDbo.Gruppetiltak(
@@ -164,7 +164,7 @@ class TiltakdeltakerEventProcessor(
                 status = status,
                 fraDato = fraDato,
                 tilDato = tilDato,
-                tiltaksgjennomforingId = tiltaksgjennomforing.id
+                tiltaksgjennomforingId = tiltaksgjennomforing.id,
             )
         } else {
             val virksomhetsnummer = tiltaksgjennomforing.arrangorId.let { id ->
@@ -184,7 +184,7 @@ class TiltakdeltakerEventProcessor(
                 tilDato = tilDato,
                 beskrivelse = tiltaksgjennomforing.navn,
                 tiltakstypeId = tiltakstype.id,
-                virksomhetsnummer = virksomhetsnummer
+                virksomhetsnummer = virksomhetsnummer,
             )
         }
     }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessor.kt
@@ -32,7 +32,7 @@ import java.util.*
 class TiltakgjennomforingEventProcessor(
     private val entities: ArenaEntityService,
     private val client: MulighetsrommetApiClient,
-    private val ords: ArenaOrdsProxyClient
+    private val ords: ArenaOrdsProxyClient,
 ) : ArenaEventProcessor {
     override val arenaTable: ArenaTable = ArenaTable.Tiltaksgjennomforing
 
@@ -43,7 +43,7 @@ class TiltakgjennomforingEventProcessor(
         if (!isGruppetiltak && isRegisteredBeforeAktivitetsplanen(data)) {
             return@either ProcessingResult(
                 Ignored,
-                "Tiltaksgjennomføring ignorert fordi den ble opprettet før Aktivitetsplanen"
+                "Tiltaksgjennomføring ignorert fordi den ble opprettet før Aktivitetsplanen",
             )
         }
 
@@ -92,7 +92,7 @@ class TiltakgjennomforingEventProcessor(
 
     private suspend fun upsertTiltaksgjennomforing(
         operation: ArenaEvent.Operation,
-        tiltaksgjennomforing: Tiltaksgjennomforing
+        tiltaksgjennomforing: Tiltaksgjennomforing,
     ): Either<ProcessingError, ProcessingResult> = either {
         val tiltakstypeMapping = entities
             .getMapping(ArenaTable.Tiltakstype, tiltaksgjennomforing.tiltakskode)
@@ -146,7 +146,7 @@ class TiltakgjennomforingEventProcessor(
                 apentForInnsok = STATUS_TREVERDIKODE_INNSOKNING != JaNeiStatus.Nei,
                 antallPlasser = ANTALL_DELTAKERE,
                 status = TILTAKSTATUSKODE,
-                avtaleId = avtaleId
+                avtaleId = avtaleId,
             )
         }.mapLeft { ProcessingError.InvalidPayload(it.localizedMessage) }
 
@@ -165,6 +165,6 @@ class TiltakgjennomforingEventProcessor(
             antallPlasser = antallPlasser,
             avtaleId = avtaleId,
             ansvarlige = emptyList(),
-            enheter = emptyList()
+            enheter = emptyList(),
         )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/ProcessingResults.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/ProcessingResults.kt
@@ -8,17 +8,17 @@ import no.nav.mulighetsrommet.database.utils.DatabaseOperationError
 sealed class ProcessingError(val status: ArenaEvent.ProcessingStatus, val message: String) {
     data class ProcessingFailed(val details: String) : ProcessingError(
         status = ArenaEvent.ProcessingStatus.Failed,
-        message = "Event processing failed: $details"
+        message = "Event processing failed: $details",
     )
 
     data class MissingDependency(val details: String) : ProcessingError(
         status = ArenaEvent.ProcessingStatus.Failed,
-        message = "Dependent event has not yet been processed: $details"
+        message = "Dependent event has not yet been processed: $details",
     )
 
     data class InvalidPayload(val details: String) : ProcessingError(
         status = ArenaEvent.ProcessingStatus.Invalid,
-        message = "Event payload is invalid: $details"
+        message = "Event payload is invalid: $details",
     )
 
     companion object {
@@ -35,5 +35,5 @@ sealed class ProcessingError(val status: ArenaEvent.ProcessingStatus, val messag
 
 data class ProcessingResult(
     val status: ArenaEntityMapping.Status,
-    val message: String? = null
+    val message: String? = null,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/Administrasjonskode.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/Administrasjonskode.kt
@@ -12,5 +12,5 @@ enum class Administrasjonskode {
     AMO,
 
     @SerialName("INST")
-    INST
+    INST,
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaSak.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaSak.kt
@@ -8,5 +8,5 @@ data class ArenaSak(
     val SAKSKODE: String,
     val AAR: Int,
     val LOPENRSAK: Int,
-    val AETATENHET_ANSVARLIG: String
+    val AETATENHET_ANSVARLIG: String,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTable.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTable.kt
@@ -9,7 +9,8 @@ enum class ArenaTable(val table: String) {
 
     Deltaker("SIAMO.TILTAKDELTAKER"),
 
-    AvtaleInfo("SIAMO.AVTALE_INFO");
+    AvtaleInfo("SIAMO.AVTALE_INFO"),
+    ;
 
     companion object {
         fun fromTable(table: String): ArenaTable {

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltak.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltak.kt
@@ -33,5 +33,5 @@ data class ArenaTiltak(
     val AUTOMATISK_TILSAGNSBREV: JaNeiStatus,
     val STATUS_BEGRUNNELSE_INNSOKT: JaNeiStatus,
     val STATUS_HENVISNING_BREV: JaNeiStatus,
-    val STATUS_KOPIBREV: JaNeiStatus
+    val STATUS_KOPIBREV: JaNeiStatus,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltaksgjennomforing.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltaksgjennomforing.kt
@@ -17,5 +17,5 @@ data class ArenaTiltaksgjennomforing(
     @Serializable(with = FloatToIntSerializer::class)
     val ANTALL_DELTAKERE: Int?,
     val TILTAKSTATUSKODE: String,
-    val AVTALE_ID: Int?
+    val AVTALE_ID: Int?,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/Handlingsplan.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/Handlingsplan.kt
@@ -16,5 +16,5 @@ enum class Handlingsplan {
     SOK,
 
     @SerialName("TIL")
-    TIL
+    TIL,
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/Rammeavtale.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/Rammeavtale.kt
@@ -12,5 +12,5 @@ enum class Rammeavtale {
     SKAL,
 
     @SerialName("IKKE")
-    IKKE
+    IKKE,
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/ArenaEntityMapping.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/ArenaEntityMapping.kt
@@ -8,11 +8,11 @@ data class ArenaEntityMapping(
     val arenaId: String,
     val entityId: UUID,
     val status: Status,
-    val message: String? = null
+    val message: String? = null,
 ) {
     enum class Status {
         Handled,
         Ignored,
-        Unhandled;
+        Unhandled,
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/ArenaEvent.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/ArenaEvent.kt
@@ -19,7 +19,8 @@ data class ArenaEvent(
     enum class Operation {
         Insert,
         Update,
-        Delete;
+        Delete,
+        ;
 
         val opType
             get(): String = when (this) {

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Avtale.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Avtale.kt
@@ -23,7 +23,8 @@ data class Avtale(
         Planlagt,
         Aktiv,
         Avsluttet,
-        Avbrutt;
+        Avbrutt,
+        ;
 
         companion object {
             fun fromArenaAvtalestatuskode(avtalestatuskode: Avtalestatuskode): Status = when (avtalestatuskode) {

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Sak.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Sak.kt
@@ -4,5 +4,5 @@ data class Sak(
     val sakId: Int,
     val lopenummer: Int,
     val aar: Int,
-    val enhet: String
+    val enhet: String,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltaksgjennomforing.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltaksgjennomforing.kt
@@ -15,5 +15,5 @@ data class Tiltaksgjennomforing(
     val apentForInnsok: Boolean = true,
     val antallPlasser: Int? = null,
     val status: String,
-    val avtaleId: Int?
+    val avtaleId: Int?,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltakstype.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Tiltakstype.kt
@@ -37,5 +37,5 @@ data class Tiltakstype(
     val tiltaksgjennomforingGenererTilsagnsbrevAutomatisk: Boolean,
     val visBegrunnelseForInnsoking: Boolean,
     val sendHenvisningsbrevOgHovedbrevTilArbeidsgiver: Boolean,
-    val sendKopibrevOgHovedbrevTilArbeidsgiver: Boolean
+    val sendKopibrevOgHovedbrevTilArbeidsgiver: Boolean,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/dto/ArenaOrdsArrangor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/dto/ArenaOrdsArrangor.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ArenaOrdsArrangor(
     val virksomhetsnummer: String,
-    val organisasjonsnummerMorselskap: String
+    val organisasjonsnummerMorselskap: String,
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/Authentication.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/Authentication.kt
@@ -9,7 +9,7 @@ import java.net.URI
 import java.util.concurrent.TimeUnit
 
 fun Application.configureAuthentication(
-    auth: AuthConfig
+    auth: AuthConfig,
 ) {
     val (azure) = auth
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
@@ -23,8 +23,8 @@ import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
 import no.nav.mulighetsrommet.env.NaisEnv
 import no.nav.mulighetsrommet.kafka.KafkaConsumerOrchestrator
-import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
-import no.nav.mulighetsrommet.slack_notifier.SlackNotifierImpl
+import no.nav.mulighetsrommet.slack.SlackNotifier
+import no.nav.mulighetsrommet.slack.SlackNotifierImpl
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -35,7 +35,7 @@ import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
 
 fun Application.configureDependencyInjection(
-    appConfig: AppConfig
+    appConfig: AppConfig,
 ) {
     val tokenClient = createM2mTokenClient(appConfig)
     install(Koin) {
@@ -46,7 +46,7 @@ fun Application.configureDependencyInjection(
             repositories(),
             services(appConfig.services, tokenClient),
             tasks(appConfig.tasks),
-            slack(appConfig.slack)
+            slack(appConfig.slack),
         )
     }
 }
@@ -126,7 +126,7 @@ private fun services(services: ServiceConfig, tokenClient: MachineToMachineToken
     single {
         MulighetsrommetApiClient(
             config = MulighetsrommetApiClient.Config(maxRetries = 5),
-            baseUri = services.mulighetsrommetApi.url
+            baseUri = services.mulighetsrommetApi.url,
         ) {
             tokenClient.createMachineToMachineToken(services.mulighetsrommetApi.scope)
         }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEntityMappingRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEntityMappingRepository.kt
@@ -48,7 +48,7 @@ class ArenaEntityMappingRepository(private val db: Database) {
             arenaId = string("arena_id"),
             entityId = uuid("entity_id"),
             status = ArenaEntityMapping.Status.valueOf(string("status")),
-            message = stringOrNull("message")
+            message = stringOrNull("message"),
         )
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepository.kt
@@ -59,8 +59,8 @@ class ArenaEventRepository(private val db: Database) {
             mapOf(
                 "table" to table.table,
                 "entity_status" to entityStatus.name,
-                "processing_status" to processingStatus.name
-            )
+                "processing_status" to processingStatus.name,
+            ),
         )
             .asUpdate
             .let { db.run(it) }
@@ -97,7 +97,7 @@ class ArenaEventRepository(private val db: Database) {
             idGreaterThan to "arena_id > :arena_id",
             status to "processing_status= :status::processing_status",
             retriesLessThan to "retries < :max_retries",
-            retriesGreaterThanOrEqual to "retries >= :retriesGreaterThanOrEqual"
+            retriesGreaterThanOrEqual to "retries >= :retriesGreaterThanOrEqual",
         )
 
         @Language("PostgreSQL")
@@ -118,7 +118,7 @@ class ArenaEventRepository(private val db: Database) {
                 "max_retries" to retriesLessThan,
                 "retriesGreaterThanOrEqual" to retriesGreaterThanOrEqual,
                 "limit" to limit,
-            )
+            ),
         )
             .map { it.toEvent() }
             .asList

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/SakRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/SakRepository.kt
@@ -65,13 +65,13 @@ class SakRepository(private val db: Database) {
         "sak_id" to sakId,
         "lopenummer" to lopenummer,
         "aar" to aar,
-        "enhet" to enhet
+        "enhet" to enhet,
     )
 
     private fun Row.toSak() = Sak(
         sakId = int("sak_id"),
         lopenummer = int("lopenummer"),
         aar = int("aar"),
-        enhet = string("enhet")
+        enhet = string("enhet"),
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/TiltaksgjennomforingRepository.kt
@@ -82,7 +82,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "apent_for_innsok" to apentForInnsok,
         "antall_plasser" to antallPlasser,
         "status" to status,
-        "avtale_id" to avtaleId
+        "avtale_id" to avtaleId,
     )
 
     private fun Row.toTiltaksgjennomforing() = Tiltaksgjennomforing(
@@ -97,6 +97,6 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         apentForInnsok = boolean("apent_for_innsok"),
         antallPlasser = intOrNull("antall_plasser"),
         status = string("status"),
-        avtaleId = intOrNull("avtale_id")
+        avtaleId = intOrNull("avtale_id"),
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/TiltakstypeRepository.kt
@@ -183,7 +183,7 @@ returning *
         "tiltaksgjennomforing_genererer_tilsagnsbrev_automatisk" to tiltaksgjennomforingGenererTilsagnsbrevAutomatisk,
         "vis_begrunnelse_for_innsoking" to visBegrunnelseForInnsoking,
         "henvisningsbrev_og_hovedbrev_til_arbeidsgiver" to sendHenvisningsbrevOgHovedbrevTilArbeidsgiver,
-        "kopibrev_og_hovedbrev_til_arbeidsgiver" to sendKopibrevOgHovedbrevTilArbeidsgiver
+        "kopibrev_og_hovedbrev_til_arbeidsgiver" to sendKopibrevOgHovedbrevTilArbeidsgiver,
     )
 
     private fun Row.toTiltakstype() = Tiltakstype(
@@ -217,6 +217,6 @@ returning *
         tiltaksgjennomforingGenererTilsagnsbrevAutomatisk = boolean("tiltaksgjennomforing_genererer_tilsagnsbrev_automatisk"),
         visBegrunnelseForInnsoking = boolean("vis_begrunnelse_for_innsoking"),
         sendHenvisningsbrevOgHovedbrevTilArbeidsgiver = boolean("henvisningsbrev_og_hovedbrev_til_arbeidsgiver"),
-        sendKopibrevOgHovedbrevTilArbeidsgiver = boolean("kopibrev_og_hovedbrev_til_arbeidsgiver")
+        sendKopibrevOgHovedbrevTilArbeidsgiver = boolean("kopibrev_og_hovedbrev_til_arbeidsgiver"),
     )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/routes/ApiRoutes.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/routes/ApiRoutes.kt
@@ -17,13 +17,13 @@ fun Route.apiRoutes() {
     get("/api/exchange/{arenaId}") {
         val arenaId = call.parameters["arenaId"] ?: return@get call.respondText(
             "Mangler eller ugyldig arena-id",
-            status = HttpStatusCode.BadRequest
+            status = HttpStatusCode.BadRequest,
         )
 
         val mapping = arenaEntityService.getMappingIfHandled(ArenaTable.Tiltaksgjennomforing, arenaId)
             ?: return@get call.respondText(
                 "Det finnes ikke noe prosessert tiltaksgjennomføring med arena-id $arenaId",
-                status = HttpStatusCode.NotFound
+                status = HttpStatusCode.NotFound,
             )
 
         call.respond(ExchangeArenaIdForIdResponse(mapping.entityId))
@@ -32,13 +32,13 @@ fun Route.apiRoutes() {
     get("/api/status/{id}") {
         val id = call.parameters["id"]?.toUUID() ?: return@get call.respondText(
             "Mangler eller ugyldig id",
-            status = HttpStatusCode.BadRequest
+            status = HttpStatusCode.BadRequest,
         )
 
         val tiltaksgjennomforing = arenaEntityService.getTiltaksgjennomforingOrNull(id)
             ?: return@get call.respondText(
                 "Det finnes ikke noe tiltaksgjennomføring med id $id",
-                status = HttpStatusCode.NotFound
+                status = HttpStatusCode.NotFound,
             )
 
         call.respond(ArenaTiltaksgjennomforingsstatusDto(tiltaksgjennomforing.status))

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/routes/ManagerRoutes.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/routes/ManagerRoutes.kt
@@ -58,7 +58,7 @@ fun Route.managerRoutes() {
 
         arenaEventService.replayEvent(
             table = request.table,
-            id = request.arenaId
+            id = request.arenaId,
         )
 
         call.respond(HttpStatusCode.Created)
@@ -69,7 +69,7 @@ fun Route.managerRoutes() {
 
         arenaEventService.deleteEntities(
             table = request.table,
-            ids = request.arenaIds
+            ids = request.arenaIds,
         )
 
         call.respond(HttpStatusCode.OK)
@@ -79,13 +79,13 @@ fun Route.managerRoutes() {
 @Serializable
 data class ReplayTopicEventRequest(
     val table: ArenaTable,
-    val arenaId: String
+    val arenaId: String,
 )
 
 @Serializable
 data class DeleteEventsRequest(
     val table: ArenaTable,
-    val arenaIds: List<String>
+    val arenaIds: List<String>,
 )
 
 @Serializable

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEntityService.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEntityService.kt
@@ -27,8 +27,8 @@ class ArenaEntityService(
                     when (event.status) {
                         ArenaEvent.ProcessingStatus.Processed -> ArenaEntityMapping.Status.Handled
                         else -> ArenaEntityMapping.Status.Unhandled
-                    }
-                )
+                    },
+                ),
             )
     }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventService.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventService.kt
@@ -29,7 +29,7 @@ class ArenaEventService(
     data class Config(
         val channelCapacity: Int = 1,
         val numChannelConsumers: Int = 1,
-        val maxRetries: Int = 0
+        val maxRetries: Int = 0,
     )
 
     suspend fun deleteEntities(table: ArenaTable, ids: List<String>) {
@@ -102,7 +102,7 @@ class ArenaEventService(
                     logger.warn("Failed to process event table=${event.arenaTable}, id=${event.arenaId}", e)
 
                     events.upsert(
-                        event.copy(status = ArenaEvent.ProcessingStatus.Failed, message = e.localizedMessage)
+                        event.copy(status = ArenaEvent.ProcessingStatus.Failed, message = e.localizedMessage),
                     )
                 }
             }
@@ -125,7 +125,7 @@ class ArenaEventService(
         table: ArenaTable?,
         status: ArenaEvent.ProcessingStatus?,
         maxRetries: Int? = null,
-        consumer: suspend (ArenaEvent) -> Unit
+        consumer: suspend (ArenaEvent) -> Unit,
     ) = coroutineScope {
         var count = 0
         var prevId: String? = null
@@ -138,7 +138,7 @@ class ArenaEventService(
                     idGreaterThan = prevId,
                     status = status,
                     retriesLessThan = maxRetries,
-                    limit = config.channelCapacity
+                    limit = config.channelCapacity,
                 )
 
                 events.forEach { send(it) }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/NotifyFailedEvents.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/NotifyFailedEvents.kt
@@ -7,19 +7,19 @@ import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
 import no.nav.mulighetsrommet.database.Database
-import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
+import no.nav.mulighetsrommet.slack.SlackNotifier
 import org.slf4j.LoggerFactory
 
 class NotifyFailedEvents(
     private val arenaEventService: ArenaEventService,
     val database: Database,
     private val slackNotifier: SlackNotifier,
-    private val config: Config
+    private val config: Config,
 ) {
 
     data class Config(
         val cron: String,
-        val maxRetries: Int
+        val maxRetries: Int,
     )
 
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/ReplayEvents.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/ReplayEvents.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
 import no.nav.mulighetsrommet.database.Database
-import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
+import no.nav.mulighetsrommet.slack.SlackNotifier
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
@@ -19,7 +19,7 @@ private const val SCHEDULER_STATE_POLL_DELAY = 1000L
 class ReplayEvents(
     private val arenaEventService: ArenaEventService,
     val database: Database,
-    private val slackNotifier: SlackNotifier
+    private val slackNotifier: SlackNotifier,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/RetryFailedEvents.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/tasks/RetryFailedEvents.kt
@@ -9,20 +9,20 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
-import no.nav.mulighetsrommet.slack_notifier.SlackNotifier
+import no.nav.mulighetsrommet.slack.SlackNotifier
 import org.slf4j.LoggerFactory
 
 class RetryFailedEvents(
     private val config: Config,
     private val arenaEventService: ArenaEventService,
-    private val slackNotifier: SlackNotifier
+    private val slackNotifier: SlackNotifier,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
     data class Config(
         val delayOfMinutes: Int,
-        val schedulerStatePollDelay: Long = 1000
+        val schedulerStatePollDelay: Long = 1000,
     )
 
     val task: RecurringTask<Void> = Tasks

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationTestConfig.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationTestConfig.kt
@@ -16,7 +16,7 @@ fun createDatabaseTestConfig() = createDatabaseTestSchema("mulighetsrommet-arena
 fun <R> withTestApplication(
     oauth: MockOAuth2Server = MockOAuth2Server(),
     config: AppConfig = createTestApplicationConfig(oauth),
-    test: suspend ApplicationTestBuilder.() -> R
+    test: suspend ApplicationTestBuilder.() -> R,
 ) {
     var flywayAdapter: FlywayDatabaseAdapter? = null
 
@@ -42,27 +42,27 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     enableFailedRecordProcessor = false,
     tasks = TaskConfig(
         retryFailedEvents = RetryFailedEvents.Config(
-            delayOfMinutes = 1
+            delayOfMinutes = 1,
         ),
         notifyFailedEvents = NotifyFailedEvents.Config(
             maxRetries = 5,
-            cron = "0 0 0 1 1 0"
-        )
+            cron = "0 0 0 1 1 0",
+        ),
     ),
     services = ServiceConfig(
         mulighetsrommetApi = ServiceClientConfig(url = "mulighetsrommet-api", scope = ""),
         arenaEventService = ArenaEventService.Config(
             channelCapacity = 0,
             numChannelConsumers = 0,
-            maxRetries = 0
+            maxRetries = 0,
         ),
-        arenaOrdsProxy = ServiceClientConfig(url = "arena-ords-proxy", scope = "")
+        arenaOrdsProxy = ServiceClientConfig(url = "arena-ords-proxy", scope = ""),
     ),
     slack = SlackConfig(
         token = "",
         channel = "",
-        enable = false
-    )
+        enable = false,
+    ),
 )
 
 fun createKafkaConfig(): KafkaConfig {
@@ -84,14 +84,14 @@ fun createKafkaConfig(): KafkaConfig {
 fun createAuthConfig(
     oauth: MockOAuth2Server,
     issuer: String = "default",
-    audience: String = "default"
+    audience: String = "default",
 ): AuthConfig {
     return AuthConfig(
         azure = AuthProvider(
             issuer = oauth.issuerUrl(issuer).toString(),
             jwksUri = oauth.jwksUrl(issuer).toUri().toString(),
             audience = audience,
-            tokenEndpointUrl = oauth.tokenEndpointUrl(issuer).toString()
-        )
+            tokenEndpointUrl = oauth.tokenEndpointUrl(issuer).toString(),
+        ),
     )
 }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/ArenaEventConsumerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/ArenaEventConsumerTest.kt
@@ -15,31 +15,31 @@ class ArenaEventConsumerTest : FunSpec({
                 createArenaTiltakEvent(Delete) { it.copy(TILTAKSKODE = "TILTAK") },
                 Delete,
                 Tiltakstype,
-                "TILTAK"
+                "TILTAK",
             ),
             row(
                 createArenaSakEvent(Insert) { it.copy(SAK_ID = 1) },
                 Insert,
                 Sak,
-                "1"
+                "1",
             ),
             row(
                 createArenaAvtaleInfoEvent(Update) { it.copy(AVTALE_ID = 2) },
                 Update,
                 AvtaleInfo,
-                "2"
+                "2",
             ),
             row(
                 createArenaTiltakgjennomforingEvent(Insert) { it.copy(TILTAKGJENNOMFORING_ID = 3) },
                 Insert,
                 Tiltaksgjennomforing,
-                "3"
+                "3",
             ),
             row(
                 createArenaTiltakdeltakerEvent(Insert) { it.copy(TILTAKDELTAKER_ID = 4) },
                 Insert,
                 Deltaker,
-                "4"
+                "4",
             ),
         ) { event, operation, table, id ->
             val decoded = decodeArenaEvent(event.payload)

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/ArenaJsonElementDeserializerTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/ArenaJsonElementDeserializerTest.kt
@@ -15,7 +15,7 @@ class ArenaJsonElementDeserializerTest : FunSpec({
             {
                 "FOO": "\u0000\u0000"
             }
-            """.trimIndent().toByteArray()
+            """.trimIndent().toByteArray(),
         )
         result.jsonObject.getValue("FOO").jsonPrimitive.content shouldBe ""
     }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessorTest.kt
@@ -62,8 +62,8 @@ class AvtaleInfoEventProcessorTest : FunSpec({
                 "/ords/arbeidsgiver" to {
                     respondJson(ArenaOrdsArrangor("123456", "1000000"))
                 },
-                "/api/v1/internal/arena/avtale.*" to { respondOk() }
-            )
+                "/api/v1/internal/arena/avtale.*" to { respondOk() },
+            ),
         ): AvtaleInfoEventProcessor {
             val client = MulighetsrommetApiClient(engine, baseUri = "api") {
                 "Bearer token"
@@ -109,8 +109,8 @@ class AvtaleInfoEventProcessorTest : FunSpec({
                         ArenaTable.Tiltakstype,
                         tiltakstype.tiltakskode,
                         tiltakstype.id,
-                        Handled
-                    )
+                        Handled,
+                    ),
                 )
             }
 
@@ -179,7 +179,7 @@ class AvtaleInfoEventProcessorTest : FunSpec({
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondError(HttpStatusCode.InternalServerError)
-                    }
+                    },
                 )
                 val processor = createProcessor(engine)
 
@@ -197,7 +197,7 @@ class AvtaleInfoEventProcessorTest : FunSpec({
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondError(HttpStatusCode.NotFound)
-                    }
+                    },
                 )
                 val processor = createProcessor(engine)
 
@@ -214,12 +214,12 @@ class AvtaleInfoEventProcessorTest : FunSpec({
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondJson(
-                            ArenaOrdsArrangor("123456", "100000")
+                            ArenaOrdsArrangor("123456", "100000"),
                         )
                     },
                     "/api/v1/internal/arena/avtale" to {
                         respondError(HttpStatusCode.InternalServerError)
-                    }
+                    },
                 )
                 val processor = createProcessor(engine)
 
@@ -237,7 +237,7 @@ class AvtaleInfoEventProcessorTest : FunSpec({
                     "/ords/arbeidsgiver" to {
                         respondJson(ArenaOrdsArrangor("123456", "1000000"))
                     },
-                    "/api/v1/internal/arena/avtale.*" to { respondOk() }
+                    "/api/v1/internal/arena/avtale.*" to { respondOk() },
                 )
                 val processor = createProcessor(engine)
 

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessorTest.kt
@@ -72,8 +72,8 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
         fun createProcessor(
             engine: HttpClientEngine = createMockEngine(
                 "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
-                "/api/v1/internal/arena/tiltakshistorikk.*" to { respondOk() }
-            )
+                "/api/v1/internal/arena/tiltakshistorikk.*" to { respondOk() },
+            ),
         ): TiltakdeltakerEventProcessor {
             val client = MulighetsrommetApiClient(engine, baseUri = "api") {
                 "Bearer token"
@@ -147,7 +147,7 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
              */
             val tiltakstypeGruppeOpphavArena = TiltakstypeFixtures.Gruppe.copy(
                 id = UUID.randomUUID(),
-                tiltakskode = "IPSUNG"
+                tiltakskode = "IPSUNG",
             )
             val sakOpphavArena = Sak(sakId = 3, lopenummer = 3, aar = 2022, enhet = "2990")
             val tiltaksgjennomforingOpphavArena = tiltaksgjennomforing.copy(
@@ -165,7 +165,7 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                 listOf(tiltakstypeGruppe, tiltakstypeIndividuell, tiltakstypeGruppeOpphavArena).forEach {
                     tiltakstyper.upsert(it).getOrThrow()
                     mappings.upsert(
-                        ArenaEntityMapping(ArenaTable.Tiltakstype, it.tiltakskode, it.id, Handled)
+                        ArenaEntityMapping(ArenaTable.Tiltakstype, it.tiltakskode, it.id, Handled),
                     )
                 }
 
@@ -182,8 +182,8 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                             ArenaTable.Tiltaksgjennomforing,
                             it.tiltaksgjennomforingId.toString(),
                             it.id,
-                            Handled
-                        )
+                            Handled,
+                        ),
                     )
                 }
             }
@@ -206,8 +206,8 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                         ArenaTable.Tiltaksgjennomforing,
                         tiltaksgjennomforing.tiltaksgjennomforingId.toString(),
                         UUID.randomUUID(),
-                        Ignored
-                    )
+                        Ignored,
+                    ),
                 )
                 val event = createArenaTiltakdeltakerEvent(Insert)
 
@@ -219,7 +219,7 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
 
                 val (e1, mapping) = prepareEvent(
                     createArenaTiltakdeltakerEvent(Insert) { it.copy(DELTAKERSTATUSKODE = "GJENN") },
-                    Ignored
+                    Ignored,
                 )
                 processor.handleEvent(e1).shouldBeRight().should { it.status shouldBe Handled }
                 database.assertThat("deltaker").row()
@@ -242,7 +242,7 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
             test("should mark the event as Failed when arena ords proxy responds with an error") {
                 val engine = createMockEngine(
                     "/ords/fnr" to { respondError(HttpStatusCode.InternalServerError) },
-                    "/api/v1/internal/arena/deltaker" to { respondOk() }
+                    "/api/v1/internal/arena/deltaker" to { respondOk() },
                 )
                 val processor = createProcessor(engine)
 
@@ -258,7 +258,7 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
             test("should mark the event as Invalid when arena ords proxy responds with NotFound") {
                 val engine = createMockEngine(
                     "/ords/fnr" to { respondError(HttpStatusCode.NotFound) },
-                    "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() }
+                    "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() },
                 )
 
                 val processor = createProcessor(engine)
@@ -274,9 +274,9 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                     "/ords/fnr" to { respondJson(ArenaOrdsFnr("12345678910")) },
                     "/api/v1/internal/arena/tiltakshistorikk" to {
                         respondError(
-                            HttpStatusCode.InternalServerError
+                            HttpStatusCode.InternalServerError,
                         )
-                    }
+                    },
                 )
                 val processor = createProcessor(engine)
 
@@ -324,9 +324,9 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                     "/api/v1/internal/arena/tiltakshistorikk" to { respondOk() },
                     "/ords/arbeidsgiver" to {
                         respondJson(
-                            ArenaOrdsArrangor("123456", "000000")
+                            ArenaOrdsArrangor("123456", "000000"),
                         )
-                    }
+                    },
                 )
                 val processor = createProcessor(engine)
 
@@ -334,10 +334,10 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                     createArenaTiltakdeltakerEvent(Insert) {
                         it.copy(
                             TILTAKDELTAKER_ID = 2,
-                            TILTAKGJENNOMFORING_ID = tiltaksgjennomforingIndividuell.tiltaksgjennomforingId
+                            TILTAKGJENNOMFORING_ID = tiltaksgjennomforingIndividuell.tiltaksgjennomforingId,
                         )
                     },
-                    Ignored
+                    Ignored,
                 )
 
                 processor.handleEvent(event).shouldBeRight()
@@ -368,7 +368,7 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                     createArenaTiltakdeltakerEvent(Insert) {
                         it.copy(TILTAKGJENNOMFORING_ID = tiltaksgjennomforingOpphavArena.tiltaksgjennomforingId)
                     },
-                    Ignored
+                    Ignored,
                 )
 
                 processor.handleEvent(event).shouldBeRight()

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessorTest.kt
@@ -74,8 +74,8 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 "/ords/arbeidsgiver" to {
                     respondJson(ArenaOrdsArrangor("123456", "000000"))
                 },
-                "/api/v1/internal/arena/tiltaksgjennomforing.*" to { respondOk() }
-            )
+                "/api/v1/internal/arena/tiltaksgjennomforing.*" to { respondOk() },
+            ),
         ): TiltakgjennomforingEventProcessor {
             val client = MulighetsrommetApiClient(engine, baseUri = "api") {
                 "Bearer token"
@@ -128,8 +128,8 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                         sakId = 13572352,
                         lopenummer = 123,
                         aar = 2022,
-                        enhet = "2990"
-                    )
+                        enhet = "2990",
+                    ),
                 )
 
                 val processor = createProcessor()
@@ -175,7 +175,7 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val tiltakstyper = TiltakstypeRepository(database.db)
                 tiltakstyper.upsert(tiltakstype)
                 entities.upsertMapping(
-                    ArenaEntityMapping(ArenaTable.Tiltakstype, tiltakstype.tiltakskode, tiltakstype.id, Handled)
+                    ArenaEntityMapping(ArenaTable.Tiltakstype, tiltakstype.tiltakskode, tiltakstype.id, Handled),
                 )
             }
 
@@ -186,10 +186,10 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                     val (event) = prepareEvent(
                         createArenaTiltakgjennomforingEvent(
                             Insert,
-                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
+                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell,
                         ) {
                             it.copy(REG_DATO = regDatoBeforeAktivitetsplanen)
-                        }
+                        },
                     )
 
                     processor.handleEvent(event).shouldBeRight().should {
@@ -204,10 +204,10 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                     val (event) = prepareEvent(
                         createArenaTiltakgjennomforingEvent(
                             Insert,
-                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
+                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell,
                         ) {
                             it.copy(REG_DATO = regDatoAfterAktivitetsplanen)
-                        }
+                        },
                     )
 
                     processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Handled }
@@ -222,8 +222,8 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                     val (event) = prepareEvent(
                         createArenaTiltakgjennomforingEvent(
                             Insert,
-                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell
-                        )
+                            TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingIndividuell,
+                        ),
                     )
 
                     processor.handleEvent(event).shouldBeRight()
@@ -242,7 +242,7 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val tiltakstyper = TiltakstypeRepository(database.db)
                 tiltakstyper.upsert(tiltakstype)
                 entities.upsertMapping(
-                    ArenaEntityMapping(ArenaTable.Tiltakstype, tiltakstype.tiltakskode, tiltakstype.id, Handled)
+                    ArenaEntityMapping(ArenaTable.Tiltakstype, tiltakstype.tiltakskode, tiltakstype.id, Handled),
                 )
             }
 
@@ -253,9 +253,9 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                     createArenaTiltakgjennomforingEvent(Insert) {
                         it.copy(
                             REG_DATO = regDatoBeforeAktivitetsplanen,
-                            LOKALTNAVN = "Navn 1"
+                            LOKALTNAVN = "Navn 1",
                         )
-                    }
+                    },
                 )
                 processor.handleEvent(e1).shouldBeRight().should { it.status shouldBe Handled }
                 database.assertThat("tiltaksgjennomforing").row()
@@ -265,7 +265,7 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val e2 = createArenaTiltakgjennomforingEvent(Update) {
                     it.copy(
                         REG_DATO = regDatoAfterAktivitetsplanen,
-                        LOKALTNAVN = "Navn 2"
+                        LOKALTNAVN = "Navn 2",
                     )
                 }
                 processor.handleEvent(e2).shouldBeRight().should { it.status shouldBe Handled }
@@ -286,7 +286,7 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondError(HttpStatusCode.InternalServerError)
-                    }
+                    },
                 )
                 val processor = createProcessor(engine)
 
@@ -303,7 +303,7 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondError(HttpStatusCode.NotFound)
-                    }
+                    },
                 )
                 val processor = createProcessor(engine)
                 val (event) = prepareEvent(createArenaTiltakgjennomforingEvent(Insert))
@@ -318,12 +318,12 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondJson(
-                            ArenaOrdsArrangor("123456", "000000")
+                            ArenaOrdsArrangor("123456", "000000"),
                         )
                     },
                     "/api/v1/internal/arena/tiltaksgjennomforing" to {
                         respondError(HttpStatusCode.InternalServerError)
-                    }
+                    },
                 )
                 val processor = createProcessor(engine)
 
@@ -339,10 +339,10 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondJson(
-                            ArenaOrdsArrangor("123456", "000000")
+                            ArenaOrdsArrangor("123456", "000000"),
                         )
                     },
-                    "/api/v1/internal/arena/tiltaksgjennomforing.*" to { respondOk() }
+                    "/api/v1/internal/arena/tiltaksgjennomforing.*" to { respondOk() },
                 )
                 val processor = createProcessor(engine)
 
@@ -350,9 +350,9 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                     createArenaTiltakgjennomforingEvent(Insert) {
                         it.copy(
                             DATO_FRA = "2022-11-11 00:00:00",
-                            DATO_TIL = "2023-11-11 00:00:00"
+                            DATO_TIL = "2023-11-11 00:00:00",
                         )
-                    }
+                    },
                 )
 
                 processor.handleEvent(event).shouldBeRight()
@@ -384,7 +384,7 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val processor = createProcessor()
 
                 val (event) = prepareEvent(
-                    createArenaTiltakgjennomforingEvent(Insert) { it.copy(AVTALE_ID = 1) }
+                    createArenaTiltakgjennomforingEvent(Insert) { it.copy(AVTALE_ID = 1) },
                 )
 
                 processor.handleEvent(event).shouldBeLeft().should {
@@ -398,11 +398,11 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
 
                 prepareEvent(
                     createArenaAvtaleInfoEvent(Insert) { it.copy(AVTALE_ID = 1) },
-                    Unhandled
+                    Unhandled,
                 )
 
                 val (event) = prepareEvent(
-                    createArenaTiltakgjennomforingEvent(Insert) { it.copy(AVTALE_ID = 1) }
+                    createArenaTiltakgjennomforingEvent(Insert) { it.copy(AVTALE_ID = 1) },
                 )
 
                 processor.handleEvent(event).shouldBeLeft().should {
@@ -421,7 +421,7 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 upsertAvtale(avtaleEvent, avtaleMapping)
 
                 val (event, mapping) = prepareEvent(
-                    createArenaTiltakgjennomforingEvent(Insert) { it.copy(AVTALE_ID = 1) }
+                    createArenaTiltakgjennomforingEvent(Insert) { it.copy(AVTALE_ID = 1) },
                 )
                 processor.handleEvent(event).shouldBeRight()
 
@@ -434,10 +434,10 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 val engine = createMockEngine(
                     "/ords/arbeidsgiver" to {
                         respondJson(
-                            ArenaOrdsArrangor("123456", "000000")
+                            ArenaOrdsArrangor("123456", "000000"),
                         )
                     },
-                    "/api/v1/internal/arena/tiltaksgjennomforing" to { respondOk() }
+                    "/api/v1/internal/arena/tiltaksgjennomforing" to { respondOk() },
                 )
                 val processor = createProcessor(engine)
 
@@ -448,7 +448,7 @@ class TiltakgjennomforingEventProcessorTest : FunSpec({
                 upsertAvtale(avtaleEvent, avtaleMapping)
 
                 val (event, mapping) = prepareEvent(
-                    createArenaTiltakgjennomforingEvent(Insert) { it.copy(AVTALE_ID = 1) }
+                    createArenaTiltakgjennomforingEvent(Insert) { it.copy(AVTALE_ID = 1) },
                 )
                 processor.handleEvent(event).shouldBeRight()
 

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/ArenaEventFixtures.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/ArenaEventFixtures.kt
@@ -9,7 +9,7 @@ fun createArenaAvtaleInfoEvent(
     operation: ArenaEvent.Operation,
     avtale: ArenaAvtaleInfo = AvtaleFixtures.ArenaAvtaleInfo,
     status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
-    modify: (avtale: ArenaAvtaleInfo) -> ArenaAvtaleInfo = { it }
+    modify: (avtale: ArenaAvtaleInfo) -> ArenaAvtaleInfo = { it },
 ): ArenaEvent = modify(avtale).let {
     createArenaEvent(
         ArenaTable.AvtaleInfo,
@@ -24,7 +24,7 @@ fun createArenaSakEvent(
     operation: ArenaEvent.Operation,
     sak: ArenaSak = SakFixtures.ArenaTiltakSak,
     status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
-    modify: (sak: ArenaSak) -> ArenaSak = { it }
+    modify: (sak: ArenaSak) -> ArenaSak = { it },
 ): ArenaEvent = modify(sak).let {
     createArenaEvent(
         ArenaTable.Sak,
@@ -39,7 +39,7 @@ fun createArenaTiltakdeltakerEvent(
     operation: ArenaEvent.Operation,
     deltaker: ArenaTiltakdeltaker = DeltakerFixtures.ArenaTiltakdeltaker,
     status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
-    modify: (deltaker: ArenaTiltakdeltaker) -> ArenaTiltakdeltaker = { it }
+    modify: (deltaker: ArenaTiltakdeltaker) -> ArenaTiltakdeltaker = { it },
 ): ArenaEvent = modify(deltaker).let {
     createArenaEvent(
         ArenaTable.Deltaker,
@@ -54,7 +54,7 @@ fun createArenaTiltakEvent(
     operation: ArenaEvent.Operation,
     tiltak: ArenaTiltak = TiltakstypeFixtures.ArenaGruppetiltak,
     status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
-    modify: (tiltak: ArenaTiltak) -> ArenaTiltak = { it }
+    modify: (tiltak: ArenaTiltak) -> ArenaTiltak = { it },
 ): ArenaEvent = modify(tiltak).let {
     createArenaEvent(
         ArenaTable.Tiltakstype,
@@ -69,7 +69,7 @@ fun createArenaTiltakgjennomforingEvent(
     operation: ArenaEvent.Operation,
     tiltaksgjennomforing: ArenaTiltaksgjennomforing = TiltaksgjennomforingFixtures.ArenaTiltaksgjennomforingGruppe,
     status: ArenaEvent.ProcessingStatus = ArenaEvent.ProcessingStatus.Pending,
-    modify: (tiltaksgjennomforing: ArenaTiltaksgjennomforing) -> ArenaTiltaksgjennomforing = { it }
+    modify: (tiltaksgjennomforing: ArenaTiltaksgjennomforing) -> ArenaTiltaksgjennomforing = { it },
 ): ArenaEvent = modify(tiltaksgjennomforing).let {
     createArenaEvent(
         ArenaTable.Tiltaksgjennomforing,
@@ -110,8 +110,8 @@ private fun createArenaEvent(
                 "before": $before,
                 "after": $after
             }
-            """.trimIndent()
+            """.trimIndent(),
         ),
-        status = status
+        status = status,
     )
 }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/AvtaleFixtures.kt
@@ -28,6 +28,6 @@ object AvtaleFixtures {
         REG_USER = "SIAMO",
         MOD_DATO = "2022-10-05 00:00:00",
         MOD_USER = "SIAMO",
-        PROFILELEMENT_ID_OPPL_TILTAK = 3000
+        PROFILELEMENT_ID_OPPL_TILTAK = 3000,
     )
 }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/SakFixtures.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/fixtures/SakFixtures.kt
@@ -8,7 +8,7 @@ object SakFixtures {
         SAKSKODE = "TILT",
         AAR = 2022,
         LOPENRSAK = 1,
-        AETATENHET_ANSVARLIG = "2990"
+        AETATENHET_ANSVARLIG = "2990",
     )
 
     val ArenaIkkeTiltakSak = ArenaSak(
@@ -16,6 +16,6 @@ object SakFixtures {
         SAKSKODE = "NOT_TILT",
         AAR = 2022,
         LOPENRSAK = 1,
-        AETATENHET_ANSVARLIG = "2990"
+        AETATENHET_ANSVARLIG = "2990",
     )
 }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltaksgjennomforingTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaTiltaksgjennomforingTest.kt
@@ -21,7 +21,7 @@ class ArenaTiltaksgjennomforingTest : FunSpec({
             "ANTALL_DELTAKERE": $antallDeltakere,
             "TILTAKSTATUSKODE": "GJENNOMFOR",
             "AVTALE_ID": "1000"
-        }"""
+        }""",
     )
 
     context("decode from JSON") {
@@ -38,7 +38,7 @@ class ArenaTiltaksgjennomforingTest : FunSpec({
                 STATUS_TREVERDIKODE_INNSOKNING = JaNeiStatus.Ja,
                 ANTALL_DELTAKERE = 5,
                 TILTAKSTATUSKODE = "GJENNOMFOR",
-                AVTALE_ID = 1000
+                AVTALE_ID = 1000,
             )
         }
 

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/AuthenticationTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/AuthenticationTest.kt
@@ -32,7 +32,7 @@ class AuthenticationTest : FunSpec({
             withTestApplication(oauth) {
                 val response = client.get(apiUrl) {
                     bearerAuth(
-                        oauth.issueToken(audience = "skatteetaten").serialize()
+                        oauth.issueToken(audience = "skatteetaten").serialize(),
                     )
                 }
                 response.status shouldBe HttpStatusCode.Unauthorized
@@ -44,7 +44,7 @@ class AuthenticationTest : FunSpec({
 
                 val response = client.get(apiUrl) {
                     bearerAuth(
-                        oauth.issueToken(audience = "skatteetaten").serialize()
+                        oauth.issueToken(audience = "skatteetaten").serialize(),
                     )
                 }
                 response.status shouldBe HttpStatusCode.Unauthorized

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepositoryTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/repositories/ArenaEventRepositoryTest.kt
@@ -38,15 +38,15 @@ class ArenaEventRepositoryTest : FunSpec({
                         operation = ArenaEvent.Operation.Insert,
                         payload = Json.parseToJsonElement("{}"),
                         status = Processed,
-                    )
+                    ),
                 )
                 mappings.upsert(
                     ArenaEntityMapping(
                         arenaTable = event.arenaTable,
                         arenaId = event.arenaId,
                         entityId = UUID.randomUUID(),
-                        status = Handled
-                    )
+                        status = Handled,
+                    ),
                 )
             }
             (6..10).forEach {
@@ -57,7 +57,7 @@ class ArenaEventRepositoryTest : FunSpec({
                         operation = ArenaEvent.Operation.Insert,
                         payload = Json.parseToJsonElement("{}"),
                         status = Pending,
-                    )
+                    ),
                 )
                 mappings.upsert(
                     ArenaEntityMapping(
@@ -65,7 +65,7 @@ class ArenaEventRepositoryTest : FunSpec({
                         arenaId = event.arenaId,
                         entityId = UUID.randomUUID(),
                         status = Ignored,
-                    )
+                    ),
                 )
             }
         }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEntityServiceTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEntityServiceTest.kt
@@ -36,13 +36,13 @@ class ArenaEntityServiceTest : FunSpec({
                     ArenaTable.Tiltaksgjennomforing,
                     arenaId,
                     entityId,
-                    ArenaEntityMapping.Status.Handled
-                )
+                    ArenaEntityMapping.Status.Handled,
+                ),
             )
 
             val mapping = arenaEntityService.getMappingIfHandled(
                 ArenaTable.Tiltaksgjennomforing,
-                arenaId
+                arenaId,
             )
 
             mapping?.entityId shouldBe entityId
@@ -54,12 +54,12 @@ class ArenaEntityServiceTest : FunSpec({
                 row(ArenaEntityMapping.Status.Ignored),
             ) { status ->
                 arenaEntityMappingRepository.upsert(
-                    ArenaEntityMapping(ArenaTable.Tiltaksgjennomforing, arenaId, entityId, status)
+                    ArenaEntityMapping(ArenaTable.Tiltaksgjennomforing, arenaId, entityId, status),
                 )
 
                 val mapping = arenaEntityService.getMappingIfHandled(
                     ArenaTable.Tiltaksgjennomforing,
-                    arenaId
+                    arenaId,
                 )
 
                 mapping shouldBe null

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventServiceTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/services/ArenaEventServiceTest.kt
@@ -39,21 +39,21 @@ class ArenaEventServiceTest : FunSpec({
         arenaTable = table,
         operation = ArenaEvent.Operation.Insert,
         arenaId = "1",
-        payload = JsonObject(mapOf("name" to JsonPrimitive("Foo")))
+        payload = JsonObject(mapOf("name" to JsonPrimitive("Foo"))),
     )
     val processedEvent = ArenaEvent(
         status = ProcessingStatus.Processed,
         arenaTable = table,
         operation = ArenaEvent.Operation.Insert,
         arenaId = "2",
-        payload = JsonObject(mapOf("name" to JsonPrimitive("Bar")))
+        payload = JsonObject(mapOf("name" to JsonPrimitive("Bar"))),
     )
     val invalidEvent = ArenaEvent(
         status = ProcessingStatus.Invalid,
         arenaTable = table,
         operation = ArenaEvent.Operation.Insert,
         arenaId = "3",
-        payload = JsonObject(mapOf("name" to JsonPrimitive("Baz")))
+        payload = JsonObject(mapOf("name" to JsonPrimitive("Baz"))),
     )
 
     lateinit var events: ArenaEventRepository
@@ -128,7 +128,7 @@ class ArenaEventServiceTest : FunSpec({
             val processor = spyk(
                 ArenaEventTestProcessor {
                     ProcessingResult(ArenaEntityMapping.Status.Ignored, "test").right()
-                }
+                },
             )
             val entitiesRepository = ArenaEntityMappingRepository(database.db)
             entitiesRepository.upsert(
@@ -136,8 +136,8 @@ class ArenaEventServiceTest : FunSpec({
                     pendingEvent.arenaTable,
                     pendingEvent.arenaId,
                     UUID.randomUUID(),
-                    Handled
-                )
+                    Handled,
+                ),
             )
             val service = ArenaEventService(events = events, processors = listOf(processor), entities = entities)
             service.processEvent(pendingEvent)
@@ -157,7 +157,7 @@ class ArenaEventServiceTest : FunSpec({
             val processor = spyk(
                 ArenaEventTestProcessor {
                     ProcessingResult(ArenaEntityMapping.Status.Ignored).right()
-                }
+                },
             )
             val service = ArenaEventService(events = events, processors = listOf(processor), entities = entities)
             service.processEvent(pendingEvent)
@@ -239,7 +239,8 @@ class ArenaEventServiceTest : FunSpec({
             val service = ArenaEventService(
                 config = ArenaEventService.Config(maxRetries = 0),
                 events = events,
-                processors = listOf(processor), entities = entities
+                processors = listOf(processor),
+                entities = entities,
             )
             service.retryEvents(table)
 
@@ -260,7 +261,8 @@ class ArenaEventServiceTest : FunSpec({
             val service = ArenaEventService(
                 config = ArenaEventService.Config(maxRetries = 1),
                 events = events,
-                processors = listOf(processor), entities = entities
+                processors = listOf(processor),
+                entities = entities,
             )
             service.retryEvents(table)
 


### PR DESCRIPTION
- Gradle plugin for `ktlint` har blitt oppgradert til siste versjon, samt at siste versjon av `ktlint` blir satt i configen for alle prosjekter (0.48.2)
- `ktlint`-regler kan nå bli definert i `.editorconfig` i stedet for byggescriptet
- Har ikke gjort noen endringer i formatteringsreglene, men nyeste versjon har nå `trailing commas` som standard (samt et par andre preferanser) og dette dro med seg ganske mange endringer
- Har også testet ut at intellij-pluginen for ktlint fungerer for siste versjon av intellij, og denne ser også ut til å respektere konfigurasjonen i `.editorconfig`, så virker som at det er mulig å bruke denne i kombinasjon med det vi har definert i gradle: https://plugins.jetbrains.com/plugin/15057-ktlint-unofficial-
    - Merk at denne pluginen enda ikke har støtte for å konfigurere ktlint-versjon selv, så nye releases av plugin kan gå i beina på det vi har definert i byggescriptet - det ser ut som at det er noe aktivtet rundt dette: https://github.com/nbadal/ktlint-intellij-plugin/issues/35
- Evt fungerer det som alltid å kjøre `gradle ktlintFormat` manuelt fra kommandolinja (eller kjøre via gradle-plugin i intellij) for å formattere filene 