### PR TITLE
BUGFIX Filtrer på region og annet felt

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -243,7 +243,7 @@ class AvtaleRepository(private val db: Database) {
             filter.tiltakstypeId to "a.tiltakstype_id = :tiltakstype_id",
             filter.search to "(lower(a.navn) like lower(:search))",
             filter.avtalestatus to filter.avtalestatus?.toDbStatement(),
-            filter.navRegion to "lower(a.nav_region) = lower(:nav_region) or lower(a.arena_ansvarlig_enhet) = lower(:nav_region) or lower(a.arena_ansvarlig_enhet) in (select enhetsnummer from nav_enhet where overordnet_enhet = :nav_region)",
+            filter.navRegion to "(lower(a.nav_region) = lower(:nav_region) or lower(a.arena_ansvarlig_enhet) = lower(:nav_region) or lower(a.arena_ansvarlig_enhet) in (select enhetsnummer from nav_enhet where overordnet_enhet = :nav_region))",
             filter.leverandorOrgnr to "a.leverandor_organisasjonsnummer = :leverandorOrgnr",
         )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -68,6 +68,7 @@ class AvtaleFixtures(private val database: FlywayDatabaseTestListener) {
         navEnheter: List<String> = emptyList(),
         leverandorUnderenheter: List<String> = emptyList(),
         opphav: ArenaMigrering.Opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
+        arenaAnsvarligEnhet: String? = null,
     ): AvtaleDbo {
         return AvtaleDbo(
             id = UUID.randomUUID(),
@@ -78,7 +79,7 @@ class AvtaleFixtures(private val database: FlywayDatabaseTestListener) {
             leverandorUnderenheter = leverandorUnderenheter,
             startDato = startDato,
             sluttDato = sluttDato,
-            arenaAnsvarligEnhet = null,
+            arenaAnsvarligEnhet = arenaAnsvarligEnhet,
             navRegion = navRegion,
             avtaletype = avtaletype,
             avslutningsstatus = avslutningsstatus,


### PR DESCRIPTION
Om bruker filtrerte på region OG et annet filter så viste vi potensielt avtaler som ikke traff 
en AND-spørring, men istedenfor ble til en OR-spørring som gjorde at vi returnerte mer enn vi 
skulle.
