### PR TITLE
Bugfix på filter

### DIFF
--- a/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstyper.ts
+++ b/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstyper.ts
@@ -5,12 +5,8 @@ import { TiltakstypeFilter } from "../atoms";
 import { mulighetsrommetClient } from "../clients";
 import { QueryKeys } from "../QueryKeys";
 
-export function useTiltakstyper(
-  filter: TiltakstypeFilter,
-  page: number,
-) {
+export function useTiltakstyper(filter: TiltakstypeFilter, page: number) {
   const debouncedSok = useDebounce(filter.sok || "", 300);
-
   return useQuery(
     QueryKeys.tiltakstyper(
       debouncedSok,

--- a/frontend/mr-admin-flate/src/components/filter/Avtalefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/Avtalefilter.tsx
@@ -24,6 +24,7 @@ import { resetPaginering } from "../../utils/Utils";
 import OpprettAvtaleModal from "../avtaler/OpprettAvtaleModal";
 import { SokeSelect } from "../skjema/SokeSelect";
 import styles from "./Filter.module.scss";
+import { RESET } from "jotai/vanilla/utils";
 
 type Filters = "tiltakstype";
 
@@ -62,6 +63,11 @@ export function Avtalefilter(props: Props) {
       searchRef?.current?.focus();
     }
   }, [data]);
+
+  useEffect(() => {
+    // Reset filter når vi unmounter
+    return () => setFilter(RESET);
+  }, []);
 
   const regionOptions = () => {
     const alleOptions = { value: "", label: "Alle regioner" };

--- a/frontend/mr-admin-flate/src/components/filter/Tiltaksgjennomforingfilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/Tiltaksgjennomforingfilter.tsx
@@ -7,7 +7,7 @@ import {
   Tiltakstypestatus,
   VirksomhetTil,
 } from "mulighetsrommet-api-client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import {
   Tiltaksgjennomforingfilter as TiltaksgjennomforingAtomFilter,
@@ -27,6 +27,7 @@ import { LeggTilGjennomforingModal } from "../modal/LeggTilGjennomforingModal";
 import { OpprettTiltaksgjennomforingModal } from "../modal/OpprettTiltaksgjennomforingModal";
 import { SokeSelect } from "../skjema/SokeSelect";
 import styles from "./Filter.module.scss";
+import { RESET } from "jotai/vanilla/utils";
 
 type Filters = "tiltakstype";
 
@@ -36,7 +37,7 @@ interface Props {
 }
 
 export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
-  const [sokefilter, setSokefilter] = useAtom(tiltaksgjennomforingfilter);
+  const [filter, setFilter] = useAtom(tiltaksgjennomforingfilter);
   const [, setPage] = useAtom(paginationAtom);
   const { data: enheter } = useAlleEnheter();
   const { data: virksomheter } = useVirksomheter(
@@ -53,10 +54,15 @@ export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
 
   const form = useForm<TiltaksgjennomforingAtomFilter>({
     defaultValues: {
-      ...sokefilter,
+      ...filter,
     },
   });
   const { register } = form;
+
+  useEffect(() => {
+    // Reset filter når vi unmounter
+    return () => setFilter(RESET);
+  }, []);
 
   const features = useFeatureToggles();
   const visOpprettTiltaksgjennomforingKnapp =
@@ -84,9 +90,9 @@ export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
           const erLokalEllerTiltaksenhet =
             enhet.type === Norg2Type.LOKAL || enhet.type === Norg2Type.TILTAK;
           const enheterFraFylke =
-            sokefilter.fylkesenhet === ""
+            filter.fylkesenhet === ""
               ? true
-              : sokefilter.fylkesenhet === enhet.overordnetEnhet;
+              : filter.fylkesenhet === enhet.overordnetEnhet;
           return erLokalEllerTiltaksenhet && enheterFraFylke;
         })
         ?.sort()
@@ -141,10 +147,8 @@ export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
               hideLabel
               size="small"
               variant="simple"
-              onChange={(search: string) =>
-                setSokefilter({ ...sokefilter, search })
-              }
-              value={sokefilter.search}
+              onChange={(search: string) => setFilter({ ...filter, search })}
+              value={filter.search}
               aria-label="Søk etter tiltaksgjennomføring"
               data-testid="filter_sokefelt"
               className={styles.form_field}
@@ -156,8 +160,8 @@ export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
               {...register("fylkesenhet")}
               onChange={(fylkesenhet) => {
                 resetPaginering(setPage);
-                setSokefilter({
-                  ...sokefilter,
+                setFilter({
+                  ...filter,
                   enhet: "",
                   fylkesenhet,
                 });
@@ -173,8 +177,8 @@ export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
               {...register("enhet")}
               onChange={(enhet) => {
                 resetPaginering(setPage);
-                setSokefilter({
-                  ...sokefilter,
+                setFilter({
+                  ...filter,
                   enhet,
                 });
               }}
@@ -189,8 +193,8 @@ export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
                 {...register("tiltakstype")}
                 onChange={(tiltakstype) => {
                   resetPaginering(setPage);
-                  setSokefilter({
-                    ...sokefilter,
+                  setFilter({
+                    ...filter,
                     tiltakstype,
                   });
                 }}
@@ -205,8 +209,8 @@ export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
               {...register("status")}
               onChange={(status) => {
                 resetPaginering(setPage);
-                setSokefilter({
-                  ...sokefilter,
+                setFilter({
+                  ...filter,
                   status,
                 });
               }}
@@ -220,8 +224,8 @@ export function Tiltaksgjennomforingfilter({ skjulFilter, avtale }: Props) {
               {...register("arrangorOrgnr")}
               onChange={(arrangorOrgnr) => {
                 resetPaginering(setPage);
-                setSokefilter({
-                  ...sokefilter,
+                setFilter({
+                  ...filter,
                   arrangorOrgnr,
                 });
               }}

--- a/frontend/mr-admin-flate/src/components/filter/Tiltakstypefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/Tiltakstypefilter.tsx
@@ -1,6 +1,6 @@
 import { Search } from "@navikt/ds-react";
 import { useAtom } from "jotai";
-import { ChangeEvent } from "react";
+import { ChangeEvent, useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import {
   TiltakstypeFilter,
@@ -10,17 +10,23 @@ import {
 import { resetPaginering } from "../../utils/Utils";
 import { SokeSelect } from "../skjema/SokeSelect";
 import styles from "./Filter.module.scss";
+import { RESET } from "jotai/vanilla/utils";
 
 export function Tiltakstypefilter() {
-  const [sokefilter, setSokefilter] = useAtom(tiltakstypeFilter);
+  const [filter, setFilter] = useAtom(tiltakstypeFilter);
   const [, setPage] = useAtom(paginationAtom);
 
   const form = useForm<TiltakstypeFilter>({
     defaultValues: {
-      ...sokefilter,
+      ...filter,
     },
   });
   const { register } = form;
+
+  useEffect(() => {
+    // Reset filter når vi unmounter
+    return () => setFilter(RESET);
+  }, []);
 
   const statusOptions = () => {
     return [
@@ -34,7 +40,7 @@ export function Tiltakstypefilter() {
   const kategoriOptions = () => {
     return [
       { label: "Gruppetiltak", value: "GRUPPE" },
-      { label: "Individuelle tiltak", value: "INDIVIDUELLE" },
+      { label: "Individuelle tiltak", value: "INDIVIDUELL" },
       { label: "Alle", value: "ALLE" },
     ];
   };
@@ -49,8 +55,8 @@ export function Tiltakstypefilter() {
               hideLabel
               variant="simple"
               data-testid="filter_sokefelt"
-              onChange={(sok: string) => setSokefilter({ ...sokefilter, sok })}
-              value={sokefilter.sok}
+              onChange={(sok: string) => setFilter({ ...filter, sok })}
+              value={filter.sok}
               aria-label="Søk etter tiltakstype"
               size="small"
               className={styles.form_field}
@@ -62,11 +68,11 @@ export function Tiltakstypefilter() {
               data-testid="filter_status"
               {...register("status")}
               className={styles.form_field}
-              onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+              onChange={(e) => {
                 resetPaginering(setPage);
-                const status = e.currentTarget.value as any;
-                setSokefilter({
-                  ...sokefilter,
+                const status = e as any;
+                setFilter({
+                  ...filter,
                   status: status === "Alle" ? undefined : status,
                 });
               }}
@@ -79,11 +85,11 @@ export function Tiltakstypefilter() {
               hideLabel
               {...register("kategori")}
               data-testid="filter_kategori"
-              onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+              onChange={(e) => {
                 resetPaginering(setPage);
-                const kategori = e.currentTarget.value as any;
-                setSokefilter({
-                  ...sokefilter,
+                const kategori = e as any;
+                setFilter({
+                  ...filter,
                   kategori: kategori === "ALLE" ? undefined : kategori,
                 });
               }}

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingInfo.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingInfo.tsx
@@ -9,7 +9,10 @@ import { useState } from "react";
 import { useFeatureToggles } from "../../api/features/feature-toggles";
 import { OpprettTiltaksgjennomforingModal } from "../../components/modal/OpprettTiltaksgjennomforingModal";
 import { useAvtale } from "../../api/avtaler/useAvtale";
-import { ExclamationmarkTriangleIcon, ExternalLinkIcon } from "@navikt/aksel-icons";
+import {
+  ExclamationmarkTriangleIcon,
+  ExternalLinkIcon,
+} from "@navikt/aksel-icons";
 
 export function TiltaksgjennomforingInfo() {
   const {
@@ -72,19 +75,35 @@ export function TiltaksgjennomforingInfo() {
             header="Sluttdato"
             verdi={formaterDato(tiltaksgjennomforing.sluttDato)}
           />
-          {Boolean(tiltaksgjennomforing.stengtFra) && Boolean(tiltaksgjennomforing.stengtTil) && new Date(tiltaksgjennomforing.stengtTil!!) > todayDate &&
-            <Metadata
-                header={todayDate >= new Date(tiltaksgjennomforing.stengtFra!!) && todayDate <= new Date(tiltaksgjennomforing.stengtTil!!)
-                  ? (
+          {Boolean(tiltaksgjennomforing.stengtFra) &&
+            Boolean(tiltaksgjennomforing.stengtTil) &&
+            new Date(tiltaksgjennomforing.stengtTil!!) > todayDate && (
+              <Metadata
+                header={
+                  todayDate >= new Date(tiltaksgjennomforing.stengtFra!!) &&
+                  todayDate <= new Date(tiltaksgjennomforing.stengtTil!!) ? (
                     <div style={{ display: "flex", flexDirection: "row" }}>
-                      <ExclamationmarkTriangleIcon style={{ marginRight: "5px" }} title="midlertidig-stengt" />
-                      <Heading size="xsmall" level="2">Midlertidig Stengt</Heading>
+                      <ExclamationmarkTriangleIcon
+                        style={{ marginRight: "5px" }}
+                        title="midlertidig-stengt"
+                      />
+                      <Heading size="xsmall" level="2">
+                        Midlertidig Stengt
+                      </Heading>
                     </div>
-                  ) : (<Heading size="xsmall" level="2">Midlertidig Stengt</Heading>)
+                  ) : (
+                    <Heading size="xsmall" level="2">
+                      Midlertidig Stengt
+                    </Heading>
+                  )
                 }
-                verdi={formaterDato(tiltaksgjennomforing.stengtFra) + " - " + formaterDato(tiltaksgjennomforing.stengtTil)}
-            />
-          }
+                verdi={
+                  formaterDato(tiltaksgjennomforing.stengtFra) +
+                  " - " +
+                  formaterDato(tiltaksgjennomforing.stengtTil)
+                }
+              />
+            )}
         </dl>
         <Separator />
         <dl className={styles.bolk}>
@@ -123,9 +142,13 @@ export function TiltaksgjennomforingInfo() {
                   <>
                     <Link
                       target="_blank"
-                      href={sanityTiltaksgjennomforingUrl + tiltaksgjennomforing.sanityId}
+                      href={
+                        sanityTiltaksgjennomforingUrl +
+                        tiltaksgjennomforing.sanityId
+                      }
                     >
-                      Åpne tiltaksgjennomføringen i Sanity <ExternalLinkIcon title="Åpner tiltaksgjennomføringen i Sanity" />
+                      Åpne tiltaksgjennomføringen i Sanity{" "}
+                      <ExternalLinkIcon title="Åpner tiltaksgjennomføringen i Sanity" />
                     </Link>
                   </>
                 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -341,7 +341,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         )
 
         val where = DatabaseUtils.andWhereParameterNotNull(
-            filter.search to "(lower(tg.navn) like lower(:search)) or (tg.tiltaksnummer like :search)",
+            filter.search to "((lower(tg.navn) like lower(:search)) or (tg.tiltaksnummer like :search))",
             filter.enhet to "lower(tg.arena_ansvarlig_enhet) = lower(:enhet)",
             filter.tiltakstypeId to "tg.tiltakstype_id = :tiltakstypeId",
             filter.status to filter.status?.toDbStatement(),


### PR DESCRIPTION
Resetter filter når vi unmounter filter-komponenten, dvs. når vi feks. navigerer til ny side.
Wrapper også søk på fritekst i parenteser så logikken i sql blir korrekt
