### PR TITLE
Hent ut og vis navRegion hvis liste over enheter tom

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -30,6 +30,7 @@ data class TiltaksgjennomforingAdminDto(
     val avtaleId: UUID? = null,
     val ansvarlig: String?,
     val navEnheter: List<NavEnhet>,
+    val navRegion: String? = null,
     val sanityId: String?,
     val oppstart: TiltaksgjennomforingDbo.Oppstartstype,
     @Serializable(with = LocalDateSerializer::class)
@@ -40,6 +41,7 @@ data class TiltaksgjennomforingAdminDto(
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
     val kontaktpersoner: List<TiltaksgjennomforingKontaktperson>? = emptyList(),
+    val avtale: AvtaleAdminDto? = null,
 ) {
     @Serializable
     data class Tiltakstype(

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -41,7 +41,6 @@ data class TiltaksgjennomforingAdminDto(
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
     val kontaktpersoner: List<TiltaksgjennomforingKontaktperson>? = emptyList(),
-    val avtale: AvtaleAdminDto? = null,
 ) {
     @Serializable
     data class Tiltakstype(

--- a/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -4,7 +4,6 @@ import Lenke from "mulighetsrommet-veileder-flate/src/components/lenke/Lenke";
 import React from "react";
 import { SorteringTiltaksgjennomforinger } from "../../../../mulighetsrommet-api-client";
 import { paginationAtom, tiltaksgjennomforingfilter } from "../../api/atoms";
-import { useAlleEnheter } from "../../api/enhet/useAlleEnheter";
 import { useAdminTiltaksgjennomforinger } from "../../api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger";
 import { useSort } from "../../hooks/useSort";
 import pageStyles from "../../pages/Page.module.scss";
@@ -72,14 +71,12 @@ export const TiltaksgjennomforingsTabell = ({ skjulKolonner }: Props) => {
   const [page, setPage] = useAtom(paginationAtom);
   const [sort, setSort] = useSort("navn");
   const [filter, setFilter] = useAtom(tiltaksgjennomforingfilter);
-  const { data: enheter, isLoading: enheterIsLoading } = useAlleEnheter();
   const pagination = data?.pagination;
   const tiltaksgjennomforinger = data?.data ?? [];
 
   if (
-    ((!tiltaksgjennomforinger || tiltaksgjennomforinger.length === 0) &&
-      isLoading) ||
-    enheterIsLoading
+    (!tiltaksgjennomforinger || tiltaksgjennomforinger.length === 0) &&
+    isLoading
   ) {
     return <Laster size="xlarge" tekst="Laster tiltaksgjennomføringer..." />;
   }

--- a/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -4,6 +4,7 @@ import Lenke from "mulighetsrommet-veileder-flate/src/components/lenke/Lenke";
 import React from "react";
 import { SorteringTiltaksgjennomforinger } from "../../../../mulighetsrommet-api-client";
 import { paginationAtom, tiltaksgjennomforingfilter } from "../../api/atoms";
+import { useAlleEnheter } from "../../api/enhet/useAlleEnheter";
 import { useAdminTiltaksgjennomforinger } from "../../api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger";
 import { useSort } from "../../hooks/useSort";
 import pageStyles from "../../pages/Page.module.scss";
@@ -71,12 +72,14 @@ export const TiltaksgjennomforingsTabell = ({ skjulKolonner }: Props) => {
   const [page, setPage] = useAtom(paginationAtom);
   const [sort, setSort] = useSort("navn");
   const [filter, setFilter] = useAtom(tiltaksgjennomforingfilter);
+  const { data: enheter, isLoading: enheterIsLoading } = useAlleEnheter();
   const pagination = data?.pagination;
   const tiltaksgjennomforinger = data?.data ?? [];
 
   if (
-    (!tiltaksgjennomforinger || tiltaksgjennomforinger.length === 0) &&
-    isLoading
+    ((!tiltaksgjennomforinger || tiltaksgjennomforinger.length === 0) &&
+      isLoading) ||
+    enheterIsLoading
   ) {
     return <Laster size="xlarge" tekst="Laster tiltaksgjennomføringer..." />;
   }
@@ -122,13 +125,14 @@ export const TiltaksgjennomforingsTabell = ({ skjulKolonner }: Props) => {
   };
 
   const formaterNavEnheter = (
+    navRegion: string = "",
     navEnheter?: { navn?: string | null; enhetsnummer?: string }[]
   ): string => {
     const liste = [...(navEnheter || [])];
     if (!liste) return "";
 
     const forsteEnhet = liste.shift();
-    if (!forsteEnhet) return "";
+    if (!forsteEnhet) return navRegion;
 
     return `${forsteEnhet?.navn} ${
       liste.length > 0 ? `+ ${liste.length}` : ""
@@ -203,7 +207,10 @@ export const TiltaksgjennomforingsTabell = ({ skjulKolonner }: Props) => {
                         .map((enhet) => enhet?.navn)
                         .join(", ")}`}
                     >
-                      {formaterNavEnheter(tiltaksgjennomforing.navEnheter)}
+                      {formaterNavEnheter(
+                        tiltaksgjennomforing.navRegion,
+                        tiltaksgjennomforing.navEnheter
+                      )}
                     </Table.DataCell>
                   </SkjulKolonne>
 

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
@@ -26,7 +26,16 @@ export const mockTiltaksgjennomforinger: PaginertTiltaksgjennomforing = {
       startDato: "2022-01-01",
       sluttDato: "2022-12-12",
       arenaAnsvarligEnhet: "2990",
-      navEnheter: [],
+      navEnheter: [
+        {
+          enhetsnummer: "5701",
+          navn: "NAV Falkenborg",
+        },
+        {
+          enhetsnummer: "5703",
+          navn: "NAV Indre Fosen",
+        },
+      ],
       status: TiltaksgjennomforingStatus.GJENNOMFORES,
       opphav: Opphav.MR_ADMIN_FLATE,
       tilgjengelighet: Tilgjengelighetsstatus.LEDIG,

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1284,6 +1284,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/EmbeddedNavEnhet"
+        navRegion:
+          type: string
         ansvarlig:
           type: string
         antallPlasser:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/kafka/amt/AmtDeltakerV1TopicConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/kafka/amt/AmtDeltakerV1TopicConsumerTest.kt
@@ -34,7 +34,7 @@ class AmtDeltakerV1TopicConsumerTest : FunSpec({
             tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Oppfolging1).getOrThrow()
         }
 
-        afterTest {
+        beforeEach {
             database.db.truncateAll()
         }
 


### PR DESCRIPTION
Henter ut navRegion fra avtalen per gjennomføring, så vi kan vise nav region i frontend i listen 
over gjennomføringer i admin-flate, dersom listen over navEnheter er tom.
