### PR TITLE
collation nb-NO-x-icu for enhetnavn så æøå sortering fungerer

### DIFF
--- a/mulighetsrommet-api/src/main/resources/db/migration/V49__collation_for_enhet.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V49__collation_for_enhet.sql
@@ -1,0 +1,2 @@
+alter table enhet
+    alter column navn set data type text collate "nb-NO-x-icu";


### PR DESCRIPTION
Uten korrekt collation fungerer ikke sortering på navn korrekt. Ved å legge til korrekt collation vil æøå-sortering oppføre seg slik vi forventer på norsk.
 
![image](https://user-images.githubusercontent.com/9053627/233266255-b4ff0355-2298-40be-abe9-f63042ab3019.png)
