### PR TITLE
:building_construction: Sender fnr eksplisitt istedenfor via header

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -9,6 +9,7 @@ import modalStyles from '../Modal.module.scss';
 import { logDelMedbrukerEvent } from './Delemodal';
 import delemodalStyles from './Delemodal.module.scss';
 import { Actions, State } from './DelemodalActions';
+import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
 
 const MAKS_ANTALL_TEGN_HILSEN = 300;
 
@@ -29,6 +30,7 @@ export function DelMedBrukerContent({
   veiledernavn,
   brukernavn,
 }: Props) {
+  const fnr = useHentFnrFraUrl();
   const [visPersonligMelding, setVisPersonligMelding] = useState(false);
   const senderTilDialogen = state.sendtStatus === 'SENDER';
   const { data: tiltaksgjennomforing } = useTiltaksgjennomforingById();
@@ -68,7 +70,7 @@ export function DelMedBrukerContent({
     const overskrift = `Tiltak gjennom NAV: ${tiltaksgjennomforingsnavn}`;
     const tekst = sySammenDeletekst();
     try {
-      const res = await mulighetsrommetClient.dialogen.delMedDialogen({ requestBody: { overskrift, tekst } });
+      const res = await mulighetsrommetClient.dialogen.delMedDialogen({ fnr, requestBody: { overskrift, tekst } });
       if (tiltaksgjennomforingId) {
         await lagreVeilederHarDeltTiltakMedBruker(res.id, tiltaksgjennomforingId);
       }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/headers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/headers.ts
@@ -3,7 +3,6 @@ import { APPLICATION_NAME } from '../../constants';
 export const headers = new Headers();
 
 headers.append('Nav-Consumer-Id', APPLICATION_NAME);
-headers.append('nav-norskident', getNorskidentFraUrl());
 
 if (import.meta.env.VITE_MULIGHETSROMMET_API_AUTH_TOKEN) {
   headers.append('Authorization', `Bearer ${import.meta.env.VITE_MULIGHETSROMMET_API_AUTH_TOKEN}`);
@@ -17,14 +16,4 @@ export function toRecord(headers: Headers) {
   });
 
   return record;
-}
-
-/**
- * Hent bruker i kontekst sin norskIdent (fnr/d-nummer) slik at vi kan gjøre tilgangssjekk i backend
- * @returns norskident for bruker fra url
- */
-function getNorskidentFraUrl() {
-  const fnrRegex = /\/(\d*)/g;
-  const regexMatches = fnrRegex.exec(window.location.pathname);
-  return regexMatches?.at(1) ?? '';
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentHistorikk.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentHistorikk.ts
@@ -5,9 +5,7 @@ import { QueryKeys } from '../query-keys';
 
 export function useHentHistorikk(prefetch: boolean = true) {
   const fnr = useHentFnrFraUrl();
-  return useQuery(
-    [QueryKeys.Historikk, fnr],
-    () => mulighetsrommetClient.historikk.hentHistorikkForBruker(),
-    { enabled: prefetch }
-  );
+  return useQuery([QueryKeys.Historikk, fnr], () => mulighetsrommetClient.historikk.hentHistorikkForBruker({ fnr }), {
+    enabled: prefetch,
+  });
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useLokasjonerForBruker.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useLokasjonerForBruker.ts
@@ -1,9 +1,11 @@
 import { useQuery } from 'react-query';
 import { mulighetsrommetClient } from '../clients';
 import { QueryKeys } from '../query-keys';
+import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
 
 export default function useLokasjonerForBruker() {
+  const fnr = useHentFnrFraUrl();
   return useQuery(QueryKeys.sanity.lokasjoner, () =>
-    mulighetsrommetClient.sanity.getLokasjonerForBrukersEnhetOgFylke()
+    mulighetsrommetClient.sanity.getLokasjonerForBrukersEnhetOgFylke({ fnr })
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforinger.ts
@@ -5,13 +5,16 @@ import { tiltaksgjennomforingsfilter } from '../../atoms/atoms';
 import { mulighetsrommetClient } from '../clients';
 import { QueryKeys } from '../query-keys';
 import { useHentBrukerdata } from './useHentBrukerdata';
+import { useHentFnrFraUrl } from '../../../hooks/useHentFnrFraUrl';
 
 export default function useTiltaksgjennomforinger() {
   const [filter] = useAtom(tiltaksgjennomforingsfilter);
   const brukerData = useHentBrukerdata();
+  const fnr = useHentFnrFraUrl();
 
   return useQuery(QueryKeys.sanity.tiltaksgjennomforinger(brukerData.data, filter), () =>
     mulighetsrommetClient.sanity.getTiltaksgjennomforingForBruker({
+      fnr,
       innsatsgruppe: filter.innsatsgruppe?.nokkel,
       sokestreng: filter.search,
       lokasjoner: filter.lokasjoner.map(({ tittel }) => tittel),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
@@ -5,6 +5,7 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
+import io.ktor.server.plugins.*
 import io.ktor.util.pipeline.*
 import no.nav.mulighetsrommet.api.AuthConfig
 import no.nav.mulighetsrommet.ktor.exception.StatusException
@@ -102,8 +103,12 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getNavAnsattAzureId(): UUID {
 }
 
 fun <T : Any> PipelineContext<T, ApplicationCall>.getNorskIdent(): String {
-    return call.request.queryParameters["fnr"] ?: throw StatusException(
+    val fnr = call.request.queryParameters["fnr"] ?: throw StatusException(
         HttpStatusCode.BadRequest,
         "fnr mangler som queryparameter",
     )
+
+    if (fnr.length != 11) throw BadRequestException("fnr må være 11 siffer")
+
+    return fnr
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
@@ -5,7 +5,6 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
-import io.ktor.server.request.*
 import io.ktor.util.pipeline.*
 import no.nav.mulighetsrommet.api.AuthConfig
 import no.nav.mulighetsrommet.ktor.exception.StatusException
@@ -103,8 +102,8 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getNavAnsattAzureId(): UUID {
 }
 
 fun <T : Any> PipelineContext<T, ApplicationCall>.getNorskIdent(): String {
-    return call.request.header("nav-norskident") ?: throw StatusException(
+    return call.request.queryParameters["fnr"] ?: throw StatusException(
         HttpStatusCode.BadRequest,
-        "nav-norskident mangler i headers",
+        "fnr mangler som queryparameter",
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/BrukerRoutes.kt.kt
@@ -1,6 +1,5 @@
 package no.nav.mulighetsrommet.api.routes.v1
 
-import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -28,11 +27,9 @@ fun Route.brukerRoutes() {
 
     route("/api/v1/internal/bruker") {
         get {
-            poaoTilgangService.verifyAccessToUserFromVeileder(getNavAnsattAzureId(), getNorskIdent())
-            val fnr = call.request.queryParameters["fnr"] ?: return@get call.respondText(
-                "Mangler eller ugyldig fnr",
-                status = HttpStatusCode.BadRequest,
-            )
+            val fnr = getNorskIdent()
+            poaoTilgangService.verifyAccessToUserFromVeileder(getNavAnsattAzureId(), fnr)
+
             val accessToken = call.getAccessToken()
             call.respond(brukerService.hentBrukerdata(fnr, accessToken))
         }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -453,6 +453,8 @@ paths:
                   $ref: "#/components/schemas/SanityTiltakstype"
 
   /api/v1/internal/sanity/lokasjoner:
+    parameters:
+      - $ref: "#/components/parameters/Fnr"
     get:
       tags:
         - Sanity
@@ -468,6 +470,8 @@ paths:
                   type: string
 
   /api/v1/internal/sanity/tiltaksgjennomforinger:
+    parameters:
+      - $ref: "#/components/parameters/Fnr"
     get:
       tags:
         - Sanity
@@ -529,6 +533,8 @@ paths:
                   $ref: "#/components/schemas/SanityTiltaksgjennomforing"
 
   /api/v1/internal/dialog:
+    parameters:
+      - $ref: "#/components/parameters/Fnr"
     post:
       tags:
         - dialogen
@@ -553,6 +559,8 @@ paths:
                 type: string
 
   /api/v1/internal/bruker/historikk:
+    parameters:
+      - $ref: "#/components/parameters/Fnr"
     get:
       tags:
         - Historikk

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
@@ -159,15 +159,6 @@ class TiltakstypeRepositoryTest : FunSpec({
             ).second shouldHaveSize 3
         }
 
-        test("Ingen filter for kategori returnerer både individuelle- og gruppetiltak") {
-            tiltakstyper.getAllSkalMigreres(
-                TiltakstypeFilter(
-                    search = null,
-                    kategori = null,
-                ),
-            ).second shouldHaveSize 3
-        }
-
         test("Filter på planlagt returnerer planlagte tiltakstyper") {
             val typer = tiltakstyper.getAllSkalMigreres(
                 TiltakstypeFilter(


### PR DESCRIPTION
Sender fnr eksplisitt når vi gjør kall som forventer fnr fra bruker, istedenfor å sette det som en header på alle fetch-kall.

Fjerner også en test som var duplisert.