### PR TITLE
add merge_group events to all workflows that contains a ci-job

### DIFF
--- a/.github/workflows/kafka-manager.yaml
+++ b/.github/workflows/kafka-manager.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - .github/workflows/kafka-manager.yaml
       - iac/kafka-manager/**
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   ci:

--- a/.github/workflows/kafka-topics-dev.yaml
+++ b/.github/workflows/kafka-topics-dev.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - .github/workflows/kafka-topics-dev.yaml
       - iac/kafka-topics/dev/*.yaml
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   ci:

--- a/.github/workflows/kafka-topics-prod.yaml
+++ b/.github/workflows/kafka-topics-prod.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - .github/workflows/kafka-topics-prod.yaml
       - iac/kafka-topics/prod/*.yaml
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   ci:

--- a/.github/workflows/mr-admin-flate-container.yaml
+++ b/.github/workflows/mr-admin-flate-container.yaml
@@ -15,6 +15,8 @@ on:
         options:
           - dev
           - dev_and_prod
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mr-admin-flate.yaml
+++ b/.github/workflows/mr-admin-flate.yaml
@@ -19,6 +19,8 @@ on:
         options:
           - dev
           - dev_and_prod
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mr-api-alerts.yaml
+++ b/.github/workflows/mr-api-alerts.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: ./.github/actions/lint-yaml
         with:
           path: mulighetsrommet-api/.nais/alerts.yaml
+  merge_group:
+    types: [checks_requested]
 
   apply-alerts:
     name: Apply alerts to cluster

--- a/.github/workflows/mr-api.yaml
+++ b/.github/workflows/mr-api.yaml
@@ -20,6 +20,8 @@ on:
         options:
           - dev
           - dev_and_prod
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mr-arena-adapter-alerts.yaml
+++ b/.github/workflows/mr-arena-adapter-alerts.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: ./.github/actions/lint-yaml
         with:
           path: mulighetsrommet-arena-adapter/.nais/alerts.yaml
+  merge_group:
+    types: [checks_requested]
 
   apply-alerts:
     name: Apply alerts to cluster

--- a/.github/workflows/mr-arena-adapter-manager-container.yaml
+++ b/.github/workflows/mr-arena-adapter-manager-container.yaml
@@ -15,6 +15,8 @@ on:
         options:
           - dev
           - dev_and_prod
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mr-arena-adapter-manager.yaml
+++ b/.github/workflows/mr-arena-adapter-manager.yaml
@@ -18,6 +18,8 @@ on:
         options:
           - dev
           - dev_and_prod
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mr-arena-adapter.yaml
+++ b/.github/workflows/mr-arena-adapter.yaml
@@ -20,6 +20,8 @@ on:
         options:
           - dev
           - dev_and_prod
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mr-sanity-studio.yaml
+++ b/.github/workflows/mr-sanity-studio.yaml
@@ -9,6 +9,8 @@ on:
       - turbo.json
       - frontend/mulighetsrommet-cms/**
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mr-veileder-flate-container.yaml
+++ b/.github/workflows/mr-veileder-flate-container.yaml
@@ -15,6 +15,8 @@ on:
         options:
           - dev
           - dev_and_prod
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mr-veileder-flate.yaml
+++ b/.github/workflows/mr-veileder-flate.yaml
@@ -19,6 +19,8 @@ on:
         options:
           - dev
           - dev_and_prod
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/unleash-apitoken.yaml
+++ b/.github/workflows/unleash-apitoken.yaml
@@ -18,6 +18,8 @@ jobs:
         uses: ./.github/actions/lint-yaml
         with:
           path: mulighetsrommet-api/.nais
+  merge_group:
+    types: [checks_requested]
 
   apply-apitoken-unleash:
     name: Apply ApiToken for Unleash to cluster


### PR DESCRIPTION
Ifølge dokumentasjonen til github så må vi gjøre følgende når vi har med en merge queue å gjøre: 
```
You must use the merge_group event to trigger your GitHub Actions workflow when a pull request is added to a merge queue.

Note: If your repository uses GitHub Actions to perform required checks on pull requests in your repository, you need to update the workflows to include the merge_group event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. The merge will fail as the required status check will not be reported. The merge_group event is separate from the pull_request and push events.
```

Hittil synes jeg pull-requests stort sett har gått ganske greit via merge-queue'en, men nå ser jeg den har stått ganske stille en stund, kanskje pga en lang kø med mange dependabot-updates? Dette blir i tilfelle en test for å sjekke om `merge_group`-eventet kan hjelpe til med å løse opp i dette..