### PR TITLE
Feature/notification done at

### DIFF
--- a/frontend/mr-admin-flate/src/api/notifikasjoner/useNotifikasjonerForAnsatt.ts
+++ b/frontend/mr-admin-flate/src/api/notifikasjoner/useNotifikasjonerForAnsatt.ts
@@ -1,9 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { mulighetsrommetClient } from "../clients";
 import { QueryKeys } from "../QueryKeys";
-import { Notifikasjonsstatus } from "mulighetsrommet-api-client";
+import { NotificationStatus } from "mulighetsrommet-api-client";
 
-export function useNotifikasjonerForAnsatt(status: Notifikasjonsstatus) {
+export function useNotifikasjonerForAnsatt(status: NotificationStatus) {
   return useQuery(QueryKeys.ansatt, () =>
     mulighetsrommetClient.notifications.getNotifications({ status })
   );

--- a/frontend/mr-admin-flate/src/api/notifikasjoner/useSetNotificationStatus.ts
+++ b/frontend/mr-admin-flate/src/api/notifikasjoner/useSetNotificationStatus.ts
@@ -1,0 +1,23 @@
+import { mulighetsrommetClient } from "../clients";
+import { NotificationStatus } from "mulighetsrommet-api-client";
+import { useMutation } from "@tanstack/react-query";
+import { useNotificationSummary } from "./useNotificationSummary";
+
+export interface SetNotificationStatusParams {
+  status: NotificationStatus;
+}
+
+export function useSetNotificationStatus(id: string) {
+  const { refetch: refetchNotificationSummary } = useNotificationSummary();
+
+  return useMutation(
+    async ({ status }: SetNotificationStatusParams): Promise<void> => {
+      await mulighetsrommetClient.notifications.setNotificationStatus({
+        id,
+        requestBody: { status },
+      });
+
+      await refetchNotificationSummary();
+    }
+  );
+}

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/BrukerNotifikasjoner.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/BrukerNotifikasjoner.tsx
@@ -9,7 +9,7 @@ export function BrukerNotifikasjoner() {
   const { data: features } = useFeatureToggles();
   const { data: bruker } = useHentAnsatt();
   const { data: notificationSummary } = useNotificationSummary();
-  const antallUlesteNotifikasjoner = notificationSummary?.unreadCount || -1;
+  const antallUlesteNotifikasjoner = notificationSummary?.notDoneCount || -1;
 
   if (!features?.["mulighetsrommet.admin-flate-se-notifikasjoner"]) return null;
 

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/CheckmarkButton.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/CheckmarkButton.tsx
@@ -1,8 +1,10 @@
+import { Dispatch, SetStateAction } from "react";
 import {
   CheckmarkCircleFillIcon,
   CheckmarkCircleIcon,
 } from "@navikt/aksel-icons";
 import { mulighetsrommetClient } from "../../api/clients";
+import { NotificationStatus } from "mulighetsrommet-api-client";
 import classNames from "classnames";
 import styles from "./CheckmarkButton.module.scss";
 import { useNotificationSummary } from "../../api/notifikasjoner/useNotificationSummary";
@@ -10,41 +12,37 @@ import { useNotificationSummary } from "../../api/notifikasjoner/useNotification
 interface Props {
   id: string;
   read: boolean;
-  setRead: React.Dispatch<React.SetStateAction<boolean>>;
+  setRead: Dispatch<SetStateAction<boolean>>;
 }
 
 export function CheckmarkButton({ id, read, setRead }: Props) {
   const { refetch } = useNotificationSummary();
-  const markUnread = async () => {
+
+  const setStatus = async (status: NotificationStatus) => {
     try {
-      await mulighetsrommetClient.notifications.markAsUnread({ id });
+      await mulighetsrommetClient.notifications.setNotificationStatus({
+        id,
+        requestBody: { status },
+      });
       await refetch();
     } catch (e) {
       return;
     }
-    setRead(false);
+
+    setRead(status === NotificationStatus.DONE);
   };
 
-  const markRead = async () => {
-    try {
-      await mulighetsrommetClient.notifications.markAsRead({ id });
-      await refetch();
-    } catch (e) {
-      return;
-    }
-    setRead(true);
-  };
 
   return read ? (
     <CheckmarkCircleFillIcon
       fontSize={"1.5rem"}
-      onClick={markUnread}
+      onClick={() => setStatus(NotificationStatus.NOT_DONE)}
       className={classNames(styles.button, styles.greenFill)}
     />
   ) : (
     <CheckmarkCircleIcon
       fontSize={"1.5rem"}
-      onClick={markRead}
+      onClick={() => setStatus(NotificationStatus.DONE)}
       className={styles.button}
     />
   );

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/CheckmarkButton.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/CheckmarkButton.tsx
@@ -3,11 +3,10 @@ import {
   CheckmarkCircleFillIcon,
   CheckmarkCircleIcon,
 } from "@navikt/aksel-icons";
-import { mulighetsrommetClient } from "../../api/clients";
 import { NotificationStatus } from "mulighetsrommet-api-client";
 import classNames from "classnames";
 import styles from "./CheckmarkButton.module.scss";
-import { useNotificationSummary } from "../../api/notifikasjoner/useNotificationSummary";
+import { useSetNotificationStatus } from "../../api/notifikasjoner/useSetNotificationStatus";
 
 interface Props {
   id: string;
@@ -16,22 +15,13 @@ interface Props {
 }
 
 export function CheckmarkButton({ id, read, setRead }: Props) {
-  const { refetch } = useNotificationSummary();
+  // TODO handle error/loading states
+  const { mutate } = useSetNotificationStatus(id);
 
   const setStatus = async (status: NotificationStatus) => {
-    try {
-      await mulighetsrommetClient.notifications.setNotificationStatus({
-        id,
-        requestBody: { status },
-      });
-      await refetch();
-    } catch (e) {
-      return;
-    }
-
+    mutate({ status });
     setRead(status === NotificationStatus.DONE);
   };
-
 
   return read ? (
     <CheckmarkCircleFillIcon

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsbjelle.tsx
@@ -10,16 +10,14 @@ function Notifier() {
 
 export function Notifikasjonsbjelle() {
   const { data: features } = useFeatureToggles();
-  const {
-    data: antallUlesteNotifikasjoner,
-    isLoading: isLoadingUlesteNotifikasjoner,
-  } = useNotificationSummary();
+  const { data: summary, isLoading: isLoadingUlesteNotifikasjoner } =
+    useNotificationSummary();
 
-  if (isLoadingUlesteNotifikasjoner && !antallUlesteNotifikasjoner) {
+  if (isLoadingUlesteNotifikasjoner || !summary) {
     return null;
   }
 
-  const harUlesteNotifikasjoner = antallUlesteNotifikasjoner?.unreadCount || -1;
+  const harUlesteNotifikasjoner = summary.notDoneCount > 0;
 
   return features?.["mulighetsrommet.admin-flate-se-notifikasjoner"] ? (
     <Link
@@ -28,7 +26,7 @@ export function Notifikasjonsbjelle() {
       data-testid="notifikasjonsbjelle"
     >
       <div className={styles.bell_container}>
-        {harUlesteNotifikasjoner > 0 ? <Notifier /> : null}
+        {harUlesteNotifikasjoner ? <Notifier /> : null}
         <BellIcon fontSize={24} title="Notifikasjonsbjelle" />
       </div>
     </Link>

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsliste.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsliste.tsx
@@ -1,7 +1,7 @@
 import { useFeatureToggles } from "../../api/features/feature-toggles";
 import { useNotifikasjonerForAnsatt } from "../../api/notifikasjoner/useNotifikasjonerForAnsatt";
 import { Laster } from "../laster/Laster";
-import { Notifikasjonsstatus } from "mulighetsrommet-api-client";
+import { NotificationStatus } from "mulighetsrommet-api-client";
 import { EmptyState } from "./EmptyState";
 import styles from "./Notifikasjoner.module.scss";
 import { Notifikasjonssrad } from "./Notifikasjonsrad";
@@ -13,7 +13,7 @@ interface Props {
 export function Notifikasjonsliste({ lest }: Props) {
   const { data: features } = useFeatureToggles();
   const { isLoading, data: paginertResultat } = useNotifikasjonerForAnsatt(
-    lest ? Notifikasjonsstatus.READ : Notifikasjonsstatus.UNREAD
+    lest ? NotificationStatus.DONE : NotificationStatus.NOT_DONE
   );
 
   if (isLoading && !paginertResultat) {

--- a/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
+++ b/frontend/mr-admin-flate/src/mocks/apiHandlers.ts
@@ -259,6 +259,11 @@ export const apiHandlers = [
       return res(ctx.status(200), ctx.json(mockUserNotificationSummary));
     }
   ),
+  rest.post<any, any, any>( "*/api/v1/internal/notifications/:id/status",
+    (req, res, ctx) => {
+      return res(ctx.status(200));
+    }
+  ),
 
   rest.get<any, any, Virksomhet[]>(
     "*/api/v1/internal/virksomhet/sok/:sok",

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_notifikasjoner.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_notifikasjoner.ts
@@ -19,7 +19,7 @@ export const mockNotifikasjoner: PaginertUserNotifications = {
         "Beskrivelse med en ganske lang tekst fordi vi har så komplekse prosesser så det viktig at det blir gitt nøyaktig beskjed om hva som skal til for å løse denne vanskelige problemstillingen.",
       user: "B99876",
       createdAt: "2023-01-26T13:51:50.417-07:00",
-      readAt: "2023-01-26T13:51:50.417-07:00",
+      doneAt: "2023-01-26T13:51:50.417-07:00",
     },
     {
       id: "eccd9a93-3f08-4006-b3cb-751762e8bccf",
@@ -30,7 +30,7 @@ export const mockNotifikasjoner: PaginertUserNotifications = {
         "Beskrivelsen her er ikke så lang som den forrige, men sånn er det av og til.",
       user: "B99876",
       createdAt: "2023-01-26T13:51:50.417-07:00",
-      readAt: "2023-01-26T13:51:50.417-07:00",
+      doneAt: "2023-01-26T13:51:50.417-07:00",
     },
   ],
 };

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_notifikasjoner.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_notifikasjoner.ts
@@ -1,6 +1,6 @@
 import {
+  NotificationType,
   PaginertUserNotifications,
-  UserNotification,
 } from "mulighetsrommet-api-client";
 
 export const mockNotifikasjoner: PaginertUserNotifications = {
@@ -12,7 +12,7 @@ export const mockNotifikasjoner: PaginertUserNotifications = {
   data: [
     {
       id: "d65c2be1-980d-4782-a51f-0ad9b52c3fda",
-      type: UserNotification.type.NOTIFICATION,
+      type: NotificationType.NOTIFICATION,
       title:
         "Avtalen Oppfølging, tjenesteområde F - Moss utløper den 30.06.2023",
       description:
@@ -23,7 +23,7 @@ export const mockNotifikasjoner: PaginertUserNotifications = {
     },
     {
       id: "eccd9a93-3f08-4006-b3cb-751762e8bccf",
-      type: UserNotification.type.NOTIFICATION,
+      type: NotificationType.NOTIFICATION,
       title:
         "Avtalen Oppfølging, tjenesteområde E - Moss utløper den 31.07.2023",
       description:

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_userNotificationSummary.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_userNotificationSummary.ts
@@ -1,5 +1,5 @@
 import { UserNotificationSummary } from "mulighetsrommet-api-client";
 
 export const mockUserNotificationSummary: UserNotificationSummary = {
-  unreadCount: 10,
+  notDoneCount: 10,
 };

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/NotificationRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/NotificationRoutes.kt
@@ -2,13 +2,16 @@ package no.nav.mulighetsrommet.api.routes.v1
 
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
+import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.plugins.getNavIdent
 import no.nav.mulighetsrommet.api.routes.v1.responses.PaginatedResponse
 import no.nav.mulighetsrommet.api.utils.getNotificationFilter
 import no.nav.mulighetsrommet.notifications.NotificationService
+import no.nav.mulighetsrommet.notifications.NotificationStatus
 import org.koin.ktor.ext.inject
 import java.util.*
 
@@ -33,22 +36,19 @@ fun Route.notificationRoutes() {
             call.respond(summary)
         }
 
-        post("{id}/read") {
+        post("{id}/status") {
             val id = call.parameters.getOrFail<UUID>("id")
             val userId = getNavIdent()
+            val body = call.receive<SetNotificationStatusRequest>()
 
-            notificationService.markNotificationAsRead(id, userId)
-
-            call.respond(HttpStatusCode.OK)
-        }
-
-        post("{id}/unread") {
-            val id = call.parameters.getOrFail<UUID>("id")
-            val userId = getNavIdent()
-
-            notificationService.markNotificationAsUnread(id, userId)
+            notificationService.setNotificationStatus(id, userId, body.status)
 
             call.respond(HttpStatusCode.OK)
         }
     }
 }
+
+@Serializable
+data class SetNotificationStatusRequest(
+    val status: NotificationStatus,
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/NotifySluttdatoForGjennomforingerNarmerSeg.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/NotifySluttdatoForGjennomforingerNarmerSeg.kt
@@ -62,7 +62,7 @@ class NotifySluttdatoForGjennomforingerNarmerSeg(
                         logger.info("Fant ingen ansvarlige for gjennomføring med id: ${it.id}")
                     } else {
                         val notification = ScheduledNotification(
-                            type = NotificationType.Task,
+                            type = NotificationType.TASK,
                             title = "Gjennomføringen \"${it.navn}\" utløper ${
                                 it.sluttDato?.format(
                                     DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -8,6 +8,7 @@ import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dto.Avtalestatus
 import no.nav.mulighetsrommet.domain.dto.Tiltaksgjennomforingsstatus
 import no.nav.mulighetsrommet.domain.dto.Tiltakstypestatus
+import no.nav.mulighetsrommet.notifications.NotificationStatus
 import no.nav.mulighetsrommet.utils.toUUID
 import java.time.LocalDate
 import java.util.*
@@ -58,10 +59,6 @@ data class TiltaksgjennomforingFilter(
 data class NotificationFilter(
     val status: NotificationStatus? = null,
 )
-
-enum class NotificationStatus {
-    Unread, Read
-}
 
 enum class Tiltakstypekategori {
     INDIVIDUELL, GRUPPE

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/Notification.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/Notification.kt
@@ -8,10 +8,14 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.util.*
 
-@Serializable
 enum class NotificationType {
     Notification,
     Task,
+}
+
+enum class NotificationStatus {
+    DONE,
+    NOT_DONE,
 }
 
 /**
@@ -43,10 +47,10 @@ data class UserNotification(
     @Serializable(with = LocalDateTimeSerializer::class)
     val createdAt: LocalDateTime,
     @Serializable(with = LocalDateTimeSerializer::class)
-    val readAt: LocalDateTime?,
+    val doneAt: LocalDateTime?,
 )
 
 @Serializable
 data class UserNotificationSummary(
-    val unreadCount: Int,
+    val notDoneCount: Int,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/Notification.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/Notification.kt
@@ -9,8 +9,8 @@ import java.time.LocalDateTime
 import java.util.*
 
 enum class NotificationType {
-    Notification,
-    Task,
+    NOTIFICATION,
+    TASK,
 }
 
 enum class NotificationStatus {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepository.kt
@@ -65,9 +65,15 @@ class NotificationRepository(private val db: Database) {
 
         @Language("PostgreSQL")
         val query = """
-            update user_notification
+            with matched_notification as (select *
+                                          from notification n
+                                               join user_notification un on n.id = un.notification_id
+                                              and notification_id = :notification_id
+                                              and user_id = :user_id)
+            update user_notification un
             set done_at = :done_at
-            where notification_id = :notification_id and user_id = :user_id
+            from matched_notification mn
+            where un.notification_id = mn.id and (un.user_id = :user_id or mn.type = 'Task')
         """.trimIndent()
 
         queryOf(query, mapOf("notification_id" to id, "user_id" to userId, "done_at" to doneAt))

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepository.kt
@@ -73,7 +73,7 @@ class NotificationRepository(private val db: Database) {
             update user_notification un
             set done_at = :done_at
             from matched_notification mn
-            where un.notification_id = mn.id and (un.user_id = :user_id or mn.type = 'Task')
+            where un.notification_id = mn.id and (un.user_id = :user_id or mn.type = 'TASK')
         """.trimIndent()
 
         queryOf(query, mapOf("notification_id" to id, "user_id" to userId, "done_at" to doneAt))

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/NotificationService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/notifications/NotificationService.kt
@@ -7,7 +7,6 @@ import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask
 import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import io.ktor.http.HttpStatusCode.Companion.BadRequest
 import io.ktor.http.HttpStatusCode.Companion.InternalServerError
-import io.ktor.server.plugins.*
 import no.nav.mulighetsrommet.api.utils.NotificationFilter
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.getOrThrow

--- a/mulighetsrommet-api/src/main/resources/db/migration/V60__notification_done_at.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V60__notification_done_at.sql
@@ -1,2 +1,5 @@
 alter table user_notification
     rename read_at to done_at;
+
+alter type notification_type rename value 'Task' to 'TASK';
+alter type notification_type rename value 'Notification' to 'NOTIFICATION';

--- a/mulighetsrommet-api/src/main/resources/db/migration/V60__notification_done_at.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V60__notification_done_at.sql
@@ -1,0 +1,2 @@
+alter table user_notification
+    rename read_at to done_at;

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -805,7 +805,7 @@ paths:
         - in: query
           name: status
           schema:
-            $ref: "#/components/schemas/Notifikasjonsstatus"
+            $ref: "#/components/schemas/NotificationStatus"
           description: Status for notifikasjon
       responses:
         200:
@@ -828,24 +828,24 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserNotificationSummary"
 
-  /api/v1/internal/notifications/{id}/read:
+  /api/v1/internal/notifications/{id}/status:
     parameters:
       - $ref: "#/components/parameters/ID"
     post:
       tags:
         - Notifications
-      operationId: markAsRead
-      responses:
-        200:
-          description: OK
-
-  /api/v1/internal/notifications/{id}/unread:
-    parameters:
-      - $ref: "#/components/parameters/ID"
-    post:
-      tags:
-        - Notifications
-      operationId: markAsUnread
+      operationId: setNotificationStatus
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  $ref: "#/components/schemas/NotificationStatus"
+              required:
+                - status
+        required: true
       responses:
         200:
           description: OK
@@ -1116,11 +1116,11 @@ components:
         - Avsluttet
         - Avbrutt
 
-    Notifikasjonsstatus:
+    NotificationStatus:
       type: string
       enum:
-        - Read
-        - Unread
+        - DONE
+        - NOT_DONE
 
     SorteringAvtaler:
       type: string
@@ -1816,7 +1816,7 @@ components:
         createdAt:
           type: string
           format: date-time
-        readAt:
+        doneAt:
           type: string
           format: date-time
       required:
@@ -1826,15 +1826,15 @@ components:
         - description
         - user
         - createdAt
-        - readAt
+        - doneAt
 
     UserNotificationSummary:
       type: object
       properties:
-        unreadCount:
+        notDoneCount:
           type: integer
       required:
-        - unreadCount
+        - notDoneCount
 
     AvtaleForGjennomforingRequest:
       type: object

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1802,10 +1802,7 @@ components:
           type: string
           format: uuid
         type:
-          type: string
-          enum:
-            - Notification
-            - Task
+          $ref: "#/components/schemas/NotificationType"
         title:
           type: string
         description:
@@ -1827,6 +1824,12 @@ components:
         - user
         - createdAt
         - doneAt
+
+    NotificationType:
+      type: string
+      enum:
+        - NOTIFICATION
+        - TASK
 
     UserNotificationSummary:
       type: object

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepositoryTest.kt
@@ -28,14 +28,14 @@ class NotificationRepositoryTest : FunSpec({
 
     val notification1 = ScheduledNotification(
         id = UUID.randomUUID(),
-        type = NotificationType.Notification,
+        type = NotificationType.NOTIFICATION,
         title = "Notifikasjon for flere brukere",
         createdAt = now,
         targets = listOf(user1, user2),
     )
     val notification2 = ScheduledNotification(
         id = UUID.randomUUID(),
-        type = NotificationType.Notification,
+        type = NotificationType.NOTIFICATION,
         title = "Notifikasjon for spesifikk bruker",
         createdAt = now,
         targets = listOf(user1),
@@ -89,7 +89,7 @@ class NotificationRepositoryTest : FunSpec({
         )
     }
 
-    test("should only set done_at for the specific user when the notification type is Notification") {
+    test("should only set done_at for the specific user when the notification type is NOTIFICATION") {
         val doneAtTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0)
         val notifications = NotificationRepository(database.db)
 
@@ -105,11 +105,11 @@ class NotificationRepositoryTest : FunSpec({
         )
     }
 
-    test("should set done_at for all users when the notification type is Task") {
+    test("should set done_at for all users when the notification type is TASK") {
         val doneAtTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0)
         val notifications = NotificationRepository(database.db)
 
-        val task = notification1.copy(type = NotificationType.Task)
+        val task = notification1.copy(type = NotificationType.TASK)
         notifications.insert(task).shouldBeRight()
         notifications.insert(notification2).shouldBeRight()
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepositoryTest.kt
@@ -4,8 +4,6 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
-import no.nav.mulighetsrommet.api.utils.NotificationFilter
-import no.nav.mulighetsrommet.api.utils.NotificationStatus
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import java.time.Instant
 import java.time.LocalDateTime
@@ -43,9 +41,7 @@ class NotificationRepositoryTest : FunSpec({
         targets = listOf(user1),
     )
 
-    val filter = NotificationFilter()
-
-    fun ScheduledNotification.asUserNotification(userId: String, readAt: LocalDateTime? = null) = run {
+    fun ScheduledNotification.asUserNotification(userId: String, doneAt: LocalDateTime? = null) = run {
         UserNotification(
             id = id,
             type = type,
@@ -53,7 +49,7 @@ class NotificationRepositoryTest : FunSpec({
             description = description,
             user = userId,
             createdAt = LocalDateTime.ofInstant(createdAt, ZoneId.systemDefault()),
-            readAt = readAt,
+            doneAt = doneAt,
         )
     }
 
@@ -83,76 +79,74 @@ class NotificationRepositoryTest : FunSpec({
         notifications.insert(notification1).shouldBeRight()
         notifications.insert(notification2).shouldBeRight()
 
-        notifications.getUserNotifications(user1, filter) shouldBeRight listOf(
+        notifications.getUserNotifications(user1) shouldBeRight listOf(
             notification1.asUserNotification(user1),
             notification2.asUserNotification(user1),
         )
 
-        notifications.getUserNotifications(user2, filter) shouldBeRight listOf(
+        notifications.getUserNotifications(user2) shouldBeRight listOf(
             notification1.asUserNotification(user2),
         )
     }
 
     test("set notification status for user") {
-        val readAtTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0)
+        val doneAtTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0)
         val notifications = NotificationRepository(database.db)
 
         notifications.insert(notification1).shouldBeRight()
         notifications.insert(notification2).shouldBeRight()
 
-        notifications.setNotificationReadAt(notification1.id, user1, readAtTime).shouldBeRight()
-        notifications.setNotificationReadAt(notification2.id, user1, readAtTime).shouldBeRight()
-        notifications.setNotificationReadAt(notification1.id, user2, readAtTime).shouldBeRight()
+        notifications.setNotificationDoneAt(notification1.id, user1, doneAtTime).shouldBeRight()
+        notifications.setNotificationDoneAt(notification2.id, user1, doneAtTime).shouldBeRight()
+        notifications.setNotificationDoneAt(notification1.id, user2, doneAtTime).shouldBeRight()
 
-        notifications.getUserNotifications(filter = filter) shouldBeRight listOf(
-            notification1.asUserNotification(user1, readAtTime),
-            notification2.asUserNotification(user1, readAtTime),
-            notification1.asUserNotification(user2, readAtTime),
+        notifications.getUserNotifications() shouldBeRight listOf(
+            notification1.asUserNotification(user1, doneAtTime),
+            notification2.asUserNotification(user1, doneAtTime),
+            notification1.asUserNotification(user2, doneAtTime),
         )
     }
 
     test("filter for notification status") {
-        val readAtTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0)
+        val doneAtTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0)
         val notifications = NotificationRepository(database.db)
-        val readFilter = NotificationFilter(status = NotificationStatus.Read)
-        val unreadFilter = NotificationFilter(status = NotificationStatus.Unread)
 
         notifications.insert(notification1).shouldBeRight()
         notifications.insert(notification2).shouldBeRight()
 
-        notifications.getUserNotifications(user1, unreadFilter) shouldBeRight listOf(
+        notifications.getUserNotifications(user1, NotificationStatus.NOT_DONE) shouldBeRight listOf(
             notification1.asUserNotification(user1),
             notification2.asUserNotification(user1),
         )
 
-        notifications.getUserNotifications(user1, readFilter) shouldBeRight emptyList()
+        notifications.getUserNotifications(user1, NotificationStatus.DONE) shouldBeRight emptyList()
 
-        notifications.setNotificationReadAt(notification2.id, user1, readAtTime)
+        notifications.setNotificationDoneAt(notification2.id, user1, doneAtTime)
             .shouldBeRight(1)
-        notifications.setNotificationReadAt(notification1.id, user1, readAtTime)
+        notifications.setNotificationDoneAt(notification1.id, user1, doneAtTime)
             .shouldBeRight(1)
 
-        notifications.getUserNotifications(user1, unreadFilter) shouldBeRight emptyList()
+        notifications.getUserNotifications(user1, NotificationStatus.NOT_DONE) shouldBeRight emptyList()
 
-        notifications.getUserNotifications(user1, readFilter) shouldBeRight listOf(
-            notification1.asUserNotification(user1, readAtTime),
-            notification2.asUserNotification(user1, readAtTime),
+        notifications.getUserNotifications(user1, NotificationStatus.DONE) shouldBeRight listOf(
+            notification1.asUserNotification(user1, doneAtTime),
+            notification2.asUserNotification(user1, doneAtTime),
         )
     }
 
     test("should not be able to set notification status for another user's notification") {
-        val readAtTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0)
+        val doneAtTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0)
         val notifications = NotificationRepository(database.db)
 
         notifications.insert(notification2).shouldBeRight()
 
-        notifications.setNotificationReadAt(notification2.id, user2, readAtTime)
+        notifications.setNotificationDoneAt(notification2.id, user2, doneAtTime)
             .shouldBeRight(0)
 
-        notifications.getUserNotifications(user1, filter) shouldBeRight listOf(
+        notifications.getUserNotifications(user1) shouldBeRight listOf(
             notification2.asUserNotification(user1, null),
         )
-        notifications.getUserNotifications(user2, filter) shouldBeRight listOf()
+        notifications.getUserNotifications(user2) shouldBeRight listOf()
     }
 
     test("get notification summary for user") {
@@ -162,20 +156,20 @@ class NotificationRepositoryTest : FunSpec({
         notifications.insert(notification2).shouldBeRight()
 
         notifications.getUserNotificationSummary(user1) shouldBeRight UserNotificationSummary(
-            unreadCount = 2,
+            notDoneCount = 2,
         )
         notifications.getUserNotificationSummary(user2) shouldBeRight UserNotificationSummary(
-            unreadCount = 1,
+            notDoneCount = 1,
         )
 
-        notifications.setNotificationReadAt(notification1.id, user1, LocalDateTime.now())
+        notifications.setNotificationDoneAt(notification1.id, user1, LocalDateTime.now())
             .shouldBeRight()
 
         notifications.getUserNotificationSummary(user1) shouldBeRight UserNotificationSummary(
-            unreadCount = 1,
+            notDoneCount = 1,
         )
         notifications.getUserNotificationSummary(user2) shouldBeRight UserNotificationSummary(
-            unreadCount = 1,
+            notDoneCount = 1,
         )
     }
 })

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationServiceTest.kt
@@ -63,7 +63,7 @@ class NotificationServiceTest : FunSpec({
                 description = description,
                 user = user,
                 createdAt = LocalDateTime.ofInstant(createdAt, ZoneOffset.systemDefault()),
-                readAt = null,
+                doneAt = null,
             )
         }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationServiceTest.kt
@@ -49,7 +49,7 @@ class NotificationServiceTest : FunSpec({
 
         val notification = ScheduledNotification(
             id = UUID.randomUUID(),
-            type = NotificationType.Notification,
+            type = NotificationType.NOTIFICATION,
             title = "Notifikasjon for alle brukere",
             createdAt = now,
             targets = listOf(user1, user2),


### PR DESCRIPTION
- Endrer ordlyd fra `read` til `done` for å få det til å passe med type `NOTIFICATION/TASK`
- Endrer `NotificaitonStatus` til å kunne være `DONE/NOT_DONE` i stedet for `READ/UNREAD`
- Det er nå følgende oppførsel når man endrer status på en notifikasjon:
    - Hvis type er `TASK` blir `done_at` satt for alle brukere som tilhører notifikasjonen, uavhengeig av brukeren som markerer notifikasjonen som done/utført
    - Hvis type er `NOTIFICATION` blir `done_at` satt kun for selve brukeren som markerer notikifikasjonen som done/lest