### PR TITLE
Hent arenakoda fra tiltakstype for indv. gjennomføringer

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltaksgjennomforingDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/views/tiltaksgjennomforing-detaljer/ViewTiltaksgjennomforingDetaljer.tsx
@@ -214,7 +214,7 @@ const ViewTiltaksgjennomforingDetaljer = () => {
                 <Button
                   size="small"
                   variant="tertiary"
-                  onClick={(event) => byttTilDialogFlate({ event, dialogId: harDeltMedBruker.dialogId!! })}
+                  onClick={event => byttTilDialogFlate({ event, dialogId: harDeltMedBruker.dialogId!! })}
                 >
                   Åpne i dialogen
                   <Chat2Icon />

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -246,7 +246,7 @@ private fun services(appConfig: AppConfig) = module {
     single { ArenaAdapterService(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     single { AvtaleService(get(), get(), get(), get(), get(), get()) }
     single { TiltakshistorikkService(get(), get()) }
-    single { VeilederflateService(get(), get(), get(), get()) }
+    single { VeilederflateService(get(), get(), get(), get(), get()) }
     single { SanityTiltaksgjennomforingEnheterTilApiService(get(), get()) }
     single { ArrangorService(get()) }
     single { BrukerService(get(), get(), get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltakstypeRepository.kt
@@ -63,6 +63,26 @@ class TiltakstypeRepository(private val db: Database) {
         return db.run(queryResult)
     }
 
+    fun getBySanityId(sanityId: UUID): TiltakstypeDto? {
+        @Language("PostgreSQL")
+        val query = """
+            select
+                id::uuid,
+                navn,
+                tiltakskode,
+                registrert_dato_i_arena,
+                sist_endret_dato_i_arena,
+                fra_dato,
+                til_dato,
+                rett_paa_tiltakspenger,
+                sanity_id
+            from tiltakstype
+            where sanity_id = ?::uuid
+        """.trimIndent()
+        val queryResult = queryOf(query, sanityId).map { it.toTiltakstypeDto() }.asSingle
+        return db.run(queryResult)
+    }
+
     fun getAll(
         paginationParams: PaginationParams = PaginationParams(),
     ): Pair<Int, List<TiltakstypeDto>> {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltakstypeService.kt
@@ -41,6 +41,10 @@ class TiltakstypeService(
         return tiltakstypeRepository.get(id)
     }
 
+    fun getBySanityId(sanityId: UUID): TiltakstypeDto? {
+        return tiltakstypeRepository.getBySanityId(sanityId)
+    }
+
     fun getNokkeltallForTiltakstype(tiltakstypeId: UUID): TiltakstypeNokkeltallDto {
         val antallGjennomforinger = tiltaksgjennomforingRepository.countGjennomforingerForTiltakstypeWithId(tiltakstypeId)
         val antallAvtaler = avtaleRepository.countAktiveAvtalerForTiltakstypeWithId(tiltakstypeId)

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
@@ -24,6 +24,7 @@ class VeilederflateServiceTest : FunSpec({
     val brukerService: BrukerService = mockk(relaxed = true)
     val tiltaksgjennomforingService: TiltaksgjennomforingService = mockk(relaxed = true)
     val virksomhetService: VirksomhetService = mockk(relaxed = true)
+    val tiltakstypeService: TiltakstypeService = mockk(relaxed = true)
 
     val sanityFylkeResult = SanityResponse.Result(
         ms = 12,
@@ -118,7 +119,8 @@ class VeilederflateServiceTest : FunSpec({
     """,
         ),
     )
-    val tiltakstype = TiltaksgjennomforingAdminDto.Tiltakstype(id = UUID.randomUUID(), navn = "Tiltakstype", arenaKode = "TT")
+    val tiltakstype =
+        TiltaksgjennomforingAdminDto.Tiltakstype(id = UUID.randomUUID(), navn = "Tiltakstype", arenaKode = "TT")
 
     val dbGjennomforing = TiltaksgjennomforingAdminDto(
         id = UUID.randomUUID(),
@@ -158,6 +160,7 @@ class VeilederflateServiceTest : FunSpec({
             brukerService,
             tiltaksgjennomforingService,
             virksomhetService,
+            tiltakstypeService,
         )
         every { tiltaksgjennomforingService.getBySanityIds(any()) } returns mapOf(
             UUID.fromString("f21d1e35-d63b-4de7-a0a5-589e57111527") to dbGjennomforing,
@@ -191,6 +194,7 @@ class VeilederflateServiceTest : FunSpec({
             brukerService,
             tiltaksgjennomforingService,
             virksomhetService,
+            tiltakstypeService,
         )
         every { tiltaksgjennomforingService.getBySanityIds(any()) } returns mapOf(
             UUID.fromString("f21d1e35-d63b-4de7-a0a5-589e57111527") to dbGjennomforing.copy(lokasjonArrangor = "Oslo"),
@@ -224,9 +228,17 @@ class VeilederflateServiceTest : FunSpec({
             brukerService,
             tiltaksgjennomforingService,
             virksomhetService,
+            tiltakstypeService,
         )
         every { tiltaksgjennomforingService.getBySanityIds(any()) } returns mapOf(
-            UUID.fromString("f21d1e35-d63b-4de7-a0a5-589e57111527") to dbGjennomforing.copy(navEnheter = listOf(NavEnhet(enhetsnummer = "0430", navn = "navn"))),
+            UUID.fromString("f21d1e35-d63b-4de7-a0a5-589e57111527") to dbGjennomforing.copy(
+                navEnheter = listOf(
+                    NavEnhet(
+                        enhetsnummer = "0430",
+                        navn = "navn",
+                    ),
+                ),
+            ),
         )
         coEvery { virksomhetService.getOrSyncVirksomhet(any()) } returns null
         coEvery { brukerService.hentBrukerdata(any(), any()) } returns BrukerService.Brukerdata(
@@ -257,6 +269,7 @@ class VeilederflateServiceTest : FunSpec({
             brukerService,
             tiltaksgjennomforingService,
             virksomhetService,
+            tiltakstypeService,
         )
         every { tiltaksgjennomforingService.getBySanityIds(any()) } returns mapOf(
             UUID.fromString("f21d1e35-d63b-4de7-a0a5-589e57111527") to dbGjennomforing.copy(tilgjengelighet = TiltaksgjennomforingTilgjengelighetsstatus.STENGT),


### PR DESCRIPTION
Henter arenakode fra tiltakstypetabellen i 
databasen dersom vi har med et individuelt 
tiltak å gjøre. Dette vil fikse problemet 
der individuelle tiltak mangler knapp for 
opprett avtale i veilederflate.
