### PR TITLE
refaktor tester

### DIFF
--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -1,95 +1,30 @@
 package no.nav.mulighetsrommet.api.fixtures
 
 import no.nav.mulighetsrommet.api.domain.dbo.AvtaleDbo
-import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
-import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
-import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
-import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
-import no.nav.mulighetsrommet.database.utils.getOrThrow
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
-import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import no.nav.mulighetsrommet.domain.dto.Avtaletype
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.*
 
-class AvtaleFixtures(private val database: FlywayDatabaseTestListener) {
-    val tiltakstypeId: UUID = UUID.fromString("0c565576-6a74-4bc2-ad5a-765580014ef9")
-
-    fun runBeforeTests() {
-        database.db.truncateAll()
-
-        val tiltakstypeRepository = TiltakstypeRepository(database.db)
-
-        tiltakstypeRepository.upsert(
-            TiltakstypeDbo(
-                tiltakstypeId,
-                "",
-                "",
-                rettPaaTiltakspenger = true,
-                registrertDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
-                sistEndretDatoIArena = LocalDateTime.of(2022, 1, 11, 0, 0, 0),
-                fraDato = LocalDate.of(2023, 1, 11),
-                tilDato = LocalDate.of(2023, 1, 12),
-            ),
-        ).mapLeft { error -> println("Shit: $error") }
-    }
-
-    fun upsertTiltakstype(tiltakstyper: List<TiltakstypeDbo>) {
-        val tiltakstypeRepository = TiltakstypeRepository(database.db)
-        tiltakstyper.forEach {
-            tiltakstypeRepository.upsert(it)
-        }
-    }
-
-    fun upsertAvtaler(avtaler: List<AvtaleDbo>): AvtaleRepository {
-        val avtaleRepository = AvtaleRepository(database.db)
-
-        avtaler.forEachIndexed { index, avtaleDbo ->
-            val avtale = avtaleDbo.copy(avtalenummer = "2023#${index + 1}-${UUID.randomUUID()}")
-            avtaleRepository.upsert(avtale).getOrThrow()
-        }
-
-        return avtaleRepository
-    }
-
-    fun createAvtaleForTiltakstype(
-        id: UUID = UUID.randomUUID(),
-        tiltakstypeId: UUID = this.tiltakstypeId,
-        navn: String = "Avtalenavn",
-        avtalenummer: String = "2023#1",
-        navRegion: String? = null,
-        avtaletype: Avtaletype = Avtaletype.Rammeavtale,
-        avslutningsstatus: Avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
-        startDato: LocalDate = LocalDate.of(2023, 1, 11),
-        sluttDato: LocalDate = LocalDate.of(2023, 2, 28),
-        leverandorOrganisasjonsnummer: String = "123456789",
-        ansvarlige: List<String> = emptyList(),
-        navEnheter: List<String> = emptyList(),
-        leverandorUnderenheter: List<String> = emptyList(),
-        opphav: ArenaMigrering.Opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-        arenaAnsvarligEnhet: String? = null,
-        leverandorKontaktpersonId: UUID? = null,
-    ): AvtaleDbo {
-        return AvtaleDbo(
-            id = id,
-            navn = navn,
-            avtalenummer = avtalenummer,
-            tiltakstypeId = tiltakstypeId,
-            leverandorOrganisasjonsnummer = leverandorOrganisasjonsnummer,
-            leverandorUnderenheter = leverandorUnderenheter,
-            startDato = startDato,
-            sluttDato = sluttDato,
-            arenaAnsvarligEnhet = arenaAnsvarligEnhet,
-            navRegion = navRegion,
-            avtaletype = avtaletype,
-            avslutningsstatus = avslutningsstatus,
-            prisbetingelser = null,
-            opphav = opphav,
-            ansvarlige = ansvarlige,
-            navEnheter = navEnheter,
-            leverandorKontaktpersonId = leverandorKontaktpersonId,
-        )
-    }
+object AvtaleFixtures {
+    val avtale1 = AvtaleDbo(
+        id = UUID.randomUUID(),
+        navn = "Avtalenavn",
+        avtalenummer = "2023#1",
+        tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
+        leverandorOrganisasjonsnummer = "123456789",
+        leverandorUnderenheter = emptyList(),
+        startDato = LocalDate.of(2023, 1, 11),
+        sluttDato = LocalDate.of(2023, 2, 28),
+        arenaAnsvarligEnhet = null,
+        navRegion = null,
+        avtaletype = Avtaletype.Rammeavtale,
+        avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
+        prisbetingelser = null,
+        opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
+        ansvarlige = emptyList(),
+        navEnheter = emptyList(),
+        leverandorKontaktpersonId = null,
+    )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleNotatFixture.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleNotatFixture.kt
@@ -1,0 +1,15 @@
+package no.nav.mulighetsrommet.api.fixtures
+
+import no.nav.mulighetsrommet.api.domain.dbo.AvtaleNotatDbo
+import java.util.*
+
+object AvtaleNotatFixture {
+    val Notat1 = AvtaleNotatDbo(
+        id = UUID.randomUUID(),
+        avtaleId = AvtaleFixtures.avtale1.id,
+        createdAt = null,
+        updatedAt = null,
+        opprettetAv = NavAnsattFixture.ansatt1.navIdent,
+        innhold = "Mitt første notat",
+    )
+}

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -6,7 +6,10 @@ import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
 import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture.ansatt1
 import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture.ansatt2
-import no.nav.mulighetsrommet.api.repositories.*
+import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
+import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
+import no.nav.mulighetsrommet.api.repositories.NavEnhetRepository
+import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
 
 data class MulighetsrommetTestDomain(
@@ -33,10 +36,5 @@ data class MulighetsrommetTestDomain(
 
         val avtaler = AvtaleRepository(database)
         avtaler.upsert(AvtaleFixtures.avtale1)
-
-        val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database)
-        tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Oppfolging1).shouldBeRight()
-        tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Oppfolging2).shouldBeRight()
-        tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Arbeidstrening1).shouldBeRight()
     }
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -2,14 +2,12 @@ package no.nav.mulighetsrommet.api.fixtures
 
 import io.kotest.assertions.arrow.core.shouldBeRight
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
-import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattDbo
-import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
-import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
-import no.nav.mulighetsrommet.api.repositories.NavEnhetRepository
+import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture.ansatt1
+import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture.ansatt2
+import no.nav.mulighetsrommet.api.repositories.*
 import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
-import java.util.*
 
 data class MulighetsrommetTestDomain(
     val enhet: NavEnhetDbo = NavEnhetDbo(
@@ -19,26 +17,7 @@ data class MulighetsrommetTestDomain(
         type = Norg2Type.DIR,
         overordnetEnhet = null,
     ),
-    val ansatt1: NavAnsattDbo = NavAnsattDbo(
-        navIdent = "DD1",
-        fornavn = "Donald",
-        etternavn = "Duck",
-        hovedenhet = "2990",
-        azureId = UUID.randomUUID(),
-        mobilnummer = "12345678",
-        epost = "donald.duck@nav.no",
-        roller = setOf(NavAnsattRolle.BETABRUKER),
-    ),
-    val ansatt2: NavAnsattDbo = NavAnsattDbo(
-        navIdent = "DD2",
-        fornavn = "Dolly",
-        etternavn = "Duck",
-        hovedenhet = "2990",
-        azureId = UUID.randomUUID(),
-        mobilnummer = "48243214",
-        epost = "dolly.duck@nav.no",
-        roller = setOf(NavAnsattRolle.BETABRUKER),
-    ),
+
 ) {
     fun initialize(database: FlywayDatabaseAdapter) {
         val enheter = NavEnhetRepository(database)
@@ -47,5 +26,17 @@ data class MulighetsrommetTestDomain(
         val ansatte = NavAnsattRepository(database)
         ansatte.upsert(ansatt1).shouldBeRight()
         ansatte.upsert(ansatt2).shouldBeRight()
+
+        val tiltakstyper = TiltakstypeRepository(database)
+        tiltakstyper.upsert(TiltakstypeFixtures.Oppfolging).shouldBeRight()
+        tiltakstyper.upsert(TiltakstypeFixtures.Arbeidstrening).shouldBeRight()
+
+        val avtaler = AvtaleRepository(database)
+        avtaler.upsert(AvtaleFixtures.avtale1)
+
+        val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database)
+        tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Oppfolging1).shouldBeRight()
+        tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Oppfolging2).shouldBeRight()
+        tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Arbeidstrening1).shouldBeRight()
     }
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/NavAnsattFixture.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/NavAnsattFixture.kt
@@ -1,0 +1,28 @@
+package no.nav.mulighetsrommet.api.fixtures
+
+import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattDbo
+import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
+import java.util.*
+
+object NavAnsattFixture {
+    val ansatt1: NavAnsattDbo = NavAnsattDbo(
+        navIdent = "DD1",
+        fornavn = "Donald",
+        etternavn = "Duck",
+        hovedenhet = "2990",
+        azureId = UUID.randomUUID(),
+        mobilnummer = "12345678",
+        epost = "donald.duck@nav.no",
+        roller = setOf(NavAnsattRolle.BETABRUKER),
+    )
+    val ansatt2: NavAnsattDbo = NavAnsattDbo(
+        navIdent = "DD2",
+        fornavn = "Dolly",
+        etternavn = "Duck",
+        hovedenhet = "2990",
+        azureId = UUID.randomUUID(),
+        mobilnummer = "48243214",
+        epost = "dolly.duck@nav.no",
+        roller = setOf(NavAnsattRolle.BETABRUKER),
+    )
+}

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleNotatRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleNotatRepositoryTest.kt
@@ -5,71 +5,44 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
-import no.nav.mulighetsrommet.api.domain.dbo.AvtaleNotatDbo
 import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
+import no.nav.mulighetsrommet.api.fixtures.AvtaleNotatFixture
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
+import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture
 import no.nav.mulighetsrommet.api.utils.NotatFilter
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import java.util.*
 
 class AvtaleNotatRepositoryTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
-    val avtaleFixture = AvtaleFixtures(database)
     val domain = MulighetsrommetTestDomain()
 
     beforeEach {
-        avtaleFixture.runBeforeTests()
+        database.db.truncateAll()
+        domain.initialize(database.db)
     }
 
     context("Notater for avtale - CRUD") {
         test("CRUD") {
-            domain.initialize(database.db)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(id = UUID.randomUUID())
             val avtaleNotater = AvtaleNotatRepository(database.db)
-            avtaleFixture.upsertAvtaler(listOf(avtale))
 
-            val notat1 = AvtaleNotatDbo(
+            val notat1 = AvtaleNotatFixture.Notat1.copy(id = UUID.randomUUID(), innhold = "Mitt første notat")
+            val notat2 = AvtaleNotatFixture.Notat1.copy(id = UUID.randomUUID(), innhold = "Mitt andre notat")
+            val notat3 = AvtaleNotatFixture.Notat1.copy(
                 id = UUID.randomUUID(),
-                avtaleId = avtale.id,
-                createdAt = null,
-                updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
-                innhold = "Mitt første notat",
-            )
-
-            val notat2 = AvtaleNotatDbo(
-                id = UUID.randomUUID(),
-                avtaleId = avtale.id,
-                createdAt = null,
-                updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
-                innhold = "Mitt andre notat",
-            )
-
-            val notat3 = AvtaleNotatDbo(
-                id = UUID.randomUUID(),
-                avtaleId = avtale.id,
-                createdAt = null,
-                updatedAt = null,
-                opprettetAv = domain.ansatt2.navIdent,
                 innhold = "En kollega sitt notat",
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
             )
-
-            val notatSomIkkeEksisterer = AvtaleNotatDbo(
-                id = UUID.randomUUID(),
-                avtaleId = avtale.id,
-                createdAt = null,
-                updatedAt = null,
-                opprettetAv = domain.ansatt2.navIdent,
-                innhold = "En kollega sitt notat",
-            )
+            val notatSomIkkeEksisterer = AvtaleNotatFixture.Notat1.copy(innhold = "Dette notatet eksisterer ikke...👻")
 
             // Upsert notater
             avtaleNotater.upsert(notat1).shouldBeRight()
             avtaleNotater.upsert(notat2).shouldBeRight()
             avtaleNotater.upsert(notat3).shouldBeRight()
 
-            avtaleNotater.getAll(filter = NotatFilter(avtaleId = avtale.id, opprettetAv = null)).shouldBeRight()
+            avtaleNotater.getAll(filter = NotatFilter(avtaleId = AvtaleFixtures.avtale1.id, opprettetAv = null))
+                .shouldBeRight()
                 .should { it.size shouldBe 3 }
 
             // Les notater
@@ -88,7 +61,8 @@ class AvtaleNotatRepositoryTest : FunSpec({
             avtaleNotater.delete(notat1.id).shouldBeRight()
             avtaleNotater.get(notat1.id).shouldBeRight(null)
 
-            avtaleNotater.getAll(filter = NotatFilter(avtaleId = avtale.id, opprettetAv = null)).shouldBeRight()
+            avtaleNotater.getAll(filter = NotatFilter(avtaleId = AvtaleFixtures.avtale1.id, opprettetAv = null))
+                .shouldBeRight()
                 .should { it.size shouldBe 2 }
         }
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
@@ -753,14 +753,12 @@ class AvtaleRepositoryTest : FunSpec({
 
                 val avtale1 =
                     AvtaleFixtures.avtale1.copy(id = UUID.randomUUID(), tiltakstypeId = tiltakstypeIdSomIkkeSkalMatche)
-
-                val tiltakstype = TiltakstypeFixtures.Oppfolging.copy(id = TiltakstypeFixtures.Oppfolging.id)
                 val tiltakstypeUtenAvtaler = TiltakstypeFixtures.Oppfolging.copy(id = tiltakstypeIdSomIkkeSkalMatche)
 
                 val gjennomforing1 = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                     tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                     startDato = LocalDate.of(2021, 1, 1),
-                    sluttDato = LocalDate.of(2022, 10, 15),
+                    sluttDato = LocalDate.of(2023, 10, 15),
                 )
                 val gjennomforing2 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                     tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
@@ -781,7 +779,6 @@ class AvtaleRepositoryTest : FunSpec({
                     sluttDato = LocalDate.of(2050, 10, 15),
                 )
 
-                tiltakstypeRepository.upsert(tiltakstype).getOrThrow()
                 tiltakstypeRepository.upsert(tiltakstypeUtenAvtaler).getOrThrow()
 
                 avtaler.upsert(avtale1).shouldBeRight()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingNotatRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingNotatRepositoryTest.kt
@@ -6,22 +6,14 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingNotatDbo
-import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
-import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
-import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures
-import no.nav.mulighetsrommet.api.fixtures.TiltakstypeFixtures
+import no.nav.mulighetsrommet.api.fixtures.*
 import no.nav.mulighetsrommet.api.utils.NotatFilter
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import java.util.*
 
 class TiltaksgjennomforingNotatRepositoryTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
-    val avtaleFixture = AvtaleFixtures(database)
     val domain = MulighetsrommetTestDomain()
-
-    beforeEach {
-        avtaleFixture.runBeforeTests()
-    }
 
     context("Notater for tiltaksgjennomføring - CRUD") {
         test("CRUD") {
@@ -30,8 +22,7 @@ class TiltaksgjennomforingNotatRepositoryTest : FunSpec({
             val tiltakstyper = TiltakstypeRepository(database.db)
             tiltakstyper.upsert(tiltakstypeFixture.Arbeidstrening).shouldBeRight()
             tiltakstyper.upsert(tiltakstypeFixture.Oppfolging).shouldBeRight()
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(id = UUID.randomUUID())
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+            val avtale = AvtaleFixtures.avtale1
             val tiltaksgjennomforingFixtures = TiltaksgjennomforingFixtures
             val gjennomforing = tiltaksgjennomforingFixtures.Oppfolging1.copy(avtaleId = avtale.id)
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
@@ -43,7 +34,7 @@ class TiltaksgjennomforingNotatRepositoryTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt første notat",
             )
 
@@ -52,7 +43,7 @@ class TiltaksgjennomforingNotatRepositoryTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt andre notat",
             )
 
@@ -61,7 +52,7 @@ class TiltaksgjennomforingNotatRepositoryTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt2.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
                 innhold = "En kollega sitt notat",
             )
 
@@ -70,7 +61,7 @@ class TiltaksgjennomforingNotatRepositoryTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt2.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
                 innhold = "En kollega sitt notat",
             )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -13,6 +13,7 @@ import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingKontaktpersonDbo
 import no.nav.mulighetsrommet.api.domain.dto.VirksomhetDto
 import no.nav.mulighetsrommet.api.fixtures.*
+import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures.avtale1
 import no.nav.mulighetsrommet.api.utils.AdminTiltaksgjennomforingFilter
 import no.nav.mulighetsrommet.api.utils.DEFAULT_PAGINATION_LIMIT
 import no.nav.mulighetsrommet.api.utils.PaginationParams
@@ -28,26 +29,14 @@ import java.util.*
 
 class TiltaksgjennomforingRepositoryTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
-
-    val tiltakstype1 = TiltakstypeFixtures.Arbeidstrening
-
-    val tiltakstype2 = TiltakstypeFixtures.Oppfolging
-
-    val avtale1 = AvtaleFixtures.avtale1
-
-    val avtale2 = AvtaleFixtures.avtale1.copy(tiltakstypeId = tiltakstype2.id)
-
-    val gjennomforing1 = TiltaksgjennomforingFixtures.Arbeidstrening1
-
-    val gjennomforing2 = TiltaksgjennomforingFixtures.Oppfolging1
     val domain = MulighetsrommetTestDomain()
 
     beforeAny {
         database.db.truncateAll()
 
         val tiltakstyper = TiltakstypeRepository(database.db)
-        tiltakstyper.upsert(tiltakstype1)
-        tiltakstyper.upsert(tiltakstype2)
+        tiltakstyper.upsert(TiltakstypeFixtures.Arbeidstrening)
+        tiltakstyper.upsert(TiltakstypeFixtures.Oppfolging)
 
         domain.initialize(database.db)
     }
@@ -57,25 +46,26 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         test("CRUD adminflate-tiltaksgjennomføringer") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
 
-            tiltaksgjennomforinger.upsert(gjennomforing1).shouldBeRight()
+            tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Oppfolging1).shouldBeRight()
 
-            tiltaksgjennomforinger.get(gjennomforing1.id).shouldBeRight() shouldBe TiltaksgjennomforingAdminDto(
-                id = gjennomforing1.id,
+            tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id)
+                .shouldBeRight() shouldBe TiltaksgjennomforingAdminDto(
+                id = TiltaksgjennomforingFixtures.Oppfolging1.id,
                 tiltakstype = TiltaksgjennomforingAdminDto.Tiltakstype(
-                    id = tiltakstype1.id,
-                    navn = tiltakstype1.navn,
-                    arenaKode = tiltakstype1.tiltakskode,
+                    id = TiltakstypeFixtures.Oppfolging.id,
+                    navn = TiltakstypeFixtures.Oppfolging.navn,
+                    arenaKode = TiltakstypeFixtures.Oppfolging.tiltakskode,
                 ),
-                navn = gjennomforing1.navn,
-                tiltaksnummer = gjennomforing1.tiltaksnummer,
-                arrangorOrganisasjonsnummer = gjennomforing1.arrangorOrganisasjonsnummer,
-                startDato = gjennomforing1.startDato,
-                sluttDato = gjennomforing1.sluttDato,
-                arenaAnsvarligEnhet = gjennomforing1.arenaAnsvarligEnhet,
+                navn = TiltaksgjennomforingFixtures.Oppfolging1.navn,
+                tiltaksnummer = TiltaksgjennomforingFixtures.Oppfolging1.tiltaksnummer,
+                arrangorOrganisasjonsnummer = TiltaksgjennomforingFixtures.Oppfolging1.arrangorOrganisasjonsnummer,
+                startDato = TiltaksgjennomforingFixtures.Oppfolging1.startDato,
+                sluttDato = TiltaksgjennomforingFixtures.Oppfolging1.sluttDato,
+                arenaAnsvarligEnhet = TiltaksgjennomforingFixtures.Oppfolging1.arenaAnsvarligEnhet,
                 status = Tiltaksgjennomforingsstatus.AVSLUTTET,
                 tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.LEDIG,
                 antallPlasser = null,
-                avtaleId = gjennomforing1.avtaleId,
+                avtaleId = TiltaksgjennomforingFixtures.Oppfolging1.avtaleId,
                 ansvarlig = TiltaksgjennomforingAdminDto.Ansvarlig(navident = null, navn = " "),
                 navEnheter = emptyList(),
                 sanityId = null,
@@ -91,9 +81,9 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 arrangorKontaktperson = null,
             )
 
-            tiltaksgjennomforinger.delete(gjennomforing1.id)
+            tiltaksgjennomforinger.delete(TiltaksgjennomforingFixtures.Oppfolging1.id)
 
-            tiltaksgjennomforinger.get(gjennomforing1.id) shouldBeRight null
+            tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id) shouldBeRight null
         }
 
         test("CRUD ArenaTiltaksgjennomforing") {
@@ -102,7 +92,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val gjennomforingFraArena = ArenaTiltaksgjennomforingDbo(
                 id = gjennomforingId,
                 navn = "Tiltak for dovne giraffer",
-                tiltakstypeId = tiltakstype1.id,
+                tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                 tiltaksnummer = "2023#1",
                 arrangorOrganisasjonsnummer = "123456789",
                 startDato = LocalDate.of(2023, 1, 1),
@@ -120,9 +110,9 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 id = gjennomforingId,
                 navn = "Tiltak for dovne giraffer",
                 tiltakstype = TiltaksgjennomforingAdminDto.Tiltakstype(
-                    id = tiltakstype1.id,
-                    navn = tiltakstype1.navn,
-                    arenaKode = tiltakstype1.tiltakskode,
+                    id = TiltakstypeFixtures.Oppfolging.id,
+                    navn = TiltakstypeFixtures.Oppfolging.navn,
+                    arenaKode = TiltakstypeFixtures.Oppfolging.tiltakskode,
                 ),
                 tiltaksnummer = "2023#1",
                 arrangorOrganisasjonsnummer = "123456789",
@@ -153,7 +143,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
 
         test("midlertidig_stengt crud") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
-            val gjennomforing = gjennomforing1.copy(
+            val gjennomforing = TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                id = UUID.randomUUID(),
                 stengtFra = LocalDate.of(2020, 1, 22),
                 stengtTil = LocalDate.of(2020, 4, 22),
             )
@@ -228,7 +219,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 ),
             ).shouldBeRight()
 
-            val gjennomforing = gjennomforing1.copy(navEnheter = listOf("1", "2"))
+            val gjennomforing =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), navEnheter = listOf("1", "2"))
 
             tiltaksgjennomforinger.upsert(gjennomforing).shouldBeRight()
             tiltaksgjennomforinger.get(gjennomforing.id).shouldBeRight().should {
@@ -333,7 +325,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 ),
             ).shouldBeRight()
 
-            val gjennomforing = gjennomforing1.copy(tiltaksnummer = "2023#1")
+            val gjennomforing = TiltaksgjennomforingFixtures.Oppfolging1
 
             tiltaksgjennomforinger.upsert(gjennomforing).shouldBeRight()
             tiltaksgjennomforinger.get(gjennomforing.id).shouldBeRight().should {
@@ -359,9 +351,10 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             val id = UUID.randomUUID()
 
-            tiltaksgjennomforinger.upsert(gjennomforing1).shouldBeRight()
-            tiltaksgjennomforinger.updateSanityTiltaksgjennomforingId(gjennomforing1.id, id).shouldBeRight()
-            tiltaksgjennomforinger.get(gjennomforing1.id).shouldBeRight().should {
+            tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Oppfolging1).shouldBeRight()
+            tiltaksgjennomforinger.updateSanityTiltaksgjennomforingId(TiltaksgjennomforingFixtures.Oppfolging1.id, id)
+                .shouldBeRight()
+            tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id).shouldBeRight().should {
                 it!!.sanityId.shouldBe(id.toString())
             }
         }
@@ -386,7 +379,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             )
             virksomhetRepository.upsertKontaktperson(thomas)
 
-            val gjennomforing = gjennomforing1.copy(arrangorKontaktpersonId = thomas.id)
+            val gjennomforing = TiltaksgjennomforingFixtures.Oppfolging1.copy(arrangorKontaktpersonId = thomas.id)
 
             tiltaksgjennomforinger.upsert(gjennomforing).shouldBeRight()
             tiltaksgjennomforinger.get(gjennomforing.id).shouldBeRight().should {
@@ -404,9 +397,11 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         test("Kun gjennomforinger tilhørende avtale blir tatt med") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
 
-            tiltaksgjennomforinger.upsert(gjennomforing1).shouldBeRight()
-            tiltaksgjennomforinger.upsert(gjennomforing2.copy(avtaleId = avtale1.id)).shouldBeRight()
-            tiltaksgjennomforinger.upsert(gjennomforing2.copy(id = UUID.randomUUID(), avtaleId = avtale2.id))
+            tiltaksgjennomforinger.upsert(
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    avtaleId = avtale1.id,
+                ),
+            )
                 .shouldBeRight()
 
             val result = tiltaksgjennomforinger.getAll(
@@ -414,30 +409,39 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             )
                 .shouldBeRight().second
             result shouldHaveSize 1
-            result.first().id shouldBe gjennomforing2.id
+            result.first().id shouldBe TiltaksgjennomforingFixtures.Oppfolging1.id
         }
     }
 
     context("Filtrer på arrangør") {
-        test("Kun gjennomforinger tilhørende arrangør blir tatt med") {
+        test("Kun gjennomføringer tilhørende arrangør blir tatt med") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
 
-            tiltaksgjennomforinger.upsert(gjennomforing1).shouldBeRight()
-            tiltaksgjennomforinger.upsert(gjennomforing2.copy(arrangorOrganisasjonsnummer = "999999999"))
+            tiltaksgjennomforinger.upsert(
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    arrangorOrganisasjonsnummer = "111111111",
+                ),
+            )
+                .shouldBeRight()
+            tiltaksgjennomforinger.upsert(
+                TiltaksgjennomforingFixtures.Oppfolging2.copy(
+                    arrangorOrganisasjonsnummer = "999999999",
+                ),
+            )
                 .shouldBeRight()
 
             tiltaksgjennomforinger.getAll(
-                filter = AdminTiltaksgjennomforingFilter(arrangorOrgnr = "222222222"),
+                filter = AdminTiltaksgjennomforingFilter(arrangorOrgnr = "111111111"),
             ).shouldBeRight().should {
                 it.second.size shouldBe 1
-                it.second[0].id shouldBe gjennomforing1.id
+                it.second[0].id shouldBe TiltaksgjennomforingFixtures.Oppfolging1.id
             }
 
             tiltaksgjennomforinger.getAll(
                 filter = AdminTiltaksgjennomforingFilter(arrangorOrgnr = "999999999"),
             ).shouldBeRight().should {
                 it.second.size shouldBe 1
-                it.second[0].id shouldBe gjennomforing2.id
+                it.second[0].id shouldBe TiltaksgjennomforingFixtures.Oppfolging2.id
             }
         }
     }
@@ -446,9 +450,21 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         test("Gamle tiltaksgjennomføringer blir ikke tatt med") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
 
-            tiltaksgjennomforinger.upsert(gjennomforing1).shouldBeRight()
             tiltaksgjennomforinger.upsert(
-                gjennomforing1.copy(
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    sluttDato = LocalDate.of(2023, 12, 31),
+                ),
+            ).shouldBeRight()
+
+            tiltaksgjennomforinger.upsert(
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    id = UUID.randomUUID(),
+                    sluttDato = LocalDate.of(2023, 6, 29),
+                ),
+            ).shouldBeRight()
+
+            tiltaksgjennomforinger.upsert(
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
                     id = UUID.randomUUID(),
                     sluttDato = LocalDate.of(2022, 12, 31),
                 ),
@@ -456,18 +472,23 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
 
             val result =
                 tiltaksgjennomforinger.getAll(filter = AdminTiltaksgjennomforingFilter()).shouldBeRight().second
-            result shouldHaveSize 1
-            result.first().id shouldBe gjennomforing1.id
+            result shouldHaveSize 2
+            result.first().id shouldBe TiltaksgjennomforingFixtures.Oppfolging1.id
         }
 
         test("Tiltaksgjennomføringer med sluttdato som er null blir tatt med") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
 
-            tiltaksgjennomforinger.upsert(gjennomforing1).shouldBeRight()
-            tiltaksgjennomforinger.upsert(gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = null)).shouldBeRight()
+            tiltaksgjennomforinger.upsert(TiltaksgjennomforingFixtures.Oppfolging1).shouldBeRight()
+            tiltaksgjennomforinger.upsert(
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    id = UUID.randomUUID(),
+                    sluttDato = null,
+                ),
+            ).shouldBeRight()
 
             tiltaksgjennomforinger.getAll(filter = AdminTiltaksgjennomforingFilter())
-                .shouldBeRight().second shouldHaveSize 2
+                .shouldBeRight().second shouldHaveSize 4
         }
     }
 
@@ -478,7 +499,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val domain = MulighetsrommetTestDomain()
             domain.initialize(database.db)
 
-            val gjennomforing = gjennomforing1.copy(ansvarlige = listOf(NavAnsattFixture.ansatt1.navIdent))
+            val gjennomforing =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(ansvarlige = listOf(NavAnsattFixture.ansatt1.navIdent))
             tiltaksgjennomforinger.upsert(gjennomforing).shouldBeRight()
 
             tiltaksgjennomforinger.get(gjennomforing.id).shouldBeRight().should {
@@ -494,16 +516,28 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
     context("Hente tiltaksgjennomføringer som nærmer seg sluttdato") {
         test("Skal hente gjennomføringer som er 14, 7 eller 1 dag til sluttdato") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
-            val gjennomforing14Dager =
-                gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = LocalDate.of(2023, 5, 30))
-            val gjennomforing7Dager = gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = LocalDate.of(2023, 5, 23))
-            val gjennomforing1Dager = gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = LocalDate.of(2023, 5, 17))
-            val gjennomforing10Dager =
-                gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = LocalDate.of(2023, 5, 26))
-            tiltaksgjennomforinger.upsert(gjennomforing14Dager).shouldBeRight()
+            val oppfolging14Dager =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    id = UUID.randomUUID(),
+                    sluttDato = LocalDate.of(2023, 5, 30),
+                )
+            val gjennomforing7Dager = TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                id = UUID.randomUUID(),
+                sluttDato = LocalDate.of(2023, 5, 23),
+            )
+            val oppfolging1Dager = TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                id = UUID.randomUUID(),
+                sluttDato = LocalDate.of(2023, 5, 17),
+            )
+            val oppfolging10Dager =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    id = UUID.randomUUID(),
+                    sluttDato = LocalDate.of(2023, 5, 26),
+                )
+            tiltaksgjennomforinger.upsert(oppfolging14Dager).shouldBeRight()
             tiltaksgjennomforinger.upsert(gjennomforing7Dager).shouldBeRight()
-            tiltaksgjennomforinger.upsert(gjennomforing1Dager).shouldBeRight()
-            tiltaksgjennomforinger.upsert(gjennomforing10Dager).shouldBeRight()
+            tiltaksgjennomforinger.upsert(oppfolging1Dager).shouldBeRight()
+            tiltaksgjennomforinger.upsert(oppfolging10Dager).shouldBeRight()
 
             val result = tiltaksgjennomforinger.getAllGjennomforingerSomNarmerSegSluttdato(
                 currentDate = LocalDate.of(
@@ -519,26 +553,32 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
     context("Hente tiltaksgjennomføringer som er midlertidig stengt og som nærmer seg sluttdato for den stengte perioden") {
         test("Skal hente gjennomføringer som er 7 eller 1 dag til stengt-til-datoen") {
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
-            val gjennomforing14Dager =
-                gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = LocalDate.of(2023, 5, 30))
-            val gjennomforing7Dager = gjennomforing1.copy(
+            val oppfolging14Dager =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    id = UUID.randomUUID(),
+                    sluttDato = LocalDate.of(2023, 5, 30),
+                )
+            val gjennomforing7Dager = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                 id = UUID.randomUUID(),
                 sluttDato = LocalDate.of(2023, 5, 23),
                 stengtFra = LocalDate.of(2023, 6, 16),
                 stengtTil = LocalDate.of(2023, 5, 23),
             )
-            val gjennomforing1Dager = gjennomforing1.copy(
+            val oppfolging1Dager = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                 id = UUID.randomUUID(),
                 sluttDato = LocalDate.of(2023, 5, 17),
                 stengtFra = LocalDate.of(2023, 6, 16),
                 stengtTil = LocalDate.of(2023, 5, 17),
             )
-            val gjennomforing10Dager =
-                gjennomforing1.copy(id = UUID.randomUUID(), sluttDato = LocalDate.of(2023, 5, 26))
-            tiltaksgjennomforinger.upsert(gjennomforing14Dager).shouldBeRight()
+            val oppfolging10Dager =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                    id = UUID.randomUUID(),
+                    sluttDato = LocalDate.of(2023, 5, 26),
+                )
+            tiltaksgjennomforinger.upsert(oppfolging14Dager).shouldBeRight()
             tiltaksgjennomforinger.upsert(gjennomforing7Dager).shouldBeRight()
-            tiltaksgjennomforinger.upsert(gjennomforing1Dager).shouldBeRight()
-            tiltaksgjennomforinger.upsert(gjennomforing10Dager).shouldBeRight()
+            tiltaksgjennomforinger.upsert(oppfolging1Dager).shouldBeRight()
+            tiltaksgjennomforinger.upsert(oppfolging10Dager).shouldBeRight()
 
             val result = tiltaksgjennomforinger.getAllMidlertidigStengteGjennomforingerSomNarmerSegSluttdato(
                 currentDate = LocalDate.of(
@@ -552,13 +592,10 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
     }
 
     context("TiltaksgjennomforingTilgjengelighetsstatus") {
-        val tiltakstyper = TiltakstypeRepository(database.db)
-        tiltakstyper.upsert(tiltakstype1)
-
         val deltakere = DeltakerRepository(database.db)
         val deltaker = DeltakerDbo(
             id = UUID.randomUUID(),
-            tiltaksgjennomforingId = gjennomforing1.id,
+            tiltaksgjennomforingId = TiltaksgjennomforingFixtures.Oppfolging1.id,
             status = Deltakerstatus.DELTAR,
             opphav = Deltakeropphav.AMT,
             startDato = null,
@@ -570,14 +607,14 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             beforeAny {
                 tiltaksgjennomforinger.upsert(
-                    gjennomforing1.copy(
+                    TiltaksgjennomforingFixtures.Oppfolging1.copy(
                         tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.STENGT,
                     ),
                 ).shouldBeRight()
             }
 
             test("should have tilgjengelighet set to Stengt") {
-                tiltaksgjennomforinger.get(gjennomforing1.id)
+                tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id)
                     .shouldBeRight()?.tilgjengelighet shouldBe TiltaksgjennomforingTilgjengelighetsstatus.STENGT
             }
         }
@@ -586,7 +623,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             beforeAny {
                 tiltaksgjennomforinger.upsert(
-                    gjennomforing1.copy(
+                    TiltaksgjennomforingFixtures.Oppfolging1.copy(
                         tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.LEDIG,
                         avslutningsstatus = Avslutningsstatus.AVSLUTTET,
                     ),
@@ -594,7 +631,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             }
 
             test("should have tilgjengelighet set to Stengt") {
-                tiltaksgjennomforinger.get(gjennomforing1.id)
+                tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id)
                     .shouldBeRight()?.tilgjengelighet shouldBe TiltaksgjennomforingTilgjengelighetsstatus.STENGT
             }
         }
@@ -603,7 +640,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             beforeAny {
                 tiltaksgjennomforinger.upsert(
-                    gjennomforing1.copy(
+                    TiltaksgjennomforingFixtures.Oppfolging1.copy(
                         tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.LEDIG,
                         antallPlasser = null,
                     ),
@@ -611,7 +648,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             }
 
             test("should have tilgjengelighet set to Ledig") {
-                tiltaksgjennomforinger.get(gjennomforing1.id)
+                tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id)
                     .shouldBeRight()?.tilgjengelighet shouldBe TiltaksgjennomforingTilgjengelighetsstatus.LEDIG
             }
         }
@@ -620,7 +657,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             beforeAny {
                 tiltaksgjennomforinger.upsert(
-                    gjennomforing1.copy(
+                    TiltaksgjennomforingFixtures.Oppfolging1.copy(
                         tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.LEDIG,
                         antallPlasser = 0,
                     ),
@@ -628,7 +665,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             }
 
             test("should have tilgjengelighet set to Venteliste") {
-                tiltaksgjennomforinger.get(gjennomforing1.id)
+                tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id)
                     .shouldBeRight()?.tilgjengelighet shouldBe TiltaksgjennomforingTilgjengelighetsstatus.VENTELISTE
             }
         }
@@ -637,7 +674,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             beforeAny {
                 tiltaksgjennomforinger.upsert(
-                    gjennomforing1.copy(
+                    TiltaksgjennomforingFixtures.Oppfolging1.copy(
                         tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.LEDIG,
                         antallPlasser = 1,
                     ),
@@ -647,7 +684,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             }
 
             test("should have tilgjengelighet set to Venteliste") {
-                tiltaksgjennomforinger.get(gjennomforing1.id)
+                tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id)
                     .shouldBeRight()?.tilgjengelighet shouldBe TiltaksgjennomforingTilgjengelighetsstatus.VENTELISTE
             }
         }
@@ -656,7 +693,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             beforeAny {
                 tiltaksgjennomforinger.upsert(
-                    gjennomforing1.copy(
+                    TiltaksgjennomforingFixtures.Oppfolging1.copy(
                         tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.LEDIG,
                         antallPlasser = 1,
                     ),
@@ -666,7 +703,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             }
 
             test("should have tilgjengelighet set to Ledig") {
-                tiltaksgjennomforinger.get(gjennomforing1.id)
+                tiltaksgjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id)
                     .shouldBeRight()?.tilgjengelighet shouldBe TiltaksgjennomforingTilgjengelighetsstatus.LEDIG
             }
         }
@@ -678,23 +715,26 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             dagensDato = LocalDate.of(2023, 2, 1),
         )
 
-        val tiltaksgjennomforingAktiv = gjennomforing1
+        val tiltaksgjennomforingAktiv = TiltaksgjennomforingFixtures.Arbeidstrening1
         val tiltaksgjennomforingAvsluttetStatus =
-            gjennomforing1.copy(id = UUID.randomUUID(), avslutningsstatus = Avslutningsstatus.AVSLUTTET)
-        val tiltaksgjennomforingAvsluttetDato = gjennomforing1.copy(
+            TiltaksgjennomforingFixtures.Oppfolging1.copy(
+                id = UUID.randomUUID(),
+                avslutningsstatus = Avslutningsstatus.AVSLUTTET,
+            )
+        val tiltaksgjennomforingAvsluttetDato = TiltaksgjennomforingFixtures.Oppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
             sluttDato = LocalDate.of(2023, 1, 31),
         )
-        val tiltaksgjennomforingAvbrutt = gjennomforing1.copy(
+        val tiltaksgjennomforingAvbrutt = TiltaksgjennomforingFixtures.Oppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.AVBRUTT,
         )
-        val tiltaksgjennomforingAvlyst = gjennomforing1.copy(
+        val tiltaksgjennomforingAvlyst = TiltaksgjennomforingFixtures.Oppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.AVLYST,
         )
-        val tiltaksgjennomforingPlanlagt = gjennomforing1.copy(
+        val tiltaksgjennomforingPlanlagt = TiltaksgjennomforingFixtures.Oppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
             startDato = LocalDate.of(2023, 2, 2),
@@ -740,7 +780,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 filter = defaultFilter.copy(status = Tiltaksgjennomforingsstatus.GJENNOMFORES),
             ).shouldBeRight()
 
-            result.second shouldHaveSize 1
+            result.second shouldHaveSize 3
             result.second[0].id shouldBe tiltaksgjennomforingAktiv.id
         }
 
@@ -788,10 +828,11 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 ),
             ).shouldBeRight()
 
-            val gj1 = gjennomforing1.copy(id = UUID.randomUUID(), navEnheter = listOf("1"))
-            val gj2 = gjennomforing1.copy(id = UUID.randomUUID(), arenaAnsvarligEnhet = "1")
-            val gj3 = gjennomforing1.copy(id = UUID.randomUUID(), navEnheter = listOf("2"))
-            val gj4 = gjennomforing1.copy(id = UUID.randomUUID(), navEnheter = listOf("1", "2"))
+            val gj1 = TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), navEnheter = listOf("1"))
+            val gj2 = TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), arenaAnsvarligEnhet = "1")
+            val gj3 = TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), navEnheter = listOf("2"))
+            val gj4 =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), navEnheter = listOf("1", "2"))
 
             tiltaksgjennomforinger.upsert(gj1).shouldBeRight()
             tiltaksgjennomforinger.upsert(gj2).shouldBeRight()
@@ -837,11 +878,12 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
 
             val avtale = avtale1.copy(navRegion = "nav_region")
             avtaler.upsert(avtale).shouldBeRight()
-            val gj1 = gjennomforing1.copy(id = UUID.randomUUID(), navEnheter = listOf("1"))
-            val gj2 = gjennomforing1.copy(id = UUID.randomUUID(), arenaAnsvarligEnhet = "1")
-            val gj3 = gjennomforing1.copy(id = UUID.randomUUID(), navEnheter = listOf("2"))
-            val gj4 = gjennomforing1.copy(id = UUID.randomUUID(), navEnheter = listOf("1", "2"))
-            val gj5 = gjennomforing1.copy(
+            val gj1 = TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), navEnheter = listOf("1"))
+            val gj2 = TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), arenaAnsvarligEnhet = "1")
+            val gj3 = TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), navEnheter = listOf("2"))
+            val gj4 =
+                TiltaksgjennomforingFixtures.Oppfolging1.copy(id = UUID.randomUUID(), navEnheter = listOf("1", "2"))
+            val gj5 = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                 id = UUID.randomUUID(),
                 navEnheter = emptyList(),
                 arenaAnsvarligEnhet = null,
@@ -870,7 +912,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     TiltaksgjennomforingDbo(
                         id = UUID.randomUUID(),
                         navn = "Tiltak - $it",
-                        tiltakstypeId = tiltakstype1.id,
+                        tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                         tiltaksnummer = "$it",
                         arrangorOrganisasjonsnummer = "123456789",
                         arenaAnsvarligEnhet = "2990",
@@ -902,8 +944,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 .shouldBeRight()
 
             items.size shouldBe DEFAULT_PAGINATION_LIMIT
-            items.first().navn shouldBe "Tiltak - 1"
-            items.last().navn shouldBe "Tiltak - 49"
+            items.first().navn shouldBe "Arbeidstrening 1"
+            items.last().navn shouldBe "Arbeidstrening 49"
 
             totalCount shouldBe 105
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -9,7 +9,6 @@ import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
-import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingKontaktpersonDbo
 import no.nav.mulighetsrommet.api.domain.dto.VirksomhetDto
 import no.nav.mulighetsrommet.api.fixtures.*
@@ -908,7 +907,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
             (1..105).forEach {
                 tiltaksgjennomforinger.upsert(
-                    TiltaksgjennomforingDbo(
+                    TiltaksgjennomforingFixtures.Oppfolging1.copy(
                         id = UUID.randomUUID(),
                         navn = "Tiltak - $it",
                         tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
@@ -918,18 +917,9 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                         avslutningsstatus = Avslutningsstatus.AVSLUTTET,
                         startDato = LocalDate.of(2022, 1, 1),
                         tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.LEDIG,
-                        antallPlasser = null,
-                        ansvarlige = emptyList(),
-                        navEnheter = emptyList(),
                         oppstart = TiltaksgjennomforingOppstartstype.FELLES,
                         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-                        kontaktpersoner = emptyList(),
                         lokasjonArrangor = "0139 Oslo",
-                        sluttDato = null,
-                        arrangorKontaktpersonId = null,
-                        stengtFra = null,
-                        stengtTil = null,
-                        estimertVentetid = null,
                     ),
                 )
             }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -473,7 +473,6 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val result =
                 tiltaksgjennomforinger.getAll(filter = AdminTiltaksgjennomforingFilter()).shouldBeRight().second
             result shouldHaveSize 2
-            result.first().id shouldBe TiltaksgjennomforingFixtures.Oppfolging1.id
         }
 
         test("Tiltaksgjennomføringer med sluttdato som er null blir tatt med") {
@@ -488,7 +487,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             ).shouldBeRight()
 
             tiltaksgjennomforinger.getAll(filter = AdminTiltaksgjennomforingFilter())
-                .shouldBeRight().second shouldHaveSize 4
+                .shouldBeRight().second shouldHaveSize 2
         }
     }
 
@@ -780,7 +779,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 filter = defaultFilter.copy(status = Tiltaksgjennomforingsstatus.GJENNOMFORES),
             ).shouldBeRight()
 
-            result.second shouldHaveSize 3
+            result.second shouldHaveSize 1
             result.second[0].id shouldBe tiltaksgjennomforingAktiv.id
         }
 
@@ -944,8 +943,8 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                 .shouldBeRight()
 
             items.size shouldBe DEFAULT_PAGINATION_LIMIT
-            items.first().navn shouldBe "Arbeidstrening 1"
-            items.last().navn shouldBe "Arbeidstrening 49"
+            items.first().navn shouldBe "Tiltak - 1"
+            items.last().navn shouldBe "Tiltak - 49"
 
             totalCount shouldBe 105
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepositoryTest.kt
@@ -337,8 +337,7 @@ class TiltakstypeRepositoryTest : FunSpec({
         test("Skal telle korrekt antall deltakere tilknyttet en avtale") {
             val tiltakstypeIdSomIkkeSkalMatche = UUID.randomUUID()
 
-            val avtale =
-                AvtaleFixtures(database).createAvtaleForTiltakstype(tiltakstypeId = tiltaksgjennomforingFixture.Oppfolging1.tiltakstypeId)
+            val avtale = AvtaleFixtures.avtale1
 
             val gjennomforing1 = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                 id = UUID.randomUUID(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/UtkastRepositoryTest.kt
@@ -12,23 +12,20 @@ import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.*
 import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
+import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture
 import no.nav.mulighetsrommet.api.utils.UtkastFilter
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import java.time.LocalDateTime
 import java.util.*
 
 class UtkastRepositoryTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
-    val avtaleFixture = AvtaleFixtures(database)
 
     val domain = MulighetsrommetTestDomain()
 
-    beforeContainer {
-        avtaleFixture.runBeforeTests()
-    }
-
     beforeEach {
-
+        database.db.truncateAll()
         domain.initialize(database.db)
 
         val navAnsatte = NavAnsattRepository(database.db)
@@ -72,13 +69,12 @@ class UtkastRepositoryTest : FunSpec({
 
     context("CRUD for Utkast") {
         val utkastRepository = UtkastRepository(database.db)
-        val avtale = avtaleFixture.createAvtaleForTiltakstype()
-        avtaleFixture.upsertAvtaler(listOf(avtale))
+        val avtale = AvtaleFixtures.avtale1
 
         val utkastId = UUID.randomUUID()
         val utkast = UtkastDbo(
             id = utkastId,
-            opprettetAv = domain.ansatt1.navIdent,
+            opprettetAv = NavAnsattFixture.ansatt1.navIdent,
             utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min gjennomføring er kul\"}"),
             createdAt = LocalDateTime.now(),
             updatedAt = LocalDateTime.now(),
@@ -90,7 +86,7 @@ class UtkastRepositoryTest : FunSpec({
             val utkastId = UUID.randomUUID()
             val utkast = UtkastDbo(
                 id = utkastId,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min gjennomføring er kul\"}"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now(),
@@ -98,7 +94,7 @@ class UtkastRepositoryTest : FunSpec({
                 avtaleId = avtale.id,
             )
             utkastRepository.upsert(utkast).shouldBeRight().should {
-                it?.opprettetAv shouldBe domain.ansatt1.navIdent
+                it?.opprettetAv shouldBe NavAnsattFixture.ansatt1.navIdent
                 Json.encodeToString(it?.utkastData) shouldContain "Min gjennomføring er kul"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }
@@ -107,14 +103,14 @@ class UtkastRepositoryTest : FunSpec({
                 utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min gjennomføring er fet\"}"),
             )
             utkastRepository.upsert(redigertUtkast).shouldBeRight().should {
-                it?.opprettetAv shouldBe domain.ansatt1.navIdent
+                it?.opprettetAv shouldBe NavAnsattFixture.ansatt1.navIdent
                 Json.encodeToString(it?.utkastData) shouldContain "Min gjennomføring er fet"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }
 
             utkastRepository.get(utkastId).shouldBeRight().should {
                 it?.id shouldBe utkastId
-                it?.opprettetAv shouldBe domain.ansatt1.navIdent
+                it?.opprettetAv shouldBe NavAnsattFixture.ansatt1.navIdent
                 Json.encodeToString(it?.utkastData) shouldContain "Min gjennomføring er fet"
                 it?.type shouldBe Utkasttype.Tiltaksgjennomforing
             }
@@ -128,17 +124,16 @@ class UtkastRepositoryTest : FunSpec({
             val ansatte = NavAnsattRepository(database.db)
 
             utkastRepository.upsert(utkast).shouldBeRight()
-            ansatte.deleteByAzureId(domain.ansatt1.azureId).shouldBeRight()
+            ansatte.deleteByAzureId(NavAnsattFixture.ansatt1.azureId).shouldBeRight()
 
             utkastRepository.get(utkastId).shouldBeRight(null)
         }
 
         test("GetAll skal støtte filter for type og opprettetAv") {
-            val avtale = avtaleFixture.createAvtaleForTiltakstype()
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+
             val utkast1 = UtkastDbo(
                 id = UUID.randomUUID(),
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min gjennomføring er kul\"}"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now(),
@@ -147,7 +142,7 @@ class UtkastRepositoryTest : FunSpec({
             )
             val utkast2 = UtkastDbo(
                 id = UUID.randomUUID(),
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min gjennomføring er fet\"}"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now(),
@@ -156,7 +151,7 @@ class UtkastRepositoryTest : FunSpec({
             )
             val utkast3 = UtkastDbo(
                 id = UUID.randomUUID(),
-                opprettetAv = domain.ansatt2.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
                 utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min avtale er fet\"}"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now(),
@@ -165,7 +160,7 @@ class UtkastRepositoryTest : FunSpec({
             )
             val utkast4 = UtkastDbo(
                 id = UUID.randomUUID(),
-                opprettetAv = domain.ansatt2.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
                 utkastData = Json.parseToJsonElement("{\"id\":\"123\",\"navn\":\"Min tiltaksgjennomføring er rar\"}"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now(),
@@ -186,13 +181,13 @@ class UtkastRepositoryTest : FunSpec({
             ).shouldBeRight()
                 .should {
                     it.size shouldBe 1
-                    it[0].opprettetAv shouldBe domain.ansatt2.navIdent
+                    it[0].opprettetAv shouldBe NavAnsattFixture.ansatt2.navIdent
                 }
 
             utkastRepository.getAll(
                 filter = UtkastFilter(
                     type = Utkasttype.Tiltaksgjennomforing,
-                    opprettetAv = domain.ansatt1.navIdent,
+                    opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                     avtaleId = avtale.id,
                 ),
             ).shouldBeRight()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/AvtaleServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/AvtaleServiceTest.kt
@@ -10,37 +10,40 @@ import io.ktor.http.*
 import io.mockk.mockk
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
+import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures
+import no.nav.mulighetsrommet.api.fixtures.TiltakstypeFixtures
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.utils.toUUID
 import java.time.LocalDate
+import java.util.*
 
 class AvtaleServiceTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
-    val avtaleFixture = AvtaleFixtures(database)
     val virksomhetService: VirksomhetService = mockk(relaxed = true)
+    val domain = MulighetsrommetTestDomain()
 
     beforeEach {
-        avtaleFixture.runBeforeTests()
+        database.db.truncateAll()
+        domain.initialize(database.db)
     }
 
     context("Slette avtale") {
-        val avtaleRepository = AvtaleRepository(database.db)
+        val avtaler = AvtaleRepository(database.db)
         val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
 
         val avtaleService = AvtaleService(
-            avtaler = avtaleRepository,
+            avtaler = avtaler,
             tiltaksgjennomforinger = tiltaksgjennomforinger,
             virksomhetService = virksomhetService,
         )
 
         test("Man skal ikke få slette dersom avtalen ikke finnes") {
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(navn = "Avtale som eksisterer")
             val avtaleIdSomIkkeFinnes = "3c9f3d26-50ec-45a7-a7b2-c2d8a3653945".toUUID()
-            avtaleFixture.upsertAvtaler(listOf(avtale))
 
             avtaleService.delete(avtaleIdSomIkkeFinnes).shouldBeLeft().should {
                 it.status shouldBe HttpStatusCode.NotFound
@@ -49,12 +52,12 @@ class AvtaleServiceTest : FunSpec({
 
         test("Man skal ikke få slette, men få en melding dersom dagens dato er mellom start- og sluttdato for avtalen") {
             val currentDate = LocalDate.of(2023, 6, 1)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(
+            val avtale = AvtaleFixtures.avtale1.copy(
                 navn = "Avtale som eksisterer",
                 startDato = LocalDate.of(2023, 6, 1),
                 sluttDato = LocalDate.of(2023, 7, 1),
             )
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+            avtaler.upsert(avtale).shouldBeRight()
 
             avtaleService.delete(avtale.id, currentDate = currentDate).shouldBeLeft().should {
                 it.status shouldBe HttpStatusCode.BadRequest
@@ -64,13 +67,13 @@ class AvtaleServiceTest : FunSpec({
 
         test("Man skal ikke få slette, men få en melding dersom opphav for avtalen ikke er admin-flate") {
             val currentDate = LocalDate.of(2023, 6, 1)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(
+            val avtale = AvtaleFixtures.avtale1.copy(
                 navn = "Avtale som eksisterer",
                 startDato = LocalDate.of(2023, 6, 1),
                 sluttDato = LocalDate.of(2023, 7, 1),
                 opphav = ArenaMigrering.Opphav.ARENA,
             )
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+            avtaler.upsert(avtale).shouldBeRight()
 
             avtaleService.delete(avtale.id, currentDate = currentDate).shouldBeLeft().should {
                 it.status shouldBe HttpStatusCode.BadRequest
@@ -80,32 +83,35 @@ class AvtaleServiceTest : FunSpec({
 
         test("Man skal ikke få slette, men få en melding dersom det finnes gjennomføringer koblet til avtalen") {
             val currentDate = LocalDate.of(2023, 6, 1)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(
+            val avtale = AvtaleFixtures.avtale1.copy(
+                id = UUID.randomUUID(),
                 navn = "Avtale som eksisterer",
                 startDato = LocalDate.of(2024, 5, 17),
                 sluttDato = LocalDate.of(2025, 7, 1),
             )
-            val avtaleSomErUinteressant = avtaleFixture.createAvtaleForTiltakstype(
+            val avtaleSomErUinteressant = AvtaleFixtures.avtale1.copy(
+                id = UUID.randomUUID(),
                 navn = "Avtale som vi ikke bryr oss om",
                 startDato = LocalDate.of(2024, 5, 17),
                 sluttDato = LocalDate.of(2025, 7, 1),
             )
-            avtaleFixture.upsertAvtaler(listOf(avtale, avtaleSomErUinteressant))
+            avtaler.upsert(avtale).shouldBeRight()
+            avtaler.upsert(avtaleSomErUinteressant).shouldBeRight()
             val oppfolging = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                 avtaleId = avtale.id,
-                tiltakstypeId = avtaleFixture.tiltakstypeId,
+                tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                 startDato = LocalDate.of(2023, 5, 1),
                 sluttDato = null,
             )
             val arbeidstrening = TiltaksgjennomforingFixtures.Arbeidstrening1.copy(
                 avtaleId = avtale.id,
-                tiltakstypeId = avtaleFixture.tiltakstypeId,
+                tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                 startDato = LocalDate.of(2023, 5, 1),
                 sluttDato = null,
             )
             val oppfolging2 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                 avtaleId = avtaleSomErUinteressant.id,
-                tiltakstypeId = avtaleFixture.tiltakstypeId,
+                tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                 startDato = LocalDate.of(2023, 5, 1),
                 sluttDato = null,
             )
@@ -122,11 +128,11 @@ class AvtaleServiceTest : FunSpec({
         test("Skal få slette avtale hvis alle sjekkene er ok") {
             val currentDate = LocalDate.of(2023, 6, 1)
 
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(
+            val avtale = AvtaleFixtures.avtale1.copy(
                 startDato = LocalDate.of(2023, 7, 1),
                 sluttDato = LocalDate.of(2024, 7, 1),
             )
-            avtaleRepository.upsert(avtale).right()
+            avtaler.upsert(avtale).right()
 
             avtaleService.delete(avtale.id, currentDate = currentDate).shouldBeRight()
         }
@@ -143,9 +149,9 @@ class AvtaleServiceTest : FunSpec({
         )
 
         test("Man skal ikke få avbryte dersom avtalen ikke finnes") {
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(navn = "Avtale som eksisterer")
+            val avtale = AvtaleFixtures.avtale1.copy(navn = "Avtale som eksisterer")
             val avtaleIdSomIkkeFinnes = "3c9f3d26-50ec-45a7-a7b2-c2d8a3653945".toUUID()
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+            avtaleRepository.upsert(avtale).shouldBeRight()
 
             avtaleService.avbrytAvtale(avtaleIdSomIkkeFinnes).shouldBeLeft().should {
                 it.status shouldBe HttpStatusCode.NotFound
@@ -154,13 +160,13 @@ class AvtaleServiceTest : FunSpec({
 
         test("Man skal ikke få avbryte, men få en melding dersom opphav for avtalen ikke er admin-flate") {
             val currentDate = LocalDate.of(2023, 6, 1)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(
+            val avtale = AvtaleFixtures.avtale1.copy(
                 navn = "Avtale som eksisterer",
                 startDato = LocalDate.of(2023, 6, 1),
                 sluttDato = LocalDate.of(2023, 7, 1),
                 opphav = ArenaMigrering.Opphav.ARENA,
             )
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+            avtaleRepository.upsert(avtale).shouldBeRight()
 
             avtaleService.avbrytAvtale(avtale.id, currentDate = currentDate).shouldBeLeft().should {
                 it.status shouldBe HttpStatusCode.BadRequest
@@ -170,13 +176,13 @@ class AvtaleServiceTest : FunSpec({
 
         test("Man skal ikke få avbryte, men få en melding dersom avtalen allerede er avsluttet") {
             val currentDate = LocalDate.of(2023, 7, 1)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(
+            val avtale = AvtaleFixtures.avtale1.copy(
                 navn = "Avtale som eksisterer",
                 startDato = LocalDate.of(2023, 5, 1),
                 sluttDato = LocalDate.of(2023, 6, 1),
                 opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
             )
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+            avtaleRepository.upsert(avtale).shouldBeRight()
 
             avtaleService.avbrytAvtale(avtale.id, currentDate = currentDate).shouldBeLeft().should {
                 it.status shouldBe HttpStatusCode.BadRequest
@@ -186,32 +192,35 @@ class AvtaleServiceTest : FunSpec({
 
         test("Man skal ikke få avbryte, men få en melding dersom det finnes gjennomføringer koblet til avtalen") {
             val currentDate = LocalDate.of(2023, 6, 1)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(
+            val avtale = AvtaleFixtures.avtale1.copy(
+                id = UUID.randomUUID(),
                 navn = "Avtale som eksisterer",
                 startDato = LocalDate.of(2024, 5, 17),
                 sluttDato = LocalDate.of(2025, 7, 1),
             )
-            val avtaleSomErUinteressant = avtaleFixture.createAvtaleForTiltakstype(
+            val avtaleSomErUinteressant = AvtaleFixtures.avtale1.copy(
+                id = UUID.randomUUID(),
                 navn = "Avtale som vi ikke bryr oss om",
                 startDato = LocalDate.of(2024, 5, 17),
                 sluttDato = LocalDate.of(2025, 7, 1),
             )
-            avtaleFixture.upsertAvtaler(listOf(avtale, avtaleSomErUinteressant))
+            avtaleRepository.upsert(avtale).shouldBeRight()
+            avtaleRepository.upsert(avtaleSomErUinteressant).shouldBeRight()
             val oppfolging = TiltaksgjennomforingFixtures.Oppfolging1.copy(
                 avtaleId = avtale.id,
-                tiltakstypeId = avtaleFixture.tiltakstypeId,
+                tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                 startDato = LocalDate.of(2023, 5, 1),
                 sluttDato = null,
             )
             val arbeidstrening = TiltaksgjennomforingFixtures.Arbeidstrening1.copy(
                 avtaleId = avtale.id,
-                tiltakstypeId = avtaleFixture.tiltakstypeId,
+                tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                 startDato = LocalDate.of(2023, 5, 1),
                 sluttDato = null,
             )
             val oppfolging2 = TiltaksgjennomforingFixtures.Oppfolging2.copy(
                 avtaleId = avtaleSomErUinteressant.id,
-                tiltakstypeId = avtaleFixture.tiltakstypeId,
+                tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                 startDato = LocalDate.of(2023, 5, 1),
                 sluttDato = null,
             )
@@ -228,7 +237,7 @@ class AvtaleServiceTest : FunSpec({
         test("Skal få avbryte avtale hvis alle sjekkene er ok") {
             val currentDate = LocalDate.of(2023, 6, 1)
 
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(
+            val avtale = AvtaleFixtures.avtale1.copy(
                 startDato = LocalDate.of(2023, 7, 1),
                 sluttDato = LocalDate.of(2024, 7, 1),
             )

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
@@ -19,8 +19,10 @@ import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle.KONTAKTPERSON
 import no.nav.mulighetsrommet.api.domain.dto.AdGruppe
 import no.nav.mulighetsrommet.api.domain.dto.NavAnsattDto
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
+import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture
 import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import java.time.LocalDate
 import java.util.*
 
@@ -29,7 +31,8 @@ class NavAnsattServiceTest : FunSpec({
 
     val domain = MulighetsrommetTestDomain()
 
-    beforeAny {
+    beforeEach {
+        database.db.truncateAll()
         domain.initialize(database.db)
     }
 
@@ -44,8 +47,8 @@ class NavAnsattServiceTest : FunSpec({
         epost = dbo.epost,
     )
 
-    val ansatt1 = toAzureAdNavAnsattDto(domain.ansatt1)
-    val ansatt2 = toAzureAdNavAnsattDto(domain.ansatt2)
+    val ansatt1 = toAzureAdNavAnsattDto(NavAnsattFixture.ansatt1)
+    val ansatt2 = toAzureAdNavAnsattDto(NavAnsattFixture.ansatt2)
 
     val betabruker = AdGruppeNavAnsattRolleMapping(adGruppeId = UUID.randomUUID(), rolle = BETABRUKER)
     val kontaktperson = AdGruppeNavAnsattRolleMapping(adGruppeId = UUID.randomUUID(), rolle = KONTAKTPERSON)

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NotatServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NotatServiceTest.kt
@@ -9,10 +9,7 @@ import io.ktor.http.*
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.domain.dbo.AvtaleNotatDbo
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingNotatDbo
-import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
-import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
-import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures
-import no.nav.mulighetsrommet.api.fixtures.TiltakstypeFixtures
+import no.nav.mulighetsrommet.api.fixtures.*
 import no.nav.mulighetsrommet.api.repositories.AvtaleNotatRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingNotatRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
@@ -23,11 +20,9 @@ import java.util.*
 class NotatServiceTest : FunSpec({
     context("NotatService") {
         val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
-        val avtaleFixture = AvtaleFixtures(database)
         val domain = MulighetsrommetTestDomain()
 
         beforeEach {
-            avtaleFixture.runBeforeTests()
             domain.initialize(database.db)
         }
 
@@ -35,16 +30,15 @@ class NotatServiceTest : FunSpec({
             val avtaleNotatRepository = AvtaleNotatRepository(database.db)
             val tiltaksgjennomforingNotatRepository = TiltaksgjennomforingNotatRepository(database.db)
             val notatService = NotatServiceImpl(avtaleNotatRepository, tiltaksgjennomforingNotatRepository)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(id = UUID.randomUUID())
+            val avtale = AvtaleFixtures.avtale1
             val avtaleNotater = AvtaleNotatRepository(database.db)
-            avtaleFixture.upsertAvtaler(listOf(avtale))
 
             val notat1 = AvtaleNotatDbo(
                 id = UUID.randomUUID(),
                 avtaleId = avtale.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt første notat",
             )
 
@@ -53,7 +47,7 @@ class NotatServiceTest : FunSpec({
                 avtaleId = avtale.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt andre notat",
             )
 
@@ -62,7 +56,7 @@ class NotatServiceTest : FunSpec({
                 avtaleId = avtale.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt2.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
                 innhold = "En kollega sitt notat",
             )
 
@@ -71,23 +65,22 @@ class NotatServiceTest : FunSpec({
             avtaleNotater.upsert(notat2).shouldBeRight()
             avtaleNotater.upsert(notat3).shouldBeRight()
 
-            notatService.deleteAvtaleNotat(notat1.id, domain.ansatt1.navIdent).shouldBeRight(1)
+            notatService.deleteAvtaleNotat(notat1.id, NavAnsattFixture.ansatt1.navIdent).shouldBeRight(1)
         }
 
         test("Skal ikke få slette notat for avtale når du ikke har opprettet notatet selv") {
             val avtaleNotatRepository = AvtaleNotatRepository(database.db)
             val tiltaksgjennomforingNotatRepository = TiltaksgjennomforingNotatRepository(database.db)
             val notatService = NotatServiceImpl(avtaleNotatRepository, tiltaksgjennomforingNotatRepository)
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(id = UUID.randomUUID())
+            val avtale = AvtaleFixtures.avtale1
             val avtaleNotater = AvtaleNotatRepository(database.db)
-            avtaleFixture.upsertAvtaler(listOf(avtale))
 
             val notat1 = AvtaleNotatDbo(
                 id = UUID.randomUUID(),
                 avtaleId = avtale.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt første notat",
             )
 
@@ -96,7 +89,7 @@ class NotatServiceTest : FunSpec({
                 avtaleId = avtale.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt andre notat",
             )
 
@@ -105,7 +98,7 @@ class NotatServiceTest : FunSpec({
                 avtaleId = avtale.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt2.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
                 innhold = "En kollega sitt notat",
             )
 
@@ -114,7 +107,7 @@ class NotatServiceTest : FunSpec({
             avtaleNotater.upsert(notat2).shouldBeRight()
             avtaleNotater.upsert(notat3).shouldBeRight()
 
-            notatService.deleteAvtaleNotat(notat3.id, domain.ansatt1.navIdent).shouldBeLeft().should {
+            notatService.deleteAvtaleNotat(notat3.id, NavAnsattFixture.ansatt1.navIdent).shouldBeLeft().should {
                 it.status shouldBe HttpStatusCode.Forbidden
                 it.message shouldBe "Kan ikke slette notat som du ikke har opprettet selv."
             }
@@ -128,8 +121,7 @@ class NotatServiceTest : FunSpec({
             val tiltakstyper = TiltakstypeRepository(database.db)
             tiltakstyper.upsert(tiltakstypeFixture.Arbeidstrening).shouldBeRight()
             tiltakstyper.upsert(tiltakstypeFixture.Oppfolging).shouldBeRight()
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(id = UUID.randomUUID())
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+            val avtale = AvtaleFixtures.avtale1
             val tiltaksgjennomforingFixtures = TiltaksgjennomforingFixtures
             val gjennomforing = tiltaksgjennomforingFixtures.Oppfolging1.copy(avtaleId = avtale.id)
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
@@ -140,7 +132,7 @@ class NotatServiceTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt første notat",
             )
 
@@ -149,7 +141,7 @@ class NotatServiceTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt andre notat",
             )
 
@@ -158,7 +150,7 @@ class NotatServiceTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt2.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
                 innhold = "En kollega sitt notat",
             )
 
@@ -167,7 +159,7 @@ class NotatServiceTest : FunSpec({
             tiltaksgjennomforingNotatRepository.upsert(notat2).shouldBeRight()
             tiltaksgjennomforingNotatRepository.upsert(notat3).shouldBeRight()
 
-            notatService.deleteTiltaksgjennomforingNotat(notat1.id, domain.ansatt1.navIdent).shouldBeRight(1)
+            notatService.deleteTiltaksgjennomforingNotat(notat1.id, NavAnsattFixture.ansatt1.navIdent).shouldBeRight(1)
         }
 
         test("Skal ikke få slette notat for tiltaksgjennomføring når du ikke har opprettet notatet selv") {
@@ -178,8 +170,7 @@ class NotatServiceTest : FunSpec({
             val tiltakstyper = TiltakstypeRepository(database.db)
             tiltakstyper.upsert(tiltakstypeFixture.Arbeidstrening).shouldBeRight()
             tiltakstyper.upsert(tiltakstypeFixture.Oppfolging).shouldBeRight()
-            val avtale = avtaleFixture.createAvtaleForTiltakstype(id = UUID.randomUUID())
-            avtaleFixture.upsertAvtaler(listOf(avtale))
+            val avtale = AvtaleFixtures.avtale1
             val tiltaksgjennomforingFixtures = TiltaksgjennomforingFixtures
             val gjennomforing = tiltaksgjennomforingFixtures.Oppfolging1.copy(avtaleId = avtale.id)
             val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
@@ -190,7 +181,7 @@ class NotatServiceTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt første notat",
             )
 
@@ -199,7 +190,7 @@ class NotatServiceTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt1.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                 innhold = "Mitt andre notat",
             )
 
@@ -208,7 +199,7 @@ class NotatServiceTest : FunSpec({
                 tiltaksgjennomforingId = gjennomforing.id,
                 createdAt = null,
                 updatedAt = null,
-                opprettetAv = domain.ansatt2.navIdent,
+                opprettetAv = NavAnsattFixture.ansatt2.navIdent,
                 innhold = "En kollega sitt notat",
             )
 
@@ -217,10 +208,11 @@ class NotatServiceTest : FunSpec({
             tiltaksgjennomforingNotatRepository.upsert(notat2).shouldBeRight()
             tiltaksgjennomforingNotatRepository.upsert(notat3).shouldBeRight()
 
-            notatService.deleteTiltaksgjennomforingNotat(notat3.id, domain.ansatt1.navIdent).shouldBeLeft().should {
-                it.status shouldBe HttpStatusCode.Forbidden
-                it.message shouldBe "Kan ikke slette notat som du ikke har opprettet selv."
-            }
+            notatService.deleteTiltaksgjennomforingNotat(notat3.id, NavAnsattFixture.ansatt1.navIdent).shouldBeLeft()
+                .should {
+                    it.status shouldBe HttpStatusCode.Forbidden
+                    it.message shouldBe "Kan ikke slette notat som du ikke har opprettet selv."
+                }
         }
     }
 })

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
@@ -8,14 +8,10 @@ import io.kotest.matchers.shouldBe
 import io.ktor.http.*
 import io.mockk.mockk
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
-import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
-import no.nav.mulighetsrommet.api.fixtures.DeltakerFixture
-import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures
-import no.nav.mulighetsrommet.api.fixtures.TiltakstypeFixtures
+import no.nav.mulighetsrommet.api.fixtures.*
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
-import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
@@ -27,23 +23,13 @@ class TiltaksgjennomforingServiceTest : FunSpec({
 
     val sanityTiltaksgjennomforingService: SanityTiltaksgjennomforingService = mockk(relaxed = true)
     val virksomhetService: VirksomhetService = mockk(relaxed = true)
-    val avtaleFixtures = AvtaleFixtures(database)
 
-    val avtaleId = UUID.randomUUID()
+    val avtaleId = AvtaleFixtures.avtale1.id
+    val domain = MulighetsrommetTestDomain()
 
     beforeEach {
         database.db.truncateAll()
-
-        val tiltakstypeRepository = TiltakstypeRepository(database.db)
-        tiltakstypeRepository.upsert(TiltakstypeFixtures.Oppfolging)
-
-        val avtaleRepository = AvtaleRepository(database.db)
-        avtaleRepository.upsert(
-            avtaleFixtures.createAvtaleForTiltakstype(
-                id = avtaleId,
-                tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
-            ),
-        )
+        domain.initialize(database.db)
     }
 
     context("Slette gjennomføring") {
@@ -200,7 +186,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
 
         test("Man skal ikke få lov og opprette dersom avtalen er avsluttet") {
             avtaleRepository.upsert(
-                avtaleFixtures.createAvtaleForTiltakstype(
+                AvtaleFixtures.avtale1.copy(
                     id = avtaleId,
                     tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                     sluttDato = LocalDate.of(2022, 1, 1),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationRepositoryTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
+import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.kotest.extensions.truncateAll
 import java.time.Instant
@@ -23,8 +24,8 @@ class NotificationRepositoryTest : FunSpec({
         domain.initialize(database.db)
     }
 
-    val user1 = domain.ansatt1.navIdent
-    val user2 = domain.ansatt2.navIdent
+    val user1 = NavAnsattFixture.ansatt1.navIdent
+    val user2 = NavAnsattFixture.ansatt2.navIdent
 
     val now = Instant.now().truncatedTo(ChronoUnit.MILLIS)
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/notifications/NotificationServiceTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.should
 import io.mockk.mockk
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
+import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.tasks.DbSchedulerKotlinSerializer
 import java.time.Instant
@@ -19,17 +20,15 @@ import java.util.*
 import kotlin.time.Duration.Companion.seconds
 
 class NotificationServiceTest : FunSpec({
-
     val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
-
     val domain = MulighetsrommetTestDomain()
 
     beforeEach {
         domain.initialize(database.db)
     }
 
-    val user1 = domain.ansatt1.navIdent
-    val user2 = domain.ansatt2.navIdent
+    val user1 = NavAnsattFixture.ansatt1.navIdent
+    val user2 = NavAnsattFixture.ansatt2.navIdent
 
     context("NotificationService") {
         val notifications = NotificationRepository(database.db)


### PR DESCRIPTION
Skriver om AvtaleFixtures til å være et "dumt" objekt.
Setter tiltakstype og avtale ved initialisering av MulighetsrommetTestDomain.

Resten av data (feks. gjennomføringer) må upsertes per test for at det skal bli
enklere å lese testene.
