### PR TITLE
Oppsett for ereg istedenfor amt-enhet

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -28,6 +28,7 @@ data class AppConfig(
     val veilarbveilederConfig: ServiceClientConfig,
     val poaoTilgang: ServiceClientConfig,
     val amtEnhetsregister: ServiceClientConfig,
+    val ereg: ServiceClientConfig,
     val arenaAdapter: ServiceClientConfig,
     val msGraphConfig: ServiceClientConfig,
     val tasks: TaskConfig,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/EregClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/EregClient.kt
@@ -1,0 +1,5 @@
+package no.nav.mulighetsrommet.api.clients.enhetsregister
+
+interface EregClient {
+    suspend fun hentVirksomhet(virksomhetsnummer: String): EregVirksomhetDto?
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/EregClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/EregClientImpl.kt
@@ -1,0 +1,43 @@
+package no.nav.mulighetsrommet.api.clients.enhetsregister
+
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.cache.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
+import no.nav.mulighetsrommet.securelog.SecureLog
+import org.slf4j.LoggerFactory
+
+class EregClientImpl(
+    private val baseUrl: String,
+    clientEngine: HttpClientEngine = CIO.create(),
+) : EregClient {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val client = httpJsonClient(clientEngine).config {
+        install(HttpCache)
+    }
+
+    override suspend fun hentVirksomhet(virksomhetsnummer: String): EregVirksomhetDto? {
+        // TODO Vurder om inkluderHierarki skal være et filter vi kan konfigurere ved kall av tjeneste
+        val response = client.get("$baseUrl/organisasjon/$virksomhetsnummer?inkluderHierarki=true") {
+            headers {
+                this.append("Nav-Consumer-Id", "team-mulighetsrommet")
+            }
+        }
+
+        return when (response.status) {
+            HttpStatusCode.OK -> response.body()
+            HttpStatusCode.NotFound -> {
+                log.debug("Virksomhet finnes ikke i Ereg, sjekk securelogs")
+                SecureLog.logger.debug("Virksomhet finnes ikke i Ereg: $virksomhetsnummer")
+                null
+            }
+
+            else -> throw ResponseException(response, "Unexpected response from Ereg")
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/EregVirksomhetDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/enhetsregister/EregVirksomhetDto.kt
@@ -1,0 +1,26 @@
+package no.nav.mulighetsrommet.api.clients.enhetsregister
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EregVirksomhetDto(
+    val organisasjonsnummer: String,
+    val navn: Navn,
+    val organisasjonsleddOver: OrganisasjonsleddOver? = null,
+)
+
+@Serializable
+data class Navn(
+    val navnelinje1: String,
+)
+
+@Serializable
+data class OrganisasjonsleddOver(
+    val organisasjonsledd: Organisasjonsledd,
+)
+
+@Serializable
+data class Organisasjonsledd(
+    val organisasjonsnummer: String,
+    val navn: Navn,
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -20,6 +20,8 @@ import no.nav.mulighetsrommet.api.clients.dialog.VeilarbdialogClient
 import no.nav.mulighetsrommet.api.clients.dialog.VeilarbdialogClientImpl
 import no.nav.mulighetsrommet.api.clients.enhetsregister.AmtEnhetsregisterClient
 import no.nav.mulighetsrommet.api.clients.enhetsregister.AmtEnhetsregisterClientImpl
+import no.nav.mulighetsrommet.api.clients.enhetsregister.EregClient
+import no.nav.mulighetsrommet.api.clients.enhetsregister.EregClientImpl
 import no.nav.mulighetsrommet.api.clients.msgraph.MicrosoftGraphClient
 import no.nav.mulighetsrommet.api.clients.msgraph.MicrosoftGraphClientImpl
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Client
@@ -152,6 +154,11 @@ private fun services(appConfig: AppConfig) = module {
             tokenProvider = {
                 m2mTokenProvider.createMachineToMachineToken(appConfig.amtEnhetsregister.scope)
             },
+        )
+    }
+    single<EregClient> {
+        EregClientImpl(
+            baseUrl = appConfig.ereg.url,
         )
     }
     single<VeilarboppfolgingClient> {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
@@ -5,10 +5,12 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.mulighetsrommet.api.clients.enhetsregister.AmtEnhetsregisterClient
+import no.nav.mulighetsrommet.api.clients.enhetsregister.EregClient
 import org.koin.ktor.ext.inject
 
 fun Route.virksomhetRoutes() {
     val amtEnhetsregisterClientImpl: AmtEnhetsregisterClient by inject()
+    val eregClientImpl: EregClient by inject()
     route("api/v1/internal/virksomhet") {
         get("{orgnr}") {
             val orgnr = call.parameters["orgnr"] ?: return@get call.respondText(
@@ -18,6 +20,19 @@ fun Route.virksomhetRoutes() {
 
             val enhet = amtEnhetsregisterClientImpl.hentVirksomhet(orgnr) ?: return@get call.respondText(
                 text = "Fant ingen enhet med orgnr: $orgnr",
+                status = HttpStatusCode.NotFound,
+            )
+
+            call.respond(enhet)
+        }
+        get("ereg/{orgnr}") {
+            val orgnr = call.parameters["orgnr"] ?: return@get call.respondText(
+                text = "Mangler eller ugyldig organisasjonsnummer",
+                status = HttpStatusCode.BadRequest,
+            )
+
+            val enhet = eregClientImpl.hentVirksomhet(orgnr) ?: return@get call.respondText(
+                text = "Fant ingen enhet med orgnr: $orgnr i Ereg",
                 status = HttpStatusCode.NotFound,
             )
 

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -69,6 +69,9 @@ app:
     url: http://amt-enhetsregister.amt
     scope: api://dev-gcp.amt.amt-enhetsregister/.default
 
+  ereg:
+    url: https://ereg-services.dev.intern.nav.no/api/v2
+
   msGraphConfig:
     url: https://graph.microsoft.com
     scope: https://graph.microsoft.com/.default

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -69,6 +69,9 @@ app:
     url: http://localhost:8090/amt-enhetsregister
     scope: default
 
+  ereg:
+    url: https://ereg-services.dev.intern.nav.no/api/v2
+
   msGraphConfig:
     url: http://localhost:8090/ms-graph
     scope: default

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -66,6 +66,9 @@ app:
     url: http://amt-enhetsregister.amt
     scope: api://prod-gcp.amt.amt-enhetsregister/.default
 
+  ereg:
+    url: https://ereg-services.prod.intern.nav.no/api/v2
+
   msGraphConfig:
     url: https://graph.microsoft.com
     scope: https://graph.microsoft.com/.default


### PR DESCRIPTION
Setter opp ereg som en egen klient. Jeg har lagt til et endepunkt for å få testet klienten ute i miljøene. Er ikke så altfor mye info om api'et så jeg tenker at en test i miljøene vil gjøre det enklere å avdekke eventuelle mangler.