### PR TITLE
Notifikasjoner når midl. stengt nærmer seg sluttdato for perioden

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingNotificationDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingNotificationDto.kt
@@ -16,4 +16,7 @@ data class TiltaksgjennomforingNotificationDto(
     @Serializable(with = LocalDateSerializer::class)
     val sluttDato: LocalDate? = null,
     val ansvarlige: List<String>,
+    val tiltaksnummer: String? = null,
+    @Serializable(with = LocalDateSerializer::class)
+    val stengtTil: LocalDate? = null,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -76,6 +76,7 @@ data class TaskConfig(
     val notifySluttdatoForGjennomforingerNarmerSeg: NotifySluttdatoForGjennomforingerNarmerSeg.Config,
     val notifySluttdatoForAvtalerNarmerSeg: NotifySluttdatoForAvtalerNarmerSeg.Config,
     val notifyFailedKafkaEvents: NotifyFailedKafkaEvents.Config,
+    val notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg: NotifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg.Config,
 )
 
 data class Norg2Config(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -295,6 +295,7 @@ private fun tasks(config: TaskConfig) = module {
             get(),
             get(),
         )
+        val notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg = NotifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg(config.notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg, get(), get(), get())
         val notificationService: NotificationService by inject()
 
         val db: Database by inject()
@@ -311,6 +312,7 @@ private fun tasks(config: TaskConfig) = module {
                 notifySluttdatoForGjennomforingerNarmerSeg.task,
                 notifySluttdatoForAvtalerNarmerSeg.task,
                 notifyFailedKafkaEvents.task,
+                notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg.task,
             )
             .serializer(DbSchedulerKotlinSerializer())
             .registerShutdownHook()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -75,4 +75,8 @@ class TiltaksgjennomforingService(
     fun getBySanitIds(sanityIds: List<UUID>): Map<String, TiltaksgjennomforingAdminDto> {
         return tiltaksgjennomforingRepository.getBySanityIds(sanityIds)
     }
+
+    fun getAllMidlertidigStengteGjennomforingerSomNarmerSegSluttdato(): List<TiltaksgjennomforingNotificationDto> {
+        return tiltaksgjennomforingRepository.getAllMidlertidigStengteGjennomforingerSomNarmerSegSluttdato()
+    }
 }

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -98,6 +98,9 @@ app:
     notifyFailedKafkaEvents:
       maxRetries: 5
       delayOfMinutes: 15
+    notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg:
+      disabled: false
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00
 
   norg2:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -98,6 +98,9 @@ app:
       disabled: true
       maxRetries: 5
       delayOfMinutes: 15
+    notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg:
+      disabled: true
+      cronPattern: "0 */1 * * * *" # Hvert 1 minutt
 
   norg2:
     baseUrl: https://norg2.dev-fss-pub.nais.io/norg2/api/v1

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -98,6 +98,9 @@ app:
     notifyFailedKafkaEvents:
       maxRetries: 5
       delayOfMinutes: 15
+    notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg:
+      disabled: false
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00
 
   norg2:
     baseUrl: https://norg2.prod-fss-pub.nais.io/norg2/api/v1

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -75,6 +75,9 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
             delayOfMinutes = 15,
             maxRetries = 5,
         ),
+        notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg = NotifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg.Config(
+            disabled = true,
+        ),
     ),
     norg2 = Norg2Config(baseUrl = ""),
     slack = SlackConfig(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -330,6 +330,41 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         }
     }
 
+    context("Hente tiltaksgjennomføringer som er midlertidig stengt og som nærmer seg sluttdato for den stengte perioden") {
+        test("Skal hente gjennomføringer som er 7 eller 1 dag til stengt-til-datoen") {
+            val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
+            val gjennomforing14Dager =
+                gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = LocalDate.of(2023, 5, 30))
+            val gjennomforing7Dager = gjennomforing1.copy(
+                id = UUID.randomUUID(),
+                sluttDato = LocalDate.of(2023, 5, 23),
+                stengtFra = LocalDate.of(2023, 6, 16),
+                stengtTil = LocalDate.of(2023, 5, 23),
+            )
+            val gjennomforing1Dager = gjennomforing1.copy(
+                id = UUID.randomUUID(),
+                sluttDato = LocalDate.of(2023, 5, 17),
+                stengtFra = LocalDate.of(2023, 6, 16),
+                stengtTil = LocalDate.of(2023, 5, 17),
+            )
+            val gjennomforing10Dager =
+                gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = LocalDate.of(2023, 5, 26))
+            tiltaksgjennomforinger.upsert(gjennomforing14Dager).shouldBeRight()
+            tiltaksgjennomforinger.upsert(gjennomforing7Dager).shouldBeRight()
+            tiltaksgjennomforinger.upsert(gjennomforing1Dager).shouldBeRight()
+            tiltaksgjennomforinger.upsert(gjennomforing10Dager).shouldBeRight()
+
+            val result = tiltaksgjennomforinger.getAllMidlertidigStengteGjennomforingerSomNarmerSegSluttdato(
+                currentDate = LocalDate.of(
+                    2023,
+                    5,
+                    16,
+                ),
+            )
+            result.size shouldBe 2
+        }
+    }
+
     context("tilgjengelighetsstatus") {
         val tiltakstyper = TiltakstypeRepository(database.db)
         tiltakstyper.upsert(tiltakstype1)


### PR DESCRIPTION
Oppretter notifikasjoner til ansvarlig for gjennomføring for gjennomføringer som er midlertidig stengt. Notifikasjoner opprettes kl. 06.00 hver morgen og man får notifikasjon en uke før, og en dag før 
gjennomføringen sin midlertidige stengte periode utløper.
