### PR TITLE
✨ Sluttdato for redaktører og i Modia

### DIFF
--- a/frontend/mulighetsrommet-cms/deskStructures/commonStructure.ts
+++ b/frontend/mulighetsrommet-cms/deskStructures/commonStructure.ts
@@ -127,6 +127,17 @@ export function commonStructure(S, Context) {
                       .params({ tiltakstype })
                   )
               ),
+            S.listItem()
+              .title("Sluttdato har passert")
+              .icon(GrDocumentPerformance)
+              .child(
+                S.documentList()
+                  .title("Sluttdato har passert")
+                  .filter(
+                    '_type == "tiltaksgjennomforing" && defined(sluttdato) && sluttdato < now()'
+                  )
+                  .defaultOrdering([{ field: "_createdAt", direction: "desc" }])
+              ),
           ])
       ),
   ];

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -150,6 +150,13 @@ export const tiltaksgjennomforing = defineType({
       hidden: ({ parent }) => parent?.oppstart !== "dato",
     }),
     defineField({
+      name: "sluttdato",
+      title: "Sluttdato",
+      description: "Dato for når gjennomføringen slutter",
+      type: "date",
+      options: { dateFormat: "DD/MM/YYYY" },
+    }),
+    defineField({
       name: "lokasjon",
       title: "Lokasjon",
       description:

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -9,11 +9,27 @@ import { SanityTiltaksgjennomforing, SanityTiltakstype } from 'mulighetsrommet-a
 const SidemenyDetaljer = () => {
   const { data } = useTiltaksgjennomforingById();
   if (!data) return null;
-  const { tiltaksnummer, kontaktinfoArrangor, tiltakstype, sluttdato } = data;
+  const { tiltaksnummer, kontaktinfoArrangor, tiltakstype, sluttdato, oppstartsdato } = data;
   const oppstart = resolveOppstart(data);
 
-  const visSluttdato = (tiltakstype: SanityTiltakstype, sluttdato?: string): boolean => {
+  const visDato = (tiltakstype: SanityTiltakstype, oppstart: string, oppstartsdato?: string, sluttdato?: string) => {
     return (
+      <div className={styles.rad}>
+        <BodyShort size="small" className={styles.tittel}>
+          {visSluttdato(tiltakstype, sluttdato, oppstartsdato) ? 'Varighet' : 'Oppstart'}
+        </BodyShort>
+        <BodyShort size="small">
+          {visSluttdato(tiltakstype, sluttdato, oppstartsdato)
+            ? `${formaterDato(oppstartsdato!!)} - ${formaterDato(sluttdato!!)}`
+            : oppstart}
+        </BodyShort>
+      </div>
+    );
+  };
+
+  const visSluttdato = (tiltakstype: SanityTiltakstype, sluttdato?: string, oppstartsdato?: string): boolean => {
+    return (
+      !!oppstartsdato &&
       !!sluttdato &&
       [
         'Opplæring - Gruppe AMO',
@@ -63,21 +79,7 @@ const SidemenyDetaljer = () => {
           <BodyShort size="small">{tiltakstype?.innsatsgruppe?.beskrivelse} </BodyShort>
         </div>
 
-        <div className={styles.rad}>
-          <BodyShort size="small" className={styles.tittel}>
-            Oppstart
-          </BodyShort>
-          <BodyShort size="small">{oppstart}</BodyShort>
-        </div>
-
-        {visSluttdato(tiltakstype, sluttdato) ? (
-          <div className={styles.rad}>
-            <BodyShort size="small" className={styles.tittel}>
-              Sluttdato
-            </BodyShort>
-            <BodyShort size="small">{formaterDato(sluttdato!!)}</BodyShort>
-          </div>
-        ) : null}
+        {visDato(tiltakstype, oppstart, oppstartsdato, sluttdato)}
 
         {(tiltakstype.regelverkFiler || tiltakstype.regelverkLenker) && (
           <div className={styles.rad}>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -4,14 +4,26 @@ import Kopiknapp from '../kopiknapp/Kopiknapp';
 import Regelverksinfo from './Regelverksinfo';
 import styles from './Sidemenydetaljer.module.scss';
 import { formaterDato, utledLopenummerFraTiltaksnummer } from '../../utils/Utils';
-import { SanityTiltaksgjennomforing } from 'mulighetsrommet-api-client';
+import { SanityTiltaksgjennomforing, SanityTiltakstype } from 'mulighetsrommet-api-client';
 
 const SidemenyDetaljer = () => {
   const { data } = useTiltaksgjennomforingById();
   if (!data) return null;
-
-  const { tiltaksnummer, kontaktinfoArrangor, tiltakstype } = data;
+  const { tiltaksnummer, kontaktinfoArrangor, tiltakstype, sluttdato } = data;
   const oppstart = resolveOppstart(data);
+
+  const visSluttdato = (tiltakstype: SanityTiltakstype, sluttdato?: string): boolean => {
+    return (
+      !!sluttdato &&
+      [
+        'Opplæring - Gruppe AMO',
+        'Jobbklubb',
+        'Digitalt oppfølgingstiltak for arbeidsledige ("digital jobbklubb")',
+        'Opplæring - Gruppe Fag- og yrkesopplæring',
+        'Opplæring - Fagskole (høyere yrkesfaglig utdanning)',
+      ].includes(tiltakstype?.tiltakstypeNavn)
+    );
+  };
 
   return (
     <>
@@ -57,6 +69,15 @@ const SidemenyDetaljer = () => {
           </BodyShort>
           <BodyShort size="small">{oppstart}</BodyShort>
         </div>
+
+        {visSluttdato(tiltakstype, sluttdato) ? (
+          <div className={styles.rad}>
+            <BodyShort size="small" className={styles.tittel}>
+              Sluttdato
+            </BodyShort>
+            <BodyShort size="small">{formaterDato(sluttdato!!)}</BodyShort>
+          </div>
+        ) : null}
 
         {(tiltakstype.regelverkFiler || tiltakstype.regelverkLenker) && (
           <div className={styles.rad}>

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -154,6 +154,7 @@ export const apiHandlers: RestHandler[] = [
     lokasjon,
     oppstart,
     oppstartsdato,
+    sluttdato,
     faneinnhold {
       forHvemInfoboks,
       forHvem,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityService.kt
@@ -175,6 +175,7 @@ class SanityService(private val config: Config, private val brukerService: Bruke
                 lokasjon,
                 oppstart,
                 oppstartsdato,
+                sluttdato,
                 faneinnhold {
                   forHvemInfoboks,
                   forHvem,

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1427,6 +1427,8 @@ components:
             - midlertidig_stengt
         oppstartsdato:
           type: string
+        sluttdato:
+          type: string
         estimert_ventetid:
           type: string
         faneinnhold:


### PR DESCRIPTION
- Legger til feltet `sluttdato` i dokumentet Tiltaksgjennomføring i Sanity
- Legger til et nytt filter for å se alle gjennomføringer der sluttdato har passert
- Viser sluttdato for et knippe tiltakstyper (se liste under)

Dersom vi har en start og sluttdato så sier vi "Varighet"  og start og sluttdato i Modia, ellers så sier vi Oppstart og om det er løpende eller en gitt oppstartsdato. 

**Tiltakstyper vi viser sluttdato for i Modia**
Opplæring - Gruppe AMO
Jobbklubb
Digitalt oppfølgingstiltak for arbeidsledige ("digital jobbklubb")
Opplæring - Gruppe Fag- og yrkesopplæring
Opplæring - Fagskole (høyere yrkesfaglig utdanning)