### PR TITLE
Chore/ci

### DIFF
--- a/.github/workflows/kafka-manager.yaml
+++ b/.github/workflows/kafka-manager.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/kafka-manager.yaml
       - iac/kafka-manager/**
-  push:
-    branches:
-      - main
 
 jobs:
   ci:

--- a/.github/workflows/kafka-manager.yaml
+++ b/.github/workflows/kafka-manager.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/kafka-manager.yaml
-      - iac/kafka-manager/**
 
 jobs:
   ci:

--- a/.github/workflows/kafka-manager.yaml
+++ b/.github/workflows/kafka-manager.yaml
@@ -1,7 +1,7 @@
 name: Kafka manager
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/kafka-manager.yaml

--- a/.github/workflows/kafka-manager.yaml
+++ b/.github/workflows/kafka-manager.yaml
@@ -1,8 +1,7 @@
 name: Kafka manager
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/kafka-manager.yaml
       - iac/kafka-manager/**

--- a/.github/workflows/kafka-topics-dev.yaml
+++ b/.github/workflows/kafka-topics-dev.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/kafka-topics-dev.yaml
       - iac/kafka-topics/dev/*.yaml
-  push:
-    branches:
-      - main
 
 jobs:
   ci:
@@ -25,7 +22,7 @@ jobs:
     name: Deploy kafka topics to dev
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.ref_name == 'main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/kafka-topics-dev.yaml
+++ b/.github/workflows/kafka-topics-dev.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Deploy kafka topics to dev
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/kafka-topics-dev.yaml
+++ b/.github/workflows/kafka-topics-dev.yaml
@@ -1,7 +1,7 @@
 name: Deploy kafka topics to dev
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/kafka-topics-dev.yaml

--- a/.github/workflows/kafka-topics-dev.yaml
+++ b/.github/workflows/kafka-topics-dev.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/kafka-topics-dev.yaml
-      - iac/kafka-topics/dev/*.yaml
 
 jobs:
   ci:

--- a/.github/workflows/kafka-topics-dev.yaml
+++ b/.github/workflows/kafka-topics-dev.yaml
@@ -1,8 +1,7 @@
 name: Deploy kafka topics to dev
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/kafka-topics-dev.yaml
       - iac/kafka-topics/dev/*.yaml

--- a/.github/workflows/kafka-topics-prod.yaml
+++ b/.github/workflows/kafka-topics-prod.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/kafka-topics-prod.yaml
       - iac/kafka-topics/prod/*.yaml
-  push:
-    branches:
-      - main
 
 jobs:
   ci:
@@ -25,7 +22,7 @@ jobs:
     name: Deploy kafka topics to prod
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.ref_name == 'main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/kafka-topics-prod.yaml
+++ b/.github/workflows/kafka-topics-prod.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/kafka-topics-prod.yaml
-      - iac/kafka-topics/prod/*.yaml
 
 jobs:
   ci:

--- a/.github/workflows/kafka-topics-prod.yaml
+++ b/.github/workflows/kafka-topics-prod.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Deploy kafka topics to prod
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/kafka-topics-prod.yaml
+++ b/.github/workflows/kafka-topics-prod.yaml
@@ -1,8 +1,7 @@
 name: Deploy kafka topics to prod
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/kafka-topics-prod.yaml
       - iac/kafka-topics/prod/*.yaml

--- a/.github/workflows/kafka-topics-prod.yaml
+++ b/.github/workflows/kafka-topics-prod.yaml
@@ -1,7 +1,7 @@
 name: Deploy kafka topics to prod
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/kafka-topics-prod.yaml

--- a/.github/workflows/mr-admin-flate-container.yaml
+++ b/.github/workflows/mr-admin-flate-container.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/mr-admin-flate-container.yaml
       - frontend/mr-admin-flate/.nais/**
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-admin-flate-container.yaml
+++ b/.github/workflows/mr-admin-flate-container.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-admin-flate-container.yaml
-      - frontend/mr-admin-flate/.nais/**
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-admin-flate-container.yaml
+++ b/.github/workflows/mr-admin-flate-container.yaml
@@ -1,7 +1,7 @@
 name: POAO-frontend (mr-admin-flate)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-admin-flate-container.yaml

--- a/.github/workflows/mr-admin-flate-container.yaml
+++ b/.github/workflows/mr-admin-flate-container.yaml
@@ -1,8 +1,7 @@
 name: POAO-frontend (mr-admin-flate)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-admin-flate-container.yaml
       - frontend/mr-admin-flate/.nais/**

--- a/.github/workflows/mr-admin-flate.yaml
+++ b/.github/workflows/mr-admin-flate.yaml
@@ -9,9 +9,6 @@ on:
       - turbo.json
       - frontend/mr-admin-flate/**
       - mulighetsrommet-api/src/main/resources/web/openapi.yaml
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-admin-flate.yaml
+++ b/.github/workflows/mr-admin-flate.yaml
@@ -1,7 +1,7 @@
 name: CI/CD (mr-admin-flate)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-admin-flate.yaml

--- a/.github/workflows/mr-admin-flate.yaml
+++ b/.github/workflows/mr-admin-flate.yaml
@@ -12,13 +12,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-admin-flate.yaml
-      - package.json
-      - package-lock.json
-      - turbo.json
-      - frontend/mr-admin-flate/**
-      - mulighetsrommet-api/src/main/resources/web/openapi.yaml
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-admin-flate.yaml
+++ b/.github/workflows/mr-admin-flate.yaml
@@ -1,8 +1,7 @@
 name: CI/CD (mr-admin-flate)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-admin-flate.yaml
       - package.json

--- a/.github/workflows/mr-api-alerts.yaml
+++ b/.github/workflows/mr-api-alerts.yaml
@@ -1,7 +1,7 @@
 name: Alerts (mr-api)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-api-alerts.yaml

--- a/.github/workflows/mr-api-alerts.yaml
+++ b/.github/workflows/mr-api-alerts.yaml
@@ -1,8 +1,7 @@
 name: Alerts (mr-api)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-api-alerts.yaml
       - mulighetsrommet-api/.nais/alerts.yaml

--- a/.github/workflows/mr-api-alerts.yaml
+++ b/.github/workflows/mr-api-alerts.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/mr-api-alerts.yaml
       - mulighetsrommet-api/.nais/alerts.yaml
-  push:
-    branches:
-      - main
 
 jobs:
   ci:
@@ -25,7 +22,7 @@ jobs:
     name: Apply alerts to cluster
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.ref_name == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/mr-api-alerts.yaml
+++ b/.github/workflows/mr-api-alerts.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-api-alerts.yaml
-      - mulighetsrommet-api/.nais/alerts.yaml
 
 jobs:
   ci:

--- a/.github/workflows/mr-api-alerts.yaml
+++ b/.github/workflows/mr-api-alerts.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Apply alerts to cluster
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/mr-api.yaml
+++ b/.github/workflows/mr-api.yaml
@@ -13,14 +13,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-api.yaml
-      - build.gradle.kts
-      - settings.gradle.kts
-      - gradle.properties
-      - gradle/libs.versions.toml
-      - common/**
-      - mulighetsrommet-api/**
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-api.yaml
+++ b/.github/workflows/mr-api.yaml
@@ -10,9 +10,6 @@ on:
       - gradle/libs.versions.toml
       - common/**
       - mulighetsrommet-api/**
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-api.yaml
+++ b/.github/workflows/mr-api.yaml
@@ -1,8 +1,7 @@
 name: CI/CD (mr-api)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-api.yaml
       - build.gradle.kts

--- a/.github/workflows/mr-api.yaml
+++ b/.github/workflows/mr-api.yaml
@@ -1,7 +1,7 @@
 name: CI/CD (mr-api)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-api.yaml

--- a/.github/workflows/mr-arena-adapter-alerts.yaml
+++ b/.github/workflows/mr-arena-adapter-alerts.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/mr-arena-adapter-alerts.yaml
       - mulighetsrommet-arena-adapter/.nais/alerts.yaml
-  push:
-    branches:
-      - main
 
 jobs:
   ci:
@@ -25,7 +22,7 @@ jobs:
     name: Apply alerts to cluster
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.ref_name == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/mr-arena-adapter-alerts.yaml
+++ b/.github/workflows/mr-arena-adapter-alerts.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-arena-adapter-alerts.yaml
-      - mulighetsrommet-arena-adapter/.nais/alerts.yaml
 
 jobs:
   ci:

--- a/.github/workflows/mr-arena-adapter-alerts.yaml
+++ b/.github/workflows/mr-arena-adapter-alerts.yaml
@@ -1,8 +1,7 @@
 name: Alerts (mr-arena-adapter)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-arena-adapter-alerts.yaml
       - mulighetsrommet-arena-adapter/.nais/alerts.yaml

--- a/.github/workflows/mr-arena-adapter-alerts.yaml
+++ b/.github/workflows/mr-arena-adapter-alerts.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Apply alerts to cluster
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/mr-arena-adapter-alerts.yaml
+++ b/.github/workflows/mr-arena-adapter-alerts.yaml
@@ -1,7 +1,7 @@
 name: Alerts (mr-arena-adapter)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-arena-adapter-alerts.yaml

--- a/.github/workflows/mr-arena-adapter-manager-container.yaml
+++ b/.github/workflows/mr-arena-adapter-manager-container.yaml
@@ -1,7 +1,7 @@
 name: POAO-frontend (mr-arena-adapter-manager)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-arena-adapter-manager-container.yaml

--- a/.github/workflows/mr-arena-adapter-manager-container.yaml
+++ b/.github/workflows/mr-arena-adapter-manager-container.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-arena-adapter-manager-container.yaml
-      - frontend/arena-adapter-manager/.nais/**
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-arena-adapter-manager-container.yaml
+++ b/.github/workflows/mr-arena-adapter-manager-container.yaml
@@ -1,8 +1,7 @@
 name: POAO-frontend (mr-arena-adapter-manager)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-arena-adapter-manager-container.yaml
       - frontend/arena-adapter-manager/.nais/**

--- a/.github/workflows/mr-arena-adapter-manager-container.yaml
+++ b/.github/workflows/mr-arena-adapter-manager-container.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/mr-arena-adapter-manager-container.yaml
       - frontend/arena-adapter-manager/.nais/**
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-arena-adapter-manager.yaml
+++ b/.github/workflows/mr-arena-adapter-manager.yaml
@@ -11,12 +11,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-arena-adapter-manager.yaml
-      - package.json
-      - package-lock.json
-      - turbo.json
-      - frontend/arena-adapter-manager/**
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-arena-adapter-manager.yaml
+++ b/.github/workflows/mr-arena-adapter-manager.yaml
@@ -8,9 +8,6 @@ on:
       - package-lock.json
       - turbo.json
       - frontend/arena-adapter-manager/**
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-arena-adapter-manager.yaml
+++ b/.github/workflows/mr-arena-adapter-manager.yaml
@@ -1,7 +1,7 @@
 name: CI/CD (mr-arena-adapter-manager)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-arena-adapter-manager.yaml

--- a/.github/workflows/mr-arena-adapter-manager.yaml
+++ b/.github/workflows/mr-arena-adapter-manager.yaml
@@ -1,8 +1,7 @@
 name: CI/CD (mr-arena-adapter-manager)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-arena-adapter-manager.yaml
       - package.json

--- a/.github/workflows/mr-arena-adapter.yaml
+++ b/.github/workflows/mr-arena-adapter.yaml
@@ -1,8 +1,7 @@
 name: CI/CD (mr-arena-adapter)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-arena-adapter.yaml
       - build.gradle.kts

--- a/.github/workflows/mr-arena-adapter.yaml
+++ b/.github/workflows/mr-arena-adapter.yaml
@@ -13,14 +13,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-arena-adapter.yaml
-      - build.gradle.kts
-      - settings.gradle.kts
-      - gradle.properties
-      - gradle/libs.versions.toml
-      - common/**
-      - mulighetsrommet-arena-adapter/**
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-arena-adapter.yaml
+++ b/.github/workflows/mr-arena-adapter.yaml
@@ -1,7 +1,7 @@
 name: CI/CD (mr-arena-adapter)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-arena-adapter.yaml

--- a/.github/workflows/mr-arena-adapter.yaml
+++ b/.github/workflows/mr-arena-adapter.yaml
@@ -10,9 +10,6 @@ on:
       - gradle/libs.versions.toml
       - common/**
       - mulighetsrommet-arena-adapter/**
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-sanity-studio.yaml
+++ b/.github/workflows/mr-sanity-studio.yaml
@@ -8,9 +8,6 @@ on:
       - package-lock.json
       - turbo.json
       - frontend/mulighetsrommet-cms/**
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mr-sanity-studio.yaml
+++ b/.github/workflows/mr-sanity-studio.yaml
@@ -1,8 +1,7 @@
 name: Deploy Sanity Studio
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-sanity-studio.yaml
       - package.json

--- a/.github/workflows/mr-sanity-studio.yaml
+++ b/.github/workflows/mr-sanity-studio.yaml
@@ -11,12 +11,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-sanity-studio.yaml
-      - package.json
-      - package-lock.json
-      - turbo.json
-      - frontend/mulighetsrommet-cms/**
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mr-sanity-studio.yaml
+++ b/.github/workflows/mr-sanity-studio.yaml
@@ -1,7 +1,7 @@
 name: Deploy Sanity Studio
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-sanity-studio.yaml

--- a/.github/workflows/mr-veileder-flate-container.yaml
+++ b/.github/workflows/mr-veileder-flate-container.yaml
@@ -1,7 +1,7 @@
 name: POAO-frontend (mr-veileder-flate)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-veileder-flate-container.yaml

--- a/.github/workflows/mr-veileder-flate-container.yaml
+++ b/.github/workflows/mr-veileder-flate-container.yaml
@@ -1,8 +1,7 @@
 name: POAO-frontend (mr-veileder-flate)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-veileder-flate-container.yaml
       - frontend/mulighetsrommet-veileder-flate/.nais/**

--- a/.github/workflows/mr-veileder-flate-container.yaml
+++ b/.github/workflows/mr-veileder-flate-container.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-veileder-flate-container.yaml
-      - frontend/mulighetsrommet-veileder-flate/.nais/**
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-veileder-flate-container.yaml
+++ b/.github/workflows/mr-veileder-flate-container.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/mr-veileder-flate-container.yaml
       - frontend/mulighetsrommet-veileder-flate/.nais/**
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-veileder-flate.yaml
+++ b/.github/workflows/mr-veileder-flate.yaml
@@ -12,13 +12,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/mr-veileder-flate.yaml
-      - package.json
-      - package-lock.json
-      - turbo.json
-      - frontend/mulighetsrommet-veileder-flate/**
-      - mulighetsrommet-api/src/main/resources/web/openapi.yaml
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-veileder-flate.yaml
+++ b/.github/workflows/mr-veileder-flate.yaml
@@ -9,9 +9,6 @@ on:
       - turbo.json
       - frontend/mulighetsrommet-veileder-flate/**
       - mulighetsrommet-api/src/main/resources/web/openapi.yaml
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mr-veileder-flate.yaml
+++ b/.github/workflows/mr-veileder-flate.yaml
@@ -1,7 +1,7 @@
 name: CI/CD (mr-veileder-flate)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/mr-veileder-flate.yaml

--- a/.github/workflows/mr-veileder-flate.yaml
+++ b/.github/workflows/mr-veileder-flate.yaml
@@ -1,8 +1,7 @@
 name: CI/CD (mr-veileder-flate)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/mr-veileder-flate.yaml
       - package.json

--- a/.github/workflows/unleash-apitoken.yaml
+++ b/.github/workflows/unleash-apitoken.yaml
@@ -1,7 +1,7 @@
 name: Unleash api-tokens (mr-api)
 
 on:
-  merge_group:
+  merge_queue:
   pull_request:
     paths:
       - .github/workflows/unleash-apitoken.yaml

--- a/.github/workflows/unleash-apitoken.yaml
+++ b/.github/workflows/unleash-apitoken.yaml
@@ -9,10 +9,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/unleash-apitoken.yaml
-      - mulighetsrommet-api/.nais/unleash-apitoken-dev.yaml
-      - mulighetsrommet-api/.nais/unleash-apitoken-prod.yaml
 
 jobs:
   ci:

--- a/.github/workflows/unleash-apitoken.yaml
+++ b/.github/workflows/unleash-apitoken.yaml
@@ -1,8 +1,7 @@
 name: Unleash api-tokens (mr-api)
 
 on:
-  merge_queue:
-  pull_request:
+  push:
     paths:
       - .github/workflows/unleash-apitoken.yaml
       - mulighetsrommet-api/.nais/unleash-apitoken-dev.yaml

--- a/.github/workflows/unleash-apitoken.yaml
+++ b/.github/workflows/unleash-apitoken.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Apply ApiToken for Unleash to cluster
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/unleash-apitoken.yaml
+++ b/.github/workflows/unleash-apitoken.yaml
@@ -6,9 +6,6 @@ on:
       - .github/workflows/unleash-apitoken.yaml
       - mulighetsrommet-api/.nais/unleash-apitoken-dev.yaml
       - mulighetsrommet-api/.nais/unleash-apitoken-prod.yaml
-  push:
-    branches:
-      - main
 
 jobs:
   ci:
@@ -26,7 +23,7 @@ jobs:
     name: Apply ApiToken for Unleash to cluster
     runs-on: ubuntu-latest
     needs: [ci]
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.ref_name == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Reverterer en oppsettet med trigger workflow for pull_request og merge_group events. Dette oppsettet førte til unødvendig mange kjøringer av workflows når pull requests lå i merge queue'en.

Vi forsøker igjen med originalt oppsett og hvis merge queue'en henger får vi heller revurdere behovet for denne tror jeg, evt. se om vi kan gjøre noen grunnleggende endringer for CI/CD av applikasjonene