### PR TITLE
POC på kjøre flere ting i én db transaksjon

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -256,7 +256,7 @@ private fun services(appConfig: AppConfig) = module {
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get()) }
     single { MicrosoftGraphService(get()) }
-    single { TiltaksgjennomforingService(get(), get(), get(), get(), get(), get(), get()) }
+    single { TiltaksgjennomforingService(get(), get(), get(), get(), get(), get(), get(), get()) }
     single { SanityTiltaksgjennomforingService(get(), get(), get(), get(), get()) }
     single { TiltakstypeService(get(), get(), get(), get()) }
     single { NavEnheterSyncService(get(), get(), get(), get()) }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -63,7 +63,7 @@ object TiltaksgjennomforingFixtures {
         startDato = LocalDate.of(2023, 1, 1),
         sluttDato = LocalDate.of(2023, 2, 1),
         antallPlasser = 1,
-        ansvarlig = "Z123456",
+        ansvarlig = "DD1",
         navEnheter = emptyList(),
         oppstart = TiltaksgjennomforingOppstartstype.FELLES,
         kontaktpersoner = emptyList(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleNotatRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleNotatRepositoryTest.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.repositories
 
 import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -24,6 +25,22 @@ class AvtaleNotatRepositoryTest : FunSpec({
     }
 
     context("Notater for avtale - CRUD") {
+        test("tx") {
+            val avtaleNotater = AvtaleNotatRepository(database.db)
+            val notat1 = AvtaleNotatFixture.Notat1.copy(id = UUID.randomUUID(), innhold = "Mitt første notat")
+            val notat2 = AvtaleNotatFixture.Notat1.copy(id = UUID.randomUUID(), innhold = "Mitt andre notat")
+
+            shouldThrow<Exception> {
+                database.db.transaction { tx ->
+                    avtaleNotater.upsert(notat1, tx).shouldBeRight()
+                    avtaleNotater.upsert(notat2, tx).shouldBeRight()
+                    throw Exception("asdf")
+                }
+            }
+
+            avtaleNotater.get(notat1.id).shouldBeRight(null)
+        }
+
         test("CRUD") {
             val avtaleNotater = AvtaleNotatRepository(database.db)
 


### PR DESCRIPTION
Hvis man har lyst til at en db metode også skal fungere i en transaksjon utenifra, splitter man den opp i en metode som tar inn en TransactionalSession, og en uten som bare kaller den andre inne i en sånn 
```
fun foo(tx: TransactionSession) { ... }

fun foo() = db.transaction { tx -> foo(tx) }
```