### PR TITLE
Synkroniserer ad-gruppen mr-nav_kontaktperson til nav-ansatt-tabell

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -36,7 +36,7 @@ class MicrosoftGraphClientImpl(
     override suspend fun getNavAnsatt(accessToken: String, navAnsattAzureId: UUID): NavAnsattDto {
         val response = client.get("$baseUrl/v1.0/users/$navAnsattAzureId") {
             bearerAuth(tokenProvider(accessToken))
-            parameter("\$select", "id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail")
+            parameter("\$select", "id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail,mobilePhone")
         }
 
         if (!response.status.isSuccess()) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -70,7 +70,7 @@ class MicrosoftGraphClientImpl(
     override suspend fun getGroupMembers(groupId: UUID): List<NavAnsattDto> {
         val response = client.get("$baseUrl/v1.0/groups/$groupId/members") {
             bearerAuth(tokenProvider.invoke(null))
-            parameter("\$select", "id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail")
+            parameter("\$select", "id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail,mobilePhone")
         }
 
         if (!response.status.isSuccess()) {
@@ -111,6 +111,14 @@ class MicrosoftGraphClientImpl(
             throw RuntimeException("Etternavn på ansatt mangler for bruker med id=${user.id}")
         }
 
+        user.mobilePhone == null -> {
+            throw RuntimeException("Mobilnummer på ansatt mangler for bruker med id=${user.id}")
+        }
+
+        user.mail == null -> {
+            throw RuntimeException("Epost på ansatt mangler for bruker med id=${user.id}")
+        }
+
         else -> NavAnsattDto(
             azureId = user.id,
             navident = user.onPremisesSamAccountName,
@@ -118,6 +126,8 @@ class MicrosoftGraphClientImpl(
             etternavn = user.surname,
             hovedenhetKode = user.streetAddress,
             hovedenhetNavn = user.city,
+            mobilnr = user.mobilePhone,
+            epost = user.mail,
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImpl.kt
@@ -111,10 +111,6 @@ class MicrosoftGraphClientImpl(
             throw RuntimeException("Etternavn på ansatt mangler for bruker med id=${user.id}")
         }
 
-        user.mobilePhone == null -> {
-            throw RuntimeException("Mobilnummer på ansatt mangler for bruker med id=${user.id}")
-        }
-
         user.mail == null -> {
             throw RuntimeException("Epost på ansatt mangler for bruker med id=${user.id}")
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MsGraphDirectoryObjects.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MsGraphDirectoryObjects.kt
@@ -44,6 +44,13 @@ internal data class MsGraphUserDto(
      * om feltet er null så antar vi at brukeren ikke er en ansatt hos NAV.
      */
     val city: String?,
+    /**
+     * NAV Enhetsnavn
+     *
+     * Vi antar at denne er definert for alle ansatte,
+     * om feltet er null så antar vi at brukeren ikke er en ansatt hos NAV.
+     */
+    val mobilePhone: String?,
 )
 
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MsGraphDirectoryObjects.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MsGraphDirectoryObjects.kt
@@ -45,10 +45,7 @@ internal data class MsGraphUserDto(
      */
     val city: String?,
     /**
-     * NAV Enhetsnavn
-     *
-     * Vi antar at denne er definert for alle ansatte,
-     * om feltet er null så antar vi at brukeren ikke er en ansatt hos NAV.
+     * Mobilnummer
      */
     val mobilePhone: String?,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
@@ -12,4 +12,6 @@ data class NavAnsattDbo(
     val hovedenhet: String,
     val azureId: UUID,
     val fraAdGruppe: UUID,
+    val mobilnr: String,
+    val epost: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
@@ -12,6 +12,6 @@ data class NavAnsattDbo(
     val hovedenhet: String,
     val azureId: UUID,
     val fraAdGruppe: UUID,
-    val mobilnr: String,
+    val mobilnr: String? = null,
     val epost: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
@@ -12,6 +12,6 @@ data class NavAnsattDbo(
     val hovedenhet: String,
     val azureId: UUID,
     val fraAdGruppe: UUID,
-    val mobilnr: String? = null,
+    val mobilnummer: String? = null,
     val epost: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavAnsattDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavAnsattDto.kt
@@ -9,4 +9,6 @@ data class NavAnsattDto(
     val etternavn: String,
     val hovedenhetKode: String,
     val hovedenhetNavn: String,
+    val mobilnr: String,
+    val epost: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavAnsattDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavAnsattDto.kt
@@ -9,6 +9,6 @@ data class NavAnsattDto(
     val etternavn: String,
     val hovedenhetKode: String,
     val hovedenhetNavn: String,
-    val mobilnr: String,
+    val mobilnr: String? = null,
     val epost: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepository.kt
@@ -79,7 +79,7 @@ class NavAnsattRepository(private val db: Database) {
         "hovedenhet" to hovedenhet,
         "azure_id" to azureId,
         "fra_ad_gruppe" to fraAdGruppe,
-        "mobilnummer" to mobilnr,
+        "mobilnummer" to mobilnummer,
         "epost" to epost,
     )
 
@@ -90,7 +90,7 @@ class NavAnsattRepository(private val db: Database) {
         hovedenhet = string("hovedenhet"),
         azureId = uuid("azure_id"),
         fraAdGruppe = uuid("fra_ad_gruppe"),
-        mobilnr = string("mobilnummer"),
+        mobilnummer = string("mobilnummer"),
         epost = string("epost"),
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepository.kt
@@ -13,14 +13,16 @@ class NavAnsattRepository(private val db: Database) {
     fun upsert(ansatt: NavAnsattDbo): QueryResult<NavAnsattDbo> = query {
         @Language("PostgreSQL")
         val query = """
-            insert into nav_ansatt(nav_ident, fornavn, etternavn, hovedenhet, azure_id, fra_ad_gruppe)
-            values (:nav_ident, :fornavn, :etternavn, :hovedenhet, :azure_id::uuid, :fra_ad_gruppe::uuid)
+            insert into nav_ansatt(nav_ident, fornavn, etternavn, hovedenhet, azure_id, fra_ad_gruppe, mobilnummer, epost)
+            values (:nav_ident, :fornavn, :etternavn, :hovedenhet, :azure_id::uuid, :fra_ad_gruppe::uuid, :mobilnummer, :epost)
             on conflict (nav_ident)
                 do update set fornavn       = excluded.fornavn,
                               etternavn     = excluded.etternavn,
                               hovedenhet    = excluded.hovedenhet,
                               azure_id      = excluded.azure_id,
-                              fra_ad_gruppe = excluded.fra_ad_gruppe
+                              fra_ad_gruppe = excluded.fra_ad_gruppe,
+                              mobilnummer   = excluded.mobilnummer,
+                              epost         = excluded.epost
             returning *
         """.trimIndent()
 
@@ -33,7 +35,7 @@ class NavAnsattRepository(private val db: Database) {
     fun getByNavIdent(navIdent: String): QueryResult<NavAnsattDbo?> = query {
         @Language("PostgreSQL")
         val query = """
-            select nav_ident, fornavn, etternavn, hovedenhet, azure_id, fra_ad_gruppe
+            select nav_ident, fornavn, etternavn, hovedenhet, azure_id, fra_ad_gruppe, mobilnummer, epost
             from nav_ansatt
             where nav_ident = :nav_ident
         """.trimIndent()
@@ -47,7 +49,7 @@ class NavAnsattRepository(private val db: Database) {
     fun getByAzureId(azureId: UUID): QueryResult<NavAnsattDbo?> = query {
         @Language("PostgreSQL")
         val query = """
-            select nav_ident, fornavn, etternavn, hovedenhet, azure_id, fra_ad_gruppe
+            select nav_ident, fornavn, etternavn, hovedenhet, azure_id, fra_ad_gruppe, mobilnummer, epost
             from nav_ansatt
             where azure_id = :azure_id::uuid
         """.trimIndent()
@@ -77,6 +79,8 @@ class NavAnsattRepository(private val db: Database) {
         "hovedenhet" to hovedenhet,
         "azure_id" to azureId,
         "fra_ad_gruppe" to fraAdGruppe,
+        "mobilnummer" to mobilnr,
+        "epost" to epost,
     )
 
     private fun Row.toNavAnsatt() = NavAnsattDbo(
@@ -86,5 +90,7 @@ class NavAnsattRepository(private val db: Database) {
         hovedenhet = string("hovedenhet"),
         azureId = uuid("azure_id"),
         fraAdGruppe = uuid("fra_ad_gruppe"),
+        mobilnr = string("mobilnummer"),
+        epost = string("epost"),
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
@@ -65,6 +65,8 @@ class SynchronizeNavAnsatte(
                                 hovedenhet = hovedenhetKode,
                                 azureId = azureId,
                                 fraAdGruppe = groupId,
+                                mobilnr = mobilnr,
+                                epost = epost,
                             )
                         }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
@@ -65,7 +65,7 @@ class SynchronizeNavAnsatte(
                                 hovedenhet = hovedenhetKode,
                                 azureId = azureId,
                                 fraAdGruppe = groupId,
-                                mobilnr = mobilnr,
+                                mobilnummer = mobilnr,
                                 epost = epost,
                             )
                         }

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -89,6 +89,7 @@ app:
       groups:
         - 639e2806-4cc2-484c-a72a-51b4308c52a1 # team-mulighetsrommet
         - ee45478c-57a5-4ee6-b28d-b65f8c1733fe # 0000-GA-mr-admin-flate_betabruker
+        - e4468c9a-fde3-4c2f-a62d-8463902512f5 # 0000-GA-mr-nav_kontaktperson
     notifySluttdatoForGjennomforingerNarmerSeg:
       disabled: false
       cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -89,6 +89,7 @@ app:
       groups:
         - 676673aa-ec8f-4606-8399-723dce26b361 # team-mulighetsrommet
         - dde41c4b-42af-401f-bedf-9e537bcbdd37 # 0000-GA-mr-admin-flate_betabruker
+        - 9b259b32-17ae-408d-845f-ef4e70be91a6 # 0000-GA-mr-nav_kontaktperson
     notifySluttdatoForGjennomforingerNarmerSeg:
       disabled: false
       cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00

--- a/mulighetsrommet-api/src/main/resources/db/migration/V65__epost_tlf_for_nav_ansatt.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V65__epost_tlf_for_nav_ansatt.sql
@@ -1,0 +1,3 @@
+alter table nav_ansatt
+    add column mobilnummer text not null default '',
+    add column epost text not null default '';

--- a/mulighetsrommet-api/src/main/resources/db/migration/V65__epost_tlf_for_nav_ansatt.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V65__epost_tlf_for_nav_ansatt.sql
@@ -1,3 +1,3 @@
 alter table nav_ansatt
-    add column mobilnummer text not null default '',
+    add column mobilnummer text,
     add column epost text not null default '';

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImplTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MicrosoftGraphClientImplTest.kt
@@ -17,7 +17,7 @@ class MicrosoftGraphClientImplTest : FunSpec({
         val id = UUID.randomUUID()
 
         val engine = createMockEngine(
-            "/v1.0/users/$id?\$select=id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail" to {
+            "/v1.0/users/$id?\$select=id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail,mobilePhone" to {
                 respondJson(
                     MsGraphUserDto(
                         id = id,
@@ -27,6 +27,7 @@ class MicrosoftGraphClientImplTest : FunSpec({
                         mail = "donald.duck@nav.no",
                         streetAddress = "0400",
                         city = "Andeby",
+                        mobilePhone = "12345678",
                     ),
                 )
             },
@@ -41,6 +42,8 @@ class MicrosoftGraphClientImplTest : FunSpec({
             etternavn = "Duck",
             hovedenhetKode = "0400",
             hovedenhetNavn = "Andeby",
+            mobilnr = "12345678",
+            epost = "donald.duck@nav.no",
         )
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -25,6 +25,8 @@ data class MulighetsrommetTestDomain(
         hovedenhet = "2990",
         azureId = UUID.randomUUID(),
         fraAdGruppe = UUID.randomUUID(),
+        mobilnr = "12345678",
+        epost = "test@test.no",
     ),
     val ansatt2: NavAnsattDbo = NavAnsattDbo(
         navIdent = "DD2",
@@ -33,6 +35,8 @@ data class MulighetsrommetTestDomain(
         hovedenhet = "2990",
         azureId = UUID.randomUUID(),
         fraAdGruppe = UUID.randomUUID(),
+        mobilnr = "48243214",
+        epost = "test@testesen.no",
     ),
 ) {
     fun initialize(database: FlywayDatabaseAdapter) {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -25,7 +25,7 @@ data class MulighetsrommetTestDomain(
         hovedenhet = "2990",
         azureId = UUID.randomUUID(),
         fraAdGruppe = UUID.randomUUID(),
-        mobilnr = "12345678",
+        mobilnummer = "12345678",
         epost = "test@test.no",
     ),
     val ansatt2: NavAnsattDbo = NavAnsattDbo(
@@ -35,7 +35,7 @@ data class MulighetsrommetTestDomain(
         hovedenhet = "2990",
         azureId = UUID.randomUUID(),
         fraAdGruppe = UUID.randomUUID(),
-        mobilnr = "48243214",
+        mobilnummer = "48243214",
         epost = "test@testesen.no",
     ),
 ) {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
@@ -36,6 +36,8 @@ class NavAnsattRepositoryTest : FunSpec({
                 etternavn = "Duck",
                 hovedenhet = "1000",
                 fraAdGruppe = UUID.randomUUID(),
+                mobilnr = "12345678",
+                epost = "test@test.no",
             )
 
             ansatte.upsert(ansatt).shouldBeRight()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
@@ -36,7 +36,7 @@ class NavAnsattRepositoryTest : FunSpec({
                 etternavn = "Duck",
                 hovedenhet = "1000",
                 fraAdGruppe = UUID.randomUUID(),
-                mobilnr = "12345678",
+                mobilnummer = "12345678",
                 epost = "test@test.no",
             )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/MicrosoftGraphServiceTest.kt
@@ -22,6 +22,8 @@ class MicrosoftGraphServiceTest : FunSpec({
                 fornavn = "Bertil",
                 etternavn = "Betabruker",
                 navident = "B123456",
+                mobilnr = "12345678",
+                epost = "test@test.no",
             )
             val mockAccessToken = "123"
 


### PR DESCRIPTION
Legger til synk av gruppen ad-gruppen mr-nav_kontaktperson til nav-ansatt-tabellen.
Utvider tabellen med lagring av mobilnummer og epost slik at den kan brukes for uthenting av 
kontaktinfo til tiltaksansvarlige i admin-flate.
