### PR TITLE
Feature/nav ansatt

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -3,6 +3,7 @@ package no.nav.mulighetsrommet.api
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.producers.TiltaksgjennomforingKafkaProducer
 import no.nav.mulighetsrommet.api.producers.TiltakstypeKafkaProducer
+import no.nav.mulighetsrommet.api.tasks.SynchronizeNavAnsatte
 import no.nav.mulighetsrommet.api.tasks.SynchronizeNorgEnheter
 import no.nav.mulighetsrommet.api.tasks.SynchronizeTilgjengelighetsstatuserToSanity
 import no.nav.mulighetsrommet.api.tasks.SynchronizeTiltaksgjennomforingEnheter
@@ -76,6 +77,7 @@ data class TaskConfig(
     val synchronizeNorgEnheter: SynchronizeNorgEnheter.Config,
     val synchronizeEnheterFraSanityTilApi: SynchronizeTiltaksgjennomforingEnheter.Config,
     val synchronizeTilgjengelighetsstatuser: SynchronizeTilgjengelighetsstatuserToSanity.Config,
+    val synchronizeNavAnsatte: SynchronizeNavAnsatte.Config,
 )
 
 data class Norg2Config(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -3,25 +3,29 @@ package no.nav.mulighetsrommet.api.clients.msgraph
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
-import io.ktor.client.plugins.*
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.mulighetsrommet.api.domain.dto.AdGruppe
 import no.nav.mulighetsrommet.api.domain.dto.NavAnsattDto
 import no.nav.mulighetsrommet.ktor.clients.httpJsonClient
-import no.nav.mulighetsrommet.securelog.SecureLog
 import org.slf4j.LoggerFactory
 import java.util.*
 
 /**
- * Graph explorer:
+ * Graph explorer kan benyttes for å utforske API'et til msgraph:
  * - https://developer.microsoft.com/en-us/graph/graph-explorer
+ *
+ * For å få tilgang til nye endepunkter/datafelter så må man spørre om spesifikke tilganger i #tech-azure.
+ *
+ * Vi har eksplisitt spurt om, og fått tildelt, følgende tilganger:
+ * - Claim: User.Read.All, Type: Application
+ * - Claim: GroupMember.Read.All, Type: Application
  */
 class MicrosoftGraphClientImpl(
     engine: HttpClientEngine = CIO.create(),
     private val baseUrl: String,
-    private val tokenProvider: (accessToken: String) -> String,
+    private val tokenProvider: (accessToken: String?) -> String,
 ) : MicrosoftGraphClient {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -35,26 +39,25 @@ class MicrosoftGraphClientImpl(
             parameter("\$select", "id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail")
         }
 
-        if ((response.status == HttpStatusCode.NotFound) || (response.status == HttpStatusCode.NoContent)) {
-            SecureLog.logger.warn("Klarte ikke finne bruker med azure-id: $navAnsattAzureId")
-            log.error("Klarte ikke finne bruker med azure-id. Se detaljer i secureLog.")
-            throw RuntimeException("Klarte ikke finne bruker med azure-id. Finnes brukeren i AD?")
+        if (!response.status.isSuccess()) {
+            log.error("Klarte ikke finne bruker med id=$navAnsattAzureId")
+            throw RuntimeException("Klarte ikke finne bruker med id=$navAnsattAzureId. Finnes brukeren i AD?")
         }
 
         val user = response.body<MsGraphUserDto>()
-        return NavAnsattDto(
-            navident = user.onPremisesSamAccountName,
-            fornavn = user.givenName,
-            etternavn = user.surname,
-            hovedenhetKode = user.streetAddress,
-            hovedenhetNavn = user.city,
-        )
+
+        return toNavAnsatt(user)
     }
 
     override suspend fun getMemberGroups(accessToken: String, navAnsattAzureId: UUID): List<AdGruppe> {
         val response = client.get("$baseUrl/v1.0/users/$navAnsattAzureId/transitiveMemberOf/microsoft.graph.group") {
             bearerAuth(tokenProvider(accessToken))
             parameter("\$select", "id,displayName")
+        }
+
+        if (!response.status.isSuccess()) {
+            log.error("Klarte ikke hente AD-grupper for bruker id=$navAnsattAzureId")
+            throw RuntimeException("Klarte ikke hente AD-grupper for bruker id=$navAnsattAzureId")
         }
 
         val result = response.body<GetMemberGroupsResponse>()
@@ -69,16 +72,42 @@ class MicrosoftGraphClientImpl(
             parameter("\$select", "id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail")
         }
 
+        if (!response.status.isSuccess()) {
+            log.error("Klarte ikke hente medlemmer i AD-gruppe med id=$groupId")
+            throw RuntimeException("Klarte ikke hente medlemmer i AD-gruppe med id=$groupId")
+        }
+
         val result = response.body<GetGroupMembersResponse>()
 
-        return result.value.map { user ->
-            NavAnsattDto(
-                navident = user.onPremisesSamAccountName,
-                fornavn = user.givenName,
-                etternavn = user.surname,
-                hovedenhetKode = user.streetAddress,
-                hovedenhetNavn = user.city,
-            )
+        return result.value
+            .filter { isNavAnsatt(it) }
+            .map { toNavAnsatt(it) }
+    }
+
+    /**
+     * Når NAVident er definert på en MsGraphUserDto så anser vi brukeren som en NAV-ansatt.
+     */
+    private fun isNavAnsatt(it: MsGraphUserDto) = it.onPremisesSamAccountName != null
+
+    private fun toNavAnsatt(user: MsGraphUserDto) = when {
+        user.onPremisesSamAccountName == null -> {
+            throw RuntimeException("NAVident mangler for bruker med id=${user.id}")
         }
+
+        user.streetAddress == null -> {
+            throw RuntimeException("NAV Enhetskode mangler for bruker med id=${user.id}")
+        }
+
+        user.city == null -> {
+            throw RuntimeException("NAV Enhetsnavn mangler for bruker med id=${user.id}")
+        }
+
+        else -> NavAnsattDto(
+            navident = user.onPremisesSamAccountName,
+            fornavn = user.givenName,
+            etternavn = user.surname,
+            hovedenhetKode = user.streetAddress,
+            hovedenhetNavn = user.city,
+        )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -69,6 +69,7 @@ class MicrosoftGraphClientImpl(
 
     override suspend fun getGroupMembers(groupId: UUID): List<NavAnsattDto> {
         val response = client.get("$baseUrl/v1.0/groups/$groupId/members") {
+            bearerAuth(tokenProvider.invoke(null))
             parameter("\$select", "id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail")
         }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -104,6 +104,7 @@ class MicrosoftGraphClientImpl(
         }
 
         else -> NavAnsattDto(
+            oid = user.id,
             navident = user.onPremisesSamAccountName,
             fornavn = user.givenName,
             etternavn = user.surname,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -104,7 +104,7 @@ class MicrosoftGraphClientImpl(
         }
 
         else -> NavAnsattDto(
-            oid = user.id,
+            azureId = user.id,
             navident = user.onPremisesSamAccountName,
             fornavn = user.givenName,
             etternavn = user.surname,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MsGraphDirectoryObjects.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MsGraphDirectoryObjects.kt
@@ -21,20 +21,29 @@ internal data class MsGraphUserDto(
     val surname: String,
     /**
      * NAVident
+     *
+     * Vi antar at denne er definert for alle ansatte,
+     * om feltet er null så antar vi at brukeren ikke er en ansatt hos NAV.
      */
-    val onPremisesSamAccountName: String,
+    val onPremisesSamAccountName: String?,
     /**
      * E-postadresse
      */
     val mail: String,
     /**
      * NAV Enhetskode
+     *
+     * Vi antar at denne er definert for alle ansatte,
+     * om feltet er null så antar vi at brukeren ikke er en ansatt hos NAV.
      */
-    val streetAddress: String,
+    val streetAddress: String?,
     /**
      * NAV Enhetsnavn
+     *
+     * Vi antar at denne er definert for alle ansatte,
+     * om feltet er null så antar vi at brukeren ikke er en ansatt hos NAV.
      */
-    val city: String,
+    val city: String?,
 )
 
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
@@ -1,13 +1,8 @@
 package no.nav.mulighetsrommet.api.domain.dbo
 
-import no.nav.mulighetsrommet.api.domain.dto.NavAnsattDto
 import java.util.*
 
 data class NavAnsattDbo(
-    /**
-     * Azure AD Object Id
-     */
-    val oid: UUID,
     val navIdent: String,
     val fornavn: String,
     val etternavn: String,
@@ -15,16 +10,6 @@ data class NavAnsattDbo(
      * Enhetsnummer til den ansattes hovedenhet.
      */
     val hovedenhet: String,
-) {
-    companion object {
-        fun fromDto(dto: NavAnsattDto) = dto.run {
-            NavAnsattDbo(
-                oid = oid,
-                navIdent = navident,
-                fornavn = fornavn,
-                etternavn = etternavn,
-                hovedenhet = hovedenhetKode,
-            )
-        }
-    }
-}
+    val azureId: UUID,
+    val fraAdGruppe: UUID,
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
@@ -1,0 +1,17 @@
+package no.nav.mulighetsrommet.api.domain.dbo
+
+import java.util.*
+
+data class NavAnsattDbo(
+    /**
+     * Azure AD Object Id
+     */
+    val oid: UUID,
+    val navIdent: String,
+    val fornavn: String,
+    val etternavn: String,
+    /**
+     * Enhetsnummer til den ansattes hovedenhet.
+     */
+    val hovedenhet: String,
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
@@ -1,5 +1,6 @@
 package no.nav.mulighetsrommet.api.domain.dbo
 
+import no.nav.mulighetsrommet.api.domain.dto.NavAnsattDto
 import java.util.*
 
 data class NavAnsattDbo(
@@ -14,4 +15,16 @@ data class NavAnsattDbo(
      * Enhetsnummer til den ansattes hovedenhet.
      */
     val hovedenhet: String,
-)
+) {
+    companion object {
+        fun fromDto(dto: NavAnsattDto) = dto.run {
+            NavAnsattDbo(
+                oid = oid,
+                navIdent = navident,
+                fornavn = fornavn,
+                etternavn = etternavn,
+                hovedenhet = hovedenhetKode,
+            )
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavAnsattDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavAnsattDto.kt
@@ -1,6 +1,12 @@
 package no.nav.mulighetsrommet.api.domain.dto
 
+import java.util.*
+
 data class NavAnsattDto(
+    /**
+     * Azure AD Object Id
+     */
+    val oid: UUID,
     val navident: String,
     val fornavn: String,
     val etternavn: String,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavAnsattDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavAnsattDto.kt
@@ -3,10 +3,7 @@ package no.nav.mulighetsrommet.api.domain.dto
 import java.util.*
 
 data class NavAnsattDto(
-    /**
-     * Azure AD Object Id
-     */
-    val oid: UUID,
+    val azureId: UUID,
     val navident: String,
     val fornavn: String,
     val etternavn: String,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -197,7 +197,11 @@ private fun services(appConfig: AppConfig) = module {
         MicrosoftGraphClientImpl(
             baseUrl = appConfig.msGraphConfig.url,
             tokenProvider = { token ->
-                oboTokenProvider.exchangeOnBehalfOfToken(appConfig.msGraphConfig.scope, token)
+                if (token == null) {
+                    m2mTokenProvider.createMachineToMachineToken(appConfig.msGraphConfig.scope)
+                } else {
+                    oboTokenProvider.exchangeOnBehalfOfToken(appConfig.msGraphConfig.scope, token)
+                }
             },
         )
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -140,6 +140,7 @@ private fun repositories() = module {
     single { NavEnhetRepository(get()) }
     single { DeltakerRepository(get()) }
     single { NotificationRepository(get()) }
+    single { NavAnsattRepository(get()) }
 }
 
 private fun services(appConfig: AppConfig) = module {
@@ -244,14 +245,23 @@ private fun services(appConfig: AppConfig) = module {
 
 private fun tasks(config: TaskConfig) = module {
     single {
-        val synchronizeTiltaksgjennomforingsstatuserToKafka =
-            SynchronizeTiltaksgjennomforingsstatuserToKafka(get(), get())
+        val synchronizeTiltaksgjennomforingsstatuserToKafka = SynchronizeTiltaksgjennomforingsstatuserToKafka(
+            get(),
+            get(),
+        )
         val synchronizeTiltakstypestatuserToKafka = SynchronizeTiltakstypestatuserToKafka(get(), get())
         val synchronizeNorgEnheterTask = SynchronizeNorgEnheter(config.synchronizeNorgEnheter, get(), get())
-        val synchronizeTiltaksgjennomforingEnheter =
-            SynchronizeTiltaksgjennomforingEnheter(config.synchronizeEnheterFraSanityTilApi, get(), get())
-        val synchronizeTilgjengelighetsstatuserToSanity =
-            SynchronizeTilgjengelighetsstatuserToSanity(config.synchronizeTilgjengelighetsstatuser, get(), get())
+        val synchronizeTiltaksgjennomforingEnheter = SynchronizeTiltaksgjennomforingEnheter(
+            config.synchronizeEnheterFraSanityTilApi,
+            get(),
+            get(),
+        )
+        val synchronizeTilgjengelighetsstatuserToSanity = SynchronizeTilgjengelighetsstatuserToSanity(
+            config.synchronizeTilgjengelighetsstatuser,
+            get(),
+            get(),
+        )
+        val synchronizeNavAnsatte = SynchronizeNavAnsatte(config.synchronizeNavAnsatte, get(), get(), get())
 
         val db: Database by inject()
 
@@ -263,6 +273,7 @@ private fun tasks(config: TaskConfig) = module {
                 synchronizeTiltakstypestatuserToKafka.task,
                 synchronizeTiltaksgjennomforingEnheter.task,
                 synchronizeTilgjengelighetsstatuserToSanity.task,
+                synchronizeNavAnsatte.task,
             )
             .registerShutdownHook()
             .build()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepository.kt
@@ -1,0 +1,87 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import kotliquery.Row
+import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattDbo
+import no.nav.mulighetsrommet.database.Database
+import no.nav.mulighetsrommet.database.utils.QueryResult
+import no.nav.mulighetsrommet.database.utils.query
+import org.intellij.lang.annotations.Language
+import java.util.*
+
+class NavAnsattRepository(private val db: Database) {
+    fun upsert(ansatt: NavAnsattDbo): QueryResult<NavAnsattDbo> = query {
+        @Language("PostgreSQL")
+        val query = """
+            insert into nav_ansatt(nav_ident, oid, fornavn, etternavn, hovedenhet)
+            values (:nav_ident, :oid, :fornavn, :etternavn, :hovedenhet)
+            on conflict (nav_ident)
+                do update set oid        = excluded.oid,
+                              fornavn    = excluded.fornavn,
+                              etternavn  = excluded.etternavn,
+                              hovedenhet = excluded.hovedenhet
+            returning *
+        """.trimIndent()
+
+        queryOf(query, ansatt.toSqlParameters())
+            .map { it.toNavAnsatt() }
+            .asSingle
+            .let { db.run(it)!! }
+    }
+
+    fun getByNavIdent(navIdent: String): QueryResult<NavAnsattDbo?> = query {
+        @Language("PostgreSQL")
+        val query = """
+            select nav_ident, oid, fornavn, etternavn, hovedenhet
+            from nav_ansatt
+            where nav_ident = :nav_ident
+        """.trimIndent()
+
+        queryOf(query, mapOf("nav_ident" to navIdent))
+            .map { it.toNavAnsatt() }
+            .asSingle
+            .let { db.run(it) }
+    }
+
+    fun getByObjectId(objectId: UUID): QueryResult<NavAnsattDbo?> = query {
+        @Language("PostgreSQL")
+        val query = """
+            select nav_ident, oid, fornavn, etternavn, hovedenhet
+            from nav_ansatt
+            where oid = :oid::uuid
+        """.trimIndent()
+
+        queryOf(query, mapOf("oid" to objectId))
+            .map { it.toNavAnsatt() }
+            .asSingle
+            .let { db.run(it) }
+    }
+
+    fun deleteByObjectId(objectId: UUID): QueryResult<Int> = query {
+        @Language("PostgreSQL")
+        val query = """
+            delete from nav_ansatt
+            where oid = :oid::uuid
+        """.trimIndent()
+
+        queryOf(query, mapOf("oid" to objectId))
+            .asUpdate
+            .let { db.run(it) }
+    }
+
+    private fun NavAnsattDbo.toSqlParameters() = mapOf(
+        "nav_ident" to navIdent,
+        "oid" to oid,
+        "fornavn" to fornavn,
+        "etternavn" to etternavn,
+        "hovedenhet" to hovedenhet,
+    )
+
+    private fun Row.toNavAnsatt() = NavAnsattDbo(
+        navIdent = string("nav_ident"),
+        oid = uuid("oid"),
+        fornavn = string("fornavn"),
+        etternavn = string("etternavn"),
+        hovedenhet = string("hovedenhet"),
+    )
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
@@ -23,8 +23,8 @@ class SynchronizeNavAnsatte(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     data class Config(
-        val cronPattern: String?,
         val disabled: Boolean = false,
+        val cronPattern: String? = null,
         val groups: List<UUID> = listOf(),
     ) {
         fun toSchedule(): Schedule {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
@@ -57,7 +57,17 @@ class SynchronizeNavAnsatte(
 
                     val members = msGraphClient.getGroupMembers(groupId)
                     members.forEach { ansatt ->
-                        val dbo = NavAnsattDbo.fromDto(ansatt)
+                        val dbo = ansatt.run {
+                            NavAnsattDbo(
+                                navIdent = navident,
+                                fornavn = fornavn,
+                                etternavn = etternavn,
+                                hovedenhet = hovedenhetKode,
+                                azureId = azureId,
+                                fraAdGruppe = groupId,
+                            )
+                        }
+
                         ansatte.upsert(dbo).onLeft {
                             throw it.error
                         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
@@ -1,0 +1,68 @@
+package no.nav.mulighetsrommet.api.tasks
+
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask
+import com.github.kagkarlsson.scheduler.task.helper.Tasks
+import com.github.kagkarlsson.scheduler.task.schedule.DisabledSchedule
+import com.github.kagkarlsson.scheduler.task.schedule.Schedule
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules
+import kotlinx.coroutines.runBlocking
+import no.nav.mulighetsrommet.api.clients.msgraph.MicrosoftGraphClient
+import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattDbo
+import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
+import no.nav.mulighetsrommet.slack.SlackNotifier
+import org.slf4j.LoggerFactory
+import java.util.*
+import kotlin.jvm.optionals.getOrNull
+
+class SynchronizeNavAnsatte(
+    config: Config,
+    msGraphClient: MicrosoftGraphClient,
+    ansatte: NavAnsattRepository,
+    slack: SlackNotifier,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    data class Config(
+        val cronPattern: String?,
+        val disabled: Boolean = false,
+        val groups: List<UUID> = listOf(),
+    ) {
+        fun toSchedule(): Schedule {
+            return if (disabled) {
+                DisabledSchedule()
+            } else {
+                Schedules.cron(cronPattern)
+            }
+        }
+    }
+
+    val task: RecurringTask<Void> = Tasks
+        .recurring("synchronize-nav-ansatte", config.toSchedule())
+        .onFailure { failure, _ ->
+            val cause = failure.cause.getOrNull()?.message
+            slack.sendMessage(
+                """
+                Klarte ikke synkronisere NAV-ansatte fra AD-grupper med id=${config.groups}.
+                Konsekvensen er at databasen over NAV-ansatte i løsningen kan være utdatert.
+                Detaljer: $cause
+                """.trimIndent(),
+            )
+        }
+        .execute { _, _ ->
+            logger.info("Synkroniserer NAV-ansatte fra Azure til database...")
+
+            runBlocking {
+                config.groups.forEach { groupId ->
+                    logger.info("Synkroniserer brukere i AD-gruppe id=$groupId")
+
+                    val members = msGraphClient.getGroupMembers(groupId)
+                    members.forEach { ansatt ->
+                        val dbo = NavAnsattDbo.fromDto(ansatt)
+                        ansatte.upsert(dbo).onLeft {
+                            throw it.error
+                        }
+                    }
+                }
+            }
+        }
+}

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -79,11 +79,13 @@ app:
 
   tasks:
     synchronizeNorgEnheter:
-      delayOfMinutes: 360  # Hver 6. time
+      delayOfMinutes: 360 # Hver 6. time
     synchronizeEnheterFraSanityTilApi:
       delayOfMinutes: 360 # Hver 6. time
     synchronizeTilgjengelighetsstatuser:
-      cronExpression: '0 0/30 6-18 * * *'
+      cronPattern: "0 0/30 6-18 * * *" # Hver halvtime fra kl 06:00 til 18:00
+    synchronizeNavAnsatte:
+      cronPattern: "0 0/10 * * * *" # Hvert 10. min
 
   norg2:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -86,6 +86,9 @@ app:
       cronPattern: "0 0/30 6-18 * * *" # Hver halvtime fra kl 06:00 til 18:00
     synchronizeNavAnsatte:
       cronPattern: "0 0/10 * * * *" # Hvert 10. min
+      groups:
+        - 639e2806-4cc2-484c-a72a-51b4308c52a1 # team-mulighetsrommet
+        - ee45478c-57a5-4ee6-b28d-b65f8c1733fe # 0000-GA-mr-admin-flate_betabruker
 
   norg2:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -79,11 +79,15 @@ app:
 
   tasks:
     synchronizeNorgEnheter:
+      disabled: true
       delayOfMinutes: 360 # Hver 6. time
     synchronizeEnheterFraSanityTilApi:
+      disabled: true
       delayOfMinutes: 360 # Hver 6. time
     synchronizeTilgjengelighetsstatuser:
-      cronExpression: '0 0/30 6-18 * * *'
+      disabled: true
+    synchronizeNavAnsatte:
+      disabled: true
 
   norg2:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -82,7 +82,11 @@ app:
     synchronizeTilgjengelighetsstatuser:
       cronPattern: "0 0/30 6-18 * * *" # Hver halvtime fra kl 06:00 til 18:00
     synchronizeNavAnsatte:
+      disabled: true
       cronPattern: "0 0 6 * * *" # Hver dag kl 06:00
+      groups:
+        - 676673aa-ec8f-4606-8399-723dce26b361 # team-mulighetsrommet
+        - dde41c4b-42af-401f-bedf-9e537bcbdd37 # 0000-GA-mr-admin-flate_betabruker
 
   norg2:
     baseUrl: https://norg2.prod-fss-pub.nais.io/norg2/api/v1

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -80,7 +80,9 @@ app:
     synchronizeEnheterFraSanityTilApi:
       delayOfMinutes: 360 # Hver 6. time
     synchronizeTilgjengelighetsstatuser:
-      cronExpression: '0 0/30 6-18 * * *'
+      cronPattern: "0 0/30 6-18 * * *" # Hver halvtime fra kl 06:00 til 18:00
+    synchronizeNavAnsatte:
+      cronPattern: "0 0 6 * * *" # Hver dag kl 06:00
 
   norg2:
     baseUrl: https://norg2.prod-fss-pub.nais.io/norg2/api/v1

--- a/mulighetsrommet-api/src/main/resources/db/migration/V53__nav_ansatt.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V53__nav_ansatt.sql
@@ -1,10 +1,11 @@
 create table nav_ansatt
 (
-    nav_ident  text primary key not null,
-    oid        uuid unique      not null,
-    fornavn    text             not null,
-    etternavn  text             not null,
-    hovedenhet text             not null references nav_enhet (enhetsnummer)
+    nav_ident     text primary key not null,
+    fornavn       text             not null,
+    etternavn     text             not null,
+    hovedenhet    text             not null references nav_enhet (enhetsnummer),
+    azure_id      uuid unique      not null,
+    fra_ad_gruppe uuid             not null
 );
 
 create index nav_ansatt_hovedenhet_idx on nav_ansatt (hovedenhet);

--- a/mulighetsrommet-api/src/main/resources/db/migration/V53__nav_ansatt.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V53__nav_ansatt.sql
@@ -1,0 +1,10 @@
+create table nav_ansatt
+(
+    nav_ident  text primary key not null,
+    oid        uuid unique      not null,
+    fornavn    text             not null,
+    etternavn  text             not null,
+    hovedenhet text             not null references nav_enhet (enhetsnummer)
+);
+
+create index nav_ansatt_hovedenhet_idx on nav_ansatt (hovedenhet);

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -4,6 +4,7 @@ import io.ktor.server.testing.*
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.producers.TiltaksgjennomforingKafkaProducer
 import no.nav.mulighetsrommet.api.producers.TiltakstypeKafkaProducer
+import no.nav.mulighetsrommet.api.tasks.SynchronizeNavAnsatte
 import no.nav.mulighetsrommet.api.tasks.SynchronizeNorgEnheter
 import no.nav.mulighetsrommet.api.tasks.SynchronizeTilgjengelighetsstatuserToSanity
 import no.nav.mulighetsrommet.api.tasks.SynchronizeTiltaksgjennomforingEnheter
@@ -62,7 +63,10 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
             disabled = true,
         ),
         synchronizeTilgjengelighetsstatuser = SynchronizeTilgjengelighetsstatuserToSanity.Config(
-            cronExpression = "* * * * * *",
+            disabled = true,
+        ),
+        synchronizeNavAnsatte = SynchronizeNavAnsatte.Config(
+            disabled = true,
         ),
     ),
     norg2 = Norg2Config(baseUrl = ""),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImplTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImplTest.kt
@@ -35,7 +35,7 @@ class MicrosoftGraphClientImplTest : FunSpec({
         val client = createClient(engine)
 
         client.getNavAnsatt("token", id) shouldBe NavAnsattDto(
-            oid = id,
+            azureId = id,
             navident = "DD123456",
             fornavn = "Donald",
             etternavn = "Duck",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImplTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImplTest.kt
@@ -35,6 +35,7 @@ class MicrosoftGraphClientImplTest : FunSpec({
         val client = createClient(engine)
 
         client.getNavAnsatt("token", id) shouldBe NavAnsattDto(
+            oid = id,
             navident = "DD123456",
             fornavn = "Donald",
             etternavn = "Duck",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImplTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImplTest.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.clients.msgraph
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.mock.*
 import no.nav.mulighetsrommet.api.domain.dto.AdGruppe
 import no.nav.mulighetsrommet.api.domain.dto.NavAnsattDto
 import no.nav.mulighetsrommet.ktor.createMockEngine
@@ -9,6 +10,8 @@ import no.nav.mulighetsrommet.ktor.respondJson
 import java.util.*
 
 class MicrosoftGraphClientImplTest : FunSpec({
+
+    fun createClient(engine: MockEngine) = MicrosoftGraphClientImpl(engine, "https://ms-graph.com") { "token" }
 
     test("should get an MsGraph user as a NavAnsatt") {
         val id = UUID.randomUUID()
@@ -29,9 +32,7 @@ class MicrosoftGraphClientImplTest : FunSpec({
             },
         )
 
-        val client = MicrosoftGraphClientImpl(engine, "https://ms-graph.com") { token ->
-            token
-        }
+        val client = createClient(engine)
 
         client.getNavAnsatt("token", id) shouldBe NavAnsattDto(
             navident = "DD123456",
@@ -53,9 +54,7 @@ class MicrosoftGraphClientImplTest : FunSpec({
             },
         )
 
-        val client = MicrosoftGraphClientImpl(engine, "https://ms-graph.com") { token ->
-            token
-        }
+        val client = createClient(engine)
 
         client.getMemberGroups("token", id) shouldBe listOf(AdGruppe(group.id, group.displayName))
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
@@ -1,0 +1,52 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.spec.style.FunSpec
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
+import no.nav.mulighetsrommet.api.createDatabaseTestConfig
+import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattDbo
+import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
+import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
+import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import java.util.*
+
+class NavAnsattRepositoryTest : FunSpec({
+
+    val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
+
+    context("NavAnsattRepository") {
+        val enheter = NavEnhetRepository(database.db)
+        val ansatte = NavAnsattRepository(database.db)
+
+        beforeAny {
+            val enhet = NavEnhetDbo(
+                enhetsnummer = "1000",
+                navn = "Andeby",
+                status = NavEnhetStatus.AKTIV,
+                type = Norg2Type.LOKAL,
+                overordnetEnhet = null,
+            )
+            enheter.upsert(enhet).shouldBeRight()
+        }
+
+        test("CRUD") {
+            val ansatt = NavAnsattDbo(
+                oid = UUID.randomUUID(),
+                navIdent = "DD123456",
+                fornavn = "Donald",
+                etternavn = "Duck",
+                hovedenhet = "1000",
+            )
+
+            ansatte.upsert(ansatt).shouldBeRight()
+
+            ansatte.getByObjectId(ansatt.oid) shouldBeRight ansatt
+            ansatte.getByNavIdent(ansatt.navIdent) shouldBeRight ansatt
+
+            ansatte.deleteByObjectId(ansatt.oid).shouldBeRight()
+
+            ansatte.getByObjectId(ansatt.oid) shouldBeRight null
+            ansatte.getByNavIdent(ansatt.navIdent) shouldBeRight null
+        }
+    }
+})

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
@@ -31,21 +31,22 @@ class NavAnsattRepositoryTest : FunSpec({
 
         test("CRUD") {
             val ansatt = NavAnsattDbo(
-                oid = UUID.randomUUID(),
+                azureId = UUID.randomUUID(),
                 navIdent = "DD123456",
                 fornavn = "Donald",
                 etternavn = "Duck",
                 hovedenhet = "1000",
+                fraAdGruppe = UUID.randomUUID(),
             )
 
             ansatte.upsert(ansatt).shouldBeRight()
 
-            ansatte.getByObjectId(ansatt.oid) shouldBeRight ansatt
+            ansatte.getByAzureId(ansatt.azureId) shouldBeRight ansatt
             ansatte.getByNavIdent(ansatt.navIdent) shouldBeRight ansatt
 
-            ansatte.deleteByObjectId(ansatt.oid).shouldBeRight()
+            ansatte.deleteByAzureId(ansatt.azureId).shouldBeRight()
 
-            ansatte.getByObjectId(ansatt.oid) shouldBeRight null
+            ansatte.getByAzureId(ansatt.azureId) shouldBeRight null
             ansatte.getByNavIdent(ansatt.navIdent) shouldBeRight null
         }
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
@@ -15,7 +15,14 @@ class MicrosoftGraphServiceTest : FunSpec({
 
     context("Hent ansattdata for nav-ansatt") {
         test("Når man kaller hentAnsattData for en nav ansatts azureId får man svar og repeterende forespørsler kommer fra cache") {
-            val mockResponse = NavAnsattDto(hovedenhetKode = "2990", hovedenhetNavn = "IT-Avdelingen", fornavn = "Bertil", etternavn = "Betabruker", navident = "B123456")
+            val mockResponse = NavAnsattDto(
+                oid = UUID.randomUUID(),
+                hovedenhetKode = "2990",
+                hovedenhetNavn = "IT-Avdelingen",
+                fornavn = "Bertil",
+                etternavn = "Betabruker",
+                navident = "B123456",
+            )
             val mockAccessToken = "123"
 
             val client: MicrosoftGraphClient = mockk()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
@@ -16,7 +16,7 @@ class MicrosoftGraphServiceTest : FunSpec({
     context("Hent ansattdata for nav-ansatt") {
         test("Når man kaller hentAnsattData for en nav ansatts azureId får man svar og repeterende forespørsler kommer fra cache") {
             val mockResponse = NavAnsattDto(
-                oid = UUID.randomUUID(),
+                azureId = UUID.randomUUID(),
                 hovedenhetKode = "2990",
                 hovedenhetNavn = "IT-Avdelingen",
                 fornavn = "Bertil",


### PR DESCRIPTION
- Litt mer dokumentasjon i koden relatert til ms-graph
- Innført noe logikk rundt hva vi anser som en "NAV-ansatt". Benytter `onPremisesSamAccountName` (NAVident) til å avgjøre dette.
- Implementert en db-scheduler task for å synkronisere ansatte fra ad-grupper til nav_ansatt-databasetabell
    - Kjører foreløpig kun i dev-miljøet 