### PR TITLE
Eksportere avtaledata excel

### DIFF
--- a/frontend/mr-admin-flate/src/api/features/feature-toggles.ts
+++ b/frontend/mr-admin-flate/src/api/features/feature-toggles.ts
@@ -15,6 +15,8 @@ export const SE_NOTIFIKASJONER_ADMIN_FLATE =
 export const LAGRE_DATA_FRA_ADMIN_FLATE =
   "mulighetsrommet.admin-flate-lagre-data-fra-admin-flate";
 export const SLETTE_AVTALE = "mulighetsrommet.admin-flate-slett-avtale";
+export const VIS_LAST_NED_EXCEL_KNAPP =
+  "mulighetsrommet.admin-flate-vis-last-ned-excel-knapp";
 
 export const ALL_TOGGLES = [
   ENABLE_ADMIN_FLATE,
@@ -25,6 +27,7 @@ export const ALL_TOGGLES = [
   SE_NOTIFIKASJONER_ADMIN_FLATE,
   LAGRE_DATA_FRA_ADMIN_FLATE,
   SLETTE_AVTALE,
+  VIS_LAST_NED_EXCEL_KNAPP,
 ] as const;
 
 export type Features = Record<(typeof ALL_TOGGLES)[number], boolean>;
@@ -38,6 +41,7 @@ export const initialFeatures: Features = {
   "mulighetsrommet.admin-flate-se-notifikasjoner": false,
   "mulighetsrommet.admin-flate-lagre-data-fra-admin-flate": false,
   "mulighetsrommet.admin-flate-slett-avtale": false,
+  "mulighetsrommet.admin-flate-vis-last-ned-excel-knapp": false,
 };
 
 const toggles = ALL_TOGGLES.map((element) => "feature=" + element).join("&");

--- a/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
@@ -85,7 +85,6 @@ export const AvtaleTabell = () => {
     const excelFil = await lastNedFil(filter);
     const blob = await excelFil.blob();
     const url = URL.createObjectURL(blob);
-    console.log(url);
     link.current.download = "avtaler.xlsx";
     link.current.href = url;
 

--- a/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
@@ -1,9 +1,13 @@
-import { Alert, Pagination, Table } from "@navikt/ds-react";
+import { Alert, Button, Pagination, Table } from "@navikt/ds-react";
 import classNames from "classnames";
 import { useAtom } from "jotai";
-import { SorteringAvtaler } from "mulighetsrommet-api-client";
+import { OpenAPI, SorteringAvtaler } from "mulighetsrommet-api-client";
 import Lenke from "mulighetsrommet-veileder-flate/src/components/lenke/Lenke";
-import { avtaleFilter, avtalePaginationAtom } from "../../api/atoms";
+import {
+  AvtaleFilterProps,
+  avtaleFilter,
+  avtalePaginationAtom,
+} from "../../api/atoms";
 import { useAvtaler } from "../../api/avtaler/useAvtaler";
 import { useSort } from "../../hooks/useSort";
 import {
@@ -16,6 +20,50 @@ import { PagineringContainer } from "../paginering/PagineringContainer";
 import { PagineringsOversikt } from "../paginering/PagineringOversikt";
 import { Avtalestatus } from "../statuselementer/Avtalestatus";
 import styles from "./Tabell.module.scss";
+import { APPLICATION_NAME } from "../../constants";
+import { createRef } from "react";
+
+async function lastNedFil(filter: AvtaleFilterProps) {
+  const headers = new Headers();
+  headers.append("Nav-Consumer-Id", APPLICATION_NAME);
+
+  if (import.meta.env.VITE_MULIGHETSROMMET_API_AUTH_TOKEN) {
+    headers.append(
+      "Authorization",
+      `Bearer ${import.meta.env.VITE_MULIGHETSROMMET_API_AUTH_TOKEN}`
+    );
+  }
+  headers.append("accept", "application/json");
+
+  const queryParams = new URLSearchParams();
+  if (filter.tiltakstype) {
+    queryParams.set("tiltakstypeId", filter.tiltakstype);
+  }
+  if (filter.sok) {
+    queryParams.set("search", filter.sok);
+  }
+
+  if (filter.status) {
+    queryParams.set("avtalestatus", filter.status);
+  }
+
+  if (filter.navRegion) {
+    queryParams.set("navRegion", filter.navRegion);
+  }
+
+  if (filter.leverandor_orgnr) {
+    queryParams.set("leverandorOrgnr", filter.leverandor_orgnr);
+  }
+
+  queryParams.set("size", "10000");
+
+  return await fetch(
+    `${OpenAPI.BASE}/api/v1/internal/avtaler/excel?${queryParams}`,
+    {
+      headers,
+    }
+  );
+}
 
 export const AvtaleTabell = () => {
   const { data, isLoading, isError } = useAvtaler();
@@ -24,6 +72,24 @@ export const AvtaleTabell = () => {
   const [sort, setSort] = useSort("navn");
   const pagination = data?.pagination;
   const avtaler = data?.data ?? [];
+
+  const link = createRef<any>();
+
+  async function lastNedExcel() {
+    if (link?.current?.href) {
+      return;
+    }
+
+    const excelFil = await lastNedFil(filter);
+    const blob = await excelFil.blob();
+    const url = URL.createObjectURL(blob);
+    console.log(url);
+    link.current.download = "avtaler.xlsx";
+    link.current.href = url;
+
+    link.current.click();
+    URL.revokeObjectURL(url);
+  }
 
   const handleSort = (sortKey: string) => {
     // Hvis man bytter sortKey starter vi med ascending
@@ -61,17 +127,30 @@ export const AvtaleTabell = () => {
 
   return (
     <div className={classNames(styles.tabell_wrapper, styles.avtaletabell)}>
-      <PagineringsOversikt
-        page={page}
-        antall={avtaler.length}
-        maksAntall={pagination?.totalCount}
-        type="avtaler"
-        antallVises={filter.antallAvtalerVises}
-        setAntallVises={(value) => {
-          resetPaginering(setPage);
-          setFilter({ ...filter, antallAvtalerVises: value });
-        }}
-      />
+      <div className={styles.tabell_topp_container}>
+        <PagineringsOversikt
+          page={page}
+          antall={avtaler.length}
+          maksAntall={pagination?.totalCount}
+          type="avtaler"
+          antallVises={filter.antallAvtalerVises}
+          setAntallVises={(value) => {
+            resetPaginering(setPage);
+            setFilter({ ...filter, antallAvtalerVises: value });
+          }}
+        />
+        <div>
+          <Button
+            icon={<ExcelIkon />}
+            variant="tertiary"
+            onClick={lastNedExcel}
+          >
+            Eksporter tabellen til Excel
+          </Button>
+          <a ref={link}></a>
+        </div>
+      </div>
+
       <Table
         sort={sort!}
         onSortChange={(sortKey) => handleSort(sortKey!)}
@@ -166,3 +245,22 @@ export const AvtaleTabell = () => {
     </div>
   );
 };
+
+function ExcelIkon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 28 28"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M5.25 4.5C5.25 3.80964 5.80964 3.25 6.5 3.25H14C14.1989 3.25 14.3897 3.32902 14.5303 3.46967L18.5303 7.46967C18.671 7.61032 18.75 7.80109 18.75 8V12.25H21C21.4142 12.25 21.75 12.5858 21.75 13V20C21.75 20.4142 21.4142 20.75 21 20.75H3C2.58579 20.75 2.25 20.4142 2.25 20V13C2.25 12.5858 2.58579 12.25 3 12.25H5.25V4.5ZM6.75 12.25H17.25V8.75H14.5C13.8096 8.75 13.25 8.19036 13.25 7.5V4.75H6.75V12.25ZM14.75 5.81066L16.1893 7.25H14.75V5.81066ZM16.4093 19.0701C16.05 19.0701 15.7373 19.0094 15.4713 18.8881C15.2053 18.7667 15 18.5964 14.8553 18.3771C14.7106 18.1577 14.6383 17.8987 14.6383 17.6001H15.6883C15.6883 17.7727 15.7536 17.9104 15.8843 18.0131C16.0196 18.1111 16.2016 18.1601 16.4303 18.1601C16.6496 18.1601 16.82 18.1111 16.9413 18.0131C17.0673 17.9151 17.1303 17.7797 17.1303 17.6071C17.1303 17.4577 17.0836 17.3294 16.9903 17.2221C16.897 17.1147 16.7663 17.0424 16.5983 17.0051L16.0803 16.8861C15.6463 16.7834 15.308 16.5944 15.0653 16.3191C14.8273 16.0391 14.7083 15.6984 14.7083 15.2971C14.7083 14.9984 14.776 14.7394 14.9113 14.5201C15.0513 14.2961 15.2473 14.1234 15.4993 14.0021C15.7513 13.8807 16.05 13.8201 16.3953 13.8201C16.918 13.8201 17.331 13.9507 17.6343 14.2121C17.9423 14.4687 18.0963 14.8164 18.0963 15.2551H17.0463C17.0463 15.0917 16.988 14.9634 16.8713 14.8701C16.7593 14.7767 16.596 14.7301 16.3813 14.7301C16.1806 14.7301 16.0266 14.7767 15.9193 14.8701C15.812 14.9587 15.7583 15.0871 15.7583 15.2551C15.7583 15.4044 15.8003 15.5327 15.8843 15.6401C15.973 15.7427 16.0966 15.8127 16.2553 15.8501L16.8013 15.9761C17.254 16.0787 17.597 16.2654 17.8303 16.5361C18.0636 16.8021 18.1803 17.1427 18.1803 17.5581C18.1803 17.8567 18.1056 18.1204 17.9563 18.3491C17.8116 18.5777 17.6063 18.7551 17.3403 18.8811C17.079 19.0071 16.7686 19.0701 16.4093 19.0701ZM7.00677 16.3611L5.63477 19.0001H6.76177L7.37777 17.7401C7.4291 17.6374 7.4711 17.5417 7.50377 17.4531C7.53643 17.3644 7.55977 17.2967 7.57377 17.2501C7.59243 17.2967 7.62043 17.3644 7.65777 17.4531C7.6951 17.5417 7.7371 17.6374 7.78377 17.7401L8.39977 19.0001H9.55477L8.18277 16.3611L9.46377 13.8901H8.33677L7.79077 15.0101C7.7441 15.1127 7.70443 15.2061 7.67177 15.2901C7.6391 15.3741 7.6181 15.4347 7.60877 15.4721C7.59943 15.4347 7.5761 15.3741 7.53877 15.2901C7.5061 15.2061 7.4641 15.1127 7.41277 15.0101L6.88077 13.8901H5.72577L7.00677 16.3611ZM10.567 13.8901V19.0001H13.682V18.0201H11.617V13.8901H10.567Z"
+        fill="#0067C5"
+      />
+    </svg>
+  );
+}

--- a/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
@@ -22,6 +22,7 @@ import { Avtalestatus } from "../statuselementer/Avtalestatus";
 import styles from "./Tabell.module.scss";
 import { APPLICATION_NAME } from "../../constants";
 import { createRef } from "react";
+import { useFeatureToggles } from "../../api/features/feature-toggles";
 
 async function lastNedFil(filter: AvtaleFilterProps) {
   const headers = new Headers();
@@ -67,6 +68,7 @@ async function lastNedFil(filter: AvtaleFilterProps) {
 
 export const AvtaleTabell = () => {
   const { data, isLoading, isError } = useAvtaler();
+  const { data: features } = useFeatureToggles();
   const [filter, setFilter] = useAtom(avtaleFilter);
   const [page, setPage] = useAtom(avtalePaginationAtom);
   const [sort, setSort] = useSort("navn");
@@ -139,16 +141,18 @@ export const AvtaleTabell = () => {
             setFilter({ ...filter, antallAvtalerVises: value });
           }}
         />
-        <div>
-          <Button
-            icon={<ExcelIkon />}
-            variant="tertiary"
-            onClick={lastNedExcel}
-          >
-            Eksporter tabellen til Excel
-          </Button>
-          <a ref={link}></a>
-        </div>
+        {features?.["mulighetsrommet.admin-flate-vis-last-ned-excel-knapp"] ? (
+          <div>
+            <Button
+              icon={<ExcelIkon />}
+              variant="tertiary"
+              onClick={lastNedExcel}
+            >
+              Eksporter tabellen til Excel
+            </Button>
+            <a style={{ display: "none" }} ref={link}></a>
+          </div>
+        ) : null}
       </div>
 
       <Table

--- a/frontend/mr-admin-flate/src/components/tabell/Tabell.module.scss
+++ b/frontend/mr-admin-flate/src/components/tabell/Tabell.module.scss
@@ -28,3 +28,8 @@
     grid-template-columns: 3fr 2fr 2fr repeat(3, 1fr);
   }
 }
+
+.tabell_topp_container {
+  display: flex;
+  justify-content: space-between;
+}

--- a/frontend/mr-admin-flate/src/mocks/api/features.ts
+++ b/frontend/mr-admin-flate/src/mocks/api/features.ts
@@ -9,4 +9,5 @@ export const mockFeatures: Features = {
   "mulighetsrommet.admin-flate-se-notifikasjoner": true,
   "mulighetsrommet.admin-flate-lagre-data-fra-admin-flate": true,
   "mulighetsrommet.admin-flate-slett-avtale": true,
+  "mulighetsrommet.admin-flate-vis-last-ned-excel-knapp": true,
 };

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
@@ -1,17 +1,60 @@
-import { Heading } from "@navikt/ds-react";
+import { Button, Heading } from "@navikt/ds-react";
+import { mulighetsrommetClient } from "../../api/clients";
 import { Avtalefilter } from "../../components/filter/Avtalefilter";
+import { AvtaleTabell } from "../../components/tabell/AvtaleTabell";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
 import { MainContainer } from "../../layouts/MainContainer";
 import styles from "../Page.module.scss";
-import { AvtaleTabell } from "../../components/tabell/AvtaleTabell";
+import { createRef } from "react";
+import { OpenAPI } from "mulighetsrommet-api-client";
+import { APPLICATION_NAME } from "../../constants";
+
+async function lastNedFil() {
+  const headers = new Headers();
+  headers.append("Nav-Consumer-Id", APPLICATION_NAME);
+
+  if (import.meta.env.VITE_MULIGHETSROMMET_API_AUTH_TOKEN) {
+    headers.append(
+      "Authorization",
+      `Bearer ${import.meta.env.VITE_MULIGHETSROMMET_API_AUTH_TOKEN}`
+    );
+  }
+
+  headers.append("accept", "application/json");
+
+  // TODO Kan ta i mot filter i metoden og sende som query-params hvis ønskelig
+  return await fetch(`${OpenAPI.BASE}/api/v1/internal/avtaler/excel`, {
+    headers,
+  });
+}
 
 export function AvtalerPage() {
+  const link = createRef<any>();
+
+  async function lastNedExcel() {
+    if (link?.current?.href) {
+      return;
+    }
+
+    const excelFil = await lastNedFil();
+    const blob = await excelFil.blob();
+    const url = URL.createObjectURL(blob);
+    console.log(url);
+    link.current.download = "avtaler.xlsx";
+    link.current.href = url;
+
+    link.current.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <MainContainer>
       <ContainerLayout>
         <Heading level="2" size="large" className={styles.header_wrapper}>
           Oversikt over avtaler
         </Heading>
+        <Button onClick={lastNedExcel}>Last ned Excel-fil</Button>
+        <a ref={link}></a>
         <Avtalefilter />
         <AvtaleTabell />
       </ContainerLayout>

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
@@ -1,60 +1,17 @@
-import { Button, Heading } from "@navikt/ds-react";
-import { mulighetsrommetClient } from "../../api/clients";
+import { Heading } from "@navikt/ds-react";
 import { Avtalefilter } from "../../components/filter/Avtalefilter";
 import { AvtaleTabell } from "../../components/tabell/AvtaleTabell";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
 import { MainContainer } from "../../layouts/MainContainer";
 import styles from "../Page.module.scss";
-import { createRef } from "react";
-import { OpenAPI } from "mulighetsrommet-api-client";
-import { APPLICATION_NAME } from "../../constants";
-
-async function lastNedFil() {
-  const headers = new Headers();
-  headers.append("Nav-Consumer-Id", APPLICATION_NAME);
-
-  if (import.meta.env.VITE_MULIGHETSROMMET_API_AUTH_TOKEN) {
-    headers.append(
-      "Authorization",
-      `Bearer ${import.meta.env.VITE_MULIGHETSROMMET_API_AUTH_TOKEN}`
-    );
-  }
-
-  headers.append("accept", "application/json");
-
-  // TODO Kan ta i mot filter i metoden og sende som query-params hvis ønskelig
-  return await fetch(`${OpenAPI.BASE}/api/v1/internal/avtaler/excel`, {
-    headers,
-  });
-}
 
 export function AvtalerPage() {
-  const link = createRef<any>();
-
-  async function lastNedExcel() {
-    if (link?.current?.href) {
-      return;
-    }
-
-    const excelFil = await lastNedFil();
-    const blob = await excelFil.blob();
-    const url = URL.createObjectURL(blob);
-    console.log(url);
-    link.current.download = "avtaler.xlsx";
-    link.current.href = url;
-
-    link.current.click();
-    URL.revokeObjectURL(url);
-  }
-
   return (
     <MainContainer>
       <ContainerLayout>
         <Heading level="2" size="large" className={styles.header_wrapper}>
           Oversikt over avtaler
         </Heading>
-        <Button onClick={lastNedExcel}>Last ned Excel-fil</Button>
-        <a ref={link}></a>
         <Avtalefilter />
         <AvtaleTabell />
       </ContainerLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,3 +104,6 @@ slack-client = "com.slack.api:slack-api-client:1.29.2"
 slf4j = "org.slf4j:slf4j-api:2.0.7"
 
 testcontainers-kafka = "org.testcontainers:kafka:1.18.3"
+
+apache-poi = "org.apache.poi:poi:5.2.3"
+apache-poi-ooxml = "org.apache.poi:poi-ooxml:5.2.3"

--- a/mulighetsrommet-api/build.gradle.kts
+++ b/mulighetsrommet-api/build.gradle.kts
@@ -65,6 +65,10 @@ dependencies {
     implementation(libs.koin.ktor)
     implementation(libs.koin.logger.slf4j)
 
+    // Excel
+    implementation(libs.apache.poi)
+    implementation(libs.apache.poi.ooxml)
+
     implementation(libs.nav.common.auditLog)
     constraints {
         implementation(libs.logback.core) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -42,8 +42,8 @@ fun Application.configure(config: AppConfig) {
         swaggerUI(path = "/swagger-ui/internal", swaggerFile = "web/openapi.yaml")
         authenticate(AuthProvider.AzureAdNavIdent.name) {
             tiltakstypeRoutes()
-            avtaleRoutes()
             tiltaksgjennomforingRoutes()
+            avtaleRoutes()
             sanityRoutes()
             brukerRoutes()
             navAnsattRoutes()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -258,6 +258,7 @@ private fun services(appConfig: AppConfig) = module {
     single { TilgjengelighetsstatusSanitySyncService(get(), get()) }
     single { NotificationService(get(), get(), get()) }
     single { VirksomhetService(get(), get()) }
+    single { ExcelService() }
 }
 
 private fun tasks(config: TaskConfig) = module {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -13,6 +13,7 @@ import no.nav.mulighetsrommet.api.routes.v1.responses.BadRequest
 import no.nav.mulighetsrommet.api.routes.v1.responses.StatusResponse
 import no.nav.mulighetsrommet.api.routes.v1.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.services.AvtaleService
+import no.nav.mulighetsrommet.api.services.ExcelService
 import no.nav.mulighetsrommet.api.utils.getAvtaleFilter
 import no.nav.mulighetsrommet.api.utils.getPaginationParams
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
@@ -27,6 +28,7 @@ import java.util.*
 
 fun Route.avtaleRoutes() {
     val avtaler: AvtaleService by inject()
+    val excelService: ExcelService by inject()
 
     val logger = application.environment.log
 
@@ -37,6 +39,24 @@ fun Route.avtaleRoutes() {
             val result = avtaler.getAll(filter, pagination)
 
             call.respond(result)
+        }
+
+        get("/excel") {
+            val pagination = getPaginationParams()
+            val filter = getAvtaleFilter()
+            val result = avtaler.getAll(filter, pagination)
+            val file = excelService.createExcelFile(result)
+            call.response.header(
+                HttpHeaders.ContentDisposition,
+                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, "test_output_.xlsx")
+                    .toString(),
+            )
+            call.response.header("Access-Control-Expose-Headers", HttpHeaders.ContentDisposition)
+            call.response.header(
+                HttpHeaders.ContentType,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
+            call.respondFile(file)
         }
 
         get("{id}") {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -45,7 +45,7 @@ fun Route.avtaleRoutes() {
             val pagination = getPaginationParams()
             val filter = getAvtaleFilter()
             val result = avtaler.getAll(filter, pagination)
-            val file = excelService.createExcelFile(result)
+            val file = excelService.createExcelFile(result.data)
             call.response.header(
                 HttpHeaders.ContentDisposition,
                 ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, "test_output_.xlsx")

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ExcelService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ExcelService.kt
@@ -32,8 +32,7 @@ class ExcelService {
                 6,
                 avtaleAdminDto.sluttDato.formaterDato(),
             )
-            opprettCelle(row, 7, avtaleAdminDto.avtaletype.name)
-            opprettCelle(row, 8, avtaleAdminDto.navRegion?.navn ?: "")
+            opprettCelle(row, 7, avtaleAdminDto.navRegion?.navn ?: "")
         }
 
         val tempFile = kotlin.io.path.createTempFile("avtaler", ".xlsx")
@@ -51,8 +50,7 @@ class ExcelService {
         opprettCelle(headers, 4, "Leverandør orgnr")
         opprettCelle(headers, 5, "Startdato")
         opprettCelle(headers, 6, "Sluttdato")
-        opprettCelle(headers, 7, "Avtaletype")
-        opprettCelle(headers, 8, "Region")
+        opprettCelle(headers, 7, "Region")
     }
 
     private fun opprettCelle(row: XSSFRow, cellIndex: Int, verdi: String) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ExcelService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ExcelService.kt
@@ -1,6 +1,5 @@
 package no.nav.mulighetsrommet.api.services
 
-import no.nav.mulighetsrommet.api.routes.v1.responses.PaginatedResponse
 import no.nav.mulighetsrommet.domain.dto.AvtaleAdminDto
 import org.apache.poi.xssf.usermodel.XSSFRow
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
@@ -11,12 +10,12 @@ import java.time.format.FormatStyle
 import kotlin.io.path.outputStream
 
 class ExcelService {
-    fun createExcelFile(result: PaginatedResponse<AvtaleAdminDto>): File {
+    fun createExcelFile(result: List<AvtaleAdminDto>): File {
         val workbook = XSSFWorkbook()
         val workSheet = workbook.createSheet()
         val headers = workSheet.createRow(0)
         opprettHeaders(headers)
-        result.data.forEachIndexed { index, avtaleAdminDto ->
+        result.forEachIndexed { index, avtaleAdminDto ->
             val row = workSheet.createRow(index + 1)
             opprettCelle(row, 0, avtaleAdminDto.navn)
             opprettCelle(row, 1, avtaleAdminDto.tiltakstype.navn)
@@ -34,6 +33,7 @@ class ExcelService {
                 avtaleAdminDto.sluttDato.formaterDato(),
             )
             opprettCelle(row, 7, avtaleAdminDto.avtaletype.name)
+            opprettCelle(row, 8, avtaleAdminDto.navRegion?.navn ?: "")
         }
 
         val tempFile = kotlin.io.path.createTempFile("avtaler", ".xlsx")
@@ -52,6 +52,7 @@ class ExcelService {
         opprettCelle(headers, 5, "Startdato")
         opprettCelle(headers, 6, "Sluttdato")
         opprettCelle(headers, 7, "Avtaletype")
+        opprettCelle(headers, 8, "Region")
     }
 
     private fun opprettCelle(row: XSSFRow, cellIndex: Int, verdi: String) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ExcelService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ExcelService.kt
@@ -1,0 +1,64 @@
+package no.nav.mulighetsrommet.api.services
+
+import no.nav.mulighetsrommet.api.routes.v1.responses.PaginatedResponse
+import no.nav.mulighetsrommet.domain.dto.AvtaleAdminDto
+import org.apache.poi.xssf.usermodel.XSSFRow
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import java.io.File
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import kotlin.io.path.outputStream
+
+class ExcelService {
+    fun createExcelFile(result: PaginatedResponse<AvtaleAdminDto>): File {
+        val workbook = XSSFWorkbook()
+        val workSheet = workbook.createSheet()
+        val headers = workSheet.createRow(0)
+        opprettHeaders(headers)
+        result.data.forEachIndexed { index, avtaleAdminDto ->
+            val row = workSheet.createRow(index + 1)
+            opprettCelle(row, 0, avtaleAdminDto.navn)
+            opprettCelle(row, 1, avtaleAdminDto.tiltakstype.navn)
+            opprettCelle(row, 2, avtaleAdminDto.avtalenummer ?: "")
+            opprettCelle(row, 3, avtaleAdminDto.leverandor.navn ?: "")
+            opprettCelle(row, 4, avtaleAdminDto.leverandor.organisasjonsnummer)
+            opprettCelle(
+                row,
+                5,
+                avtaleAdminDto.startDato.formaterDato(),
+            )
+            opprettCelle(
+                row,
+                6,
+                avtaleAdminDto.sluttDato.formaterDato(),
+            )
+            opprettCelle(row, 7, avtaleAdminDto.avtaletype.name)
+        }
+
+        val tempFile = kotlin.io.path.createTempFile("avtaler", ".xlsx")
+        workbook.write(tempFile.outputStream())
+        workbook.close()
+
+        return tempFile.toFile()
+    }
+
+    private fun opprettHeaders(headers: XSSFRow) {
+        opprettCelle(headers, 0, "Avtalenavn")
+        opprettCelle(headers, 1, "Tiltakstype")
+        opprettCelle(headers, 2, "Avtalenummer")
+        opprettCelle(headers, 3, "Leverandør")
+        opprettCelle(headers, 4, "Leverandør orgnr")
+        opprettCelle(headers, 5, "Startdato")
+        opprettCelle(headers, 6, "Sluttdato")
+        opprettCelle(headers, 7, "Avtaletype")
+    }
+
+    private fun opprettCelle(row: XSSFRow, cellIndex: Int, verdi: String) {
+        row.createCell(cellIndex).setCellValue(verdi)
+    }
+
+    private fun LocalDate.formaterDato(): String {
+        return this.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT))
+    }
+}

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -163,6 +163,20 @@ paths:
               schema:
                 type: string
 
+  /api/v1/internal/avtaler/excel:
+    get:
+      tags:
+        - Avtaler
+      operationId: lastNedAvtalerSomExcel
+      responses:
+        200:
+          description: Excel-fil med avtaler
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+
   /api/v1/internal/tiltaksgjennomforinger:
     get:
       tags:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/excel/ExcelServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/excel/ExcelServiceTest.kt
@@ -1,0 +1,32 @@
+package no.nav.mulighetsrommet.excel
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.poi.ss.usermodel.FillPatternType
+import org.apache.poi.ss.usermodel.IndexedColors
+import org.apache.poi.ss.usermodel.WorkbookFactory
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import kotlin.io.path.outputStream
+
+class ExcelServiceTest : FunSpec({
+    test("Opprett Excel-fil oppretter fil") {
+        val workbook = XSSFWorkbook()
+        val workSheet = workbook.createSheet()
+        val cellStyle = workbook.createCellStyle()
+        cellStyle.fillForegroundColor = IndexedColors.RED.getIndex()
+        cellStyle.fillPattern = FillPatternType.SOLID_FOREGROUND
+        val firstCell = workSheet
+            .createRow(0)
+            .createCell(0)
+        firstCell.setCellValue("SAVED VALUE")
+        firstCell.cellStyle = cellStyle
+
+        val tempFile = kotlin.io.path.createTempFile("test_output_", ".xlsx")
+        workbook.write(tempFile.outputStream())
+        workbook.close()
+
+        val inputWorkbook = WorkbookFactory.create(tempFile.toFile().inputStream())
+        val firstSheet = inputWorkbook.getSheetAt(0)
+        firstSheet.getRow(0).getCell(0).stringCellValue shouldBe "SAVED VALUE"
+    }
+})


### PR DESCRIPTION
Legger til mulighet for å laste ned avtaler som en Excel-fil. Nedlastingen baserer seg på hva man har valgt i filteret, men returnerer alle rader, uavhengig av paginering.

Jeg måtte bruke en native fetch (ikke mulighetsrommetClient) fordi clienten ikke støtter fetching av blob. 

Jeg har wrappet knappen i togglen https://unleash.nais.io/#/features/strategies/mulighetsrommet.admin-flate-vis-last-ned-excel-knapp så den kan skrus på for noen få til å teste det ut først.

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/55701244-8daa-410b-b01e-a816badfe938)
