### PR TITLE
Henter lokasjon fra db istedenfor Sanity for gjennomføringer

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/OpprettTiltaksgjennomforingContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/OpprettTiltaksgjennomforingContainer.tsx
@@ -318,11 +318,12 @@ export const OpprettTiltaksgjennomforingContainer = (
   async function getLokasjonForArrangor(arrangorOrgnr?: string) {
     if (!arrangorOrgnr) return;
 
-    const lokasjon = await mulighetsrommetClient.virksomhet.hentVirksomhet({
-      orgnr: arrangorOrgnr,
-    });
+    const { postnummer = "", poststed = "" } =
+      await mulighetsrommetClient.virksomhet.hentVirksomhet({
+        orgnr: arrangorOrgnr,
+      });
 
-    const lokasjonsStreng = `${lokasjon.postnummer} ${lokasjon.poststed}`;
+    const lokasjonsStreng = `${postnummer} ${poststed}`;
 
     if (lokasjonsStreng !== watch("lokasjonArrangor")) {
       setValue("lokasjonArrangor", lokasjonsStreng);

--- a/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/InnsatsgruppeFilter.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/filtrering/InnsatsgruppeFilter.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Alert, Loader, Radio, RadioGroup, Skeleton } from '@navikt/ds-react';
+import { Accordion, Alert, Loader, Radio, RadioGroup } from '@navikt/ds-react';
 import { useAtom } from 'jotai';
 import { Innsatsgruppe } from 'mulighetsrommet-api-client';
 import { logEvent } from '../../core/api/logger';

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -241,7 +241,7 @@ private fun services(appConfig: AppConfig) = module {
     single { ArenaAdapterService(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     single { AvtaleService(get(), get(), get()) }
     single { TiltakshistorikkService(get(), get()) }
-    single { VeilederflateSanityService(get(), get(), get(), get(), get()) }
+    single { VeilederflateService(get(), get(), get()) }
     single { SanityTiltaksgjennomforingEnheterTilApiService(get(), get()) }
     single { ArrangorService(get()) }
     single { BrukerService(get(), get(), get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -655,4 +655,24 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             .asList
             .let { db.run(it) }
     }
+
+    fun getLokasjonerForEnhet(enhetsId: String, fylkeId: String): List<String> {
+        val params = mapOf(
+            "enhetsId" to enhetsId,
+            "fylkesId" to fylkeId,
+        )
+
+        @Language("PostgreSQL")
+        val query = """
+            select distinct tg.lokasjon_arrangor from tiltaksgjennomforing tg
+            join tiltaksgjennomforing_nav_enhet tne on tg.id = tne.tiltaksgjennomforing_id
+            join avtale a on a.id = tg.avtale_id
+            where tne.enhetsnummer = :enhetsId or a.nav_region = :fylkesId
+        """.trimIndent()
+
+        return queryOf(query, params)
+            .map { it.stringOrNull("lokasjon_arrangor") }
+            .asList
+            .let { db.run(it) }
+    }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/SanityRoutes.kt
@@ -9,7 +9,7 @@ import no.nav.mulighetsrommet.api.domain.dto.SanityResponse
 import no.nav.mulighetsrommet.api.plugins.getNavAnsattAzureId
 import no.nav.mulighetsrommet.api.plugins.getNorskIdent
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
-import no.nav.mulighetsrommet.api.services.VeilederflateSanityService
+import no.nav.mulighetsrommet.api.services.VeilederflateService
 import no.nav.mulighetsrommet.api.utils.getAccessToken
 import no.nav.mulighetsrommet.api.utils.getTiltaksgjennomforingsFilter
 import org.koin.ktor.ext.inject
@@ -19,34 +19,34 @@ import org.slf4j.LoggerFactory
 val log: Logger = LoggerFactory.getLogger("sanityRouteLogger")
 
 fun Route.sanityRoutes() {
-    val veilederflateSanityService: VeilederflateSanityService by inject()
+    val veilederflateService: VeilederflateService by inject()
     val poaoTilgangService: PoaoTilgangService by inject()
 
     route("/api/v1/internal/sanity") {
         get("/innsatsgrupper") {
             poaoTilgangService.verfiyAccessToModia(getNavAnsattAzureId())
-            call.respondWithData(veilederflateSanityService.hentInnsatsgrupper().toResponse())
+            call.respondWithData(veilederflateService.hentInnsatsgrupper().toResponse())
         }
 
         get("/tiltakstyper") {
             poaoTilgangService.verfiyAccessToModia(getNavAnsattAzureId())
-            call.respondWithData(veilederflateSanityService.hentTiltakstyper().toResponse())
+            call.respondWithData(veilederflateService.hentTiltakstyper().toResponse())
         }
 
         get("/lokasjoner") {
             poaoTilgangService.verfiyAccessToModia(getNavAnsattAzureId())
-            call.respondWithData(
-                veilederflateSanityService.hentLokasjonerForBrukersEnhetOgFylke(
+            call.respond(
+                veilederflateService.hentLokasjonerForBrukersEnhetOgFylke(
                     getNorskIdent(),
                     call.getAccessToken(),
-                ).toResponse(),
+                ),
             )
         }
 
         get("/tiltaksgjennomforinger") {
             poaoTilgangService.verfiyAccessToModia(getNavAnsattAzureId())
 
-            val result = veilederflateSanityService.hentTiltaksgjennomforingerForBrukerBasertPaEnhetOgFylke(
+            val result = veilederflateService.hentTiltaksgjennomforingerForBrukerBasertPaEnhetOgFylke(
                 getNorskIdent(),
                 call.getAccessToken(),
                 getTiltaksgjennomforingsFilter(),
@@ -57,7 +57,7 @@ fun Route.sanityRoutes() {
         get("/tiltaksgjennomforing/{id}") {
             poaoTilgangService.verfiyAccessToModia(getNavAnsattAzureId())
             val id = call.parameters.getOrFail("id")
-            val result = veilederflateSanityService.hentTiltaksgjennomforing(
+            val result = veilederflateService.hentTiltaksgjennomforing(
                 id,
                 getNorskIdent(),
                 call.getAccessToken(),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -115,4 +115,8 @@ class TiltaksgjennomforingService(
     fun getAllMidlertidigStengteGjennomforingerSomNarmerSegSluttdato(): List<TiltaksgjennomforingNotificationDto> {
         return tiltaksgjennomforingRepository.getAllMidlertidigStengteGjennomforingerSomNarmerSegSluttdato()
     }
+
+    fun getLokasjonerForBrukersEnhet(enhetsId: String, fylkeId: String): List<String> {
+        return tiltaksgjennomforingRepository.getLokasjonerForEnhet(enhetsId, fylkeId)
+    }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityFilters.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityFilters.kt
@@ -2,14 +2,6 @@ package no.nav.mulighetsrommet.api.utils
 
 import no.nav.mulighetsrommet.api.clients.vedtak.Innsatsgruppe
 
-fun byggLokasjonsFilter(lokasjoner: List<String>): String {
-    if (lokasjoner.isEmpty()) return ""
-
-    return """
-            && lokasjon in ${lokasjoner.toSanityListe()}
-    """.trimIndent()
-}
-
 fun byggEnhetOgFylkeFilter(enhetsId: String, fylkeId: String): String {
     return """
             && ('enhet.lokal.$enhetsId' in enheter[]._ref || (enheter[0] == null && 'enhet.fylke.$fylkeId' == fylke._ref))

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityFiltersKtTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityFiltersKtTest.kt
@@ -7,18 +7,6 @@ import no.nav.mulighetsrommet.api.clients.vedtak.Innsatsgruppe
 class SanityFiltersKtTest : FunSpec({
 
     context("Filter for Groq-spørringer") {
-        test("byggLokasjonsFilter skal returnere tom streng når ingen lokasjoner er valgt") {
-            val lokasjoner = emptyList<String>()
-            val result = byggLokasjonsFilter(lokasjoner)
-            result shouldBe ""
-        }
-
-        test("byggLokasjonsfilter skal returnere korrekt Groq-uttrykk når lokasjoner er valgt") {
-            val lokasjoner = listOf("Fredrikstad", "Oslo")
-            val result = byggLokasjonsFilter(lokasjoner)
-            result shouldBe "&& lokasjon in ['Fredrikstad', 'Oslo']"
-        }
-
         test("byggEnhetOgFylkeFilter skal korrekt Groq-uttrykk for brukers enhet og fylkeId") {
             val enhetsId = "0200"
             val fylkesId = "0400"


### PR DESCRIPTION
I Modia bruker vi lokasjoner for å filtrere på gjennomføringer.
Jeg endrer henting fra Sanity til admin-flate-db siden vi skal ha lokasjon bort fra Sanity.
Konsekvensen vil være at lokasjoner for individuelle gjennomføringer ikke lenger vises.
Disse individuelle lokasjonene er uansett dårlig data så vi tar en liten spansk en og fjerner dem.
