### PR TITLE
Skru av jobb for sync av status i prod

### DIFF
--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -83,6 +83,7 @@ app:
     synchronizeEnheterFraSanityTilApi:
       delayOfMinutes: 360 # Hver 6. time
     synchronizeTilgjengelighetsstatuser:
+      disabled: true
       cronPattern: "0 0/30 6-18 * * *" # Hver halvtime fra kl 06:00 til 18:00
     synchronizeNavAnsatte:
       cronPattern: "0 0 6 * * *" # Hver dag kl 06:00


### PR DESCRIPTION
Skrur av jobb for sync av tilgjengelighetsstatus til Sanity. 
Henter også status direkte fra db, men fallbacker til Sanity.

Logger litt ekstra for å kunne monitorere antagelsen om at denne endringen bør gå smertefritt.
Jeg kommer til å sjekke at alt ser ok ut før jeg lager ny PR som fjerner task for sync av status osv.