### PR TITLE
Skeleton istedenfor loader for bedre cls

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
@@ -1,4 +1,4 @@
-import { Alert, BodyShort, Button, Loader, Pagination } from '@navikt/ds-react';
+import { Alert, BodyShort, Button, Loader, Pagination, Skeleton } from '@navikt/ds-react';
 import { useAtom } from 'jotai';
 import { RESET } from 'jotai/utils';
 import { useEffect, useRef, useState } from 'react';
@@ -45,7 +45,7 @@ const Tiltaksgjennomforingsoversikt = () => {
   if (tiltaksgjennomforinger.length === 0 && (isLoading || brukerdata.isLoading)) {
     return (
       <div className={styles.filter_loader}>
-        <Loader size="xlarge" />
+        <Skeleton variant="rounded" width="100%" height="100vh" />
       </div>
     );
   }


### PR DESCRIPTION
Ønsker å prøve å bytte ut loader med Skeleton for å se om det hjelper på cumulative layout shift når veileder laster siden.
