### PR TITLE
Notifikasjonsbjelle i header

### DIFF
--- a/frontend/mr-admin-flate/src/App.tsx
+++ b/frontend/mr-admin-flate/src/App.tsx
@@ -12,6 +12,7 @@ import { DetaljerTiltakstypePage } from "./pages/tiltakstyper/DetaljerTiltakstyp
 import { TiltakstyperPage } from "./pages/tiltakstyper/TiltakstyperPage";
 import { TiltaksgjennomforingerPage } from "./pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage";
 import { DetaljerTiltaksgjennomforingerPage } from "./pages/tiltaksgjennomforinger/DetaljerTiltaksgjennomforingerPage";
+import { NotifikasjonerPage } from "./pages/notifikasjoner/NotifikasjonerPage";
 
 export function App() {
   const optionalAnsatt = useHentAnsatt();
@@ -84,6 +85,11 @@ export function App() {
       <Route
         path="tiltaksgjennomforinger/:tiltaksgjennomforingId"
         element={<DetaljerTiltaksgjennomforingerPage />}
+        errorElement={<ErrorPage />}
+      />
+      <Route
+        path="notifikasjoner"
+        element={<NotifikasjonerPage />}
         errorElement={<ErrorPage />}
       />
 

--- a/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.module.scss
+++ b/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.module.scss
@@ -1,7 +1,9 @@
 @use "@navikt/ds-tokens/dist/tokens" as *;
 
 :global(.navdsi-header) {
-  flex-wrap: wrap;
+  @media (max-width: $a-breakpoint-md) {
+    flex-wrap: wrap;
+  }
 }
 
 .link {
@@ -10,7 +12,14 @@
 }
 
 .user {
-  @media (min-width: $a-breakpoint-sm) {
+  @media (min-width: $a-breakpoint-md) {
     margin-left: auto;
   }
+}
+
+.content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex: 1;
 }

--- a/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.tsx
+++ b/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.tsx
@@ -4,6 +4,7 @@ import { useHentAnsatt } from "../../api/administrator/useHentAdministrator";
 import { NavigeringHeader } from "../../pages/forside/NavigeringHeader";
 import { capitalize } from "../../utils/Utils";
 import styles from "./AdministratorHeader.module.scss";
+import { Notifikasjonsbjelle } from "../notifikasjoner/Notifikasjonsbjelle";
 
 export function AdministratorHeader() {
   const response = useHentAnsatt();
@@ -16,12 +17,15 @@ export function AdministratorHeader() {
 
   return (
     <Header>
-      <Header.Title as="h1">
+      <Header.Title className={styles.title} as="h1">
         <Link className={styles.link} to="/">
           NAV arbeidsmarkedstiltak
         </Link>
       </Header.Title>
-      <NavigeringHeader />
+      <div className={styles.content}>
+        <NavigeringHeader />
+        <Notifikasjonsbjelle />
+      </div>
       <Header.User
         data-testid="header-navident"
         name={ansattNavn}

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.module.scss
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.module.scss
@@ -1,0 +1,19 @@
+.lenke {
+  color: white;
+  margin-right: 1rem;
+}
+
+.bell_container {
+  position: relative;
+}
+
+.notifier {
+  width: 10px;
+  height: 10px;
+  background-color: var(--a-icon-danger);
+  display: inline-block;
+  border-radius: 100%;
+  position: absolute;
+  right: 2px;
+  bottom: 25px;
+}

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.tsx
@@ -10,7 +10,7 @@ function Notifier() {
 export function Notifikasjonsbjelle() {
   const { data: features } = useFeatureToggles();
 
-  const harUlesteNotifikasjoner = true; // TODO Må utledes fra API
+  const harUlesteNotifikasjoner = true; // TODO Må utledes om man har uleste notifikasjoner fra API
 
   return features?.["mulighetsrommet.admin-flate-se-notifikasjoner"] ? (
     <Link to="/notifikasjoner" className={styles.lenke}>

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.tsx
@@ -1,0 +1,12 @@
+import { BellDotIcon } from "@navikt/aksel-icons";
+import { useFeatureToggles } from "../../api/features/feature-toggles";
+
+export function Notifikasjonsbjelle() {
+  const { data: features } = useFeatureToggles();
+
+  return features?.["mulighetsrommet.admin-flate-se-notifikasjoner"] ? (
+    <div>
+      <BellDotIcon fontSize={30} title="Notifikasjonsbjelle" />
+    </div>
+  ) : null;
+}

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.tsx
@@ -1,12 +1,23 @@
-import { BellDotIcon } from "@navikt/aksel-icons";
+import { BellIcon } from "@navikt/aksel-icons";
 import { useFeatureToggles } from "../../api/features/feature-toggles";
+import { Link } from "react-router-dom";
+import styles from "./Notifikasjonsbjelle.module.scss";
+
+function Notifier() {
+  return <span className={styles.notifier}></span>;
+}
 
 export function Notifikasjonsbjelle() {
   const { data: features } = useFeatureToggles();
 
+  const harUlesteNotifikasjoner = true; // TODO Må utledes fra API
+
   return features?.["mulighetsrommet.admin-flate-se-notifikasjoner"] ? (
-    <div>
-      <BellDotIcon fontSize={30} title="Notifikasjonsbjelle" />
-    </div>
+    <Link to="/notifikasjoner" className={styles.lenke}>
+      <div className={styles.bell_container}>
+        {harUlesteNotifikasjoner ? <Notifier /> : null}
+        <BellIcon fontSize={30} title="Notifikasjonsbjelle" />
+      </div>
+    </Link>
   ) : null;
 }

--- a/frontend/mr-admin-flate/src/pages/notifikasjoner/NotifikasjonerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/notifikasjoner/NotifikasjonerPage.tsx
@@ -1,0 +1,14 @@
+import { Alert, BodyShort } from "@navikt/ds-react";
+import { ContainerLayout } from "../../layouts/ContainerLayout";
+
+export function NotifikasjonerPage() {
+  return (
+    <ContainerLayout>
+      <Alert variant="info">
+        <BodyShort>
+          Her kommer det funksjonalitet for å vise varsler og beskjeder.
+        </BodyShort>
+      </Alert>
+    </ContainerLayout>
+  );
+}


### PR DESCRIPTION
Laget en notifikasjonsbjelle man kan trykke på for å komme til en side med notifikasjoner.
Uthenting av data fra API er ikke klart, men designet er klart.

Ingen uleste notifikasjoner:
![image](https://user-images.githubusercontent.com/9053627/235681821-4812181f-fe03-49b4-9852-d88319fe04b0.png)

Uleste notifikasjoner:
![image](https://user-images.githubusercontent.com/9053627/235681948-dc30a308-b4da-47d6-ab16-0b4deee94310.png)
