### PR TITLE
Kan velge underenhet for arrangør basert på valg fra avtale

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/OpprettTiltaksgjennomforingContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/OpprettTiltaksgjennomforingContainer.tsx
@@ -38,6 +38,11 @@ const Schema = z.object({
     .string()
     .array()
     .nonempty({ message: "Du må velge minst én enhet" }),
+  tiltaksArrangorUnderenhetOrganisasjonsnummer: z
+    .string({
+      required_error: "Du må velge en underenhet for tiltaksarrangør",
+    })
+    .min(1, "Du må velge en underenhet for tiltaksarrangør"),
   ansvarlig: z.string({ required_error: "Du må velge en ansvarlig" }),
 });
 
@@ -53,39 +58,42 @@ interface OpprettTiltaksgjennomforingContainerProps {
 
 const tekniskFeilError = () => (
   <>
-    Gjennomføringen kunne ikke opprettes på grunn av en teknisk feil
-    hos oss. Forsøk på nytt eller ta <a href={porten}>kontakt</a> i
-    Porten dersom du trenger mer hjelp.
+    Gjennomføringen kunne ikke opprettes på grunn av en teknisk feil hos oss.
+    Forsøk på nytt eller ta <a href={porten}>kontakt</a> i Porten dersom du
+    trenger mer hjelp.
   </>
-)
+);
 
 const avtaleManglerNavRegionError = () => (
   <>
-    Avtalen mangler NAV region. Du må oppdatere avtalens NAV region for
-    å kunne opprette en gjennomføring. Ta <a href={porten}>kontakt</a> i
-    Porten dersom du trenger mer hjelp.
+    Avtalen mangler NAV region. Du må oppdatere avtalens NAV region for å kunne
+    opprette en gjennomføring. Ta <a href={porten}>kontakt</a> i Porten dersom
+    du trenger mer hjelp.
   </>
-)
+);
 
 export const OpprettTiltaksgjennomforingContainer = (
   props: OpprettTiltaksgjennomforingContainerProps
 ) => {
+  const { avtale, tiltaksgjennomforing, setError, onAvbryt } = props;
   const form = useForm<inferredSchema>({
     resolver: zodResolver(Schema),
     defaultValues: {
-      tittel: props.tiltaksgjennomforing?.navn,
+      tittel: tiltaksgjennomforing?.navn,
       navEnheter:
-        props.tiltaksgjennomforing?.navEnheter.length === 0
+        tiltaksgjennomforing?.navEnheter.length === 0
           ? ["alle_enheter"]
-          : props.tiltaksgjennomforing?.navEnheter,
-      ansvarlig: props.tiltaksgjennomforing?.ansvarlig,
-      antallPlasser: props.tiltaksgjennomforing?.antallPlasser,
-      startDato: props.tiltaksgjennomforing?.startDato
-        ? new Date(props.tiltaksgjennomforing.startDato)
+          : tiltaksgjennomforing?.navEnheter,
+      ansvarlig: tiltaksgjennomforing?.ansvarlig,
+      antallPlasser: tiltaksgjennomforing?.antallPlasser,
+      startDato: tiltaksgjennomforing?.startDato
+        ? new Date(tiltaksgjennomforing.startDato)
         : undefined,
-      sluttDato: props.tiltaksgjennomforing?.sluttDato
-        ? new Date(props.tiltaksgjennomforing.sluttDato)
+      sluttDato: tiltaksgjennomforing?.sluttDato
+        ? new Date(tiltaksgjennomforing.sluttDato)
         : undefined,
+      tiltaksArrangorUnderenhetOrganisasjonsnummer:
+        tiltaksgjennomforing?.virksomhetsnummer || "",
     },
   });
   const {
@@ -116,23 +124,28 @@ export const OpprettTiltaksgjennomforingContainer = (
     }
   }, [ansatt, isLoadingAnsatt, setValue]);
 
-  const redigeringsModus = !!props.tiltaksgjennomforing;
+  const redigeringsModus = !!tiltaksgjennomforing;
 
   const postData: SubmitHandler<inferredSchema> = async (
     data
   ): Promise<void> => {
     const body: TiltaksgjennomforingRequest = {
-      id: props.tiltaksgjennomforing ? props.tiltaksgjennomforing.id : uuidv4(),
+      id: tiltaksgjennomforing ? tiltaksgjennomforing.id : uuidv4(),
       antallPlasser: data.antallPlasser,
-      tiltakstypeId: props.avtale.tiltakstype.id,
-      navEnheter: data.navEnheter.includes("alle_enheter") ? [] : data.navEnheter,
+      tiltakstypeId: avtale.tiltakstype.id,
+      navEnheter: data.navEnheter.includes("alle_enheter")
+        ? []
+        : data.navEnheter,
       navn: data.tittel,
       sluttDato: formaterDatoSomYYYYMMDD(data.sluttDato),
       startDato: formaterDatoSomYYYYMMDD(data.startDato),
-      avtaleId: props.avtale.id,
+      avtaleId: avtale.id,
       ansvarlig: data.ansvarlig,
-      virksomhetsnummer: props.avtale.leverandor.organisasjonsnummer,
-      tiltaksnummer: props.tiltaksgjennomforing?.tiltaksnummer,
+      virksomhetsnummer:
+        data.tiltaksArrangorUnderenhetOrganisasjonsnummer ||
+        tiltaksgjennomforing?.virksomhetsnummer ||
+        "",
+      tiltaksnummer: tiltaksgjennomforing?.tiltaksnummer,
     };
 
     try {
@@ -144,7 +157,7 @@ export const OpprettTiltaksgjennomforingContainer = (
         );
       navigerTilTiltaksgjennomforing(response.id);
     } catch {
-      props.setError(tekniskFeilError());
+      setError(tekniskFeilError());
     }
   };
 
@@ -157,22 +170,29 @@ export const OpprettTiltaksgjennomforingContainer = (
   if (!enheter) {
     return <Laster />;
   }
-  if (!props.avtale.navRegion) {
-    props.setError(avtaleManglerNavRegionError());
+  if (!avtale.navRegion) {
+    setError(avtaleManglerNavRegionError());
   }
 
   if (isErrorAnsatt || isErrorEnheter) {
-    props.setError(tekniskFeilError());
+    setError(tekniskFeilError());
   }
 
   const enheterOptions = () => {
     const options = enheter
-      .filter((enhet: NavEnhet) => props.avtale.navRegion?.enhetsnummer === enhet.overordnetEnhet)
-      .filter((enhet: NavEnhet) => props.avtale.navEnheter.length === 0 || props.avtale.navEnheter.includes(enhet.enhetsnummer))
+      .filter(
+        (enhet: NavEnhet) =>
+          avtale.navRegion?.enhetsnummer === enhet.overordnetEnhet
+      )
+      .filter(
+        (enhet: NavEnhet) =>
+          avtale.navEnheter.length === 0 ||
+          avtale.navEnheter.includes(enhet.enhetsnummer)
+      )
       .map((enhet) => ({
         label: enhet.navn,
-        value: enhet.enhetsnummer
-      }))
+        value: enhet.enhetsnummer,
+      }));
 
     options?.unshift({ value: "alle_enheter", label: "Alle enheter" });
     return options || [];
@@ -193,7 +213,7 @@ export const OpprettTiltaksgjennomforingContainer = (
             readOnly
             style={{ backgroundColor: "#F1F1F1" }}
             label={"Avtale"}
-            value={props.avtale.navn || ""}
+            value={avtale.navn || ""}
           />
         </FormGroup>
         <FormGroup>
@@ -222,13 +242,34 @@ export const OpprettTiltaksgjennomforingContainer = (
             readOnly
             style={{ backgroundColor: "#F1F1F1" }}
             label={"NAV region"}
-            value={props.avtale.navRegion?.navn || ""}
+            value={avtale.navRegion?.navn || ""}
           />
           <ControlledMultiSelect
             placeholder={isLoadingEnheter ? "Laster enheter..." : "Velg en"}
             label={"NAV enhet (kontorer)"}
             {...register("navEnheter")}
             options={enheterOptions()}
+          />
+        </FormGroup>
+        <FormGroup>
+          <TextField
+            label="Tiltaksarrangør hovedenhet"
+            placeholder=""
+            defaultValue={`${avtale.leverandor.navn} - ${avtale.leverandor.organisasjonsnummer}`}
+            style={{ backgroundColor: "#F1F1F1" }}
+            readOnly
+          />
+          <SokeSelect
+            label="Tiltaksarrangør underenhet"
+            placeholder="Velg underenhet for tiltaksarrangør"
+            {...register("tiltaksArrangorUnderenhetOrganisasjonsnummer")}
+            disabled={!avtale.leverandor.organisasjonsnummer}
+            options={avtale.leverandorUnderenheter.map((lev) => {
+              return {
+                label: `${lev.navn} - ${lev.organisasjonsnummer}`,
+                value: lev.organisasjonsnummer,
+              };
+            })}
           />
         </FormGroup>
         <FormGroup>
@@ -253,7 +294,7 @@ export const OpprettTiltaksgjennomforingContainer = (
         <div className={styles.button_row}>
           <Button
             className={styles.button}
-            onClick={props.onAvbryt}
+            onClick={onAvbryt}
             variant="tertiary"
             type="button"
           >

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_avtaler.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_avtaler.ts
@@ -24,7 +24,11 @@ export const mockAvtaler: PaginertAvtale = {
         organisasjonsnummer: "864965962",
         navn: "ÅMLI KOMMUNE",
       },
-      leverandorUnderenheter: [],
+      leverandorUnderenheter: [
+        { organisasjonsnummer: "456798321", navn: "Underenhet 1" },
+        { organisasjonsnummer: "456798322", navn: "Underenhet 2" },
+        { organisasjonsnummer: "456798323", navn: "Underenhet 3" },
+      ],
       startDato: "2021-08-02",
       sluttDato: "2026-08-01",
       navEnheter: [],


### PR DESCRIPTION
Ved opprettelse av tiltaksgjennomføring må man velge en av underenhetene til en tiltaksleverandør, basert på valg fra avtalen. 


(Se bort fra merkelig visning av navn på underenhet i video, det er pga. wiremock mot amt-enhetsregister lokalt)
https://github.com/navikt/mulighetsrommet/assets/9053627/eadfbc25-a127-46b7-b3b4-b945a23bf334

