### PR TITLE
Ikke lukk opprettelsesskjemaer ved esc

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/OpprettAvtaleModal.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/OpprettAvtaleModal.tsx
@@ -54,6 +54,7 @@ const OpprettAvtaleModal = ({
       {!error && !result && (
         <Modal
           shouldCloseOnOverlayClick={false}
+          shouldCloseOnEsc={false}
           closeButton
           open={modalOpen}
           onClose={clickCancel}

--- a/frontend/mr-admin-flate/src/components/modal/OpprettTiltaksgjennomforingModal.tsx
+++ b/frontend/mr-admin-flate/src/components/modal/OpprettTiltaksgjennomforingModal.tsx
@@ -46,6 +46,7 @@ export const OpprettTiltaksgjennomforingModal = ({
       {!error && !result && (
         <Modal
           shouldCloseOnOverlayClick={false}
+          shouldCloseOnEsc={false}
           closeButton
           open={modalOpen}
           onClose={clickCancel}


### PR DESCRIPTION
Dersom man navigerer inn i feks. datovelger og trykker esc så lukker man hele skjema og alt man har gjort forsvinner. Det er kjipt, så jeg skrur av lukking av modal via escape-tasten.
