### PR TITLE
Lagre underenheter i egen tabell basert på valg i frontend for avtaler

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/AvtaleDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/AvtaleDbo.kt
@@ -16,6 +16,7 @@ data class AvtaleDbo(
     val tiltakstypeId: UUID,
     val avtalenummer: String? = null,
     val leverandorOrganisasjonsnummer: String,
+    val leverandorUnderenheter: List<String>,
     @Serializable(with = LocalDateSerializer::class)
     val startDato: LocalDate,
     @Serializable(with = LocalDateSerializer::class)

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/AvtaleAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/AvtaleAdminDto.kt
@@ -14,6 +14,7 @@ data class AvtaleAdminDto(
     val navn: String,
     val avtalenummer: String?,
     val leverandor: Leverandor,
+    val leverandorUnderenheter: List<Leverandor>,
     @Serializable(with = LocalDateSerializer::class)
     val startDato: LocalDate,
     @Serializable(with = LocalDateSerializer::class)

--- a/frontend/mr-admin-flate/src/api/QueryKeys.ts
+++ b/frontend/mr-admin-flate/src/api/QueryKeys.ts
@@ -45,4 +45,5 @@ export const QueryKeys = {
   enheter: () => ["enheter"],
   antallUlesteNotifikasjoner: () => ["antallUlesteNotifikasjoner"],
   virksomhetSok: (sokestreng: string) => ["virksomhetSok", sokestreng],
+  virksomhetOppslag: (orgnr: string) => ["virksometOppslag", orgnr],
 };

--- a/frontend/mr-admin-flate/src/api/virksomhet/useSokVirksomhet.ts
+++ b/frontend/mr-admin-flate/src/api/virksomhet/useSokVirksomhet.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { useDebounce } from "mulighetsrommet-frontend-common";
+import { QueryKeys } from "../QueryKeys";
+import { mulighetsrommetClient } from "../clients";
+
+export function useSokVirksomheter(sokestreng: string) {
+  const debouncedSok = useDebounce(sokestreng, 300);
+
+  return useQuery(
+    QueryKeys.virksomhetSok(debouncedSok),
+    () =>
+      mulighetsrommetClient.virksomhet.sokVirksomhet({
+        sok: debouncedSok.trim(),
+      }),
+    {
+      enabled: !!debouncedSok,
+    }
+  );
+}

--- a/frontend/mr-admin-flate/src/api/virksomhet/useVirksomhet.ts
+++ b/frontend/mr-admin-flate/src/api/virksomhet/useVirksomhet.ts
@@ -1,19 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { useDebounce } from "mulighetsrommet-frontend-common";
 import { QueryKeys } from "../QueryKeys";
 import { mulighetsrommetClient } from "../clients";
 
-export function useSokVirksomheter(sokestreng: string) {
-  const debouncedSok = useDebounce(sokestreng, 300);
-
+export function useVirksomhet(orgnr: string) {
   return useQuery(
-    QueryKeys.virksomhetSok(debouncedSok),
-    () =>
-      mulighetsrommetClient.virksomhet.sokVirksomhet({
-        sok: debouncedSok.trim(),
-      }),
-    {
-      enabled: !!debouncedSok,
-    }
+    QueryKeys.virksomhetOppslag(orgnr),
+    () => mulighetsrommetClient.virksomhet.hentVirksomhet({ orgnr }),
+    { enabled: !!orgnr }
   );
 }

--- a/frontend/mr-admin-flate/src/components/avtaler/OpprettAvtaleContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/OpprettAvtaleContainer.tsx
@@ -147,9 +147,7 @@ export function OpprettAvtaleContainer({
     watch,
   } = form;
 
-  const { data: leverandorData } = useVirksomhet(
-    watch("leverandor", "") || avtale?.leverandor.organisasjonsnummer || ""
-  );
+  const { data: leverandorData } = useVirksomhet(watch("leverandor"));
   const underenheterForLeverandor = leverandorData?.underenheter || [];
 
   const erAnskaffetTiltak = (tiltakstypeId: string): boolean => {

--- a/frontend/mr-admin-flate/src/components/avtaler/OpprettAvtaleContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/OpprettAvtaleContainer.tsx
@@ -26,7 +26,8 @@ import { ControlledMultiSelect } from "../skjema/ControlledMultiSelect";
 import { Datovelger } from "../skjema/Datovelger";
 import { SokeSelect } from "../skjema/SokeSelect";
 import styles from "./OpprettAvtaleContainer.module.scss";
-import { useSokVirksomheter } from "../../api/virksomhet/useVirksomhet";
+import { useSokVirksomheter } from "../../api/virksomhet/useSokVirksomhet";
+import { useVirksomhet } from "../../api/virksomhet/useVirksomhet";
 
 interface OpprettAvtaleContainerProps {
   onAvbryt: () => void;
@@ -53,6 +54,7 @@ const Schema = z.object({
     .min(9, "Du må velge en leverandør")
     .max(9, "Du må velge en leverandør")
     .regex(/^\d+$/, "Leverandør må være et nummer"),
+  leverandorUnderenheter: z.string().array(),
   navRegion: z.string({ required_error: "Du må velge en enhet" }),
   navEnheter: z
     .string()
@@ -94,7 +96,9 @@ export function OpprettAvtaleContainer({
   const [navRegion, setNavRegion] = useState<string | undefined>(
     avtale?.navRegion?.enhetsnummer
   );
-  const [sokLeverandor, setSokLeverandor] = useState("");
+  const [sokLeverandor, setSokLeverandor] = useState(
+    avtale?.leverandor.organisasjonsnummer || ""
+  );
   const { data: leverandorVirksomheter = [] } =
     useSokVirksomheter(sokLeverandor);
 
@@ -123,6 +127,12 @@ export function OpprettAvtaleContainer({
       avtalenavn: avtale?.navn || "",
       avtaletype: avtale?.avtaletype || Avtaletype.AVTALE,
       leverandor: avtale?.leverandor?.organisasjonsnummer || "",
+      leverandorUnderenheter:
+        avtale?.leverandorUnderenheter.length === 0
+          ? []
+          : avtale?.leverandorUnderenheter?.map(
+              (enhet) => enhet.organisasjonsnummer
+            ),
       antallPlasser: avtale?.antallPlasser || 0,
       startDato: avtale?.startDato ? new Date(avtale.startDato) : null,
       sluttDato: avtale?.sluttDato ? new Date(avtale.sluttDato) : null,
@@ -136,6 +146,11 @@ export function OpprettAvtaleContainer({
     formState: { errors },
     watch,
   } = form;
+
+  const { data: leverandorData } = useVirksomhet(
+    watch("leverandor", "") || avtale?.leverandor.organisasjonsnummer || ""
+  );
+  const underenheterForLeverandor = leverandorData?.underenheter || [];
 
   const erAnskaffetTiltak = (tiltakstypeId: string): boolean => {
     const tiltakstype = tiltakstyper.find((type) => type.id === tiltakstypeId);
@@ -156,6 +171,11 @@ export function OpprettAvtaleContainer({
         : data.navEnheter,
       avtalenummer: avtale?.avtalenummer || "",
       leverandorOrganisasjonsnummer: data.leverandor,
+      leverandorUnderenheter: data.leverandorUnderenheter.includes(
+        "alle_underenheter"
+      )
+        ? []
+        : data.leverandorUnderenheter,
       navn: data.avtalenavn,
       sluttDato: formaterDatoSomYYYYMMDD(data.sluttDato),
       startDato: formaterDatoSomYYYYMMDD(data.startDato),
@@ -226,6 +246,19 @@ export function OpprettAvtaleContainer({
       }));
     options?.unshift({ value: "alle_enheter", label: "Alle enheter" });
     return options || [];
+  };
+
+  const underenheterOptions = () => {
+    const options = underenheterForLeverandor.map((enhet) => ({
+      value: enhet.organisasjonsnummer,
+      label: `${enhet.navn} - ${enhet.organisasjonsnummer}`,
+    }));
+
+    options?.unshift({
+      value: "alle_underenheter",
+      label: "Alle underenheter",
+    });
+    return options;
   };
 
   return (
@@ -323,6 +356,13 @@ export function OpprettAvtaleContainer({
               value: enhet.organisasjonsnummer,
               label: `${enhet.navn} - ${enhet.organisasjonsnummer}`,
             }))}
+          />
+          <ControlledMultiSelect
+            placeholder="Velg underenhet for tiltaksarrangør"
+            label={"Tiltaksarrangør underenhet"}
+            disabled={!watch("leverandor")}
+            {...register("leverandorUnderenheter")}
+            options={underenheterOptions()}
           />
         </FormGroup>
         <FormGroup>

--- a/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
+++ b/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
@@ -273,4 +273,17 @@ export const apiHandlers = [
       );
     }
   ),
+  rest.get<any, any, Virksomhet | undefined>(
+    "*/api/v1/internal/virksomhet/:orgnr",
+    (req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json(
+          mockVirksomheter.find(
+            (enhet) => enhet.organisasjonsnummer === req.params.orgnr
+          )
+        )
+      );
+    }
+  ),
 ];

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_avtaler.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_avtaler.ts
@@ -24,7 +24,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "864965962",
         navn: "ÅMLI KOMMUNE",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2021-08-02",
       sluttDato: "2026-08-01",
       navEnheter: [],
@@ -51,7 +51,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "911830868",
         navn: "KRIMINALOMSORGSDIREKTORATET",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2020-07-01",
       sluttDato: "2024-06-30",
       navEnheter: [],
@@ -76,7 +76,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "983887457",
         navn: "ARBEIDS- OG INKLUDERINGSDEPARTEMENTET",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2020-07-01",
       sluttDato: "2023-06-30",
       navEnheter: [],
@@ -102,7 +102,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "911830868",
         navn: "KRIMINALOMSORGSDIREKTORATET",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2020-07-01",
       sluttDato: "2024-06-30",
       navEnheter: [],
@@ -127,7 +127,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "911615649",
         navn: "ASKØY KOMMUNE BARNEHAGE",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2021-11-01",
       sluttDato: "2023-10-31",
       navEnheter: [],
@@ -152,7 +152,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "964338442",
         navn: "ASKØY KOMMUNE",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2021-11-01",
       sluttDato: "2024-06-30",
       navEnheter: [],
@@ -177,7 +177,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "974760983",
         navn: "DIREKTORATET FOR SAMFUNNSSIKKERHET OG BEREDSKAP (DSB)",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2019-08-20",
       sluttDato: "2023-08-19",
       navEnheter: [],
@@ -202,7 +202,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "995448394",
         navn: "BÆRUM KOMMUNE MILJØTEKNISK",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2022-01-01",
       sluttDato: "2025-05-09",
       navEnheter: [],
@@ -227,10 +227,10 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "918781390",
         navn: "KRISTIANSAND KOMMUNE SAMHANDLING OG INNOVASJON",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2021-10-01",
       sluttDato: "2024-12-31",
-      navEnheter: ['alle_enheter'],
+      navEnheter: ["alle_enheter"],
       navRegion: {
         enhetsnummer: "1087",
         navn: "NAV Våler",
@@ -252,9 +252,10 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "976821580",
         navn: "BERGEN KOMMUNE BYRÅDSAVDELING FOR KLIMA, MILJØ OG BYUTVIKLING",
       },
+      leverandorUnderenheter: [],
       startDato: "2020-07-01",
       sluttDato: "2023-06-30",
-      navEnheter: ['alle_enheter'],
+      navEnheter: ["alle_enheter"],
       navRegion: {
         enhetsnummer: "1287",
         navn: "NAV Våler",
@@ -276,7 +277,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "870534612",
         navn: "OSLO KOMMUNE BYDEL 2 GRUNERLØKKA",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2019-07-01",
       sluttDato: "2023-06-30",
       navEnheter: [],
@@ -301,7 +302,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "984054408",
         navn: "DRAMMENSREGIONENS BRANNVESEN IKS",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2020-10-01",
       sluttDato: "2023-09-30",
       navEnheter: [],
@@ -326,7 +327,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "964969590",
         navn: "HÅ KOMMUNE",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2021-09-21",
       sluttDato: "2024-09-20",
       navEnheter: [],
@@ -351,7 +352,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "974761076",
         navn: "SKATTEETATEN",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2022-01-01",
       sluttDato: "2024-12-31",
       navEnheter: [],
@@ -376,7 +377,7 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "974761076",
         navn: "SKATTEETATEN",
       },
-
+      leverandorUnderenheter: [],
       startDato: "2022-01-01",
       sluttDato: "2024-12-31",
       navEnheter: [],

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_virksomhet.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_virksomhet.ts
@@ -1,7 +1,0 @@
-import { Virksomhet } from "mulighetsrommet-api-client";
-
-export const mockVirksomhet: Virksomhet = {
-  navn: "Joblearn AS - Avd. Bergen",
-  organisasjonsnummer: "876456342",
-  overordnetEnhet: "876456344",
-};

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_virksomheter.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_virksomheter.ts
@@ -4,6 +4,13 @@ export const mockVirksomheter: Virksomhet[] = [
   {
     organisasjonsnummer: "123456789",
     navn: "Testbedrift AS",
+    underenheter: [
+      {
+        organisasjonsnummer: "876543987",
+        navn: "Underenhet AS",
+        overordnetEnhet: "123456789",
+      },
+    ],
   },
   {
     organisasjonsnummer: "987654321",

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/Virksomhetstype.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/Virksomhetstype.kt
@@ -1,5 +1,0 @@
-package no.nav.mulighetsrommet.api.domain.dbo
-
-enum class Virksomhetstype {
-    Hovedenhet, Underenhet
-}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/Virksomhetstype.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/Virksomhetstype.kt
@@ -1,0 +1,5 @@
+package no.nav.mulighetsrommet.api.domain.dbo
+
+enum class Virksomhetstype {
+    Hovedenhet, Underenhet
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.api.repositories
 
 import kotliquery.Row
 import kotliquery.queryOf
-import no.nav.mulighetsrommet.api.domain.dbo.Virksomhetstype
 import no.nav.mulighetsrommet.api.utils.*
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.QueryResult
@@ -101,14 +100,14 @@ class AvtaleRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val upsertUnderenheter = """
-             insert into leverandor_virksomhet_avtale (avtale_id, organisasjonsnummer, type_virksomhet)
-             values (?::uuid, ?, ?::virksomhetstype)
+             insert into avtale_underleverandor (avtale_id, organisasjonsnummer)
+             values (?::uuid, ?)
              on conflict (avtale_id, organisasjonsnummer) do nothing
         """.trimIndent()
 
         @Language("PostgreSQL")
         val deleteUnderenheter = """
-             delete from leverandor_virksomhet_avtale
+             delete from avtale_underleverandor
              where avtale_id = ?::uuid and not (organisasjonsnummer = any (?))
         """.trimIndent()
 
@@ -148,7 +147,6 @@ class AvtaleRepository(private val db: Database) {
                     upsertUnderenheter,
                     avtale.id,
                     underenhet,
-                    Virksomhetstype.Underenhet.name,
                 ).asExecute.let { tx.run(it) }
             }
 
@@ -187,7 +185,7 @@ class AvtaleRepository(private val db: Database) {
                      left join avtale_ansvarlig aa on a.id = aa.avtale_id
                      left join nav_enhet on a.nav_region = nav_enhet.enhetsnummer
                      left join avtale_nav_enhet e on e.avtale_id = a.id
-                     left join leverandor_virksomhet_avtale lva on lva.avtale_id = a.id
+                     left join avtale_underleverandor lva on lva.avtale_id = a.id
             where a.id = ?::uuid
             group by a.id, t.tiltakskode, t.navn, aa.navident, nav_enhet.navn
         """.trimIndent()
@@ -277,7 +275,7 @@ class AvtaleRepository(private val db: Database) {
                      left join nav_enhet on a.nav_region = nav_enhet.enhetsnummer
                      left join avtale_ansvarlig aa on a.id = aa.avtale_id
                      left join avtale_nav_enhet ae on ae.avtale_id = a.id
-                     left join leverandor_virksomhet_avtale lva on lva.avtale_id = a.id
+                     left join avtale_underleverandor lva on lva.avtale_id = a.id
             $where
             group by a.id, t.navn, t.tiltakskode, aa.navident, nav_enhet.navn
             order by $order

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -101,6 +101,7 @@ data class AvtaleRequest(
     @Serializable(with = UUIDSerializer::class)
     val tiltakstypeId: UUID,
     val leverandorOrganisasjonsnummer: String,
+    val leverandorUnderenheter: List<String> = emptyList(),
     val avtalenummer: String,
     @Serializable(with = LocalDateSerializer::class)
     val startDato: LocalDate,
@@ -121,6 +122,7 @@ data class AvtaleRequest(
             avtalenummer = avtalenummer,
             tiltakstypeId = tiltakstypeId,
             leverandorOrganisasjonsnummer = leverandorOrganisasjonsnummer,
+            leverandorUnderenheter = leverandorUnderenheter,
             startDato = startDato,
             sluttDato = sluttDato,
             arenaAnsvarligEnhet = null,

--- a/mulighetsrommet-api/src/main/resources/db/migration/V55__leverandor_virksomhet_avtale.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V55__leverandor_virksomhet_avtale.sql
@@ -1,14 +1,12 @@
-create type virksomhetstype as enum ('Hovedenhet', 'Underenhet');
 
-create table leverandor_virksomhet_avtale
+create table avtale_underleverandor
 (
     avtale_id           uuid                    not null
         constraint fk_avtale references avtale (id) on delete cascade,
     organisasjonsnummer text                    not null,
-    type_virksomhet     virksomhetstype         not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp default now() not null,
     primary key (avtale_id, organisasjonsnummer)
 );
 
-create index leverandor_virksomhet_avtale_orgnr_idx on leverandor_virksomhet_avtale (organisasjonsnummer);
+create index avtale_underleverandor_orgnr_idx on avtale_underleverandor (organisasjonsnummer);

--- a/mulighetsrommet-api/src/main/resources/db/migration/V55__leverandor_virksomhet_avtale.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V55__leverandor_virksomhet_avtale.sql
@@ -1,0 +1,14 @@
+create type virksomhetstype as enum ('Hovedenhet', 'Underenhet');
+
+create table leverandor_virksomhet_avtale
+(
+    avtale_id           uuid                    not null
+        constraint fk_avtale references avtale (id) on delete cascade,
+    organisasjonsnummer text                    not null,
+    type_virksomhet     virksomhetstype         not null,
+    created_at          timestamp default now() not null,
+    updated_at          timestamp default now() not null,
+    primary key (avtale_id, organisasjonsnummer)
+);
+
+create index leverandor_virksomhet_avtale_orgnr_idx on leverandor_virksomhet_avtale (organisasjonsnummer);

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -970,6 +970,10 @@ components:
           type: string
         leverandor:
           $ref: "#/components/schemas/Leverandor"
+        leverandorUnderenheter:
+          type: array
+          items:
+            $ref: "#/components/schemas/Leverandor"
         startDato:
           type: string
           format: date
@@ -1004,6 +1008,7 @@ components:
         - navn
         - avtalenummer
         - leverandor
+        - leverandorUnderenheter
         - startDato
         - sluttDato
         - avtaletype
@@ -1026,6 +1031,10 @@ components:
           type: string
         leverandorOrganisasjonsnummer:
           type: string
+        leverandorUnderenheter:
+          type: array
+          items:
+            type: string
         startDato:
           type: string
           format: date
@@ -1053,6 +1062,7 @@ components:
         - navn
         - avtalenummer
         - leverandorOrganisasjonsnummer
+        - leverandorUnderenheter
         - startDato
         - sluttDato
         - navRegion

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -64,6 +64,7 @@ class AvtaleFixtures(private val database: FlywayDatabaseTestListener) {
         sluttDato: LocalDate = LocalDate.of(2023, 2, 28),
         ansvarlige: List<String> = emptyList(),
         navEnheter: List<String> = emptyList(),
+        leverandorUnderenheter: List<String> = emptyList(),
     ): AvtaleDbo {
         return AvtaleDbo(
             id = UUID.randomUUID(),
@@ -71,6 +72,7 @@ class AvtaleFixtures(private val database: FlywayDatabaseTestListener) {
             avtalenummer = avtalenummer,
             tiltakstypeId = tiltakstypeId,
             leverandorOrganisasjonsnummer = "12345678910",
+            leverandorUnderenheter = leverandorUnderenheter,
             startDato = startDato,
             sluttDato = sluttDato,
             arenaAnsvarligEnhet = null,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
@@ -72,7 +72,7 @@ class AvtaleRepositoryTest : FunSpec({
             )
             avtaleFixture.upsertAvtaler(listOf(avtale1))
             avtaleFixture.upsertAvtaler(listOf(avtale1))
-            database.assertThat("leverandor_virksomhet_avtale").row()
+            database.assertThat("avtale_underleverandor").row()
                 .value("organisasjonsnummer").isEqualTo(underenhet)
                 .value("avtale_id").isEqualTo(avtale1.id)
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
@@ -64,6 +64,20 @@ class AvtaleRepositoryTest : FunSpec({
         }
     }
 
+    context("Underenheter for leverandør til avtalen") {
+        test("Underenheter blir populert i korrekt tabell") {
+            val underenhet = "123456789"
+            val avtale1 = avtaleFixture.createAvtaleForTiltakstype(
+                leverandorUnderenheter = listOf(underenhet),
+            )
+            avtaleFixture.upsertAvtaler(listOf(avtale1))
+            avtaleFixture.upsertAvtaler(listOf(avtale1))
+            database.assertThat("leverandor_virksomhet_avtale").row()
+                .value("organisasjonsnummer").isEqualTo(underenhet)
+                .value("avtale_id").isEqualTo(avtale1.id)
+        }
+    }
+
     context("Filter for avtaler") {
 
         val defaultFilter = AvtaleFilter(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
@@ -45,6 +45,7 @@ class ArenaAdapterServiceTest : FunSpec({
         tiltakstypeId = tiltakstype.id,
         avtalenummer = "2023#1000",
         leverandorOrganisasjonsnummer = "123456789",
+        leverandorUnderenheter = emptyList(),
         startDato = LocalDate.of(2022, 11, 11),
         sluttDato = LocalDate.of(2023, 11, 11),
         arenaAnsvarligEnhet = "2990",

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
@@ -1,7 +1,10 @@
 package no.nav.mulighetsrommet.arena.adapter.events.processors
 
-import arrow.core.*
+import arrow.core.Either
 import arrow.core.continuations.either
+import arrow.core.flatMap
+import arrow.core.left
+import arrow.core.right
 import io.ktor.http.*
 import no.nav.mulighetsrommet.arena.adapter.MulighetsrommetApiClient
 import no.nav.mulighetsrommet.arena.adapter.clients.ArenaOrdsProxyClient
@@ -122,6 +125,7 @@ class AvtaleInfoEventProcessor(
             tiltakstypeId = tiltakstypeMapping.entityId,
             avtalenummer = "${avtale.aar}#${avtale.lopenr}",
             leverandorOrganisasjonsnummer = leverandorOrganisasjonsnummer,
+            leverandorUnderenheter = emptyList(),
             startDato = startDato,
             sluttDato = sluttDato,
             arenaAnsvarligEnhet = avtale.ansvarligEnhet,


### PR DESCRIPTION
Legger til felt i skjema for opprettelse av avtale som lar bruker velge underenhetene til en gitt overordnet enhet (hovedenhet). Lagrer valget i en egen tabell i db slik at det skalerer bedre i fremtiden når vi kan koble den tabellen til en egen virksomhet-tabell. 


https://github.com/navikt/mulighetsrommet/assets/9053627/4476ae0c-c0a8-4383-aa14-d43125549af1

