### PR TITLE
Fiks feil query param navn

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -225,7 +225,7 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getUtkastFilter(): UtkastFilte
 
 fun <T : Any> PipelineContext<T, ApplicationCall>.getNotatFilter(): NotatFilter {
     val avtaleId = call.request.queryParameters["avtaleId"]?.toUUID()
-    val tiltaksgjennomforingId = call.request.queryParameters["tiltaksgjennomforingID"]?.toUUID()
+    val tiltaksgjennomforingId = call.request.queryParameters["tiltaksgjennomforingId"]?.toUUID()
     val sortering = call.request.queryParameters["order"]
 
     return NotatFilter(


### PR DESCRIPTION
Fikser at alle notater blir returnert for gjennomforinger