### PR TITLE
Synkroniserer notifikasjonsbjelle med antall uleste meldinger

### DIFF
--- a/frontend/mr-admin-flate/src/api/notifikasjoner/useNotificationSummary.ts
+++ b/frontend/mr-admin-flate/src/api/notifikasjoner/useNotificationSummary.ts
@@ -3,7 +3,11 @@ import { QueryKeys } from "../QueryKeys";
 import { mulighetsrommetClient } from "../clients";
 
 export function useNotificationSummary() {
-  return useQuery(QueryKeys.antallUlesteNotifikasjoner(), () =>
-    mulighetsrommetClient.notifications.getNotificationSummary()
+  return useQuery(
+    QueryKeys.antallUlesteNotifikasjoner(),
+    () => mulighetsrommetClient.notifications.getNotificationSummary(),
+    {
+      refetchInterval: 1000 * 60 * 5, // Hvert 5. minutt
+    }
   );
 }

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/CheckmarkButton.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/CheckmarkButton.tsx
@@ -5,6 +5,7 @@ import {
 import { mulighetsrommetClient } from "../../api/clients";
 import classNames from "classnames";
 import styles from "./CheckmarkButton.module.scss";
+import { useNotificationSummary } from "../../api/notifikasjoner/useNotificationSummary";
 
 interface Props {
   id: string;
@@ -13,18 +14,21 @@ interface Props {
 }
 
 export function CheckmarkButton({ id, read, setRead }: Props) {
-  const markUnread = () => {
+  const { refetch } = useNotificationSummary();
+  const markUnread = async () => {
     try {
-      mulighetsrommetClient.notifications.markAsUnread({ id });
+      await mulighetsrommetClient.notifications.markAsUnread({ id });
+      await refetch();
     } catch (e) {
       return;
     }
     setRead(false);
   };
 
-  const markRead = () => {
+  const markRead = async () => {
     try {
-      mulighetsrommetClient.notifications.markAsRead({ id });
+      await mulighetsrommetClient.notifications.markAsRead({ id });
+      await refetch();
     } catch (e) {
       return;
     }

--- a/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsliste.tsx
+++ b/frontend/mr-admin-flate/src/components/notifikasjoner/Notifikasjonsliste.tsx
@@ -49,13 +49,7 @@ export function Notifikasjonsliste({ lest }: Props) {
   return (
     <ul className={styles.notifikasjonsliste_ul}>
       {data.map((n) => {
-        return (
-          <Notifikasjonssrad
-            lest={lest}
-            key={n.id}
-            notifikasjon={n}
-          ></Notifikasjonssrad>
-        );
+        return <Notifikasjonssrad lest={lest} key={n.id} notifikasjon={n} />;
       })}
     </ul>
   );


### PR DESCRIPTION
Hvert 5. min sjekker vi om det er nye uleste notifikasjoner.
Når man trykker lest/ulest på en notifikasjon så synker vi notifikasjonsbjellen så ikon for uleste forsvinner hvis vi ikke har flere uleste.