### PR TITLE
Syncer enheter med type 'ALS' til Sanity

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/enhet.ts
+++ b/frontend/mulighetsrommet-cms/schemas/enhet.ts
@@ -4,6 +4,7 @@ import { defineType, defineField } from "sanity";
 export enum EnhetType {
   Fylke = "Fylke",
   Lokal = "Lokal",
+  Als = "Als",
 }
 
 export const enhet = defineType({

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -189,7 +189,7 @@ export const tiltaksgjennomforing = defineType({
             disableNew: true,
             filter: ({ document }) => {
               return {
-                filter: `fylke._ref == $fylke`,
+                filter: `fylke._ref == $fylke || type == 'Als'`,
                 params: {
                   fylke: document.fylke._ref,
                 },
@@ -206,9 +206,12 @@ export const tiltaksgjennomforing = defineType({
 
           const validEnheter = await getClient({
             apiVersion: API_VERSION,
-          }).fetch("*[_type == 'enhet' && fylke._ref == $fylke]._id", {
-            fylke: document.fylke._ref,
-          });
+          }).fetch(
+            "*[(_type == 'enhet' && fylke._ref == $fylke) || type == 'Als']._id",
+            {
+              fylke: document.fylke._ref,
+            }
+          );
 
           const paths = enheter
             ?.filter((enhet) => !validEnheter.includes(enhet._ref))

--- a/frontend/nav-enheter-to-sanity/src/sanity-enhet.ts
+++ b/frontend/nav-enheter-to-sanity/src/sanity-enhet.ts
@@ -26,7 +26,22 @@ const relevantEnhetStatus: Array<string | undefined> = [
   "Aktiv",
 ];
 
-export function toSanityEnheter(
+type Enhetstype = "LOKAL" | "TILTAK" | "FYLKE" | "ALS";
+
+export function spesialEnheterToSanity(
+  enheter: RsEnhetInkludertKontaktinformasjon[],
+  whitelistTyper: Enhetstype[]
+): SanityEnhet[] {
+  return enheter
+    .filter(
+      (enhet): enhet is AvailableEnhet =>
+        whitelistTyper.includes(enhet.enhet?.type as Enhetstype) &&
+        relevantEnhetStatus.includes(enhet.enhet?.status)
+    )
+    .map((enhet) => toSanityEnhet(enhet?.enhet));
+}
+
+export function fylkeOgUnderenheterToSanity(
   enheter: RsEnhetInkludertKontaktinformasjon[]
 ): SanityEnhet[] {
   return enheter
@@ -94,6 +109,7 @@ function toType(type?: string) {
   switch (type) {
     case "FYLKE":
     case "LOKAL":
+    case "ALS":
       return capitalize(type);
     default:
       throw new Error(`Unexpected type '${type}'`);


### PR DESCRIPTION
For å støtte enheter som ikke er en direkte underenhet av et fylke må vi ta inn ALS-enhet (Arbeidslivssenter) slik at redaktører i Sanity kan gi tilgang til ALS-enhetene sånn at veiledere for ALS-enheten får tilgang til å bruke Modia for sine brukere når de får tilgang på sikt.