### PR TITLE
fikset knappeoppsett på avtaler

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvbrytAvtaleModal.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvbrytAvtaleModal.tsx
@@ -69,6 +69,9 @@ const AvbrytAvtaleModal = ({ modalOpen, onClose, avtale }: Props) => {
           <p>Du kan ikke angre denne handlingen</p>
         )}
         <div className={styles.knapperad}>
+          <Button variant="secondary" onClick={clickCancel}>
+            Avbryt handling
+          </Button>
           {avtaleFraArena ? null : mutation?.isError ? (
             <Lenkeknapp
               to={`/avtaler/skjema?avtaleId=${avtale?.id}`}
@@ -81,9 +84,6 @@ const AvbrytAvtaleModal = ({ modalOpen, onClose, avtale }: Props) => {
               Avbryt avtale
             </Button>
           )}
-          <Button variant="secondary-neutral" onClick={clickCancel}>
-            Avbryt handling
-          </Button>
         </div>
       </>
     );
@@ -103,11 +103,7 @@ const AvbrytAvtaleModal = ({ modalOpen, onClose, avtale }: Props) => {
         aria-label="modal"
       >
         <Modal.Content>
-          <Heading
-            size="medium"
-            level="2"
-            data-testid="slett_avtale_modal_header"
-          >
+          <Heading size="medium" level="2">
             {headerInnhold(avtale)}
           </Heading>
           {modalInnhold(avtale)}

--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaKnapperad.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaKnapperad.tsx
@@ -12,7 +12,7 @@ export function AvtaleSkjemaKnapperad({ redigeringsModus, onClose }: Props) {
       <Button
         className={styles.button}
         onClick={onClose}
-        variant="secondary"
+        variant="tertiary"
         data-testid="avtaleskjema-avbrytknapp"
       >
         Avbryt

--- a/frontend/mr-admin-flate/src/components/modal/Modal.module.scss
+++ b/frontend/mr-admin-flate/src/components/modal/Modal.module.scss
@@ -29,6 +29,6 @@
 .knapperad {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-evenly;
   gap: 2rem;
 }

--- a/frontend/mr-admin-flate/src/components/modal/SletteModal.tsx
+++ b/frontend/mr-admin-flate/src/components/modal/SletteModal.tsx
@@ -59,6 +59,9 @@ const SletteModal = ({
         )}
 
         <div className={styles.knapperad}>
+          <Button variant="secondary" onClick={clickCancel}>
+            Avbryt
+          </Button>
           {mutation?.isError ? null : (
             <Button
               variant="danger"
@@ -68,10 +71,6 @@ const SletteModal = ({
               Slett
             </Button>
           )}
-
-          <Button variant="secondary-neutral" onClick={clickCancel}>
-            Avbryt
-          </Button>
         </div>
       </>
     );

--- a/frontend/mr-admin-flate/src/components/utkast/Utkastkort.tsx
+++ b/frontend/mr-admin-flate/src/components/utkast/Utkastkort.tsx
@@ -64,13 +64,6 @@ export function UtkastKort({ utkast, mutation }: UtkastKortProps) {
         </BodyShort>
       </div>
       <div className={styles.knapper}>
-        <Lenkeknapp
-          to={`/avtaler/skjema?utkastId=${utkast.id}`}
-          lenketekst="Rediger utkast"
-          dataTestId="rediger-utkast-knapp"
-          variant="primary"
-          size="small"
-        />
         <Button
           data-testid="slett-utkast-knapp"
           size="small"
@@ -79,6 +72,13 @@ export function UtkastKort({ utkast, mutation }: UtkastKortProps) {
         >
           Slett utkast
         </Button>
+        <Lenkeknapp
+          to={`/avtaler/skjema?utkastId=${utkast.id}`}
+          lenketekst="Rediger utkast"
+          dataTestId="rediger-utkast-knapp"
+          variant="primary"
+          size="small"
+        />
       </div>
 
       {utkastIdForSletting ? (

--- a/frontend/mr-admin-flate/src/components/virksomhet/DeleteVirksomhetKontaktpersonModal.tsx
+++ b/frontend/mr-admin-flate/src/components/virksomhet/DeleteVirksomhetKontaktpersonModal.tsx
@@ -52,11 +52,7 @@ export const DeleteVirksomhetKontaktpersonModal = ({
         aria-label="modal"
       >
         <Modal.Content>
-          <Heading
-            size="medium"
-            level="2"
-            data-testid="slett_avtale_modal_header"
-          >
+          <Heading size="medium" level="2">
             <div className={styles.heading}>
               <XMarkOctagonFillIcon className={styles.warningicon} />
               {mutation.isError ? (

--- a/frontend/mr-admin-flate/src/pages/DetaljerInfo.module.scss
+++ b/frontend/mr-admin-flate/src/pages/DetaljerInfo.module.scss
@@ -24,7 +24,7 @@
 
 .knapperad {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   grid-area: knapperad;
   border-top: 1px solid var(--a-border-divider);
   margin: 1rem;

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleKnapperad.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleKnapperad.tsx
@@ -29,7 +29,7 @@ export function AvtaleKnapperad({ handleSlett, handleAvbryt, avtale }: Props) {
             onClick={handleAvbryt}
             data-testid="avbryt-avtale"
           >
-            Avbryt
+            Avbryt avtale
           </Button>
         ) : (
           <Button
@@ -46,8 +46,8 @@ export function AvtaleKnapperad({ handleSlett, handleAvbryt, avtale }: Props) {
       {redigerAvtaleEnabled ? (
         <Lenkeknapp
           to={`/avtaler/skjema?avtaleId=${avtaleId}`}
-          lenketekst="Endre"
-          variant="tertiary"
+          lenketekst="Rediger avtale"
+          variant="primary"
           dataTestId="endre-avtale"
         />
       ) : null}


### PR DESCRIPTION
Denne vil bli oppdatert sammen med https://trello.com/c/iMsNdVcq . Tiltaksgjennomføringer har ikke fått samme oppussing på knapper, men det kommer etter at vi har tatt bort modal.

![image](https://github.com/navikt/mulighetsrommet/assets/21334782/e49c02cc-4fa5-4e61-9e43-46801b20ca4d)

![image](https://github.com/navikt/mulighetsrommet/assets/21334782/cda6ec0b-97eb-4199-b75f-a0af55725483)

![image](https://github.com/navikt/mulighetsrommet/assets/21334782/ed1f3950-7de6-470a-9ac9-84166fefd443)
