### PR TITLE
Stylingfix, bugfix enter og fiks flashing skjema

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/opprett/OpprettAvtaleContainer.tsx
@@ -294,6 +294,7 @@ export function OpprettAvtaleContainer({
             className={styles.button}
             onClick={onAvbryt}
             variant="tertiary"
+            type="button"
           >
             Avbryt
           </Button>

--- a/frontend/mr-admin-flate/src/components/skjema/ControlledMultiSelect.tsx
+++ b/frontend/mr-admin-flate/src/components/skjema/ControlledMultiSelect.tsx
@@ -7,16 +7,11 @@ export interface MultiSelectProps {
   label: string;
   placeholder: string;
   options: SelectOption[];
-  size?: "small" | "medium",
+  size?: "small" | "medium";
 }
 
 const ControlledMultiSelect = React.forwardRef((props: MultiSelectProps) => {
-  const {
-    label,
-    placeholder,
-    options,
-    ...rest
-  } = props;
+  const { label, placeholder, options, ...rest } = props;
 
   return (
     <div>
@@ -24,8 +19,8 @@ const ControlledMultiSelect = React.forwardRef((props: MultiSelectProps) => {
         name={label}
         {...rest}
         render={({
-            field: { onChange, value, name, ref },
-            fieldState: { error },
+          field: { onChange, value, name, ref },
+          fieldState: { error },
         }) => (
           <>
             <label
@@ -39,11 +34,9 @@ const ControlledMultiSelect = React.forwardRef((props: MultiSelectProps) => {
               placeholder={placeholder}
               ref={ref}
               name={name}
-              value={
-                options.filter((c) => value?.includes(c.value))
-              }
+              value={options.filter((c) => value?.includes(c.value))}
               onChange={(e) => {
-                onChange(e.map((option: SelectOption) => option.value))
+                onChange(e.map((option: SelectOption) => option.value));
               }}
               options={options}
             />
@@ -59,7 +52,6 @@ const ControlledMultiSelect = React.forwardRef((props: MultiSelectProps) => {
   );
 });
 
-ControlledMultiSelect.displayName = 'ControlledMultiSelect';
+ControlledMultiSelect.displayName = "ControlledMultiSelect";
 
 export { ControlledMultiSelect };
-

--- a/frontend/mr-admin-flate/src/components/skjema/MultiSelect.tsx
+++ b/frontend/mr-admin-flate/src/components/skjema/MultiSelect.tsx
@@ -7,27 +7,19 @@ export interface MultiSelectProps {
   ref: React.Ref<any>;
   placeholder: string;
   options: SelectOption[];
-  size?: "small" | "medium",
+  size?: "small" | "medium";
   value: SelectOption[];
-  onChange: (e: any) => void,
+  onChange: (e: any) => void;
   error: boolean;
 }
 
 const MultiSelect = React.forwardRef((props: MultiSelectProps) => {
-  const {
-    name,
-    placeholder,
-    options,
-    onChange,
-    value,
-    ref,
-    error,
-  } = props;
+  const { name, placeholder, options, onChange, value, ref, error } = props;
 
   const customStyles = (isError: boolean) => ({
     control: (provided: any, state: any) => ({
       ...provided,
-      background: '#fff',
+      background: "#fff",
       borderColor: isError ? "#C30000" : "#0000008f",
       borderWidth: isError ? "2px" : "1px",
       minHeight: "48px",
@@ -35,26 +27,34 @@ const MultiSelect = React.forwardRef((props: MultiSelectProps) => {
     }),
     multiValue: (provided: any) => ({
       ...provided,
-      backgroundColor: '#005b82',
-      borderRadius: '15px',
-      color: 'white'
+      backgroundColor: "#005b82",
+      borderRadius: "15px",
+      color: "white",
     }),
     multiValueLabel: (provided: any) => ({
       ...provided,
-      color: 'white'
+      color: "white",
     }),
     multiValueRemove: (provided: any) => ({
       ...provided,
-      color: '#cce1ff',
-      ':hover': {
-        backgroundColor: '#3380a5',
-        borderRadius: '15px',
+      color: "#cce1ff",
+      ":hover": {
+        backgroundColor: "#3380a5",
+        borderRadius: "15px",
         color: "white",
       },
     }),
     indicatorSeparator: (state: any) => ({
       ...state,
-      display: 'none',
+      display: "none",
+    }),
+    dropdownIndicator: (provided: any) => ({
+      ...provided,
+      color: "black",
+    }),
+    placeholder: (provided: any) => ({
+      ...provided,
+      color: "#0000008f",
     }),
   });
 
@@ -73,8 +73,8 @@ const MultiSelect = React.forwardRef((props: MultiSelectProps) => {
         ...theme,
         colors: {
           ...theme.colors,
-          primary25: '#cce1ff',
-          primary: '#0067c5',
+          primary25: "#cce1ff",
+          primary: "#0067c5",
           danger: "black",
           dangerLight: "#0000004f",
           neutral10: "#cce1ff",

--- a/frontend/mr-admin-flate/src/components/skjema/SokeSelect.tsx
+++ b/frontend/mr-admin-flate/src/components/skjema/SokeSelect.tsx
@@ -29,7 +29,11 @@ const SokeSelect = React.forwardRef((props: SelectProps) => {
     indicatorSeparator: () => ({
       display: "none",
     }),
-    singleValue: (provided: any) => ({
+    dropdownIndicator: (provided: any) => ({
+      ...provided,
+      color: "black",
+    }),
+    placeholder: (provided: any) => ({
       ...provided,
       color: "#0000008f",
     }),
@@ -57,12 +61,7 @@ const SokeSelect = React.forwardRef((props: SelectProps) => {
               noOptionsMessage={() => "Ingen funnet"}
               name={name}
               defaultInputValue={defaultValue}
-              value={
-                options.find((c) => c.value === value) || {
-                  label: placeholder,
-                  value: "",
-                }
-              }
+              value={options.find((c) => c.value === value)}
               onChange={(e) => {
                 onChange(e?.value);
               }}


### PR DESCRIPTION
Fikser følgende:
- Enter i input-felt lukker ikke lenger modalen
- Viser bare `<Laster />` dersom vi ikke har verken tiltakstyper, enheter eller avtaler. i Alle andre tilfeller viser vi laster som en placeholder i input-felt for å redusere blinking når man skifter tiltakstyper.
- Endrer til sort-farge for chevron i select-komponent og grå farge for placeholder.