### PR TITLE
Abryt gjennomføring backend

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -547,7 +547,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
     )
 
     private fun Row.toTiltaksgjennomforingAdminDto(): TiltaksgjennomforingAdminDto {
-        val ansvarlige = Json.decodeFromString<List<TiltaksgjennomforingAdminDto.Ansvarlig?>>(string("ansvarlige")).filterNotNull()
+        val ansvarlige =
+            Json.decodeFromString<List<TiltaksgjennomforingAdminDto.Ansvarlig?>>(string("ansvarlige")).filterNotNull()
         val navEnheter = Json.decodeFromString<List<NavEnhet?>>(string("nav_enheter")).filterNotNull()
         val kontaktpersoner =
             Json.decodeFromString<List<TiltaksgjennomforingKontaktperson?>>(string("kontaktpersoner")).filterNotNull()
@@ -730,5 +731,16 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             .map { it.stringOrNull("lokasjon_arrangor") }
             .asList
             .let { db.run(it) }
+    }
+
+    fun avbrytGjennomforing(gjennomforingId: UUID): QueryResult<Int> = query {
+        @Language("PostgreSQL")
+        val query = """
+            update tiltaksgjennomforing
+            set avslutningsstatus = 'AVBRUTT'
+            where id = ?::uuid
+        """.trimIndent()
+
+        queryOf(query, gjennomforingId).asUpdate.let { db.run(it) }
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -72,6 +72,11 @@ fun Route.tiltaksgjennomforingRoutes() {
             call.respond(tiltaksgjennomforingService.kobleGjennomforingTilAvtale(gjennomforingId, request.avtaleId))
         }
 
+        put("{id}/avbryt") {
+            val gjennomforingId = call.parameters.getOrFail<UUID>("id")
+            call.respond(tiltaksgjennomforingService.avbrytGjennomforing(gjennomforingId))
+        }
+
         get("{id}/nokkeltall") {
             val id = call.parameters.getOrFail<UUID>("id")
             call.respond(tiltaksgjennomforingService.getNokkeltallForTiltaksgjennomforing(id))

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
@@ -125,6 +125,6 @@ class AvtaleService(
 
         return avtaler.avbrytAvtale(avtaleId).map {
             true
-        }.mapLeft { ServerError("Internal server error when 'Avbryt avtale'") }
+        }.mapLeft { error -> ServerError("Internal server error when 'Avbryt avtale'. Error: $error") }
     }
 }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -326,6 +326,27 @@ paths:
               schema:
                 type: string
 
+  /api/v1/internal/tiltaksgjennomforinger/{id}/avbryt:
+    parameters:
+      - $ref: "#/components/parameters/ID"
+    get:
+      tags:
+        - Tiltaksgjennomforinger
+      operationId: avbrytTiltaksgjennomforing
+      responses:
+        200:
+          description: The specified tiltaksgjennomføring you want to 'Avbryte'
+          content:
+            application/json:
+              schema:
+                type: string
+        404:
+          description: "Mangler eller ugyldig id."
+          content:
+            application/json:
+              schema:
+                type: string
+
   /api/v1/internal/tiltaksgjennomforinger/{id}/nokkeltall:
     get:
       tags:


### PR DESCRIPTION
Legger til rette for å kunne avbryte tiltaksgjennomføring ved å sette `avslutningsstatus` til `AVBRUTT`.