### PR TITLE
Fjerner limits.cpu fordi vi ikke trenger det spesifisert

### DIFF
--- a/frontend/arena-adapter-manager/.nais/nais-dev.yaml
+++ b/frontend/arena-adapter-manager/.nais/nais-dev.yaml
@@ -22,7 +22,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/frontend/arena-adapter-manager/.nais/nais-prod.yaml
+++ b/frontend/arena-adapter-manager/.nais/nais-prod.yaml
@@ -22,7 +22,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/frontend/mr-admin-flate/.nais/nais-demo.yaml
+++ b/frontend/mr-admin-flate/.nais/nais-demo.yaml
@@ -23,7 +23,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/frontend/mr-admin-flate/.nais/nais-dev.yaml
+++ b/frontend/mr-admin-flate/.nais/nais-dev.yaml
@@ -22,7 +22,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/frontend/mr-admin-flate/.nais/nais-prod.yaml
+++ b/frontend/mr-admin-flate/.nais/nais-prod.yaml
@@ -22,7 +22,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/frontend/mulighetsrommet-cms/.nais/nais-prod.yaml
+++ b/frontend/mulighetsrommet-cms/.nais/nais-prod.yaml
@@ -24,7 +24,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/frontend/mulighetsrommet-veileder-flate/.nais/nais-demo.yaml
+++ b/frontend/mulighetsrommet-veileder-flate/.nais/nais-demo.yaml
@@ -23,7 +23,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/frontend/mulighetsrommet-veileder-flate/.nais/nais-dev.yaml
+++ b/frontend/mulighetsrommet-veileder-flate/.nais/nais-dev.yaml
@@ -22,7 +22,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/frontend/mulighetsrommet-veileder-flate/.nais/nais-prod.yaml
+++ b/frontend/mulighetsrommet-veileder-flate/.nais/nais-prod.yaml
@@ -22,7 +22,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 512Mi
     requests:
       cpu: 250m

--- a/iac/kafka-manager/dev/kafka-manager-dev.yaml
+++ b/iac/kafka-manager/dev/kafka-manager-dev.yaml
@@ -26,7 +26,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 1024Mi
     requests:
       cpu: 250m

--- a/iac/kafka-manager/prod/kafka-manager-prod.yaml
+++ b/iac/kafka-manager/prod/kafka-manager-prod.yaml
@@ -26,7 +26,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 1024Mi
     requests:
       cpu: 250m

--- a/mulighetsrommet-api/.nais/nais-dev.yaml
+++ b/mulighetsrommet-api/.nais/nais-dev.yaml
@@ -27,7 +27,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 1024Mi
     requests:
       cpu: 250m

--- a/mulighetsrommet-api/.nais/nais-prod.yaml
+++ b/mulighetsrommet-api/.nais/nais-prod.yaml
@@ -27,7 +27,6 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      cpu: "1"
       memory: 1024Mi
     requests:
       cpu: 250m

--- a/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-dev.yaml
@@ -30,7 +30,6 @@ spec:
       cpu: 250m
       memory: 512Mi
     limits:
-      cpu: 4000m
       memory: 8192Mi
   gcp:
     sqlInstances:

--- a/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
+++ b/mulighetsrommet-arena-adapter/.nais/nais-prod.yaml
@@ -30,7 +30,6 @@ spec:
       cpu: 250m
       memory: 512Mi
     limits:
-      cpu: 4000m
       memory: 8192Mi
   gcp:
     sqlInstances:


### PR DESCRIPTION
Ref. https://nav-it.slack.com/archives/C5KUST8N6/p1685083616554329?thread_ts=1685083371.794519&cid=C5KUST8N6 så trenger vi ikke limits.cpu i nais-config. Fjerner det derfor.
