### PR TITLE
Kan ha flere brukere med samme nav-ident i nav-ansatt-tabell

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavKontaktpersonDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/NavKontaktpersonDto.kt
@@ -1,0 +1,17 @@
+package no.nav.mulighetsrommet.api.domain.dto
+
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
+import java.util.*
+
+@Serializable
+data class NavKontaktpersonDto(
+    @Serializable(with = UUIDSerializer::class)
+    val azureId: UUID,
+    val navident: String,
+    val fornavn: String,
+    val etternavn: String,
+    val hovedenhetKode: String,
+    val mobilnr: String? = null,
+    val epost: String,
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -245,7 +245,7 @@ private fun services(appConfig: AppConfig) = module {
     single { ArrangorService(get()) }
     single { BrukerService(get(), get(), get()) }
     single { DialogService(get()) }
-    single { NavAnsattService(get()) }
+    single { NavAnsattService(get(), get()) }
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get()) }
     single { MicrosoftGraphService(get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/NavAnsattRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/NavAnsattRoutes.kt
@@ -6,13 +6,18 @@ import io.ktor.server.routing.*
 import no.nav.mulighetsrommet.api.plugins.getNavAnsattAzureId
 import no.nav.mulighetsrommet.api.services.NavAnsattService
 import no.nav.mulighetsrommet.api.utils.getAccessToken
+import no.nav.mulighetsrommet.api.utils.getNavAnsattFilter
 import org.koin.ktor.ext.inject
 
 fun Route.navAnsattRoutes() {
     val ansattService: NavAnsattService by inject()
 
-    route("/api/v1/internal/ansatt/me") {
+    route("/api/v1/internal/ansatt") {
         get {
+            val filter = getNavAnsattFilter()
+            call.respond(ansattService.hentAnsatte(filter))
+        }
+        get("/me") {
             val accessToken = call.getAccessToken()
             call.respond(ansattService.hentAnsattData(accessToken, getNavAnsattAzureId()))
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
@@ -2,12 +2,17 @@ package no.nav.mulighetsrommet.api.services
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.domain.dto.AdGruppe
+import no.nav.mulighetsrommet.api.domain.dto.NavKontaktpersonDto
+import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
 import no.nav.mulighetsrommet.api.tilgangskontroll.AdGrupper.ADMIN_FLATE_BETABRUKER
 import no.nav.mulighetsrommet.api.tilgangskontroll.AdGrupper.TEAM_MULIGHETSROMMET
+import no.nav.mulighetsrommet.api.utils.NavAnsattFilter
+import no.nav.mulighetsrommet.database.utils.getOrThrow
 import java.util.*
 
 class NavAnsattService(
     private val microsoftGraphService: MicrosoftGraphService,
+    private val navAnsattRepository: NavAnsattRepository,
 ) {
     suspend fun hentAnsattData(accessToken: String, navAnsattAzureId: UUID): AnsattData {
         val ansatt = microsoftGraphService.getNavAnsatt(accessToken, navAnsattAzureId)
@@ -21,6 +26,22 @@ class NavAnsattService(
             hovedenhet = ansatt.hovedenhetKode,
             hovedenhetNavn = ansatt.hovedenhetNavn,
         )
+    }
+
+    fun hentAnsatte(filter: NavAnsattFilter): List<NavKontaktpersonDto> {
+        return navAnsattRepository.getAll(filter).map { ansatte ->
+            ansatte.map {
+                NavKontaktpersonDto(
+                    navident = it.navIdent,
+                    azureId = it.azureId,
+                    fornavn = it.fornavn,
+                    etternavn = it.etternavn,
+                    hovedenhetKode = it.hovedenhet,
+                    mobilnr = it.mobilnummer,
+                    epost = it.epost,
+                )
+            }
+        }.getOrThrow()
     }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -181,3 +181,14 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getTiltaksgjennomforingsFilter
         lokasjoner = lokasjoner,
     )
 }
+
+data class NavAnsattFilter(
+    val azureIder: List<UUID> = emptyList(),
+)
+
+fun <T : Any> PipelineContext<T, ApplicationCall>.getNavAnsattFilter(): NavAnsattFilter {
+    val azureIder = call.parameters.getAll("azureIder")?.map { it.toUUID() } ?: emptyList()
+    return NavAnsattFilter(
+        azureIder = azureIder,
+    )
+}

--- a/mulighetsrommet-api/src/main/resources/db/migration/V66__fra_ad_gruppe_primary_key.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V66__fra_ad_gruppe_primary_key.sql
@@ -1,0 +1,3 @@
+alter table nav_ansatt drop constraint nav_ansatt_pkey cascade;
+alter table nav_ansatt drop constraint nav_ansatt_azure_id_key cascade;
+alter table nav_ansatt add PRIMARY KEY (nav_ident, fra_ad_gruppe);

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -627,6 +627,27 @@ paths:
                 items:
                   $ref: "#/components/schemas/HistorikkForBruker"
 
+  /api/v1/internal/ansatt:
+    get:
+      tags:
+        - Ansatt
+      operationId: hentAnsatte
+      parameters:
+        - in: query
+          name: azureIder
+          schema:
+            type: array
+            items:
+              type: string
+          description: Azure-id koblet til brukere
+      responses:
+        200:
+          description: Get list of employeees
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NavKontaktperson"
+
   /api/v1/internal/ansatt/me:
     get:
       tags:
@@ -1394,6 +1415,36 @@ components:
         - fnr
         - oppfolgingsenhet
         - geografiskEnhet
+
+    NavKontaktperson:
+      type: object
+      properties:
+        etternavn:
+          type: string
+          nullable: true
+        fornavn:
+          type: string
+          nullable: true
+        ident:
+          type: string
+          nullable: true
+        navn:
+          type: string
+          nullable: true
+        hovedenhet:
+          type: string
+        mobilnummer:
+          type: string
+          nullable: true
+        epost:
+          type: string
+      required:
+        - etternavn
+        - fornavn
+        - ident
+        - navn
+        - hovedenhet
+        - epost
 
     Ansatt:
       type: object

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
@@ -29,26 +29,46 @@ class NavAnsattRepositoryTest : FunSpec({
         }
 
         test("CRUD") {
+            val adGruppe1 = UUID.randomUUID()
+            val adGruppe2 = UUID.randomUUID()
+            val azureId = UUID.randomUUID()
+
             val ansatt = NavAnsattDbo(
-                azureId = UUID.randomUUID(),
+                azureId = azureId,
                 navIdent = "DD123456",
                 fornavn = "Donald",
                 etternavn = "Duck",
                 hovedenhet = "1000",
-                fraAdGruppe = UUID.randomUUID(),
+                fraAdGruppe = adGruppe1,
+                mobilnummer = "12345678",
+                epost = "test@test.no",
+            )
+
+            val ansatt2 = NavAnsattDbo(
+                azureId = azureId,
+                navIdent = "DD123456",
+                fornavn = "Donald",
+                etternavn = "Duck",
+                hovedenhet = "1000",
+                fraAdGruppe = adGruppe2,
                 mobilnummer = "12345678",
                 epost = "test@test.no",
             )
 
             ansatte.upsert(ansatt).shouldBeRight()
+            ansatte.upsert(ansatt2).shouldBeRight()
 
-            ansatte.getByAzureId(ansatt.azureId) shouldBeRight ansatt
-            ansatte.getByNavIdent(ansatt.navIdent) shouldBeRight ansatt
+            ansatte.getByAzureIdAndAdGruppe(ansatt.azureId, adGruppe1) shouldBeRight ansatt
+            ansatte.getByNavIdentAndAdGruppe(ansatt.navIdent, adGruppe1) shouldBeRight ansatt
+            ansatte.getByAzureIdAndAdGruppe(ansatt2.azureId, adGruppe2) shouldBeRight ansatt2
+            ansatte.getByNavIdentAndAdGruppe(ansatt2.navIdent, adGruppe2) shouldBeRight ansatt2
 
             ansatte.deleteByAzureId(ansatt.azureId).shouldBeRight()
 
-            ansatte.getByAzureId(ansatt.azureId) shouldBeRight null
-            ansatte.getByNavIdent(ansatt.navIdent) shouldBeRight null
+            ansatte.getByAzureIdAndAdGruppe(ansatt.azureId, adGruppe1) shouldBeRight null
+            ansatte.getByNavIdentAndAdGruppe(ansatt.navIdent, adGruppe1) shouldBeRight null
+            ansatte.getByAzureIdAndAdGruppe(ansatt2.azureId, adGruppe2) shouldBeRight null
+            ansatte.getByNavIdentAndAdGruppe(ansatt2.navIdent, adGruppe2) shouldBeRight null
         }
     }
 })

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/NavAnsattRepositoryTest.kt
@@ -2,12 +2,15 @@ package no.nav.mulighetsrommet.api.repositories
 
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
+import no.nav.mulighetsrommet.api.utils.NavAnsattFilter
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.database.utils.getOrThrow
 import java.util.*
 
 class NavAnsattRepositoryTest : FunSpec({
@@ -69,6 +72,40 @@ class NavAnsattRepositoryTest : FunSpec({
             ansatte.getByNavIdentAndAdGruppe(ansatt.navIdent, adGruppe1) shouldBeRight null
             ansatte.getByAzureIdAndAdGruppe(ansatt2.azureId, adGruppe2) shouldBeRight null
             ansatte.getByNavIdentAndAdGruppe(ansatt2.navIdent, adGruppe2) shouldBeRight null
+        }
+
+        test("Skal hente alle ansatte for en gitt ad-gruppe") {
+            val adGruppe1 = UUID.randomUUID()
+            val adGruppe2 = UUID.randomUUID()
+            val azureId = UUID.randomUUID()
+
+            val ansatt = NavAnsattDbo(
+                azureId = azureId,
+                navIdent = "DD123456",
+                fornavn = "Donald",
+                etternavn = "Duck",
+                hovedenhet = "1000",
+                fraAdGruppe = adGruppe1,
+                mobilnummer = "12345678",
+                epost = "test@test.no",
+            )
+
+            val ansatt2 = NavAnsattDbo(
+                azureId = azureId,
+                navIdent = "DD123456",
+                fornavn = "Donald",
+                etternavn = "Duck",
+                hovedenhet = "1000",
+                fraAdGruppe = adGruppe2,
+                mobilnummer = "12345678",
+                epost = "test@test.no",
+            )
+
+            ansatte.upsert(ansatt).shouldBeRight()
+            ansatte.upsert(ansatt2).shouldBeRight()
+
+            val result = ansatte.getAll(filter = NavAnsattFilter(azureIder = listOf(adGruppe1))).getOrThrow()
+            result.size shouldBe 1
         }
     }
 })


### PR DESCRIPTION
Legger til rette for at vi kan lagre nav-kontaktpersoner (tiltaksansvarlige) i nav-ansatt-tabellen.

For å gjøre det så må skjema for nav-ansatt-tabellen endres. Følgende endringer er gjort:
- Fjernet unique constrainten på azure-id
- Fjernet nav-ident som primary key
- Lagt til nav-ident + fra_ad_gruppe som komposittnøkkel

Jeg har også endret uthenting av ansatt slik at man ber om enten navident + ad-gruppe, eller azure id + ad-gruppe.

Sletting basert på azure-id vil slette brukeren fra alle rader, uavhengig av hvilken ad-gruppe brukerne kommer fra.