### PR TITLE
Endrer på ordlyd i deletekst

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -66,8 +66,10 @@ function sySammenBrukerTekst(chattekst: string, tiltaksgjennomforingsnavn: strin
 
 function sySammenHilsenTekst(veiledernavn?: string) {
   const interessant =
-    'Er dette tiltaket aktuelt for deg? Gi meg gjerne et ja/nei svar her i dialogen.\nDitt svar (ja/nei) vil ikke påvirke ditt forhold til NAV.';
-  return veiledernavn ? `${interessant}\n\nHilsen ${veiledernavn}` : `${interessant}\n\nHilsen `;
+    'Er dette aktuelt for deg? Gi meg tilbakemelding her i dialogen.\nSvaret ditt vil ikke endre din utbetaling fra NAV.';
+  return veiledernavn
+    ? `${interessant}\n\nVi holder kontakten!\nHilsen ${veiledernavn}`
+    : `${interessant}\n\nVi holder kontakten!\nHilsen `;
 }
 
 const Delemodal = ({


### PR DESCRIPTION
Etter avklaring med Tom Stian endrer vi litt på ordlyden på deletekst som veileder bruker ved deling av informasjon om tiltak til bruker via Dialogen.