### PR TITLE
Fjern arrangør feltet fra sanity

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -110,17 +110,6 @@ export const tiltaksgjennomforing = defineType({
       readOnly: erIkkeAdmin,
     }),
     defineField({
-      name: "kontaktinfoArrangor",
-      title: "Arrangør",
-      description:
-        "Ikke velg arrangør dersom tiltakstypen gjelder individuelle tiltak.",
-      type: "reference",
-      to: [{ type: "arrangor" }],
-      hidden: ({document} ) => {
-        return !isIndividueltTiltak(document.tiltakstype?._ref);
-      },
-    }),
-    defineField({
       name: "beskrivelse",
       title: "Beskrivelse",
       description: "Beskrivelse av formålet med tiltaksgjennomføringen.",


### PR DESCRIPTION
Siden det har blitt flyttet til admin-flate for gruppetiltak og ikke brukes av individuelle tiltak