### PR TITLE
Fjern at tom liste betyr alle valgt i multiselect

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaConst.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaConst.tsx
@@ -130,21 +130,13 @@ export const enheterOptions = (navRegion: string, enheter: NavEnhet[]) => {
       label: enhet.navn,
       value: enhet.enhetsnummer,
     }));
-  options?.unshift({ value: "alle_enheter", label: "Alle enheter" });
   return options || [];
 };
 
 export const underenheterOptions = (
   underenheterForLeverandor: Virksomhet[],
-) => {
-  const options = underenheterForLeverandor.map((leverandor: LeverandorUnderenhet) => ({
+) =>
+  underenheterForLeverandor.map((leverandor: LeverandorUnderenhet) => ({
     value: leverandor.organisasjonsnummer,
     label: `${leverandor.navn} - ${leverandor.organisasjonsnummer}`,
   }));
-
-  options?.unshift({
-    value: "alle_underenheter",
-    label: "Alle underenheter",
-  });
-  return options;
-};

--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
@@ -83,10 +83,7 @@ export function AvtaleSkjemaContainer({
     defaultValues: {
       tiltakstype: avtale?.tiltakstype?.id,
       navRegion: defaultEnhet(avtale!, enheter, ansatt),
-      navEnheter:
-        avtale?.navEnheter?.length === 0
-          ? ["alle_enheter"]
-          : avtale?.navEnheter?.map((e) => e.enhetsnummer) || [],
+      navEnheter: avtale?.navEnheter?.map((e) => e.enhetsnummer) || [],
       avtaleansvarlig: avtale?.ansvarlig?.navident || ansatt.navIdent || "",
       avtalenavn: getValueOrDefault(avtale?.navn, ""),
       avtaletype: getValueOrDefault(avtale?.avtaletype, Avtaletype.AVTALE),
@@ -166,7 +163,7 @@ export function AvtaleSkjemaContainer({
     const requestBody: AvtaleRequest = {
       id: utkastIdRef.current,
       navRegion,
-      navEnheter: navEnheter.includes("alle_enheter") ? [] : navEnheter,
+      navEnheter,
       avtalenummer: getValueOrDefault(avtale?.avtalenummer, ""),
       leverandorOrganisasjonsnummer,
       leverandorUnderenheter: leverandorUnderenheter.includes(

--- a/frontend/mr-admin-flate/src/components/skjema/MultiSelect.tsx
+++ b/frontend/mr-admin-flate/src/components/skjema/MultiSelect.tsx
@@ -77,9 +77,19 @@ const MultiSelect = React.forwardRef((props: MultiSelectProps, _) => {
       noOptionsMessage={() => "Ingen funnet"}
       name={name}
       value={value}
-      onChange={onChange}
+      onChange={(e) => {
+        if (e.find(o => o.value === "*")) {
+          if (value.length === options.length) {
+            onChange([]);
+          } else {
+            onChange(options);
+          }
+        } else {
+            onChange(e);
+        }
+      }}
       styles={customStyles(Boolean(error))}
-      options={options}
+      options={[{ label: "Velg alle", value: "*" }, ...options ]}
       theme={(theme: any) => ({
         ...theme,
         spacing: {

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaConst.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaConst.tsx
@@ -29,8 +29,7 @@ export function defaultValuesForKontaktpersoner(
 
   return kontaktpersoner?.map((person) => ({
     navIdent: person.navIdent,
-    navEnheter:
-      person.navEnheter?.length === 0 ? ["alle_enheter"] : person.navEnheter,
+    navEnheter: person.navEnheter,
   }));
 }
 
@@ -81,7 +80,6 @@ export const enheterOptions = (
       value: enhet.enhetsnummer,
     }));
 
-  options?.unshift({ value: "alle_enheter", label: "Alle enheter" });
   return options || [];
 };
 

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
@@ -161,12 +161,7 @@ export const TiltaksgjennomforingSkjemaContainer = ({
     resolver: zodResolver(TiltaksgjennomforingSchema),
     defaultValues: {
       navn: tiltaksgjennomforing?.navn,
-      navEnheter:
-        tiltaksgjennomforing?.navEnheter?.length === 0
-          ? ["alle_enheter"]
-          : tiltaksgjennomforing?.navEnheter?.map(
-              (enhet) => enhet.enhetsnummer,
-            ) || [],
+      navEnheter: tiltaksgjennomforing?.navEnheter?.map((enhet) => enhet.enhetsnummer) || [],
       ansvarlig: tiltaksgjennomforing?.ansvarlig?.navident,
       antallPlasser: tiltaksgjennomforing?.antallPlasser,
       startOgSluttDato: {
@@ -253,9 +248,7 @@ export const TiltaksgjennomforingSkjemaContainer = ({
       id: tiltaksgjennomforing ? tiltaksgjennomforing.id : uuidv4(),
       antallPlasser: data.antallPlasser,
       tiltakstypeId: avtale.tiltakstype.id,
-      navEnheter: data.navEnheter.includes("alle_enheter")
-        ? []
-        : data.navEnheter,
+      navEnheter: data.navEnheter,
       navn: data.navn,
       sluttDato: formaterDatoSomYYYYMMDD(data.startOgSluttDato.sluttDato),
       startDato: formaterDatoSomYYYYMMDD(data.startOgSluttDato.startDato),
@@ -279,9 +272,7 @@ export const TiltaksgjennomforingSkjemaContainer = ({
           ?.filter((kontakt) => kontakt.navIdent !== "")
           ?.map((kontakt) => ({
             ...kontakt,
-            navEnheter: kontakt.navEnheter.includes("alle_enheter")
-              ? []
-              : kontakt.navEnheter,
+            navEnheter: kontakt.navEnheter,
           })) || [],
       estimertVentetid: data.estimertVentetid ?? null,
       lokasjonArrangor: data.lokasjonArrangor,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -129,6 +129,12 @@ data class AvtaleRequest(
         if (!startDato.isBefore(sluttDato)) {
             return Either.Left(BadRequest("Startdato må være før sluttdato"))
         }
+        if (navEnheter.isEmpty()) {
+            return Either.Left(BadRequest("Minst étt nav kontor må være valgt"))
+        }
+        if (leverandorUnderenheter.isEmpty()) {
+            return Either.Left(BadRequest("Minst én underenhet til leverandøren må være valgt"))
+        }
 
         return Either.Right(
             AvtaleDbo(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -126,6 +126,9 @@ data class TiltaksgjennomforingRequest(
         if (antallPlasser <= 0) {
             return Either.Left(BadRequest("Antall plasser må være større enn 0"))
         }
+        if (navEnheter.isEmpty()) {
+            return Either.Left(BadRequest("Navenheter kan ikke være tom"))
+        }
 
         return Either.Right(
             TiltaksgjennomforingDbo(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -37,7 +37,7 @@ object AvtaleFixtures {
         avtalenummer = "2023#1",
         tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
         leverandorOrganisasjonsnummer = "123456789",
-        leverandorUnderenheter = emptyList(),
+        leverandorUnderenheter = listOf("123456789"),
         startDato = LocalDate.of(2023, 1, 11),
         sluttDato = LocalDate.of(2023, 2, 28),
         navRegion = "2990",
@@ -46,7 +46,7 @@ object AvtaleFixtures {
         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
         ansvarlig = "B123456",
         url = "google.com",
-        navEnheter = emptyList(),
+        navEnheter = listOf("2990"),
         leverandorKontaktpersonId = null,
     )
 


### PR DESCRIPTION
I stedet må alle faktisk velges. Legger til en "Velg alle" option som er en shorthand for å velge alle.


https://github.com/navikt/mulighetsrommet/assets/3830767/93e422db-6b0d-4fd5-8b2b-b435a0f37070

