### PR TITLE
Lokasjon til admin flate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: weekly
       day: monday
       time: "07:00"
+      timezone: Europe/Oslo
     open-pull-requests-limit: 10
 
   - package-ecosystem: gradle
@@ -14,6 +15,7 @@ updates:
       interval: weekly
       day: monday
       time: "07:00"
+      timezone: Europe/Oslo
     open-pull-requests-limit: 10
 
   - package-ecosystem: npm
@@ -22,6 +24,7 @@ updates:
       interval: weekly
       day: monday
       time: "07:00"
+      timezone: Europe/Oslo
     open-pull-requests-limit: 10
 
   # Test versjonsoppdatering av docker images i nais config

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -36,6 +36,7 @@ data class TiltaksgjennomforingDbo(
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
     val kontaktpersoner: List<TiltaksgjennomforingKontaktpersonDbo> = emptyList(),
+    val lokasjon: String,
 ) {
     enum class Tilgjengelighetsstatus {
         LEDIG,

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -36,7 +36,7 @@ data class TiltaksgjennomforingDbo(
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
     val kontaktpersoner: List<TiltaksgjennomforingKontaktpersonDbo> = emptyList(),
-    val lokasjon: String,
+    val lokasjonArrangor: String? = null,
 ) {
     enum class Tilgjengelighetsstatus {
         LEDIG,

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -41,6 +41,7 @@ data class TiltaksgjennomforingAdminDto(
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
     val kontaktpersoner: List<TiltaksgjennomforingKontaktperson> = emptyList(),
+    val lokasjon: String? = null,
 ) {
     @Serializable
     data class Tiltakstype(

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -41,7 +41,7 @@ data class TiltaksgjennomforingAdminDto(
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
     val kontaktpersoner: List<TiltaksgjennomforingKontaktperson> = emptyList(),
-    val lokasjon: String? = null,
+    val lokasjonArrangor: String? = null,
 ) {
     @Serializable
     data class Tiltakstype(

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/OpprettTiltaksgjennomforingContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/OpprettTiltaksgjennomforingContainer.tsx
@@ -88,7 +88,7 @@ const Schema = z
         required_error: "Du må velge en underenhet for tiltaksarrangør",
       })
       .min(1, "Du må velge en underenhet for tiltaksarrangør"),
-    lokasjon: z.string().refine((data) => data.length > 0, {
+    lokasjonArrangor: z.string().refine((data) => data.length > 0, {
       message: "Du må skrive inn lokasjon for hvor gjennomføringen finner sted",
     }),
     ansvarlig: z.string({ required_error: "Du må velge en ansvarlig" }),
@@ -264,7 +264,7 @@ export const OpprettTiltaksgjennomforingContainer = (
         tiltaksgjennomforing?.kontaktpersoner
       ),
       estimertVentetid: tiltaksgjennomforing?.estimertVentetid,
-      lokasjon: tiltaksgjennomforing?.lokasjon,
+      lokasjonArrangor: tiltaksgjennomforing?.lokasjonArrangor,
     },
   });
   const {
@@ -324,8 +324,8 @@ export const OpprettTiltaksgjennomforingContainer = (
 
     const lokasjonsStreng = `${lokasjon.postnummer} ${lokasjon.poststed}`;
 
-    if (lokasjonsStreng !== watch("lokasjon")) {
-      setValue("lokasjon", lokasjonsStreng);
+    if (lokasjonsStreng !== watch("lokasjonArrangor")) {
+      setValue("lokasjonArrangor", lokasjonsStreng);
     }
   }
 
@@ -376,7 +376,7 @@ export const OpprettTiltaksgjennomforingContainer = (
               : kontakt.navEnheter,
           })) || [],
       estimertVentetid: data.estimertVentetid,
-      lokasjon: data.lokasjon,
+      lokasjonArrangor: data.lokasjonArrangor,
     };
 
     try {
@@ -501,6 +501,7 @@ export const OpprettTiltaksgjennomforingContainer = (
             readOnly={arenaOpphav}
             error={errors.tittel?.message}
             label="Tiltaksnavn"
+            autoFocus
             {...register("tittel")}
           />
         </FormGroup>
@@ -637,9 +638,11 @@ export const OpprettTiltaksgjennomforingContainer = (
           />
           <TextField
             size="small"
-            label="Lokasjon"
-            {...register("lokasjon")}
-            error={errors.lokasjon ? errors.lokasjon.message : null}
+            label="Lokasjon for arrangør"
+            {...register("lokasjonArrangor")}
+            error={
+              errors.lokasjonArrangor ? errors.lokasjonArrangor.message : null
+            }
           />
         </FormGroup>
         {features?.[

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/OpprettTiltaksgjennomforingContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/OpprettTiltaksgjennomforingContainer.tsx
@@ -638,7 +638,8 @@ export const OpprettTiltaksgjennomforingContainer = (
           />
           <TextField
             size="small"
-            label="Lokasjon for arrangør"
+            label="Sted for gjennomføring"
+            description="Sted for gjennomføring, f.eks. Fredrikstad eller Tromsø. Veileder kan filtrere på verdiene i dette feltet, så ikke skriv fulle adresser."
             {...register("lokasjonArrangor")}
             error={
               errors.lokasjonArrangor ? errors.lokasjonArrangor.message : null

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
@@ -18,6 +18,7 @@ export const mockTiltaksgjennomforinger: PaginertTiltaksgjennomforing = {
       tiltaksnummer: "123456",
       virksomhetsnummer: "1000",
       virksomhetsnavn: "Valp AS",
+      avtaleId: "d1f163b7-1a41-4547-af16-03fd4492b7ba",
       tiltakstype: {
         id: "afb69ca8-ddff-45be-9fd0-8f968519468d",
         navn: "TILTAKSTYPENAVN",

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingInfo.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingInfo.tsx
@@ -171,10 +171,10 @@ export function TiltaksgjennomforingInfo() {
               verdi={tiltaksgjennomforing.virksomhetsnavn}
             />
           ) : null}
-          {tiltaksgjennomforing.lokasjon ? (
+          {tiltaksgjennomforing.lokasjonArrangor ? (
             <Metadata
               header="Lokasjon for arrangør"
-              verdi={tiltaksgjennomforing.lokasjon}
+              verdi={tiltaksgjennomforing.lokasjonArrangor}
             />
           ) : null}
         </dl>

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingInfo.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingInfo.tsx
@@ -173,7 +173,7 @@ export function TiltaksgjennomforingInfo() {
           ) : null}
           {tiltaksgjennomforing.lokasjonArrangor ? (
             <Metadata
-              header="Lokasjon for arrangør"
+              header="Lokasjon for gjennomføring"
               verdi={tiltaksgjennomforing.lokasjonArrangor}
             />
           ) : null}

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingInfo.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingInfo.tsx
@@ -74,10 +74,12 @@ export function TiltaksgjennomforingInfo() {
             header="Tiltakstype"
             verdi={tiltaksgjennomforing.tiltakstype.navn}
           />
-          <Metadata
-            header="Tiltaksnummer"
-            verdi={tiltaksgjennomforing.tiltaksnummer}
-          />
+          {tiltaksgjennomforing.tiltaksnummer ? (
+            <Metadata
+              header="Tiltaksnummer"
+              verdi={tiltaksgjennomforing.tiltaksnummer}
+            />
+          ) : null}
         </dl>
         <Separator />
         <dl className={styles.bolk}>
@@ -167,6 +169,12 @@ export function TiltaksgjennomforingInfo() {
             <Metadata
               header="Arrangør"
               verdi={tiltaksgjennomforing.virksomhetsnavn}
+            />
+          ) : null}
+          {tiltaksgjennomforing.lokasjon ? (
+            <Metadata
+              header="Lokasjon for arrangør"
+              verdi={tiltaksgjennomforing.lokasjon}
             />
           ) : null}
         </dl>

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -25,7 +25,6 @@ class TiltaksgjennomforingRepository(private val db: Database) {
 
     fun upsert(tiltaksgjennomforing: TiltaksgjennomforingDbo): QueryResult<Unit> = query {
         logger.info("Lagrer tiltaksgjennomføring id=${tiltaksgjennomforing.id}")
-
         @Language("PostgreSQL")
         val query = """
             insert into tiltaksgjennomforing (
@@ -45,7 +44,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 oppstart,
                 opphav,
                 stengt_fra,
-                stengt_til
+                stengt_til,
+                lokasjon
             )
             values (
                 :id::uuid,
@@ -64,7 +64,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 :oppstart::tiltaksgjennomforing_oppstartstype,
                 :opphav::opphav,
                 :stengt_fra,
-                :stengt_til
+                :stengt_til,
+                :lokasjon
             )
             on conflict (id)
                 do update set navn                  = excluded.navn,
@@ -82,7 +83,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                               oppstart              = excluded.oppstart,
                               opphav                = excluded.opphav,
                               stengt_fra            = excluded.stengt_fra,
-                              stengt_til            = excluded.stengt_til
+                              stengt_til            = excluded.stengt_til,
+                              lokasjon              = excluded.lokasjon
             returning *
         """.trimIndent()
 
@@ -475,6 +477,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "opphav" to opphav.name,
         "stengt_fra" to stengtFra,
         "stengt_til" to stengtTil,
+        "lokasjon" to lokasjon,
     )
 
     private fun Row.toTiltaksgjennomforingDbo() = TiltaksgjennomforingDbo(
@@ -495,6 +498,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         navEnheter = emptyList(),
         oppstart = TiltaksgjennomforingDbo.Oppstartstype.valueOf(string("oppstart")),
         opphav = ArenaMigrering.Opphav.valueOf(string("opphav")),
+        lokasjon = string("lokasjon"),
     )
 
     private fun Row.toTiltaksgjennomforingAdminDto(): TiltaksgjennomforingAdminDto {
@@ -538,6 +542,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             stengtFra = localDateOrNull("stengt_fra"),
             stengtTil = localDateOrNull("stengt_til"),
             kontaktpersoner = kontaktpersoner,
+            lokasjon = stringOrNull("lokasjon"),
         )
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -45,7 +45,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 opphav,
                 stengt_fra,
                 stengt_til,
-                lokasjon
+                lokasjon_arrangor
             )
             values (
                 :id::uuid,
@@ -65,7 +65,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 :opphav::opphav,
                 :stengt_fra,
                 :stengt_til,
-                :lokasjon
+                :lokasjon_arrangor
             )
             on conflict (id)
                 do update set navn                  = excluded.navn,
@@ -84,7 +84,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                               opphav                = excluded.opphav,
                               stengt_fra            = excluded.stengt_fra,
                               stengt_til            = excluded.stengt_til,
-                              lokasjon              = excluded.lokasjon
+                              lokasjon_arrangor              = excluded.lokasjon_arrangor
             returning *
         """.trimIndent()
 
@@ -477,7 +477,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "opphav" to opphav.name,
         "stengt_fra" to stengtFra,
         "stengt_til" to stengtTil,
-        "lokasjon" to lokasjon,
+        "lokasjon_arrangor" to lokasjonArrangor,
     )
 
     private fun Row.toTiltaksgjennomforingDbo() = TiltaksgjennomforingDbo(
@@ -498,7 +498,6 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         navEnheter = emptyList(),
         oppstart = TiltaksgjennomforingDbo.Oppstartstype.valueOf(string("oppstart")),
         opphav = ArenaMigrering.Opphav.valueOf(string("opphav")),
-        lokasjon = string("lokasjon"),
     )
 
     private fun Row.toTiltaksgjennomforingAdminDto(): TiltaksgjennomforingAdminDto {
@@ -542,7 +541,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             stengtFra = localDateOrNull("stengt_fra"),
             stengtTil = localDateOrNull("stengt_til"),
             kontaktpersoner = kontaktpersoner,
-            lokasjon = stringOrNull("lokasjon"),
+            lokasjonArrangor = stringOrNull("lokasjon_arrangor"),
         )
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -106,6 +106,7 @@ data class TiltaksgjennomforingRequest(
     val apenForInnsok: Boolean = true,
     val kontaktpersoner: List<NavKontaktpersonForGjennomforing> = emptyList(),
     val estimertVentetid: String? = null,
+    val lokasjon: String? = null,
 ) {
     fun toDbo(): StatusResponse<TiltaksgjennomforingDbo> {
         if (!startDato.isBefore(sluttDato)) {
@@ -120,6 +121,9 @@ data class TiltaksgjennomforingRequest(
         if (antallPlasser <= 0) {
             return Either.Left(BadRequest("Antall plasser må være større enn 0"))
         }
+        if (lokasjon.isNullOrEmpty()) {
+            return Either.Left(BadRequest("Lokasjon må være satt"))
+        }
 
         return Either.Right(
             TiltaksgjennomforingDbo(
@@ -132,7 +136,11 @@ data class TiltaksgjennomforingRequest(
                 arenaAnsvarligEnhet = enhet,
                 avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
                 antallPlasser = antallPlasser,
-                tilgjengelighet = if (apenForInnsok) TiltaksgjennomforingDbo.Tilgjengelighetsstatus.LEDIG else { TiltaksgjennomforingDbo.Tilgjengelighetsstatus.STENGT },
+                tilgjengelighet = if (apenForInnsok) {
+                    TiltaksgjennomforingDbo.Tilgjengelighetsstatus.LEDIG
+                } else {
+                    TiltaksgjennomforingDbo.Tilgjengelighetsstatus.STENGT
+                },
                 estimertVentetid = estimertVentetid,
                 tiltaksnummer = tiltaksnummer,
                 virksomhetsnummer = virksomhetsnummer,
@@ -148,6 +156,7 @@ data class TiltaksgjennomforingRequest(
                         navEnheter = it.navEnheter,
                     )
                 },
+                lokasjon = lokasjon,
             ),
         )
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -106,7 +106,7 @@ data class TiltaksgjennomforingRequest(
     val apenForInnsok: Boolean = true,
     val kontaktpersoner: List<NavKontaktpersonForGjennomforing> = emptyList(),
     val estimertVentetid: String? = null,
-    val lokasjon: String? = null,
+    val lokasjonArrangor: String? = null,
 ) {
     fun toDbo(): StatusResponse<TiltaksgjennomforingDbo> {
         if (!startDato.isBefore(sluttDato)) {
@@ -121,8 +121,8 @@ data class TiltaksgjennomforingRequest(
         if (antallPlasser <= 0) {
             return Either.Left(BadRequest("Antall plasser må være større enn 0"))
         }
-        if (lokasjon.isNullOrEmpty()) {
-            return Either.Left(BadRequest("Lokasjon må være satt"))
+        if (lokasjonArrangor.isNullOrEmpty()) {
+            return Either.Left(BadRequest("Lokasjon for arrangørw må være satt"))
         }
 
         return Either.Right(
@@ -156,7 +156,7 @@ data class TiltaksgjennomforingRequest(
                         navEnheter = it.navEnheter,
                     )
                 },
-                lokasjon = lokasjon,
+                lokasjonArrangor = lokasjonArrangor,
             ),
         )
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -122,7 +122,7 @@ data class TiltaksgjennomforingRequest(
             return Either.Left(BadRequest("Antall plasser må være større enn 0"))
         }
         if (lokasjonArrangor.isNullOrEmpty()) {
-            return Either.Left(BadRequest("Lokasjon for arrangørw må være satt"))
+            return Either.Left(BadRequest("Lokasjon for gjennomføring må være satt"))
         }
 
         return Either.Right(

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -21,7 +21,6 @@ select tg.id::uuid,
        tg.stengt_fra,
        tg.stengt_til,
        avtale_ne.navn           as navRegionForAvtale,
-       tg.lokasjon_arrangor,
        array_agg(tg_a.navident) as ansvarlige,
        jsonb_agg(distinct
                  case
@@ -36,7 +35,8 @@ select tg.id::uuid,
                                              concat(na.fornavn, ' ', na.etternavn), 'epost', na.epost, 'mobilnummer',
                                              na.mobilnummer, 'navEnheter', tgk.enheter, 'hovedenhet', na.hovedenhet)
                      end
-           )                    as kontaktpersoner
+           )                    as kontaktpersoner,
+       tg.lokasjon_arrangor
 from tiltaksgjennomforing tg
          inner join tiltakstype t on tg.tiltakstype_id = t.id
          left join tiltaksgjennomforing_ansvarlig tg_a on tg_a.tiltaksgjennomforing_id = tg.id

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -21,7 +21,7 @@ select tg.id::uuid,
        tg.stengt_fra,
        tg.stengt_til,
        avtale_ne.navn           as navRegionForAvtale,
-       tg.lokasjon,
+       tg.lokasjon_arrangor,
        array_agg(tg_a.navident) as ansvarlige,
        jsonb_agg(distinct
                  case

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -21,6 +21,7 @@ select tg.id::uuid,
        tg.stengt_fra,
        tg.stengt_til,
        avtale_ne.navn           as navRegionForAvtale,
+       tg.lokasjon,
        array_agg(tg_a.navident) as ansvarlige,
        jsonb_agg(distinct
                  case

--- a/mulighetsrommet-api/src/main/resources/db/migration/V72__tiltaksgjennomforing_lokasjon.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V72__tiltaksgjennomforing_lokasjon.sql
@@ -1,2 +1,2 @@
 alter table tiltaksgjennomforing
-add column lokasjon text;
+add column lokasjon_arrangor text;

--- a/mulighetsrommet-api/src/main/resources/db/migration/V72__tiltaksgjennomforing_lokasjon.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V72__tiltaksgjennomforing_lokasjon.sql
@@ -1,0 +1,2 @@
+alter table tiltaksgjennomforing
+add column lokasjon text;

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1361,6 +1361,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TiltaksgjennomforingKontaktpersoner"
+        lokasjon:
+          type: string
       required:
         - id
         - tiltakstype
@@ -1420,6 +1422,8 @@ components:
             $ref: "#/components/schemas/TiltaksgjennomforingKontaktpersonerRequest"
         estimertVentetid:
           type: string
+        lokasjon:
+          type: string
       required:
         - id
         - avtaleId
@@ -1433,6 +1437,7 @@ components:
         - navEnheter
         - oppstart
         - kontaktpersoner
+        - lokasjon
 
     TiltaksgjennomforingAvslutningsstatus:
       type: string
@@ -2070,6 +2075,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Virksomhet"
+          nullable: true
+        postnummer:
+          type: string
+          nullable: true
+        poststed:
+          type: string
           nullable: true
       required:
         - organisasjonsnummer

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1361,7 +1361,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TiltaksgjennomforingKontaktpersoner"
-        lokasjon:
+        lokasjonArrangor:
           type: string
       required:
         - id
@@ -1422,7 +1422,7 @@ components:
             $ref: "#/components/schemas/TiltaksgjennomforingKontaktpersonerRequest"
         estimertVentetid:
           type: string
-        lokasjon:
+        lokasjonArrangor:
           type: string
       required:
         - id
@@ -1437,7 +1437,7 @@ components:
         - navEnheter
         - oppstart
         - kontaktpersoner
-        - lokasjon
+        - lokasjonArrangor
 
     TiltaksgjennomforingAvslutningsstatus:
       type: string

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -22,7 +22,10 @@ import no.nav.mulighetsrommet.database.utils.getOrThrow
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.*
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingDbo.Tilgjengelighetsstatus
-import no.nav.mulighetsrommet.domain.dto.*
+import no.nav.mulighetsrommet.domain.dto.NavEnhet
+import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingAdminDto
+import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingKontaktperson
+import no.nav.mulighetsrommet.domain.dto.Tiltaksgjennomforingsstatus
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -109,12 +112,29 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         test("Skal hente ut navRegion fra avtale for en gitt gjennomføring") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             val navEnheter = NavEnhetRepository(database.db)
-            navEnheter.upsert(NavEnhetDbo(navn = "NAV Andeby", enhetsnummer = "2990", status = NavEnhetStatus.AKTIV, type = Norg2Type.FYLKE, overordnetEnhet = null))
-            navEnheter.upsert(NavEnhetDbo(navn = "NAV Gåseby", enhetsnummer = "2980", status = NavEnhetStatus.AKTIV, type = Norg2Type.LOKAL, overordnetEnhet = null))
+            navEnheter.upsert(
+                NavEnhetDbo(
+                    navn = "NAV Andeby",
+                    enhetsnummer = "2990",
+                    status = NavEnhetStatus.AKTIV,
+                    type = Norg2Type.FYLKE,
+                    overordnetEnhet = null,
+                ),
+            )
+            navEnheter.upsert(
+                NavEnhetDbo(
+                    navn = "NAV Gåseby",
+                    enhetsnummer = "2980",
+                    status = NavEnhetStatus.AKTIV,
+                    type = Norg2Type.LOKAL,
+                    overordnetEnhet = null,
+                ),
+            )
             val avtaleFixtures = AvtaleFixtures(database)
             val avtale = avtale1.copy(navRegion = "2990")
             avtaleFixtures.upsertAvtaler(listOf(avtale))
-            val tiltaksgjennomforing = TiltaksgjennomforingFixtures.Oppfolging1.copy(avtaleId = avtale.id, navEnheter = listOf("2980"))
+            val tiltaksgjennomforing =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(avtaleId = avtale.id, navEnheter = listOf("2980"))
             tiltaksgjennomforinger.upsert(tiltaksgjennomforing).shouldBeRight()
             tiltaksgjennomforinger.get(tiltaksgjennomforing.id).shouldBeRight().should {
                 it?.navRegion shouldBe "NAV Andeby"
@@ -672,6 +692,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                         navEnheter = emptyList(),
                         oppstart = TiltaksgjennomforingDbo.Oppstartstype.FELLES,
                         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
+                        lokasjonArrangor = "0139 Oslo",
                     ),
                 )
             }


### PR DESCRIPTION
Dette er del 1 av å flytte felt for arrangørs lokasjon fra Sanity til admin-flate. Denne PRen gjør følgende:

1. Oppretter ny kolonne `lokasjon_arrangor` direkte på tiltaksgjennomføringen i databasen.
2. Prepopulerer feltet for lokasjon i skjema for tiltaksgjennomføring når bruker velger arrangør. Bruker kan overstyre det prepopulerte valget hvis ønskelig

Del 2 blir å hente lokasjon fra database istedenfor Sanity, samt hente ut lokasjoner til bruk i filter i Modia.