### PR TITLE
Table, repo, service og route for utkast

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -53,6 +53,7 @@ fun Application.configure(config: AppConfig) {
             navEnhetRoutes()
             virksomhetRoutes()
             notificationRoutes()
+            utkastRoutes()
         }
 
         authenticate(AuthProvider.AzureAdDefaultApp.name) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/UtkastDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/UtkastDbo.kt
@@ -1,12 +1,13 @@
 package no.nav.mulighetsrommet.api.domain.dbo
 
+import kotlinx.serialization.json.JsonElement
 import java.time.LocalDateTime
 import java.util.*
 
 data class UtkastDbo(
     val id: UUID,
     val opprettetAv: String,
-    val utkastData: String,
+    val utkastData: JsonElement,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
     val type: Utkasttype,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/UtkastDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/UtkastDbo.kt
@@ -5,7 +5,7 @@ import java.util.*
 
 data class UtkastDbo(
     val id: UUID,
-    val bruker: String,
+    val opprettetAv: String,
     val utkastData: String,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/UtkastDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/UtkastDbo.kt
@@ -1,0 +1,17 @@
+package no.nav.mulighetsrommet.api.domain.dbo
+
+import java.time.LocalDateTime
+import java.util.*
+
+data class UtkastDbo(
+    val id: UUID,
+    val bruker: String,
+    val utkastData: String,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val type: Utkasttype,
+)
+
+enum class Utkasttype {
+    Avtale, Tiltaksgjennomforing
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/UtkastDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/UtkastDto.kt
@@ -1,0 +1,33 @@
+package no.nav.mulighetsrommet.api.domain.dto
+
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.api.domain.dbo.UtkastDbo
+import no.nav.mulighetsrommet.api.domain.dbo.Utkasttype
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
+import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
+import java.time.LocalDateTime
+import java.util.*
+
+@Serializable
+data class UtkastDto(
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID,
+    val bruker: String,
+    val utkastData: String,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val createdAt: LocalDateTime,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val updatedAt: LocalDateTime,
+    val type: Utkasttype,
+) {
+    fun toDbo(): UtkastDbo {
+        return UtkastDbo(
+            id = id,
+            bruker = bruker,
+            utkastData = utkastData,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            type = type,
+        )
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/UtkastDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/UtkastDto.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.domain.dto
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import no.nav.mulighetsrommet.api.domain.dbo.UtkastDbo
 import no.nav.mulighetsrommet.api.domain.dbo.Utkasttype
 import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
@@ -13,7 +14,7 @@ data class UtkastDto(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val opprettetAv: String,
-    val utkastData: String,
+    val utkastData: JsonElement,
     @Serializable(with = LocalDateTimeSerializer::class)
     val createdAt: LocalDateTime,
     @Serializable(with = LocalDateTimeSerializer::class)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/UtkastDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/UtkastDto.kt
@@ -12,7 +12,7 @@ import java.util.*
 data class UtkastDto(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    val bruker: String,
+    val opprettetAv: String,
     val utkastData: String,
     @Serializable(with = LocalDateTimeSerializer::class)
     val createdAt: LocalDateTime,
@@ -23,7 +23,7 @@ data class UtkastDto(
     fun toDbo(): UtkastDbo {
         return UtkastDbo(
             id = id,
-            bruker = bruker,
+            opprettetAv = opprettetAv,
             utkastData = utkastData,
             createdAt = createdAt,
             updatedAt = updatedAt,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -154,6 +154,7 @@ private fun repositories() = module {
     single { VirksomhetRepository(get()) }
     single { KafkaConsumerRepository(get()) }
     single { MetrikkRepository(get()) }
+    single { UtkastRepository(get()) }
 }
 
 private fun services(appConfig: AppConfig) = module {
@@ -262,6 +263,7 @@ private fun services(appConfig: AppConfig) = module {
     single { VirksomhetService(get(), get()) }
     single { ExcelService() }
     single { MetrikkService(get()) }
+    single { UtkastService(get()) }
 }
 
 private fun tasks(config: TaskConfig) = module {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.mulighetsrommet.api.repositories
 
+import kotlinx.serialization.json.Json
 import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.domain.dbo.UtkastDbo
@@ -71,7 +72,7 @@ class UtkastRepository(private val db: Database) {
     private fun UtkastDbo.toSqlParams() = mapOf(
         "id" to id,
         "opprettet_av" to opprettetAv,
-        "utkast_data" to utkastData,
+        "utkast_data" to utkastData.toString(),
         "utkast_type" to type.name,
     )
 
@@ -79,7 +80,7 @@ class UtkastRepository(private val db: Database) {
         return UtkastDto(
             id = uuid("id"),
             opprettetAv = string("opprettet_av"),
-            utkastData = string("utkast_data"),
+            utkastData = Json.decodeFromString(string("utkast_data")),
             createdAt = localDateTime("created_at"),
             updatedAt = localDateTime("updated_at"),
             type = Utkasttype.valueOf(string("utkast_type")),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepository.kt
@@ -24,16 +24,16 @@ class UtkastRepository(private val db: Database) {
         @Language("PostgreSQL")
         val query = """
             insert into utkast(id,
-                               bruker,
+                               opprettet_av,
                                utkast_data,
                                utkast_type)
             values (:id::uuid,
-                    :bruker,
+                    :opprettet_av,
                     :utkast_data::jsonb,
                     :utkast_type::utkasttype)
-            on conflict (id) do update set  bruker      = excluded.bruker,
-                                            utkast_data = excluded.utkast_data,
-                                            utkast_type = excluded.utkast_type
+            on conflict (id) do update set  opprettet_av        = excluded.opprettet_av,
+                                            utkast_data         = excluded.utkast_data,
+                                            utkast_type         = excluded.utkast_type
             returning *
         """.trimIndent()
 
@@ -70,7 +70,7 @@ class UtkastRepository(private val db: Database) {
 
     private fun UtkastDbo.toSqlParams() = mapOf(
         "id" to id,
-        "bruker" to bruker,
+        "opprettet_av" to opprettetAv,
         "utkast_data" to utkastData,
         "utkast_type" to type.name,
     )
@@ -78,7 +78,7 @@ class UtkastRepository(private val db: Database) {
     private fun Row.toUtkastDto(): UtkastDto {
         return UtkastDto(
             id = uuid("id"),
-            bruker = string("bruker"),
+            opprettetAv = string("opprettet_av"),
             utkastData = string("utkast_data"),
             createdAt = localDateTime("created_at"),
             updatedAt = localDateTime("updated_at"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepository.kt
@@ -1,0 +1,88 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import kotliquery.Row
+import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.domain.dbo.UtkastDbo
+import no.nav.mulighetsrommet.api.domain.dbo.Utkasttype
+import no.nav.mulighetsrommet.api.domain.dto.UtkastDto
+import no.nav.mulighetsrommet.api.utils.*
+import no.nav.mulighetsrommet.database.Database
+import no.nav.mulighetsrommet.database.utils.QueryResult
+import no.nav.mulighetsrommet.database.utils.query
+import no.nav.mulighetsrommet.domain.dto.*
+import org.intellij.lang.annotations.Language
+import org.slf4j.LoggerFactory
+import java.util.*
+
+class UtkastRepository(private val db: Database) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun upsert(utkast: UtkastDbo): QueryResult<UtkastDto?> = query {
+        logger.info("Lagrer utkast id=${utkast.id}")
+
+        @Language("PostgreSQL")
+        val query = """
+            insert into utkast(id,
+                               bruker,
+                               utkast_data,
+                               utkast_type)
+            values (:id::uuid,
+                    :bruker,
+                    :utkast_data::jsonb,
+                    :utkast_type::utkasttype)
+            on conflict (id) do update set  bruker      = excluded.bruker,
+                                            utkast_data = excluded.utkast_data,
+                                            utkast_type = excluded.utkast_type
+            returning *
+        """.trimIndent()
+
+        queryOf(query, utkast.toSqlParams())
+            .map { it.toUtkastDto() }
+            .asSingle
+            .let { db.run(it) }
+    }
+
+    fun get(id: UUID): QueryResult<UtkastDto?> = query {
+        logger.info("Henter utkast med id: $id")
+        @Language("PostgreSQL")
+        val query = """
+            select * from utkast where id = ?
+        """.trimIndent()
+
+        queryOf(query, id)
+            .map { it.toUtkastDto() }
+            .asSingle
+            .let { db.run(it) }
+    }
+
+    fun delete(id: UUID) = query {
+        logger.info("Sletter utkast med id: $id")
+        @Language("PostgreSQL")
+        val query = """
+            delete from utkast where id = ?::uuid
+        """.trimIndent()
+
+        queryOf(query, id)
+            .asUpdate
+            .let { db.run(it) }
+    }
+
+    private fun UtkastDbo.toSqlParams() = mapOf(
+        "id" to id,
+        "bruker" to bruker,
+        "utkast_data" to utkastData,
+        "utkast_type" to type.name,
+    )
+
+    private fun Row.toUtkastDto(): UtkastDto {
+        return UtkastDto(
+            id = uuid("id"),
+            bruker = string("bruker"),
+            utkastData = string("utkast_data"),
+            createdAt = localDateTime("created_at"),
+            updatedAt = localDateTime("updated_at"),
+            type = Utkasttype.valueOf(string("utkast_type")),
+        )
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/UtkastRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/UtkastRoutes.kt
@@ -1,0 +1,32 @@
+package no.nav.mulighetsrommet.api.routes.v1
+
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.routing.*
+import io.ktor.server.util.*
+import no.nav.mulighetsrommet.api.domain.dto.UtkastDto
+import no.nav.mulighetsrommet.api.routes.v1.responses.respondWithStatusResponse
+import no.nav.mulighetsrommet.api.services.UtkastService
+import org.koin.ktor.ext.inject
+import java.util.*
+
+fun Route.utkastRoutes() {
+    val utkastService: UtkastService by inject()
+
+    route("/api/v1/internal/utkast") {
+        get("{id}") {
+            val id = call.parameters.getOrFail<UUID>("id")
+            call.respondWithStatusResponse(utkastService.get(id))
+        }
+
+        put {
+            val utkastData = call.receive<UtkastDto>()
+            call.respondWithStatusResponse(utkastService.upsert(utkastData.toDbo()))
+        }
+
+        delete("{id}") {
+            val id = call.parameters.getOrFail<UUID>("id")
+            call.respondWithStatusResponse(utkastService.deleteUtkast(id))
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/UtkastService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/UtkastService.kt
@@ -17,7 +17,7 @@ class UtkastService(
 
     fun upsert(utkast: UtkastDbo): StatusResponse<UtkastDto> {
         return utkastRepository.upsert(utkast).map { it!! }
-            .mapLeft { ServerError("Klarte ikke lagre utkast med id: ${utkast.id}") }
+            .mapLeft { error -> ServerError("Klarte ikke lagre utkast med id: ${utkast.id}. Cause: ${error?.toString()}") }
     }
 
     fun deleteUtkast(id: UUID): StatusResponse<Unit> {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/UtkastService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/UtkastService.kt
@@ -1,0 +1,29 @@
+package no.nav.mulighetsrommet.api.services
+
+import no.nav.mulighetsrommet.api.domain.dbo.UtkastDbo
+import no.nav.mulighetsrommet.api.domain.dto.UtkastDto
+import no.nav.mulighetsrommet.api.repositories.UtkastRepository
+import no.nav.mulighetsrommet.api.routes.v1.responses.NotFound
+import no.nav.mulighetsrommet.api.routes.v1.responses.ServerError
+import no.nav.mulighetsrommet.api.routes.v1.responses.StatusResponse
+import java.util.*
+
+class UtkastService(
+    private val utkastRepository: UtkastRepository,
+) {
+    fun get(id: UUID): StatusResponse<UtkastDto> {
+        return utkastRepository.get(id).map { it!! }.mapLeft { NotFound("Fant ingen utkast med id: $id") }
+    }
+
+    fun upsert(utkast: UtkastDbo): StatusResponse<UtkastDto> {
+        return utkastRepository.upsert(utkast).map { it!! }
+            .mapLeft { ServerError("Klarte ikke lagre utkast med id: ${utkast.id}") }
+    }
+
+    fun deleteUtkast(id: UUID): StatusResponse<Unit> {
+        return utkastRepository.delete(id).map {}
+            .mapLeft {
+                ServerError(message = "Det oppsto en feil ved sletting av utkastet")
+            }
+    }
+}

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__triggers.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__triggers.sql
@@ -38,3 +38,11 @@ CREATE TRIGGER set_timestamp
     ON avtale
     FOR EACH ROW
 EXECUTE PROCEDURE trigger_set_timestamp();
+
+DROP TRIGGER IF EXISTS set_timestamp ON utkast;
+
+CREATE TRIGGER set_timestamp
+    BEFORE UPDATE
+    ON utkast
+    FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();

--- a/mulighetsrommet-api/src/main/resources/db/migration/V77__utkast_table.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V77__utkast_table.sql
@@ -4,7 +4,7 @@ create table utkast
 (
     id uuid primary key,
     bruker text references nav_ansatt(nav_ident) on delete cascade,
-    utkast_data json not null,
+    utkast_data jsonb not null,
     created_at timestamp default now() not null,
     updated_at timestamp default now() not null,
     utkast_type utkasttype not null

--- a/mulighetsrommet-api/src/main/resources/db/migration/V77__utkast_table.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V77__utkast_table.sql
@@ -1,0 +1,11 @@
+create type utkasttype as enum ('Avtale', 'Tiltaksgjennomforing');
+
+create table utkast
+(
+    id uuid primary key,
+    bruker text references nav_ansatt(nav_ident) on delete cascade,
+    utkast_data json not null,
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null,
+    utkast_type utkasttype not null
+)

--- a/mulighetsrommet-api/src/main/resources/db/migration/V77__utkast_table.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V77__utkast_table.sql
@@ -3,7 +3,7 @@ create type utkasttype as enum ('Avtale', 'Tiltaksgjennomforing');
 create table utkast
 (
     id uuid primary key,
-    bruker text references nav_ansatt(nav_ident) on delete cascade,
+    opprettet_av text references nav_ansatt(nav_ident) on delete cascade,
     utkast_data jsonb not null,
     created_at timestamp default now() not null,
     updated_at timestamp default now() not null,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
@@ -1,0 +1,84 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
+import no.nav.mulighetsrommet.api.createDatabaseTestConfig
+import no.nav.mulighetsrommet.api.domain.dbo.*
+import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import java.time.LocalDateTime
+import java.util.*
+
+class UtkastRepositoryTest : FunSpec({
+    val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
+
+    beforeEach {
+        val navAnsatte = NavAnsattRepository(database.db)
+        val enheter = NavEnhetRepository(database.db)
+        enheter.upsert(
+            NavEnhetDbo(
+                navn = "IT-avdelingen",
+                enhetsnummer = "2990",
+                status = NavEnhetStatus.AKTIV,
+                type = Norg2Type.LOKAL,
+                overordnetEnhet = null,
+            ),
+        )
+
+        navAnsatte.upsert(
+            NavAnsattDbo(
+                navIdent = "B123456",
+                fornavn = "Bertil",
+                etternavn = "Betabruker",
+                hovedenhet = "2990",
+                azureId = UUID.randomUUID(),
+                mobilnummer = null,
+                epost = "",
+                roller = emptyList(),
+                skalSlettesDato = null,
+            ),
+        )
+    }
+
+    context("CRUD for Utkast") {
+        val utkastRepository = UtkastRepository(database.db)
+
+        test("Upsert, Get og Delete") {
+            val utkastId = UUID.randomUUID()
+            val utkast = UtkastDbo(
+                id = utkastId,
+                bruker = "B123456",
+                utkastData = "{\"id\":\"123\",\"navn\":\"Min gjennomføring er kul\"}",
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now(),
+                type = Utkasttype.Tiltaksgjennomforing,
+            )
+            utkastRepository.upsert(utkast).shouldBeRight().should {
+                it?.bruker shouldBe "B123456"
+                it?.utkastData shouldContain "Min gjennomføring er kul"
+                it?.type shouldBe Utkasttype.Tiltaksgjennomforing
+            }
+
+            val redigertUtkast = utkast.copy(utkastData = "{\"id\":\"123\",\"navn\":\"Min gjennomføring er fet\"}")
+            utkastRepository.upsert(redigertUtkast).shouldBeRight().should {
+                it?.bruker shouldBe "B123456"
+                it?.utkastData shouldContain "Min gjennomføring er fet"
+                it?.type shouldBe Utkasttype.Tiltaksgjennomforing
+            }
+
+            utkastRepository.get(utkastId).shouldBeRight().should {
+                it?.id shouldBe utkastId
+                it?.bruker shouldBe "B123456"
+                it?.utkastData shouldContain "Min gjennomføring er fet"
+                it?.type shouldBe Utkasttype.Tiltaksgjennomforing
+            }
+
+            utkastRepository.delete(utkastId).shouldBeRight()
+
+            utkastRepository.get(utkastId).shouldBeRight(null)
+        }
+    }
+})

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
@@ -51,28 +51,28 @@ class UtkastRepositoryTest : FunSpec({
             val utkastId = UUID.randomUUID()
             val utkast = UtkastDbo(
                 id = utkastId,
-                bruker = "B123456",
+                opprettetAv = "B123456",
                 utkastData = "{\"id\":\"123\",\"navn\":\"Min gjennomføring er kul\"}",
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now(),
                 type = Utkasttype.Tiltaksgjennomforing,
             )
             utkastRepository.upsert(utkast).shouldBeRight().should {
-                it?.bruker shouldBe "B123456"
+                it?.opprettetAv shouldBe "B123456"
                 it?.utkastData shouldContain "Min gjennomføring er kul"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }
 
             val redigertUtkast = utkast.copy(utkastData = "{\"id\":\"123\",\"navn\":\"Min gjennomføring er fet\"}")
             utkastRepository.upsert(redigertUtkast).shouldBeRight().should {
-                it?.bruker shouldBe "B123456"
+                it?.opprettetAv shouldBe "B123456"
                 it?.utkastData shouldContain "Min gjennomføring er fet"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }
 
             utkastRepository.get(utkastId).shouldBeRight().should {
                 it?.id shouldBe utkastId
-                it?.bruker shouldBe "B123456"
+                it?.opprettetAv shouldBe "B123456"
                 it?.utkastData shouldContain "Min gjennomføring er fet"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
@@ -9,6 +9,7 @@ import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.*
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import java.time.LocalDateTime
 import java.util.*
 
@@ -16,6 +17,7 @@ class UtkastRepositoryTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
 
     beforeEach {
+        database.db.truncateAll()
         val navAnsatte = NavAnsattRepository(database.db)
         val enheter = NavEnhetRepository(database.db)
         enheter.upsert(
@@ -27,7 +29,6 @@ class UtkastRepositoryTest : FunSpec({
                 overordnetEnhet = null,
             ),
         )
-
         navAnsatte.upsert(
             NavAnsattDbo(
                 navIdent = "B123456",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
@@ -5,6 +5,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.*
@@ -52,28 +54,29 @@ class UtkastRepositoryTest : FunSpec({
             val utkast = UtkastDbo(
                 id = utkastId,
                 opprettetAv = "B123456",
-                utkastData = "{\"id\":\"123\",\"navn\":\"Min gjennomføring er kul\"}",
+                utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min gjennomføring er kul\"}"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now(),
                 type = Utkasttype.Tiltaksgjennomforing,
             )
             utkastRepository.upsert(utkast).shouldBeRight().should {
                 it?.opprettetAv shouldBe "B123456"
-                it?.utkastData shouldContain "Min gjennomføring er kul"
+                Json.encodeToString(it?.utkastData) shouldContain "Min gjennomføring er kul"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }
 
-            val redigertUtkast = utkast.copy(utkastData = "{\"id\":\"123\",\"navn\":\"Min gjennomføring er fet\"}")
+            val redigertUtkast =
+                utkast.copy(utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min gjennomføring er fet\"}"))
             utkastRepository.upsert(redigertUtkast).shouldBeRight().should {
                 it?.opprettetAv shouldBe "B123456"
-                it?.utkastData shouldContain "Min gjennomføring er fet"
+                Json.encodeToString(it?.utkastData) shouldContain "Min gjennomføring er fet"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }
 
             utkastRepository.get(utkastId).shouldBeRight().should {
                 it?.id shouldBe utkastId
                 it?.opprettetAv shouldBe "B123456"
-                it?.utkastData shouldContain "Min gjennomføring er fet"
+                Json.encodeToString(it?.utkastData) shouldContain "Min gjennomføring er fet"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }
 


### PR DESCRIPTION
Setter opp skjelett for å støtte utkast.
- Oppretter dbo og dto for utkast
- Egen route for GET, PUT og DELETE
- Tester put, get og delete for repository

Har foreløpig tenkt at man ønsker å vite hvem sitt utkast det gjelder (for å støtte 'Mine utkast'), vi ønsker å vite når utkastet sist ble
lagret så vi kan ha noe visning i frontend med timestamp. I tillegg kan vi skille mellom avtale og tiltaksgjennomforing i utkast-tabellen
så vi ikke trenger egen tabell for de ulike typene.
