### PR TITLE
Feature/tiltaksgjennomforing oppstart

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,8 @@ allprojects {
     }
 
     tasks.withType<Test> {
+        failFast = System.getenv("CI") == "true"
+
         useJUnitPlatform()
 
         testLogging {

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/Tiltakskoder.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/Tiltakskoder.kt
@@ -24,6 +24,16 @@ object Tiltakskoder {
     )
 
     /**
+     * Tiltakskoder som, enn så lenge, blir antatt å ha en felles oppstartsdato for alle deltakere.
+     * Disse har blitt referert til som "kurs" av komet.
+     */
+    val TiltakMedFellesOppstart = listOf(
+        "GRUPPEAMO",
+        "JOBBK",
+        "GRUFAGYRKE",
+    )
+
+    /**
      * Tiltakskoder der Komet har tatt eierskap til deltakelsene.
      */
     val AmtTiltak = listOf(
@@ -37,6 +47,10 @@ object Tiltakskoder {
 
     fun isGruppetiltak(tiltakskode: String): Boolean {
         return tiltakskode in Gruppetiltak
+    }
+
+    fun hasFellesOppstart(tiltakskode: String): Boolean {
+        return tiltakskode in TiltakMedFellesOppstart
     }
 
     fun isAmtTiltak(tiltakskode: String): Boolean {

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -27,10 +27,16 @@ data class TiltaksgjennomforingDbo(
     val avtaleId: UUID? = null,
     val ansvarlige: List<String>,
     val navEnheter: List<String>,
+    val oppstart: Oppstartstype,
 ) {
     enum class Tilgjengelighetsstatus {
         Ledig,
         Venteliste,
         Stengt,
+    }
+
+    enum class Oppstartstype {
+        Lopende,
+        Dato,
     }
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -36,7 +36,7 @@ data class TiltaksgjennomforingDbo(
     }
 
     enum class Oppstartstype {
-        Lopende,
-        Felles,
+        LOPENDE,
+        FELLES,
     }
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -37,6 +37,6 @@ data class TiltaksgjennomforingDbo(
 
     enum class Oppstartstype {
         Lopende,
-        Dato,
+        Felles,
     }
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/NavEnhet.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/NavEnhet.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class NavEnhet(
     val enhetsnummer: String,
-    val navn: String? = null,
+    val navn: String,
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -29,6 +29,7 @@ data class TiltaksgjennomforingAdminDto(
     val ansvarlige: List<String>,
     val navEnheter: List<NavEnhet>,
     val sanityId: String?,
+    val oppstart: TiltaksgjennomforingDbo.Oppstartstype,
 ) {
     @Serializable
     data class Tiltakstype(

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingDto.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.domain.dto
 
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDate
@@ -18,6 +19,7 @@ data class TiltaksgjennomforingDto(
     val sluttDato: LocalDate? = null,
     val status: Tiltaksgjennomforingsstatus,
     val virksomhetsnummer: String,
+    val oppstart: TiltaksgjennomforingDbo.Oppstartstype,
 ) {
     @Serializable
     data class Tiltakstype(
@@ -28,19 +30,21 @@ data class TiltaksgjennomforingDto(
     )
 
     companion object {
-        fun from(tiltaksgjennomforing: TiltaksgjennomforingAdminDto) =
+        fun from(tiltaksgjennomforing: TiltaksgjennomforingAdminDto) = tiltaksgjennomforing.run {
             TiltaksgjennomforingDto(
-                id = tiltaksgjennomforing.id,
+                id = id,
                 tiltakstype = Tiltakstype(
-                    id = tiltaksgjennomforing.tiltakstype.id,
-                    navn = tiltaksgjennomforing.tiltakstype.navn,
-                    arenaKode = tiltaksgjennomforing.tiltakstype.arenaKode,
+                    id = tiltakstype.id,
+                    navn = tiltakstype.navn,
+                    arenaKode = tiltakstype.arenaKode,
                 ),
-                navn = tiltaksgjennomforing.navn,
-                startDato = tiltaksgjennomforing.startDato,
-                sluttDato = tiltaksgjennomforing.sluttDato,
-                status = tiltaksgjennomforing.status,
-                virksomhetsnummer = tiltaksgjennomforing.virksomhetsnummer,
+                navn = navn,
+                startDato = startDato,
+                sluttDato = sluttDato,
+                status = status,
+                virksomhetsnummer = virksomhetsnummer,
+                oppstart = oppstart,
             )
+        }
     }
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingNotificationDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingNotificationDto.kt
@@ -16,5 +16,4 @@ data class TiltaksgjennomforingNotificationDto(
     @Serializable(with = LocalDateSerializer::class)
     val sluttDato: LocalDate? = null,
     val ansvarlige: List<String>,
-    val navEnheter: List<String>,
 )

--- a/frontend/mr-admin-flate/src/utils/tiltakskoder.ts
+++ b/frontend/mr-admin-flate/src/utils/tiltakskoder.ts
@@ -1,0 +1,4 @@
+export function isTiltakMedFellesOppstart(tiltakskode: string): boolean {
+  const tiltakMedFellesOppstart = ["GRUPPEAMO", "JOBBK", "GRUFAGYRKE"];
+  return tiltakMedFellesOppstart.includes(tiltakskode);
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -243,7 +243,7 @@ private fun services(appConfig: AppConfig) = module {
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get()) }
     single { MicrosoftGraphService(get()) }
-    single { TiltaksgjennomforingService(get(), get(), get(), get(), get(), get(), get()) }
+    single { TiltaksgjennomforingService(get(), get(), get(), get(), get()) }
     single { SanityTiltaksgjennomforingService(get(), get(), get(), get()) }
     single { TiltakstypeService(get(), get(), get(), get()) }
     single { NavEnheterSyncService(get(), get(), get(), get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -243,7 +243,7 @@ private fun services(appConfig: AppConfig) = module {
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get()) }
     single { MicrosoftGraphService(get()) }
-    single { TiltaksgjennomforingService(get(), get(), get(), get(), get(), get()) }
+    single { TiltaksgjennomforingService(get(), get(), get(), get(), get(), get(), get()) }
     single { SanityTiltaksgjennomforingService(get(), get(), get(), get()) }
     single { TiltakstypeService(get(), get(), get(), get()) }
     single { NavEnheterSyncService(get(), get(), get(), get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -29,7 +29,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         @Language("PostgreSQL")
         val query = """
             insert into tiltaksgjennomforing (id, navn, tiltakstype_id, tiltaksnummer, virksomhetsnummer, arena_ansvarlig_enhet, start_dato, slutt_dato, avslutningsstatus, tilgjengelighet, antall_plasser, avtale_id, oppstart)
-            values (:id::uuid, :navn, :tiltakstype_id::uuid, :tiltaksnummer, :virksomhetsnummer, :arena_ansvarlig_enhet, :start_dato, :slutt_dato, :avslutningsstatus::avslutningsstatus, :tilgjengelighet::tilgjengelighetsstatus, :antall_plasser, :avtale_id, :oppstart::tiltaksgjennomforing_oppstart)
+            values (:id::uuid, :navn, :tiltakstype_id::uuid, :tiltaksnummer, :virksomhetsnummer, :arena_ansvarlig_enhet, :start_dato, :slutt_dato, :avslutningsstatus::avslutningsstatus, :tilgjengelighet::tilgjengelighetsstatus, :antall_plasser, :avtale_id, :oppstart::tiltaksgjennomforing_oppstartstype)
             on conflict (id)
                 do update set navn                  = excluded.navn,
                               tiltakstype_id        = excluded.tiltakstype_id,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -88,7 +88,7 @@ data class TiltaksgjennomforingRequest(
         }
 
         val oppstart = if (Tiltakskoder.hasFellesOppstart(tiltakstype.arenaKode)) {
-            TiltaksgjennomforingDbo.Oppstartstype.Dato
+            TiltaksgjennomforingDbo.Oppstartstype.Felles
         } else {
             TiltaksgjennomforingDbo.Oppstartstype.Lopende
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -88,9 +88,9 @@ data class TiltaksgjennomforingRequest(
         }
 
         val oppstart = if (Tiltakskoder.hasFellesOppstart(tiltakstype.arenaKode)) {
-            TiltaksgjennomforingDbo.Oppstartstype.Felles
+            TiltaksgjennomforingDbo.Oppstartstype.FELLES
         } else {
-            TiltaksgjennomforingDbo.Oppstartstype.Lopende
+            TiltaksgjennomforingDbo.Oppstartstype.LOPENDE
         }
         return Either.Right(
             TiltaksgjennomforingDbo(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/responses/StatusResponse.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/responses/StatusResponse.kt
@@ -2,6 +2,8 @@ package no.nav.mulighetsrommet.api.routes.v1.responses
 
 import arrow.core.Either
 import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
 
 /**
  * Et forsøk på å definere noen utility-klasser som gjør det lettere å benytte Arrow's [Either] i kombinasjon
@@ -9,8 +11,20 @@ import io.ktor.http.*
  */
 typealias StatusResponse<T> = Either<StatusResponseError, T>
 
-sealed class StatusResponseError(val status: HttpStatusCode, val message: String)
+sealed class StatusResponseError(val status: HttpStatusCode, val message: String?)
 
-class ServerError(message: String) : StatusResponseError(HttpStatusCode.InternalServerError, message)
+class ServerError(message: String? = null) : StatusResponseError(HttpStatusCode.InternalServerError, message)
 
-class BadRequest(message: String = "Bad request") : StatusResponseError(HttpStatusCode.BadRequest, message)
+class BadRequest(message: String? = null) : StatusResponseError(HttpStatusCode.BadRequest, message)
+
+class NotFound(message: String? = null) : StatusResponseError(HttpStatusCode.NotFound, message)
+
+suspend inline fun <reified T : Any> ApplicationCall.respondWithStatusResponse(result: StatusResponse<T>) {
+    result
+        .onRight { message ->
+            respond(message)
+        }
+        .onLeft { error ->
+            respond(error.status, error.message ?: error.status.description)
+        }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/responses/StatusResponse.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/responses/StatusResponse.kt
@@ -1,0 +1,16 @@
+package no.nav.mulighetsrommet.api.routes.v1.responses
+
+import arrow.core.Either
+import io.ktor.http.*
+
+/**
+ * Et forsøk på å definere noen utility-klasser som gjør det lettere å benytte Arrow's [Either] i kombinasjon
+ * med ktor routes.
+ */
+typealias StatusResponse<T> = Either<StatusResponseError, T>
+
+sealed class StatusResponseError(val status: HttpStatusCode, val message: String)
+
+class ServerError(message: String) : StatusResponseError(HttpStatusCode.InternalServerError, message)
+
+class BadRequest(message: String = "Bad request") : StatusResponseError(HttpStatusCode.BadRequest, message)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -2,16 +2,16 @@ package no.nav.mulighetsrommet.api.services
 
 import arrow.core.Either
 import arrow.core.flatMap
-import arrow.core.left
-import arrow.core.right
 import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingNokkeltallDto
 import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
-import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
-import no.nav.mulighetsrommet.api.routes.v1.TiltaksgjennomforingRequest
-import no.nav.mulighetsrommet.api.routes.v1.responses.*
+import no.nav.mulighetsrommet.api.routes.v1.responses.PaginatedResponse
+import no.nav.mulighetsrommet.api.routes.v1.responses.Pagination
 import no.nav.mulighetsrommet.api.utils.AdminTiltaksgjennomforingFilter
 import no.nav.mulighetsrommet.api.utils.PaginationParams
+import no.nav.mulighetsrommet.database.utils.DatabaseOperationError
+import no.nav.mulighetsrommet.database.utils.QueryResult
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingAdminDto
 import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingNotificationDto
 import org.slf4j.Logger
@@ -19,70 +19,48 @@ import org.slf4j.LoggerFactory
 import java.util.*
 
 class TiltaksgjennomforingService(
-    private val tiltakstyper: TiltakstypeRepository,
     private val tiltaksgjennomforingRepository: TiltaksgjennomforingRepository,
     private val arrangorService: ArrangorService,
     private val deltakerRepository: DeltakerRepository,
     private val sanityTiltaksgjennomforingService: SanityTiltaksgjennomforingService,
     private val virksomhetService: VirksomhetService,
-    private val enhetService: NavEnhetService,
 ) {
     private val log: Logger = LoggerFactory.getLogger(javaClass)
 
-    suspend fun get(id: UUID): StatusResponse<TiltaksgjennomforingAdminDto> =
-        tiltaksgjennomforingRepository.get(id)
-            .mapLeft {
-                log.error("Klarte ikke hente tiltaksgjennomføring", it.error)
-                ServerError("Klarte ikke hente tiltaksgjennomføring med id=$id")
+    suspend fun upsert(dbo: TiltaksgjennomforingDbo): QueryResult<TiltaksgjennomforingAdminDto> {
+        virksomhetService.syncEnhetFraBrreg(dbo.virksomhetsnummer)
+        return tiltaksgjennomforingRepository.upsert(dbo)
+            .flatMap { tiltaksgjennomforingRepository.get(dbo.id) }
+            .onLeft { log.error("Klarte ikke lagre tiltaksgjennomføring", it.error) }
+            .map { it!! } // If upsert is successful it should exist here
+            .onRight {
+                sanityTiltaksgjennomforingService.opprettSanityTiltaksgjennomforing(it)
             }
-            .flatMap { it?.right() ?: NotFound("Ingen tiltaksgjennomføring med id=$id").left() }
-            .map { withVirksomhetsnavn(it) }
+    }
+
+    suspend fun get(id: UUID): QueryResult<TiltaksgjennomforingAdminDto?> =
+        tiltaksgjennomforingRepository.get(id)
+            .onLeft { log.error("Klarte ikke hente tiltaksgjennomføring", it.error) }
+            .map { it?.let { withVirksomhetsnavn(it) } }
 
     suspend fun getAll(
-        paginationParams: PaginationParams,
+        pagination: PaginationParams,
         filter: AdminTiltaksgjennomforingFilter,
-    ): StatusResponse<PaginatedResponse<TiltaksgjennomforingAdminDto>> =
+    ): Either<DatabaseOperationError, PaginatedResponse<TiltaksgjennomforingAdminDto>> =
         tiltaksgjennomforingRepository
-            .getAll(paginationParams, filter)
-            .mapLeft {
-                log.error("Klarte ikke hente tiltaksgjennomføringer", it.error)
-                ServerError("Klarte ikke hente tiltaksgjennomføringer")
-            }
+            .getAll(pagination, filter)
+            .onLeft { log.error("Klarte ikke hente tiltaksgjennomføringer", it.error) }
             .map { (totalCount, items) ->
                 val data = items.map { withVirksomhetsnavn(it) }
                 PaginatedResponse(
                     pagination = Pagination(
                         totalCount = totalCount,
-                        currentPage = paginationParams.page,
-                        pageSize = paginationParams.limit,
+                        currentPage = pagination.page,
+                        pageSize = pagination.limit,
                     ),
                     data = data,
                 )
             }
-
-    suspend fun upsert(gjennomforing: TiltaksgjennomforingRequest): StatusResponse<TiltaksgjennomforingAdminDto> {
-        return Either
-            .catch { tiltakstyper.get(gjennomforing.tiltakstypeId) }
-            .mapLeft {
-                log.error("Klarte ikke hente tiltakstype", it)
-                ServerError("Klarte ikke hente tiltakstype for id=${gjennomforing.tiltakstypeId}")
-            }
-            .flatMap { it?.right() ?: BadRequest("Tiltakstype mangler for id=${gjennomforing.tiltakstypeId}").left() }
-            .flatMap { gjennomforing.toDbo(it) }
-            .flatMap { dbo ->
-                virksomhetService.syncEnhetFraBrreg(dbo.virksomhetsnummer)
-                tiltaksgjennomforingRepository.upsert(dbo)
-                    .flatMap { tiltaksgjennomforingRepository.get(gjennomforing.id) }
-                    .mapLeft {
-                        log.error("Klarte ikke lagre tiltaksgjennomføring", it.error)
-                        ServerError("Klarte ikke lagre tiltaksgjennomføring")
-                    }
-                    .flatMap { dto -> dto?.right() ?: ServerError("Klarte ikke lagre tiltaksgjennomføring").left() }
-            }
-            .onRight {
-                sanityTiltaksgjennomforingService.opprettSanityTiltaksgjennomforing(it)
-            }
-    }
 
     fun getNokkeltallForTiltaksgjennomforing(tiltaksgjennomforingId: UUID): TiltaksgjennomforingNokkeltallDto =
         TiltaksgjennomforingNokkeltallDto(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -1,19 +1,29 @@
 package no.nav.mulighetsrommet.api.services
 
+import arrow.core.Either
 import arrow.core.flatMap
+import arrow.core.left
+import arrow.core.right
 import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingNokkeltallDto
 import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
+import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
+import no.nav.mulighetsrommet.api.routes.v1.TiltaksgjennomforingRequest
+import no.nav.mulighetsrommet.api.routes.v1.responses.BadRequest
+import no.nav.mulighetsrommet.api.routes.v1.responses.ServerError
+import no.nav.mulighetsrommet.api.routes.v1.responses.StatusResponseError
 import no.nav.mulighetsrommet.api.utils.AdminTiltaksgjennomforingFilter
 import no.nav.mulighetsrommet.api.utils.PaginationParams
 import no.nav.mulighetsrommet.database.utils.QueryResult
-import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dto.NavEnhet
 import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingAdminDto
 import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingNotificationDto
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.*
 
 class TiltaksgjennomforingService(
+    private val tiltakstyper: TiltakstypeRepository,
     private val tiltaksgjennomforingRepository: TiltaksgjennomforingRepository,
     private val arrangorService: ArrangorService,
     private val deltakerRepository: DeltakerRepository,
@@ -21,6 +31,7 @@ class TiltaksgjennomforingService(
     private val virksomhetService: VirksomhetService,
     private val enhetService: NavEnhetService,
 ) {
+    private val log: Logger = LoggerFactory.getLogger(javaClass)
 
     suspend fun get(id: UUID): QueryResult<TiltaksgjennomforingAdminDto?> =
         tiltaksgjennomforingRepository.get(id)
@@ -36,11 +47,25 @@ class TiltaksgjennomforingService(
                 totalCount to items.map { it.hentVirksomhetsnavnForTiltaksgjennomforing().hentEnhetsnavn() }
             }
 
-    suspend fun upsert(tiltaksgjennomforingDbo: TiltaksgjennomforingDbo): QueryResult<TiltaksgjennomforingAdminDto> {
-        virksomhetService.syncEnhetFraBrreg(tiltaksgjennomforingDbo.virksomhetsnummer)
-        return tiltaksgjennomforingRepository.upsert(tiltaksgjennomforingDbo)
-            .flatMap { tiltaksgjennomforingRepository.get(tiltaksgjennomforingDbo.id) }
-            .map { it!! } // If upsert is successful it should exist here
+    suspend fun upsert(gjennomforing: TiltaksgjennomforingRequest): Either<StatusResponseError, TiltaksgjennomforingAdminDto> {
+        return Either
+            .catch { tiltakstyper.get(gjennomforing.tiltakstypeId) }
+            .mapLeft {
+                log.error("Klarte ikke hente tiltakstype", it)
+                ServerError("Klarte ikke hente tiltakstype for id=${gjennomforing.tiltakstypeId}")
+            }
+            .flatMap { it?.right() ?: BadRequest("Tiltakstype mangler for id=${gjennomforing.tiltakstypeId}").left() }
+            .flatMap { gjennomforing.toDbo(it) }
+            .flatMap { dbo ->
+                virksomhetService.syncEnhetFraBrreg(dbo.virksomhetsnummer)
+                tiltaksgjennomforingRepository.upsert(dbo)
+                    .flatMap { tiltaksgjennomforingRepository.get(gjennomforing.id) }
+                    .mapLeft {
+                        log.error("Klarte ikke lagre tiltaksgjennomføring", it.error)
+                        ServerError("Klarte ikke lagre tiltaksgjennomføring")
+                    }
+                    .flatMap { dto -> dto?.right() ?: ServerError("Klarte ikke lagre tiltaksgjennomføring").left() }
+            }
             .onRight {
                 sanityTiltaksgjennomforingService.opprettSanityTiltaksgjennomforing(it)
             }

--- a/mulighetsrommet-api/src/main/resources/db/migration/V59__tiltaksgjennomforing_oppstart.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V59__tiltaksgjennomforing_oppstart.sql
@@ -1,0 +1,14 @@
+create type tiltaksgjennomforing_oppstart as enum ('Dato', 'Lopende');
+
+alter table tiltaksgjennomforing
+    add oppstart tiltaksgjennomforing_oppstart;
+
+update tiltaksgjennomforing tg
+set oppstart = case
+                   when tt.tiltakskode in ('GRUPPEAMO', 'JOBBK', 'GRUFAGYRKE') then 'Dato'
+                   else 'Lopende' end::tiltaksgjennomforing_oppstart
+from tiltakstype tt
+where tt.id = tg.tiltakstype_id;
+
+alter table tiltaksgjennomforing
+    alter oppstart set not null;

--- a/mulighetsrommet-api/src/main/resources/db/migration/V59__tiltaksgjennomforing_oppstart.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V59__tiltaksgjennomforing_oppstart.sql
@@ -1,12 +1,12 @@
-create type tiltaksgjennomforing_oppstartstype as enum ('Felles', 'Lopende');
+create type tiltaksgjennomforing_oppstartstype as enum ('FELLES', 'LOPENDE');
 
 alter table tiltaksgjennomforing
     add oppstart tiltaksgjennomforing_oppstartstype;
 
 update tiltaksgjennomforing tg
 set oppstart = case
-                   when tt.tiltakskode in ('GRUPPEAMO', 'JOBBK', 'GRUFAGYRKE') then 'Felles'
-                   else 'Lopende' end::tiltaksgjennomforing_oppstartstype
+                   when tt.tiltakskode in ('GRUPPEAMO', 'JOBBK', 'GRUFAGYRKE') then 'FELLES'
+                   else 'LOPENDE' end::tiltaksgjennomforing_oppstartstype
 from tiltakstype tt
 where tt.id = tg.tiltakstype_id;
 

--- a/mulighetsrommet-api/src/main/resources/db/migration/V59__tiltaksgjennomforing_oppstart.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V59__tiltaksgjennomforing_oppstart.sql
@@ -1,12 +1,12 @@
-create type tiltaksgjennomforing_oppstart as enum ('Dato', 'Lopende');
+create type tiltaksgjennomforing_oppstartstype as enum ('Felles', 'Lopende');
 
 alter table tiltaksgjennomforing
-    add oppstart tiltaksgjennomforing_oppstart;
+    add oppstart tiltaksgjennomforing_oppstartstype;
 
 update tiltaksgjennomforing tg
 set oppstart = case
-                   when tt.tiltakskode in ('GRUPPEAMO', 'JOBBK', 'GRUFAGYRKE') then 'Dato'
-                   else 'Lopende' end::tiltaksgjennomforing_oppstart
+                   when tt.tiltakskode in ('GRUPPEAMO', 'JOBBK', 'GRUFAGYRKE') then 'Felles'
+                   else 'Lopende' end::tiltaksgjennomforing_oppstartstype
 from tiltakstype tt
 where tt.id = tg.tiltakstype_id;
 

--- a/mulighetsrommet-api/src/main/resources/web/openapi-external.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi-external.yaml
@@ -205,12 +205,16 @@ components:
           $ref: "#/components/schemas/TiltaksgjennomforingStatus"
         virksomhetsnummer:
           type: string
+        oppstart:
+          $ref: "#/components/schemas/TiltaksgjennomforingOppstartstype"
       required:
         - id
         - tiltakstype
         - navn
+        - startDato
         - status
         - virksomhetsnummer
+        - oppstart
 
     TiltaksgjennomforingStatus:
       type: string
@@ -220,6 +224,12 @@ components:
         - AVLYST
         - AVSLUTTET
         - APENT_FOR_INNSOK
+
+    TiltaksgjennomforingOppstartstype:
+      type: string
+      enum:
+        - LOPENDE
+        - FELLES
 
     TiltaksgjennomforingIdResponse:
       type: object

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1225,6 +1225,8 @@ components:
           type: array
           items:
             type: string
+        oppstart:
+          $ref: "#/components/schemas/TiltaksgjennomforingOppstartstype"
       required:
         - id
         - avtaleId
@@ -1236,6 +1238,7 @@ components:
         - virksomhetsnummer
         - ansvarlig
         - navEnheter
+        - oppstart
 
     TiltaksgjennomforingAvslutningsstatus:
       type: string

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1257,8 +1257,8 @@ components:
     TiltaksgjennomforingOppstartstype:
       type: string
       enum:
-        - Lopende
-        - Felles
+        - LOPENDE
+        - FELLES
 
     Bruker:
       type: object

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -983,7 +983,7 @@ components:
           type: string
           format: date
         navRegion:
-          $ref: "#/components/schemas/AvtaleNavEnhet"
+          $ref: "#/components/schemas/EmbeddedNavEnhet"
         avtaletype:
           $ref: "#/components/schemas/Avtaletype"
         avtalestatus:
@@ -1175,13 +1175,7 @@ components:
         navEnheter:
           type: array
           items:
-            type: object
-            properties:
-              enhetsnummer:
-                type: string
-              navn:
-                type: string
-                nullable: true
+            $ref: "#/components/schemas/EmbeddedNavEnhet"
         ansvarlig:
           type: string
         antallPlasser:
@@ -1489,13 +1483,16 @@ components:
       required:
         - organisasjonsnummer
 
-    AvtaleNavEnhet:
+    EmbeddedNavEnhet:
       type: object
       properties:
         navn:
           type: string
         enhetsnummer:
           type: string
+      required:
+        - navn
+        - enhetsnummer
 
     SanityInnsatsgruppe:
       type: object

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1183,6 +1183,8 @@ components:
         avtaleId:
           type: string
           format: uuid
+        oppstart:
+          $ref: "#/components/schemas/TiltaksgjennomforingOppstartstype"
       required:
         - id
         - tiltakstype
@@ -1251,6 +1253,12 @@ components:
         - AVLYST
         - AVSLUTTET
         - APENT_FOR_INNSOK
+
+    TiltaksgjennomforingOppstartstype:
+      type: string
+      enum:
+        - Lopende
+        - Felles
 
     Bruker:
       type: object

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -22,7 +22,7 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = Oppstartstype.Felles,
+        oppstart = Oppstartstype.FELLES,
     )
 
     val Oppfolging2 = TiltaksgjennomforingDbo(
@@ -39,7 +39,7 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = Oppstartstype.Felles,
+        oppstart = Oppstartstype.FELLES,
     )
 
     val Arbeidstrening1 = TiltaksgjennomforingDbo(
@@ -56,6 +56,6 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = Oppstartstype.Felles,
+        oppstart = Oppstartstype.FELLES,
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -22,7 +22,7 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = Oppstartstype.Dato,
+        oppstart = Oppstartstype.Felles,
     )
 
     val Oppfolging2 = TiltaksgjennomforingDbo(
@@ -39,7 +39,7 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = Oppstartstype.Dato,
+        oppstart = Oppstartstype.Felles,
     )
 
     val Arbeidstrening1 = TiltaksgjennomforingDbo(
@@ -56,6 +56,6 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = Oppstartstype.Dato,
+        oppstart = Oppstartstype.Felles,
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.fixtures
 
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Tilgjengelighetsstatus
 import java.time.LocalDate
 import java.util.*
@@ -21,6 +22,7 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
+        oppstart = Oppstartstype.Dato,
     )
 
     val Oppfolging2 = TiltaksgjennomforingDbo(
@@ -37,6 +39,7 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
+        oppstart = Oppstartstype.Dato,
     )
 
     val Arbeidstrening1 = TiltaksgjennomforingDbo(
@@ -53,5 +56,6 @@ object TiltaksgjennomforingFixtures {
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
+        oppstart = Oppstartstype.Dato,
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -86,6 +86,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 ansvarlige = emptyList(),
                 navEnheter = emptyList(),
                 sanityId = null,
+                oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
             )
 
             tiltaksgjennomforinger.delete(gjennomforing1.id)
@@ -541,6 +542,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                         antallPlasser = null,
                         ansvarlige = emptyList(),
                         navEnheter = emptyList(),
+                        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
                     ),
                 )
             }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -86,7 +86,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 ansvarlige = emptyList(),
                 navEnheter = emptyList(),
                 sanityId = null,
-                oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
+                oppstart = TiltaksgjennomforingDbo.Oppstartstype.FELLES,
             )
 
             tiltaksgjennomforinger.delete(gjennomforing1.id)
@@ -533,7 +533,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                         antallPlasser = null,
                         ansvarlige = emptyList(),
                         navEnheter = emptyList(),
-                        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
+                        oppstart = TiltaksgjennomforingDbo.Oppstartstype.FELLES,
                     ),
                 )
             }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -86,7 +86,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 ansvarlige = emptyList(),
                 navEnheter = emptyList(),
                 sanityId = null,
-                oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
+                oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
             )
 
             tiltaksgjennomforinger.delete(gjennomforing1.id)
@@ -533,7 +533,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                         antallPlasser = null,
                         ansvarlige = emptyList(),
                         navEnheter = emptyList(),
-                        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
+                        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
                     ),
                 )
             }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -130,22 +130,18 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
 
             tiltaksgjennomforinger.upsert(gjennomforing).shouldBeRight()
             tiltaksgjennomforinger.get(gjennomforing.id).shouldBeRight().should {
-                it!!.navEnheter.shouldContainExactlyInAnyOrder(
-                    listOf(
-                        NavEnhet(enhetsnummer = "1", navn = null),
-                        NavEnhet(enhetsnummer = "2", navn = null),
-                    ),
+                it!!.navEnheter shouldContainExactlyInAnyOrder listOf(
+                    NavEnhet(enhetsnummer = "1", navn = "Navn1"),
+                    NavEnhet(enhetsnummer = "2", navn = "Navn2"),
                 )
             }
             database.assertThat("tiltaksgjennomforing_nav_enhet").hasNumberOfRows(2)
 
             tiltaksgjennomforinger.upsert(gjennomforing.copy(navEnheter = listOf("3", "1"))).shouldBeRight()
             tiltaksgjennomforinger.get(gjennomforing.id).shouldBeRight().should {
-                it!!.navEnheter.shouldContainExactlyInAnyOrder(
-                    listOf(
-                        NavEnhet(enhetsnummer = "1", navn = null),
-                        NavEnhet(enhetsnummer = "3", navn = null),
-                    ),
+                it!!.navEnheter shouldContainExactlyInAnyOrder listOf(
+                    NavEnhet(enhetsnummer = "1", navn = "Navn1"),
+                    NavEnhet(enhetsnummer = "3", navn = "Navn3"),
                 )
             }
             database.assertThat("tiltaksgjennomforing_nav_enhet").hasNumberOfRows(2)
@@ -181,18 +177,16 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             }
             tiltaksgjennomforinger.updateEnheter("1", listOf("1", "2")).shouldBeRight()
             tiltaksgjennomforinger.get(gjennomforing.id).shouldBeRight().should {
-                it!!.navEnheter.shouldContainExactlyInAnyOrder(
-                    listOf(
-                        NavEnhet(enhetsnummer = "1", navn = null),
-                        NavEnhet(enhetsnummer = "2", navn = null),
-                    ),
+                it!!.navEnheter shouldContainExactlyInAnyOrder listOf(
+                    NavEnhet(enhetsnummer = "1", navn = "Navn1"),
+                    NavEnhet(enhetsnummer = "2", navn = "Navn2"),
                 )
             }
             database.assertThat("tiltaksgjennomforing_nav_enhet").hasNumberOfRows(2)
 
             tiltaksgjennomforinger.updateEnheter("1", listOf("2")).shouldBeRight()
             tiltaksgjennomforinger.get(gjennomforing.id).shouldBeRight().should {
-                it!!.navEnheter.shouldContainExactlyInAnyOrder(listOf(NavEnhet(enhetsnummer = "2", navn = null)))
+                it!!.navEnheter.shouldContainExactlyInAnyOrder(listOf(NavEnhet(enhetsnummer = "2", navn = "Navn2")))
             }
             database.assertThat("tiltaksgjennomforing_nav_enhet").hasNumberOfRows(1)
         }
@@ -218,13 +212,10 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             tiltaksgjennomforinger.upsert(gjennomforing2.copy(id = UUID.randomUUID(), avtaleId = avtale2.id))
                 .shouldBeRight()
 
-            val result =
-                tiltaksgjennomforinger.getAll(
-                    filter = AdminTiltaksgjennomforingFilter(
-                        avtaleId = avtale1.id,
-                    ),
-                )
-                    .shouldBeRight().second
+            val result = tiltaksgjennomforinger.getAll(
+                filter = AdminTiltaksgjennomforingFilter(avtaleId = avtale1.id),
+            )
+                .shouldBeRight().second
             result shouldHaveSize 1
             result.first().id shouldBe gjennomforing2.id
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
@@ -71,6 +71,7 @@ class ArenaAdapterServiceTest : FunSpec({
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
+        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
     )
 
     val tiltakshistorikkGruppe = TiltakshistorikkDbo.Gruppetiltak(
@@ -124,6 +125,7 @@ class ArenaAdapterServiceTest : FunSpec({
             ansvarlige = emptyList(),
             navEnheter = emptyList(),
             sanityId = null,
+            oppstart = oppstart,
         )
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
@@ -71,7 +71,7 @@ class ArenaAdapterServiceTest : FunSpec({
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
+        oppstart = TiltaksgjennomforingDbo.Oppstartstype.FELLES,
     )
 
     val tiltakshistorikkGruppe = TiltakshistorikkDbo.Gruppetiltak(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
@@ -71,7 +71,7 @@ class ArenaAdapterServiceTest : FunSpec({
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
+        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
     )
 
     val tiltakshistorikkGruppe = TiltakshistorikkDbo.Gruppetiltak(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
@@ -62,6 +62,7 @@ class KafkaSyncServiceTest : FunSpec({
             antallPlasser = null,
             ansvarlige = emptyList(),
             navEnheter = emptyList(),
+            oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
         )
     }
 
@@ -78,6 +79,7 @@ class KafkaSyncServiceTest : FunSpec({
             startDato = startDato,
             sluttDato = sluttDato,
             status = tiltaksgjennomforingsstatus,
+            oppstart = oppstart,
         )
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
@@ -62,7 +62,7 @@ class KafkaSyncServiceTest : FunSpec({
             antallPlasser = null,
             ansvarlige = emptyList(),
             navEnheter = emptyList(),
-            oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
+            oppstart = TiltaksgjennomforingDbo.Oppstartstype.FELLES,
         )
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
@@ -62,7 +62,7 @@ class KafkaSyncServiceTest : FunSpec({
             antallPlasser = null,
             ansvarlige = emptyList(),
             navEnheter = emptyList(),
-            oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
+            oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
         )
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
@@ -44,6 +44,7 @@ class TiltakshistorikkServiceTest : FunSpec({
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
+        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
     )
 
     val tiltakshistorikkGruppe = TiltakshistorikkDbo.Gruppetiltak(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
@@ -44,7 +44,7 @@ class TiltakshistorikkServiceTest : FunSpec({
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Dato,
+        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
     )
 
     val tiltakshistorikkGruppe = TiltakshistorikkDbo.Gruppetiltak(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
@@ -44,7 +44,7 @@ class TiltakshistorikkServiceTest : FunSpec({
         antallPlasser = null,
         ansvarlige = emptyList(),
         navEnheter = emptyList(),
-        oppstart = TiltaksgjennomforingDbo.Oppstartstype.Felles,
+        oppstart = TiltaksgjennomforingDbo.Oppstartstype.FELLES,
     )
 
     val tiltakshistorikkGruppe = TiltakshistorikkDbo.Gruppetiltak(

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessor.kt
@@ -26,7 +26,7 @@ import no.nav.mulighetsrommet.domain.Tiltakskoder.hasFellesOppstart
 import no.nav.mulighetsrommet.domain.Tiltakskoder.isGruppetiltak
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype.Dato
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype.Felles
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype.Lopende
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Tilgjengelighetsstatus.Ledig
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Tilgjengelighetsstatus.Stengt
@@ -169,6 +169,6 @@ class TiltakgjennomforingEventProcessor(
             avtaleId = avtaleId,
             ansvarlige = emptyList(),
             navEnheter = emptyList(),
-            oppstart = if (hasFellesOppstart(tiltakskode)) Dato else Lopende,
+            oppstart = if (hasFellesOppstart(tiltakskode)) Felles else Lopende,
         )
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessor.kt
@@ -26,8 +26,8 @@ import no.nav.mulighetsrommet.domain.Tiltakskoder.hasFellesOppstart
 import no.nav.mulighetsrommet.domain.Tiltakskoder.isGruppetiltak
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype.Felles
-import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype.Lopende
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype.FELLES
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype.LOPENDE
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Tilgjengelighetsstatus.Ledig
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Tilgjengelighetsstatus.Stengt
 import java.util.*
@@ -169,6 +169,6 @@ class TiltakgjennomforingEventProcessor(
             avtaleId = avtaleId,
             ansvarlige = emptyList(),
             navEnheter = emptyList(),
-            oppstart = if (hasFellesOppstart(tiltakskode)) Felles else Lopende,
+            oppstart = if (hasFellesOppstart(tiltakskode)) FELLES else LOPENDE,
         )
 }


### PR DESCRIPTION
Har introdusert en ny property `oppstart` på tiltaksgjennomføring-modellen tilsvarende feltet med samme navn i sanity-modellen for tiltaksgjennomføringer.
Dette er enum med verdiene `Dato` eller `Lopende`, men selv synes jeg dette er litt rar navngiving da det strengt tatt er en startdato for gjennomføringer med løpende oppstart for deltakere også. `Felles` eller `Lopende` oppstart kunne kanskje vært et alternativ.

I tillegg har jeg introdusert noen enkle utility-klasser for å gjøre det litt lettere å integrere arrow's `Either` med ktor routes. 