### PR TITLE
Feature/tiltakshistorikk

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/Tiltakshistorikk.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/Tiltakshistorikk.kt
@@ -5,10 +5,10 @@ import java.time.LocalDateTime
 import java.time.Period
 
 object Tiltakshistorikk {
-    val TiltakshistorikkTimePeriod = Period.ofYears(5)
+    val TiltakshistorikkTimePeriod: Period = Period.ofYears(5)
 
     fun isRelevantTiltakshistorikk(date: LocalDateTime, today: LocalDate = LocalDate.now()): Boolean {
-        val minmumTiltakshistorikkDate = today.minus(TiltakshistorikkTimePeriod)
-        return !minmumTiltakshistorikkDate.isAfter(date.toLocalDate())
+        val tiltakshistorikkExpirationDate = today.minus(TiltakshistorikkTimePeriod)
+        return !tiltakshistorikkExpirationDate.isAfter(date.toLocalDate())
     }
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/Tiltakshistorikk.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/Tiltakshistorikk.kt
@@ -1,0 +1,14 @@
+package no.nav.mulighetsrommet.domain
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.Period
+
+object Tiltakshistorikk {
+    val TiltakshistorikkTimePeriod = Period.ofYears(5)
+
+    fun isRelevantTiltakshistorikk(date: LocalDateTime, today: LocalDate = LocalDate.now()): Boolean {
+        val minmumTiltakshistorikkDate = today.minus(TiltakshistorikkTimePeriod)
+        return !minmumTiltakshistorikkDate.isAfter(date.toLocalDate())
+    }
+}

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/ArenaTiltakshistorikkDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/ArenaTiltakshistorikkDbo.kt
@@ -9,7 +9,7 @@ import java.util.*
 
 @Serializable
 @Polymorphic
-sealed class TiltakshistorikkDbo {
+sealed class ArenaTiltakshistorikkDbo {
     @Serializable(with = UUIDSerializer::class)
     abstract val id: UUID
     abstract val norskIdent: String
@@ -38,7 +38,7 @@ sealed class TiltakshistorikkDbo {
         override val registrertIArenaDato: LocalDateTime,
         @Serializable(with = UUIDSerializer::class)
         val tiltaksgjennomforingId: UUID,
-    ) : TiltakshistorikkDbo()
+    ) : ArenaTiltakshistorikkDbo()
 
     @Serializable
     data class IndividueltTiltak(
@@ -56,5 +56,5 @@ sealed class TiltakshistorikkDbo {
         @Serializable(with = UUIDSerializer::class)
         val tiltakstypeId: UUID,
         val arrangorOrganisasjonsnummer: String,
-    ) : TiltakshistorikkDbo()
+    ) : ArenaTiltakshistorikkDbo()
 }

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakshistorikkDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/TiltakshistorikkDbo.kt
@@ -22,7 +22,7 @@ sealed class TiltakshistorikkDbo {
     abstract val tilDato: LocalDateTime?
 
     @Serializable(with = LocalDateTimeSerializer::class)
-    abstract val registrertIArenaDato: LocalDateTime?
+    abstract val registrertIArenaDato: LocalDateTime
 
     @Serializable
     data class Gruppetiltak(
@@ -35,7 +35,7 @@ sealed class TiltakshistorikkDbo {
         @Serializable(with = LocalDateTimeSerializer::class)
         override val tilDato: LocalDateTime?,
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val registrertIArenaDato: LocalDateTime?,
+        override val registrertIArenaDato: LocalDateTime,
         @Serializable(with = UUIDSerializer::class)
         val tiltaksgjennomforingId: UUID,
     ) : TiltakshistorikkDbo()
@@ -51,7 +51,7 @@ sealed class TiltakshistorikkDbo {
         @Serializable(with = LocalDateTimeSerializer::class)
         override val tilDato: LocalDateTime?,
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val registrertIArenaDato: LocalDateTime?,
+        override val registrertIArenaDato: LocalDateTime,
         val beskrivelse: String,
         @Serializable(with = UUIDSerializer::class)
         val tiltakstypeId: UUID,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -71,6 +71,7 @@ data class ServiceClientConfig(
 )
 
 data class TaskConfig(
+    val deleteExpiredTiltakshistorikk: DeleteExpiredTiltakshistorikk.Config,
     val synchronizeNorgEnheter: SynchronizeNorgEnheter.Config,
     val synchronizeEnheterFraSanityTilApi: SynchronizeTiltaksgjennomforingEnheter.Config,
     val synchronizeNavAnsatte: SynchronizeNavAnsatte.Config,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/AvtaleDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/AvtaleDbo.kt
@@ -1,29 +1,20 @@
 package no.nav.mulighetsrommet.api.domain.dbo
 
-import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dto.Avtaletype
-import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
-import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDate
 import java.util.*
 
-@Serializable
 data class AvtaleDbo(
-    @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val navn: String,
-    @Serializable(with = UUIDSerializer::class)
     val tiltakstypeId: UUID,
     val avtalenummer: String? = null,
     val leverandorOrganisasjonsnummer: String,
     val leverandorUnderenheter: List<String>,
-    @Serializable(with = UUIDSerializer::class)
     val leverandorKontaktpersonId: UUID? = null,
-    @Serializable(with = LocalDateSerializer::class)
     val startDato: LocalDate,
-    @Serializable(with = LocalDateSerializer::class)
     val sluttDato: LocalDate,
     val arenaAnsvarligEnhet: String?,
     val navRegion: String?,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -1,50 +1,37 @@
-package no.nav.mulighetsrommet.api.domain.dto
+package no.nav.mulighetsrommet.api.domain.dbo
 
-import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingTilgjengelighetsstatus
-import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
-import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDate
 import java.util.*
 
-@Serializable
 data class TiltaksgjennomforingDbo(
-    @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val navn: String,
-    @Serializable(with = UUIDSerializer::class)
     val tiltakstypeId: UUID,
     val tiltaksnummer: String?,
     val arrangorOrganisasjonsnummer: String,
-    @Serializable(with = UUIDSerializer::class)
     val arrangorKontaktpersonId: UUID?,
-    @Serializable(with = LocalDateSerializer::class)
     val startDato: LocalDate,
-    @Serializable(with = LocalDateSerializer::class)
     val sluttDato: LocalDate?,
     val arenaAnsvarligEnhet: String?,
     val avslutningsstatus: Avslutningsstatus,
     val tilgjengelighet: TiltaksgjennomforingTilgjengelighetsstatus,
     val estimertVentetid: String?,
     val antallPlasser: Int?,
-    @Serializable(with = UUIDSerializer::class)
     val avtaleId: UUID? = null,
     val ansvarlige: List<String>,
     val navEnheter: List<String>,
     val oppstart: TiltaksgjennomforingOppstartstype,
     val opphav: ArenaMigrering.Opphav,
-    @Serializable(with = LocalDateSerializer::class)
     val stengtFra: LocalDate?,
-    @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate?,
     val kontaktpersoner: List<TiltaksgjennomforingKontaktpersonDbo>,
     val lokasjonArrangor: String?,
 )
 
-@Serializable
 data class TiltaksgjennomforingKontaktpersonDbo(
     val navIdent: String,
     val navEnheter: List<String>,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/TiltakshistorikkDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/TiltakshistorikkDbo.kt
@@ -1,0 +1,15 @@
+package no.nav.mulighetsrommet.api.domain.dbo
+
+import no.nav.mulighetsrommet.domain.dbo.Deltakerstatus
+import java.time.LocalDateTime
+import java.util.*
+
+data class TiltakshistorikkDbo(
+    val id: UUID,
+    val fraDato: LocalDateTime? = null,
+    val tilDato: LocalDateTime? = null,
+    val status: Deltakerstatus,
+    val tiltaksnavn: String?,
+    val tiltakstype: String,
+    val arrangorOrganisasjonsnummer: String?,
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -268,6 +268,11 @@ private fun services(appConfig: AppConfig) = module {
 
 private fun tasks(config: TaskConfig) = module {
     single {
+        val deleteExpiredTiltakshistorikk = DeleteExpiredTiltakshistorikk(
+            config.deleteExpiredTiltakshistorikk,
+            get(),
+            get(),
+        )
         val synchronizeTiltaksgjennomforingsstatuserToKafka = SynchronizeTiltaksgjennomforingsstatuserToKafka(
             get(),
             get(),
@@ -286,8 +291,12 @@ private fun tasks(config: TaskConfig) = module {
             get(),
             get(),
         )
-        val notifySluttdatoForAvtalerNarmerSeg =
-            NotifySluttdatoForAvtalerNarmerSeg(config.notifySluttdatoForAvtalerNarmerSeg, get(), get(), get())
+        val notifySluttdatoForAvtalerNarmerSeg = NotifySluttdatoForAvtalerNarmerSeg(
+            config.notifySluttdatoForAvtalerNarmerSeg,
+            get(),
+            get(),
+            get(),
+        )
         val notifyFailedKafkaEvents = NotifyFailedKafkaEvents(
             config.notifyFailedKafkaEvents,
             get(),
@@ -309,6 +318,7 @@ private fun tasks(config: TaskConfig) = module {
         Scheduler
             .create(db.getDatasource(), notificationService.getScheduledNotificationTask())
             .startTasks(
+                deleteExpiredTiltakshistorikk.task,
                 synchronizeNorgEnheterTask.task,
                 synchronizeTiltaksgjennomforingsstatuserToKafka.task,
                 synchronizeTiltakstypestatuserToKafka.task,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -4,7 +4,7 @@ import io.ktor.utils.io.core.*
 import kotlinx.serialization.json.Json
 import kotliquery.Row
 import kotliquery.queryOf
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.api.utils.AdminTiltaksgjennomforingFilter
 import no.nav.mulighetsrommet.api.utils.DatabaseUtils
 import no.nav.mulighetsrommet.api.utils.PaginationParams

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepository.kt
@@ -10,6 +10,7 @@ import no.nav.mulighetsrommet.domain.dbo.ArenaTiltakshistorikkDbo
 import no.nav.mulighetsrommet.domain.dbo.Deltakerstatus
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
+import java.time.LocalDate
 import java.util.*
 
 class TiltakshistorikkRepository(private val db: Database) {
@@ -52,6 +53,18 @@ class TiltakshistorikkRepository(private val db: Database) {
         """.trimIndent()
 
         run { queryOf(query, id) }
+            .asExecute
+            .let { db.run(it) }
+    }
+
+    fun deleteByExpirationDate(date: LocalDate): QueryResult<Unit> = query {
+        @Language("PostgreSQL")
+        val query = """
+            delete from tiltakshistorikk
+            where til_dato < :date or til_dato is null and registrert_i_arena_dato < :date
+        """.trimIndent()
+
+        run { queryOf(query, mapOf("date" to date)) }
             .asExecute
             .let { db.run(it) }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepository.kt
@@ -57,7 +57,7 @@ class TiltakshistorikkRepository(private val db: Database) {
             .let { db.run(it) }
     }
 
-    fun deleteByExpirationDate(date: LocalDate): QueryResult<Unit> = query {
+    fun deleteByExpirationDate(date: LocalDate): QueryResult<Int> = query {
         @Language("PostgreSQL")
         val query = """
             delete from tiltakshistorikk
@@ -65,7 +65,7 @@ class TiltakshistorikkRepository(private val db: Database) {
         """.trimIndent()
 
         run { queryOf(query, mapOf("date" to date)) }
-            .asExecute
+            .asUpdate
             .let { db.run(it) }
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepository.kt
@@ -107,7 +107,7 @@ class TiltakshistorikkRepository(private val db: Database) {
                     status = Deltakerstatus.valueOf(string("status")),
                     fraDato = localDateTimeOrNull("fra_dato"),
                     tilDato = localDateTimeOrNull("til_dato"),
-                    registrertIArenaDato = localDateTimeOrNull("registrert_i_arena_dato"),
+                    registrertIArenaDato = localDateTime("registrert_i_arena_dato"),
                 )
             }
             ?: TiltakshistorikkDbo.IndividueltTiltak(
@@ -116,7 +116,7 @@ class TiltakshistorikkRepository(private val db: Database) {
                 status = Deltakerstatus.valueOf(string("status")),
                 fraDato = localDateTimeOrNull("fra_dato"),
                 tilDato = localDateTimeOrNull("til_dato"),
-                registrertIArenaDato = localDateTimeOrNull("registrert_i_arena_dato"),
+                registrertIArenaDato = localDateTime("registrert_i_arena_dato"),
                 beskrivelse = string("beskrivelse"),
                 tiltakstypeId = uuid("tiltakstypeid"),
                 arrangorOrganisasjonsnummer = string("arrangor_organisasjonsnummer"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaAdapterRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/ArenaAdapterRoutes.kt
@@ -88,7 +88,7 @@ fun Route.arenaAdapterRoutes() {
         }
 
         put("tiltakshistorikk") {
-            val tiltakshistorikk = call.receive<TiltakshistorikkDbo>()
+            val tiltakshistorikk = call.receive<ArenaTiltakshistorikkDbo>()
 
             arenaAdapterService.upsertTiltakshistorikk(tiltakshistorikk)
                 .map { call.respond(HttpStatusCode.OK, it) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -10,8 +10,8 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingKontaktpersonDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingKontaktpersonDbo
 import no.nav.mulighetsrommet.api.routes.v1.responses.*
 import no.nav.mulighetsrommet.api.services.TiltaksgjennomforingService
 import no.nav.mulighetsrommet.api.services.UtkastService

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterService.kt
@@ -75,7 +75,7 @@ class ArenaAdapterService(
             }
     }
 
-    fun upsertTiltakshistorikk(tiltakshistorikk: TiltakshistorikkDbo): QueryResult<TiltakshistorikkDbo> {
+    fun upsertTiltakshistorikk(tiltakshistorikk: ArenaTiltakshistorikkDbo): QueryResult<ArenaTiltakshistorikkDbo> {
         return this.tiltakshistorikk.upsert(tiltakshistorikk)
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -2,7 +2,7 @@ package no.nav.mulighetsrommet.api.services
 
 import arrow.core.Either
 import arrow.core.flatMap
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingNokkeltallDto
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.DeltakerRepository

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkService.kt
@@ -14,11 +14,21 @@ class TiltakshistorikkService(
 
     suspend fun hentHistorikkForBruker(norskIdent: String): List<TiltakshistorikkDto> {
         return tiltakshistorikkRepository.getTiltakshistorikkForBruker(norskIdent).map {
-            val arrangor = it.arrangor?.let { arrangor ->
-                val navn = hentArrangorNavn(arrangor.organisasjonsnummer)
-                arrangor.copy(navn = navn)
+            val arrangor = it.arrangorOrganisasjonsnummer?.let { orgnr ->
+                val navn = hentArrangorNavn(orgnr)
+                TiltakshistorikkDto.Arrangor(organisasjonsnummer = orgnr, navn = navn)
             }
-            it.copy(arrangor = arrangor)
+            it.run {
+                TiltakshistorikkDto(
+                    id = id,
+                    fraDato = fraDato,
+                    tilDato = tilDato,
+                    status = status,
+                    tiltaksnavn = tiltaksnavn,
+                    tiltakstype = tiltakstype,
+                    arrangor = arrangor,
+                )
+            }
         }
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/DeleteExpiredTiltakshistorikk.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/DeleteExpiredTiltakshistorikk.kt
@@ -1,0 +1,55 @@
+package no.nav.mulighetsrommet.api.tasks
+
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask
+import com.github.kagkarlsson.scheduler.task.helper.Tasks
+import com.github.kagkarlsson.scheduler.task.schedule.DisabledSchedule
+import com.github.kagkarlsson.scheduler.task.schedule.Schedule
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules
+import no.nav.mulighetsrommet.api.repositories.TiltakshistorikkRepository
+import no.nav.mulighetsrommet.database.utils.getOrThrow
+import no.nav.mulighetsrommet.domain.Tiltakshistorikk
+import no.nav.mulighetsrommet.slack.SlackNotifier
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import kotlin.jvm.optionals.getOrNull
+
+class DeleteExpiredTiltakshistorikk(
+    config: Config,
+    private val tiltakshistorikk: TiltakshistorikkRepository,
+    slack: SlackNotifier,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    data class Config(
+        val disabled: Boolean = false,
+        val cronPattern: String? = null,
+    ) {
+        fun toSchedule(): Schedule {
+            return if (disabled) {
+                DisabledSchedule()
+            } else {
+                Schedules.cron(cronPattern)
+            }
+        }
+    }
+
+    val task: RecurringTask<Void> = Tasks
+        .recurring(javaClass.name, config.toSchedule())
+        .onFailure { failure, _ ->
+            val cause = failure.cause.getOrNull()?.message
+            val stackTrace = failure.cause.getOrNull()?.stackTrace
+            slack.sendMessage(
+                """
+                Klarte ikke slette utgått tiltakshistorikk. Konsekvensen er at databasen kan inneholde tiltakshistorikk
+                lengre tilbake i tid enn det vi har skrevet i PVK.
+                Detaljer: $cause
+                Stacktrace: $stackTrace
+                """.trimIndent(),
+            )
+        }
+        .execute { _, _ ->
+            logger.info("Sletter utgått tiltakshistorikk...")
+            val expirationDate = LocalDate.now().minus(Tiltakshistorikk.TiltakshistorikkTimePeriod)
+            tiltakshistorikk.deleteByExpirationDate(expirationDate).getOrThrow()
+        }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/DeleteExpiredTiltakshistorikk.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/DeleteExpiredTiltakshistorikk.kt
@@ -49,7 +49,12 @@ class DeleteExpiredTiltakshistorikk(
         }
         .execute { _, _ ->
             logger.info("Sletter utgått tiltakshistorikk...")
+
             val expirationDate = LocalDate.now().minus(Tiltakshistorikk.TiltakshistorikkTimePeriod)
-            tiltakshistorikk.deleteByExpirationDate(expirationDate).getOrThrow()
+            tiltakshistorikk.deleteByExpirationDate(expirationDate)
+                .onRight {
+                    logger.info("Slettet $it rader med tiltakshistorikk")
+                }
+                .getOrThrow()
         }
 }

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -87,26 +87,24 @@ app:
         rolle: KONTAKTPERSON
 
   tasks:
+    deleteExpiredTiltakshistorikk:
+      cronPattern: "0 0 1 * * *" # Hver morgen kl. 01:00
     synchronizeNorgEnheter:
       delayOfMinutes: 360 # Hver 6. time
     synchronizeEnheterFraSanityTilApi:
       delayOfMinutes: 360 # Hver 6. time
     synchronizeNavAnsatte:
-      cronPattern: "0 0 6 * * *" # Hver dag kl 06:00
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     notifySluttdatoForGjennomforingerNarmerSeg:
-      disabled: false
-      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     notifySluttdatoForAvtalerNarmerSeg:
-      disabled: false
-      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     notifyFailedKafkaEvents:
       maxRetries: 5
       delayOfMinutes: 15
     notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg:
-      disabled: false
-      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     oppdaterMetrikker:
-      disabled: false
       delayOfMinutes: 5
 
   norg2:

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -83,6 +83,8 @@ app:
         rolle: BETABRUKER
 
   tasks:
+    deleteExpiredTiltakshistorikk:
+      disabled: true
     synchronizeNorgEnheter:
       disabled: true
       delayOfMinutes: 360 # Hver 6. time

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -87,6 +87,8 @@ app:
         rolle: KONTAKTPERSON
 
   tasks:
+    deleteExpiredTiltakshistorikk:
+      cronPattern: "0 0 1 * * *" # Hver morgen kl. 01:00
     synchronizeNorgEnheter:
       delayOfMinutes: 360 # Hver 6. time
     synchronizeEnheterFraSanityTilApi:
@@ -94,19 +96,15 @@ app:
     synchronizeNavAnsatte:
       cronPattern: "0 0 6-18 * * MON-FRI" # Hver time i løpet av arbeidsdagen
     notifySluttdatoForGjennomforingerNarmerSeg:
-      disabled: false
-      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     notifySluttdatoForAvtalerNarmerSeg:
-      disabled: false
-      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     notifyFailedKafkaEvents:
       maxRetries: 5
       delayOfMinutes: 15
     notifySluttdatoForMidlertidigStengtGjennomforingerNarmerSeg:
-      disabled: false
-      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06.00
+      cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     oppdaterMetrikker:
-      disabled: false
       delayOfMinutes: 5
 
   norg2:

--- a/mulighetsrommet-api/src/main/resources/db/migration/V80__tiltakshistorikk_reg_dato_not_null.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V80__tiltakshistorikk_reg_dato_not_null.sql
@@ -1,0 +1,2 @@
+alter table tiltakshistorikk
+    alter registrert_i_arena_dato set not null;

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -50,6 +50,7 @@ fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
     msGraphConfig = createServiceClientConfig("ms-graph"),
     arenaAdapter = createServiceClientConfig("arena-adapter"),
     tasks = TaskConfig(
+        deleteExpiredTiltakshistorikk = DeleteExpiredTiltakshistorikk.Config(disabled = true),
         synchronizeNorgEnheter = SynchronizeNorgEnheter.Config(
             delayOfMinutes = 10,
             disabled = true,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -1,6 +1,6 @@
 package no.nav.mulighetsrommet.api.fixtures
 
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -9,8 +9,8 @@ import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingKontaktpersonDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingKontaktpersonDbo
 import no.nav.mulighetsrommet.api.domain.dto.VirksomhetDto
 import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepositoryTest.kt
@@ -61,7 +61,7 @@ class TiltakshistorikkRepositoryTest : FunSpec({
             tiltakshistorikk.upsert(historikkUtenTilDato).shouldBeRight()
             tiltakshistorikk.upsert(historikkMedTilDato).shouldBeRight()
 
-            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2015, 1, 1)).shouldBeRight()
+            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2015, 1, 1)).shouldBeRight(0)
 
             tiltakshistorikk.getTiltakshistorikkForBruker("12345678910").shouldHaveSize(2)
         }
@@ -71,11 +71,11 @@ class TiltakshistorikkRepositoryTest : FunSpec({
             tiltakshistorikk.upsert(historikkUtenTilDato).shouldBeRight()
             tiltakshistorikk.upsert(historikkMedTilDato).shouldBeRight()
 
-            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2019, 1, 1)).shouldBeRight()
+            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2019, 1, 1)).shouldBeRight(1)
 
             tiltakshistorikk.getTiltakshistorikkForBruker("12345678910").shouldHaveSize(1)
 
-            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2020, 1, 1)).shouldBeRight()
+            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2020, 1, 1)).shouldBeRight(1)
 
             tiltakshistorikk.getTiltakshistorikkForBruker("12345678910").shouldHaveSize(0)
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakshistorikkRepositoryTest.kt
@@ -1,0 +1,83 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import no.nav.mulighetsrommet.api.createDatabaseTestConfig
+import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.domain.dbo.ArenaTiltakshistorikkDbo
+import no.nav.mulighetsrommet.domain.dbo.Deltakerstatus
+import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+class TiltakshistorikkRepositoryTest : FunSpec({
+    val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
+
+    val tiltakstypeIndividuell = TiltakstypeDbo(
+        id = UUID.randomUUID(),
+        navn = "Høyere utdanning",
+        tiltakskode = "HOYEREUTD",
+        rettPaaTiltakspenger = true,
+        registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
+        sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
+        fraDato = LocalDate.of(2023, 1, 11),
+        tilDato = LocalDate.of(2023, 1, 12),
+    )
+
+    beforeSpec {
+        val tiltakstyper = TiltakstypeRepository(database.db)
+        tiltakstyper.upsert(tiltakstypeIndividuell)
+    }
+
+    context("deleteByExpirationDate") {
+        val historikkUtenTilDato = ArenaTiltakshistorikkDbo.IndividueltTiltak(
+            id = UUID.randomUUID(),
+            tiltakstypeId = tiltakstypeIndividuell.id,
+            norskIdent = "12345678910",
+            status = Deltakerstatus.VENTER,
+            fraDato = null,
+            tilDato = null,
+            registrertIArenaDato = LocalDateTime.of(2018, 1, 1, 0, 0),
+            beskrivelse = "Utdanning",
+            arrangorOrganisasjonsnummer = "123456789",
+        )
+
+        val historikkMedTilDato = ArenaTiltakshistorikkDbo.IndividueltTiltak(
+            id = UUID.randomUUID(),
+            tiltakstypeId = tiltakstypeIndividuell.id,
+            norskIdent = "12345678910",
+            status = Deltakerstatus.VENTER,
+            fraDato = LocalDateTime.of(2019, 1, 1, 0, 0),
+            tilDato = LocalDateTime.of(2019, 12, 1, 0, 0),
+            registrertIArenaDato = LocalDateTime.of(2018, 1, 1, 0, 0),
+            beskrivelse = "Utdanning",
+            arrangorOrganisasjonsnummer = "123456789",
+        )
+
+        test("should not delete historikk that is newer than the specified expiration date") {
+            val tiltakshistorikk = TiltakshistorikkRepository(database.db)
+            tiltakshistorikk.upsert(historikkUtenTilDato).shouldBeRight()
+            tiltakshistorikk.upsert(historikkMedTilDato).shouldBeRight()
+
+            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2015, 1, 1)).shouldBeRight()
+
+            tiltakshistorikk.getTiltakshistorikkForBruker("12345678910").shouldHaveSize(2)
+        }
+
+        test("should delete historikk that is older than the specified expiration date") {
+            val tiltakshistorikk = TiltakshistorikkRepository(database.db)
+            tiltakshistorikk.upsert(historikkUtenTilDato).shouldBeRight()
+            tiltakshistorikk.upsert(historikkMedTilDato).shouldBeRight()
+
+            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2019, 1, 1)).shouldBeRight()
+
+            tiltakshistorikk.getTiltakshistorikkForBruker("12345678910").shouldHaveSize(1)
+
+            tiltakshistorikk.deleteByExpirationDate(LocalDate.of(2020, 1, 1)).shouldBeRight()
+
+            tiltakshistorikk.getTiltakshistorikkForBruker("12345678910").shouldHaveSize(0)
+        }
+    }
+})

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/VirksomhetRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/VirksomhetRepositoryTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.AvtaleDbo
 import no.nav.mulighetsrommet.api.domain.dbo.OverordnetEnhetDbo
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.api.domain.dto.VirksomhetDto
 import no.nav.mulighetsrommet.api.utils.VirksomhetFilter
 import no.nav.mulighetsrommet.api.utils.VirksomhetTil

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
@@ -71,7 +71,7 @@ class ArenaAdapterServiceTest : FunSpec({
         avtaleId = null,
     )
 
-    val tiltakshistorikkGruppe = TiltakshistorikkDbo.Gruppetiltak(
+    val tiltakshistorikkGruppe = ArenaTiltakshistorikkDbo.Gruppetiltak(
         id = UUID.randomUUID(),
         tiltaksgjennomforingId = tiltaksgjennomforing.id,
         norskIdent = "12345678910",
@@ -92,7 +92,7 @@ class ArenaAdapterServiceTest : FunSpec({
         tilDato = LocalDate.of(2023, 1, 12),
     )
 
-    val tiltakshistorikkIndividuell = TiltakshistorikkDbo.IndividueltTiltak(
+    val tiltakshistorikkIndividuell = ArenaTiltakshistorikkDbo.IndividueltTiltak(
         id = UUID.randomUUID(),
         norskIdent = "12345678910",
         status = Deltakerstatus.VENTER,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/KafkaSyncServiceTest.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.mockk.mockk
 import io.mockk.verifyAll
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.api.producers.TiltaksgjennomforingKafkaProducer
 import no.nav.mulighetsrommet.api.producers.TiltakstypeKafkaProducer
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
@@ -57,7 +57,7 @@ class TiltakshistorikkServiceTest : FunSpec({
         estimertVentetid = null,
     )
 
-    val tiltakshistorikkGruppe = TiltakshistorikkDbo.Gruppetiltak(
+    val tiltakshistorikkGruppe = ArenaTiltakshistorikkDbo.Gruppetiltak(
         id = UUID.randomUUID(),
         tiltaksgjennomforingId = tiltaksgjennomforing.id,
         norskIdent = "12345678910",
@@ -78,7 +78,7 @@ class TiltakshistorikkServiceTest : FunSpec({
         tilDato = LocalDate.of(2023, 1, 12),
     )
 
-    val tiltakshistorikkIndividuell = TiltakshistorikkDbo.IndividueltTiltak(
+    val tiltakshistorikkIndividuell = ArenaTiltakshistorikkDbo.IndividueltTiltak(
         id = UUID.randomUUID(),
         norskIdent = "12345678910",
         status = Deltakerstatus.VENTER,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltakshistorikkServiceTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.api.domain.dto.TiltakshistorikkDto
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakshistorikkRepository

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessor.kt
@@ -13,12 +13,15 @@ import no.nav.mulighetsrommet.arena.adapter.models.ProcessingError
 import no.nav.mulighetsrommet.arena.adapter.models.ProcessingResult
 import no.nav.mulighetsrommet.arena.adapter.models.arena.ArenaTable
 import no.nav.mulighetsrommet.arena.adapter.models.arena.ArenaTiltakdeltaker
-import no.nav.mulighetsrommet.arena.adapter.models.db.*
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Handled
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Ignored
+import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
+import no.nav.mulighetsrommet.arena.adapter.models.db.Deltaker
+import no.nav.mulighetsrommet.arena.adapter.models.db.Tiltaksgjennomforing
+import no.nav.mulighetsrommet.arena.adapter.models.db.Tiltakstype
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
-import no.nav.mulighetsrommet.arena.adapter.utils.AktivitetsplanenLaunchDate
 import no.nav.mulighetsrommet.arena.adapter.utils.ArenaUtils
+import no.nav.mulighetsrommet.domain.Tiltakshistorikk
 import no.nav.mulighetsrommet.domain.Tiltakskoder.isAmtTiltak
 import no.nav.mulighetsrommet.domain.Tiltakskoder.isGruppetiltak
 import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
@@ -36,8 +39,11 @@ class TiltakdeltakerEventProcessor(
     override suspend fun handleEvent(event: ArenaEvent) = either {
         val data = event.decodePayload<ArenaTiltakdeltaker>()
 
-        if (isRegisteredBeforeAktivitetsplanen(data)) {
-            return@either ProcessingResult(Ignored, "Deltaker ignorert fordi den registrert før Aktivitetsplanen")
+        if (isNoLongerRelevantForBrukersTiltakshistorikk(data)) {
+            return@either ProcessingResult(
+                Ignored,
+                "Deltaker ignorert fordi den ikke lengre er relevant for brukers tiltakshistorikk",
+            )
         }
 
         val tiltaksgjennomforingIsIgnored = entities
@@ -133,8 +139,8 @@ class TiltakdeltakerEventProcessor(
         entities.deleteDeltaker(mapping.entityId).bind()
     }
 
-    private fun isRegisteredBeforeAktivitetsplanen(data: ArenaTiltakdeltaker): Boolean {
-        return ArenaUtils.parseTimestamp(data.REG_DATO).isBefore(AktivitetsplanenLaunchDate)
+    private fun isNoLongerRelevantForBrukersTiltakshistorikk(data: ArenaTiltakdeltaker): Boolean {
+        return !Tiltakshistorikk.isRelevantTiltakshistorikk(ArenaUtils.parseTimestamp(data.REG_DATO))
     }
 
     private fun ArenaTiltakdeltaker.toDeltaker(id: UUID) = Either

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessor.kt
@@ -24,9 +24,9 @@ import no.nav.mulighetsrommet.arena.adapter.utils.ArenaUtils
 import no.nav.mulighetsrommet.domain.Tiltakshistorikk
 import no.nav.mulighetsrommet.domain.Tiltakskoder.isAmtTiltak
 import no.nav.mulighetsrommet.domain.Tiltakskoder.isGruppetiltak
+import no.nav.mulighetsrommet.domain.dbo.ArenaTiltakshistorikkDbo
 import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
 import no.nav.mulighetsrommet.domain.dbo.Deltakeropphav
-import no.nav.mulighetsrommet.domain.dbo.TiltakshistorikkDbo
 import java.util.*
 
 class TiltakdeltakerEventProcessor(
@@ -162,9 +162,9 @@ class TiltakdeltakerEventProcessor(
         tiltakstype: Tiltakstype,
         tiltaksgjennomforing: Tiltaksgjennomforing,
         norskIdent: String,
-    ) = either<ProcessingError, TiltakshistorikkDbo> {
+    ) = either<ProcessingError, ArenaTiltakshistorikkDbo> {
         if (isGruppetiltak(tiltakstype.tiltakskode)) {
-            TiltakshistorikkDbo.Gruppetiltak(
+            ArenaTiltakshistorikkDbo.Gruppetiltak(
                 id = id,
                 norskIdent = norskIdent,
                 status = status,
@@ -183,7 +183,7 @@ class TiltakdeltakerEventProcessor(
                     .map { it.virksomhetsnummer }
                     .bind()
             }
-            TiltakshistorikkDbo.IndividueltTiltak(
+            ArenaTiltakshistorikkDbo.IndividueltTiltak(
                 id = id,
                 norskIdent = norskIdent,
                 status = status,

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessorTest.kt
@@ -30,11 +30,11 @@ import no.nav.mulighetsrommet.arena.adapter.models.dto.ArenaOrdsArrangor
 import no.nav.mulighetsrommet.arena.adapter.models.dto.ArenaOrdsFnr
 import no.nav.mulighetsrommet.arena.adapter.repositories.*
 import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
-import no.nav.mulighetsrommet.arena.adapter.utils.AktivitetsplanenLaunchDate
 import no.nav.mulighetsrommet.arena.adapter.utils.ArenaUtils
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import no.nav.mulighetsrommet.database.utils.getOrThrow
+import no.nav.mulighetsrommet.domain.Tiltakshistorikk
 import no.nav.mulighetsrommet.domain.Tiltakskoder
 import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
 import no.nav.mulighetsrommet.domain.dbo.TiltakshistorikkDbo
@@ -51,10 +51,6 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
     afterEach {
         database.db.truncateAll()
     }
-
-    val regDatoBeforeAktivitetsplanen = AktivitetsplanenLaunchDate
-        .minusDays(1)
-        .format(ArenaUtils.TimestampFormatter)
 
     context("handleEvent") {
         val entities = ArenaEntityService(
@@ -180,14 +176,22 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                 }
             }
 
-            test("should be ignored when REG_DATO is before aktivitetsplanen") {
+            test("should be ignored when it's no longer relevant for brukers tiltakshistorikk") {
+                val regDatoBeforeTiltakshistorikkStart = LocalDateTime.now()
+                    .minus(Tiltakshistorikk.TiltakshistorikkTimePeriod)
+                    .minusDays(1)
+                    .format(ArenaUtils.TimestampFormatter)
+
                 val processor = createProcessor()
 
                 val event = createArenaTiltakdeltakerEvent(Insert) {
-                    it.copy(REG_DATO = regDatoBeforeAktivitetsplanen)
+                    it.copy(REG_DATO = regDatoBeforeTiltakshistorikkStart)
                 }
 
-                processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
+                processor.handleEvent(event).shouldBeRight().should {
+                    it.status shouldBe Ignored
+                    it.message shouldBe "Deltaker ignorert fordi den ikke lengre er relevant for brukers tiltakshistorikk"
+                }
             }
 
             test("should be ignored when dependent tiltaksgjennomforing is ignored") {

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakdeltakerEventProcessorTest.kt
@@ -36,8 +36,8 @@ import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import no.nav.mulighetsrommet.database.utils.getOrThrow
 import no.nav.mulighetsrommet.domain.Tiltakshistorikk
 import no.nav.mulighetsrommet.domain.Tiltakskoder
+import no.nav.mulighetsrommet.domain.dbo.ArenaTiltakshistorikkDbo
 import no.nav.mulighetsrommet.domain.dbo.DeltakerDbo
-import no.nav.mulighetsrommet.domain.dbo.TiltakshistorikkDbo
 import no.nav.mulighetsrommet.ktor.createMockEngine
 import no.nav.mulighetsrommet.ktor.decodeRequestBody
 import no.nav.mulighetsrommet.ktor.getLastPathParameterAsUUID
@@ -305,8 +305,8 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                 engine.requestHistory.last().apply {
                     method shouldBe HttpMethod.Put
 
-                    decodeRequestBody<TiltakshistorikkDbo>().apply {
-                        shouldBeInstanceOf<TiltakshistorikkDbo.Gruppetiltak>()
+                    decodeRequestBody<ArenaTiltakshistorikkDbo>().apply {
+                        shouldBeInstanceOf<ArenaTiltakshistorikkDbo.Gruppetiltak>()
                         id shouldBe mapping.entityId
                         tiltaksgjennomforingId shouldBe tiltaksgjennomforing.id
                         norskIdent shouldBe "12345678910"
@@ -349,8 +349,8 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                 engine.requestHistory.last().apply {
                     method shouldBe HttpMethod.Put
 
-                    decodeRequestBody<TiltakshistorikkDbo>().apply {
-                        shouldBeInstanceOf<TiltakshistorikkDbo.IndividueltTiltak>()
+                    decodeRequestBody<ArenaTiltakshistorikkDbo>().apply {
+                        shouldBeInstanceOf<ArenaTiltakshistorikkDbo.IndividueltTiltak>()
                         id shouldBe mapping.entityId
                         beskrivelse shouldBe tiltaksgjennomforingIndividuell.navn
                         arrangorOrganisasjonsnummer shouldBe "123456"
@@ -380,7 +380,7 @@ class TiltakdeltakerEventProcessorTest : FunSpec({
                 engine.requestHistory shouldHaveSingleElement {
                     it.method == HttpMethod.Put &&
                         it.url.encodedPath == "/api/v1/internal/arena/tiltakshistorikk" &&
-                        it.decodeRequestBody<TiltakshistorikkDbo>().id == mapping.entityId
+                        it.decodeRequestBody<ArenaTiltakshistorikkDbo>().id == mapping.entityId
                 }
 
                 engine.requestHistory shouldHaveSingleElement {


### PR DESCRIPTION
- Ignorerer og sletter tiltakshistorikk eldre enn 5 år, enten basert på deltakelsens `til_dato` eller `reg_dato` (hvis `til_dato` ikke er satt`
- Venter til tiltakshistorikken i prod har blitt oppdatert med reg_dato før jeg merger