### PR TITLE
Feature/normalize nav ansatt roller

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.domain.dbo
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
-import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingKontaktperson
 import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDate
@@ -36,7 +35,7 @@ data class TiltaksgjennomforingDbo(
     val stengtFra: LocalDate? = null,
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
-    val kontaktpersoner: List<TiltaksgjennomforingKontaktperson>? = emptyList(),
+    val kontaktpersoner: List<TiltaksgjennomforingKontaktpersonDbo> = emptyList(),
 ) {
     enum class Tilgjengelighetsstatus {
         LEDIG,
@@ -49,3 +48,9 @@ data class TiltaksgjennomforingDbo(
         FELLES,
     }
 }
+
+@Serializable
+data class TiltaksgjennomforingKontaktpersonDbo(
+    val navIdent: String,
+    val navEnheter: List<String>,
+)

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -39,7 +39,7 @@ data class TiltaksgjennomforingAdminDto(
     val stengtFra: LocalDate?,
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
-    val kontaktpersoner: List<TiltaksgjennomforingKontaktperson>? = emptyList(),
+    val kontaktpersoner: List<TiltaksgjennomforingKontaktperson> = emptyList(),
 ) {
     @Serializable
     data class Tiltakstype(

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingKontaktperson.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingKontaktperson.kt
@@ -9,4 +9,5 @@ data class TiltaksgjennomforingKontaktperson(
     val epost: String? = null,
     val mobilnummer: String? = null,
     val navEnheter: List<String>,
+    val hovedenhet: String? = null,
 )

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingKontaktperson.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingKontaktperson.kt
@@ -5,9 +5,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TiltaksgjennomforingKontaktperson(
     val navIdent: String,
-    val navn: String? = null,
-    val epost: String? = null,
+    val navn: String,
+    val epost: String,
     val mobilnummer: String? = null,
     val navEnheter: List<String>,
-    val hovedenhet: String? = null,
+    val hovedenhet: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NavAnsattDbo.kt
@@ -11,10 +11,9 @@ data class NavAnsattDbo(
      */
     val hovedenhet: String,
     val azureId: UUID,
-    val fraAdGruppe: UUID,
     val mobilnummer: String? = null,
     val epost: String,
-    val rolle: NavAnsattRolle,
+    val roller: List<NavAnsattRolle>,
 )
 
 enum class NavAnsattRolle {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -201,7 +201,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 ).asExecute,
             )
 
-            tiltaksgjennomforing.kontaktpersoner?.forEach { kontakt ->
+            tiltaksgjennomforing.kontaktpersoner.forEach { kontakt ->
                 tx.run(
                     queryOf(
                         upsertKontaktperson,
@@ -217,7 +217,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 queryOf(
                     deleteKontaktpersoner,
                     tiltaksgjennomforing.id,
-                    tiltaksgjennomforing.kontaktpersoner?.let { kontakt -> db.createTextArray(kontakt.map { it.navIdent }) },
+                    tiltaksgjennomforing.kontaktpersoner.let { kontakt -> db.createTextArray(kontakt.map { it.navIdent }) },
                 ).asExecute,
             )
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -55,7 +55,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         jsonb_agg(distinct
             case
                 when tgk.tiltaksgjennomforing_id is null then null::jsonb
-                else jsonb_build_object('navIdent', tgk.kontaktperson_nav_ident, 'navn', concat(na.fornavn, ' ', na.etternavn), 'epost', na.epost, 'mobilnummer', na.mobilnummer, 'navEnheter', tgk.enheter)
+                else jsonb_build_object('navIdent', tgk.kontaktperson_nav_ident, 'navn', concat(na.fornavn, ' ', na.etternavn), 'epost', na.epost, 'mobilnummer', na.mobilnummer, 'navEnheter', tgk.enheter, 'hovedenhet', na.hovedenhet)
             end
         ) as kontaktpersoner
         """

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -17,7 +17,7 @@ import no.nav.mulighetsrommet.api.utils.getPaginationParams
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingKontaktperson
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingKontaktpersonDbo
 import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import org.koin.ktor.ext.inject
@@ -104,7 +104,7 @@ data class TiltaksgjennomforingRequest(
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
     val apenForInnsok: Boolean = true,
-    val kontaktpersoner: List<NavKontaktpersonForGjennomforing>? = emptyList(),
+    val kontaktpersoner: List<NavKontaktpersonForGjennomforing> = emptyList(),
     val estimertVentetid: String? = null,
 ) {
     fun toDbo(): StatusResponse<TiltaksgjennomforingDbo> {
@@ -142,8 +142,8 @@ data class TiltaksgjennomforingRequest(
                 opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
                 stengtFra = stengtFra,
                 stengtTil = stengtTil,
-                kontaktpersoner = kontaktpersoner?.map {
-                    TiltaksgjennomforingKontaktperson(
+                kontaktpersoner = kontaktpersoner.map {
+                    TiltaksgjennomforingKontaktpersonDbo(
                         navIdent = it.navIdent,
                         navEnheter = it.navEnheter,
                     )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
@@ -1,7 +1,6 @@
 package no.nav.mulighetsrommet.api.services
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
 import no.nav.mulighetsrommet.api.domain.dto.AdGruppe
 import no.nav.mulighetsrommet.api.domain.dto.NavKontaktpersonDto
 import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
@@ -30,7 +29,7 @@ class NavAnsattService(
     }
 
     fun hentKontaktpersoner(filter: NavAnsattFilter): List<NavKontaktpersonDto> {
-        return navAnsattRepository.getAll(filter = filter)
+        return navAnsattRepository.getAll(roller = filter.roller)
             .map { ansatte ->
                 ansatte.map {
                     NavKontaktpersonDto(
@@ -44,22 +43,6 @@ class NavAnsattService(
                     )
                 }
             }.getOrThrow()
-    }
-
-    fun hentKontaktperson(navident: String): NavKontaktpersonDto? {
-        return navAnsattRepository.getByNavIdentAndRolle(navident, NavAnsattRolle.KONTAKTPERSON).map {
-            it?.let {
-                NavKontaktpersonDto(
-                    navident = it.navIdent,
-                    azureId = it.azureId,
-                    fornavn = it.fornavn,
-                    etternavn = it.etternavn,
-                    hovedenhetKode = it.hovedenhet,
-                    mobilnr = it.mobilnummer,
-                    epost = it.epost,
-                )
-            }
-        }.getOrThrow()
     }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateSanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateSanityService.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.api.services
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
-import io.ktor.server.plugins.*
 import io.prometheus.client.cache.caffeine.CacheMetricsCollector
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.domain.dto.FylkeResponse
@@ -185,7 +184,7 @@ class VeilederflateSanityService(
         return gjennomforingerFraSanity
             .map { sanityData ->
                 val apiGjennomforing = gjennomforingerFraDb[sanityData._id]
-                val kontaktpersoner = hentKontaktpersoner(gjennomforingerFraDb[sanityData._id], enhetsId)
+                val kontaktpersoner = apiGjennomforing?.let { hentKontaktpersoner(it, enhetsId) } ?: emptyList()
                 val oppstart = apiGjennomforing?.oppstart?.name?.lowercase() ?: sanityData.oppstart
                 val oppstartsdato = apiGjennomforing?.oppstartsdato ?: sanityData.oppstartsdato
                 val estimertVentetid = apiGjennomforing?.estimertVentetid ?: sanityData.estimert_ventetid
@@ -202,30 +201,28 @@ class VeilederflateSanityService(
     }
 
     private fun hentKontaktpersoner(
-        tiltaksgjennomforingAdminDto: TiltaksgjennomforingAdminDto?,
+        tiltaksgjennomforingAdminDto: TiltaksgjennomforingAdminDto,
         enhetsId: String,
     ): List<KontaktinfoTiltaksansvarlige> {
-        return tiltaksgjennomforingAdminDto?.kontaktpersoner?.filter {
-            it.navEnheter.isEmpty() || it.navEnheter.contains(
-                enhetsId,
-            )
-        }
-            ?.map {
-                val kontaktperson = navAnsattService.hentKontaktperson(it.navIdent)
-                    ?: throw NotFoundException("Fant ikke kontaktperson med ident: ${it.navIdent}")
-                val enhet = navEnhetService.hentEnhet(kontaktperson.hovedenhetKode)
+        return tiltaksgjennomforingAdminDto.kontaktpersoner
+            .filter {
+                it.navEnheter.isEmpty() || it.navEnheter.contains(
+                    enhetsId,
+                )
+            }
+            .map {
                 KontaktinfoTiltaksansvarlige(
-                    navn = "${kontaktperson.fornavn} ${kontaktperson.etternavn}",
-                    telefonnummer = kontaktperson.mobilnr ?: "",
-                    enhet = enhet?.navn,
-                    epost = kontaktperson.epost,
+                    navn = it.navn,
+                    telefonnummer = it.mobilnummer ?: "",
+                    enhet = it.hovedenhet,
+                    epost = it.epost,
                     _rev = null,
                     _type = null,
                     _id = null,
                     _updatedAt = null,
                     _createdAt = null,
                 )
-            } ?: emptyList()
+            }
     }
 
     private suspend fun getFylkeIdBasertPaaEnhetsId(enhetsId: String?): String? {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateSanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateSanityService.kt
@@ -213,7 +213,7 @@ class VeilederflateSanityService(
             .map {
                 KontaktinfoTiltaksansvarlige(
                     navn = it.navn,
-                    telefonnummer = it.mobilnummer ?: "",
+                    telefonnummer = it.mobilnummer,
                     enhet = it.hovedenhet,
                     epost = it.epost,
                     _rev = null,

--- a/mulighetsrommet-api/src/main/resources/db/migration/V70__normalize_nav_ansatt_roles.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V70__normalize_nav_ansatt_roles.sql
@@ -1,0 +1,15 @@
+alter table nav_ansatt
+    drop constraint nav_ansatt_pkey cascade;
+
+alter table nav_ansatt
+    drop rolle,
+    drop fra_ad_gruppe;
+
+alter table nav_ansatt
+    add primary key (nav_ident);
+
+alter table nav_ansatt
+    add constraint nav_ansatt_azure_id_key unique (azure_id);
+
+alter table nav_ansatt
+    add roller nav_ansatt_rolle[] not null default array []::nav_ansatt_rolle[];

--- a/mulighetsrommet-api/src/main/resources/db/migration/V70__normalize_nav_ansatt_roles.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V70__normalize_nav_ansatt_roles.sql
@@ -13,3 +13,6 @@ alter table nav_ansatt
 
 alter table nav_ansatt
     add roller nav_ansatt_rolle[] not null default array []::nav_ansatt_rolle[];
+
+alter table tiltaksgjennomforing_kontaktperson
+    add constraint fk_kontaktperson_nav_ident foreign key (kontaktperson_nav_ident) references nav_ansatt (nav_ident) on delete cascade;

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -9,7 +9,6 @@ import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
 import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
 import no.nav.mulighetsrommet.api.repositories.NavEnhetRepository
 import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
-import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import java.util.*
 
 data class MulighetsrommetTestDomain(
@@ -27,7 +26,7 @@ data class MulighetsrommetTestDomain(
         hovedenhet = "2990",
         azureId = UUID.randomUUID(),
         mobilnummer = "12345678",
-        epost = "test@test.no",
+        epost = "donald.duck@nav.no",
         roller = listOf(NavAnsattRolle.BETABRUKER),
     ),
     val ansatt2: NavAnsattDbo = NavAnsattDbo(
@@ -37,13 +36,11 @@ data class MulighetsrommetTestDomain(
         hovedenhet = "2990",
         azureId = UUID.randomUUID(),
         mobilnummer = "48243214",
-        epost = "test@testesen.no",
+        epost = "dolly.duck@nav.no",
         roller = listOf(NavAnsattRolle.BETABRUKER),
     ),
 ) {
     fun initialize(database: FlywayDatabaseAdapter) {
-        database.truncateAll()
-
         val enheter = NavEnhetRepository(database)
         enheter.upsert(enhet).shouldBeRight()
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -26,10 +26,9 @@ data class MulighetsrommetTestDomain(
         etternavn = "Duck",
         hovedenhet = "2990",
         azureId = UUID.randomUUID(),
-        fraAdGruppe = UUID.randomUUID(),
         mobilnummer = "12345678",
         epost = "test@test.no",
-        rolle = NavAnsattRolle.BETABRUKER,
+        roller = listOf(NavAnsattRolle.BETABRUKER),
     ),
     val ansatt2: NavAnsattDbo = NavAnsattDbo(
         navIdent = "DD2",
@@ -37,10 +36,9 @@ data class MulighetsrommetTestDomain(
         etternavn = "Duck",
         hovedenhet = "2990",
         azureId = UUID.randomUUID(),
-        fraAdGruppe = UUID.randomUUID(),
         mobilnummer = "48243214",
         epost = "test@testesen.no",
-        rolle = NavAnsattRolle.BETABRUKER,
+        roller = listOf(NavAnsattRolle.BETABRUKER),
     ),
 ) {
     fun initialize(database: FlywayDatabaseAdapter) {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -5,7 +5,6 @@ import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Oppstartstype
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Tilgjengelighetsstatus
-import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingKontaktperson
 import java.time.LocalDate
 import java.util.*
 
@@ -26,15 +25,7 @@ object TiltaksgjennomforingFixtures {
         navEnheter = emptyList(),
         oppstart = Oppstartstype.FELLES,
         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-        kontaktpersoner = listOf(
-            TiltaksgjennomforingKontaktperson(
-                navIdent = "D123456",
-                navn = "Donald Duck",
-                mobilnummer = "12345678",
-                epost = "donald.duck@nav.no",
-                navEnheter = listOf("2990", "2991"),
-            ),
-        ),
+        kontaktpersoner = emptyList(),
     )
 
     val Oppfolging2 = TiltaksgjennomforingDbo(
@@ -53,15 +44,7 @@ object TiltaksgjennomforingFixtures {
         navEnheter = emptyList(),
         oppstart = Oppstartstype.FELLES,
         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-        kontaktpersoner = listOf(
-            TiltaksgjennomforingKontaktperson(
-                navIdent = "D123456",
-                navn = "Donald Duck",
-                mobilnummer = "12345678",
-                epost = "donald.duck@nav.no",
-                navEnheter = listOf("2990", "2991"),
-            ),
-        ),
+        kontaktpersoner = emptyList(),
     )
 
     val Arbeidstrening1 = TiltaksgjennomforingDbo(
@@ -80,14 +63,6 @@ object TiltaksgjennomforingFixtures {
         navEnheter = emptyList(),
         oppstart = Oppstartstype.FELLES,
         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-        kontaktpersoner = listOf(
-            TiltaksgjennomforingKontaktperson(
-                navIdent = "D123456",
-                navn = "Donald Duck",
-                mobilnummer = "12345678",
-                epost = "donald.duck@nav.no",
-                navEnheter = listOf("2990", "2991"),
-            ),
-        ),
+        kontaktpersoner = emptyList(),
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -66,7 +66,15 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         test("CRUD") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             val navEnheter = NavEnhetRepository(database.db)
-            navEnheter.upsert(NavEnhetDbo(navn = "NAV Andeby", enhetsnummer = "2990", status = NavEnhetStatus.AKTIV, type = Norg2Type.TILTAK, overordnetEnhet = null))
+            navEnheter.upsert(
+                NavEnhetDbo(
+                    navn = "NAV Andeby",
+                    enhetsnummer = "2990",
+                    status = NavEnhetStatus.AKTIV,
+                    type = Norg2Type.TILTAK,
+                    overordnetEnhet = null,
+                ),
+            )
             val navAnsatte = NavAnsattRepository(database.db)
             navAnsatte.upsert(
                 NavAnsattDbo(
@@ -75,10 +83,9 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     etternavn = "Duck",
                     hovedenhet = "2990",
                     azureId = UUID.randomUUID(),
-                    fraAdGruppe = UUID.randomUUID(),
                     mobilnummer = "12345678",
                     epost = "donald.duck@nav.no",
-                    rolle = NavAnsattRolle.KONTAKTPERSON,
+                    roller = listOf(NavAnsattRolle.KONTAKTPERSON),
                 ),
             ).shouldBeRight()
 
@@ -117,6 +124,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                         mobilnummer = "12345678",
                         epost = "donald.duck@nav.no",
                         navEnheter = listOf("2990", "2991"),
+                        hovedenhet = "2990",
                     ),
                 ),
             )

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepositoryTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -18,6 +19,7 @@ class NotificationRepositoryTest : FunSpec({
     val domain = MulighetsrommetTestDomain()
 
     beforeEach {
+        database.db.truncateAll()
         domain.initialize(database.db)
     }
 


### PR DESCRIPTION
- Grupperer rollene til `nav_ansatt` slik at vi ikke ender opp med duplikater på `nav_ident`
- Fjerner `fra_ad_gruppe` siden en rolle implisitt kan benyttes til å spore opp hvilke ad-grupper brukeren tilhører
- Legger til en foreign key constraint fra `tiltaksgjennomforing_kontaktperson` til `nav_ansatt` slik at vi sørger for at kontaktpersonene må være en nav_ansatt i løsningen, samt at kontaktpersoner for en tiltaksgjennomføring blir fjernet hvis den ansatte blir slettet fra løsningen (f.eks. slutter)