### PR TITLE
Se varslingsboks hvis du har uleste notifikasjoner

### DIFF
--- a/frontend/mr-admin-flate/src/components/notifikasjoner/BrukerNotifikasjoner.module.scss
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/BrukerNotifikasjoner.module.scss
@@ -2,3 +2,8 @@
   margin-bottom: 1rem;
   max-width: 70ch;
 }
+
+.link {
+  text-decoration: none;
+  color: black;
+}

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/BrukerNotifikasjoner.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/BrukerNotifikasjoner.tsx
@@ -3,22 +3,27 @@ import { useHentAnsatt } from "../../api/administrator/useHentAdministrator";
 import { useFeatureToggles } from "../../api/features/feature-toggles";
 import styles from "./BrukerNotifikasjoner.module.scss";
 import { Varsel } from "./Varsel";
+import { useNotificationSummary } from "../../api/notifikasjoner/useNotificationSummary";
+import { Link } from "react-router-dom";
 
 export function BrukerNotifikasjoner() {
   const { data: features } = useFeatureToggles();
   const { data: bruker } = useHentAnsatt();
+  const { data: notificationSummary } = useNotificationSummary();
+  const antallUlesteNotifikasjoner = notificationSummary?.unreadCount || -1;
 
   if (!features?.["mulighetsrommet.admin-flate-se-notifikasjoner"]) return null;
+
+  if (antallUlesteNotifikasjoner <= 0) return null;
 
   return (
     <section className={styles.container}>
       <Heading level="3" size="medium">
         Hei {bruker?.fornavn}
       </Heading>
-      <Varsel
-        tittel="Varsler"
-        melding="Her kommer det funksjonalitet for varsler"
-      />
+      <Link className={styles.link} to="/notifikasjoner">
+        <Varsel tittel="Varsler" melding="Du har nye varsler" />
+      </Link>
     </section>
   );
 }


### PR DESCRIPTION
Viser varslingsboks på forsiden av admin-flate dersom du har uleste notifikasjoner. Vises ikke hvis man ikke har uleste meldinger. 

![image](https://user-images.githubusercontent.com/9053627/236793719-19f89132-faf8-456c-a316-b9fad46c7d2e.png)
