### PR TITLE
also resolve overordnetEnhet for TILTAK-enheter to sanity

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavEnheterSyncService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavEnheterSyncService.kt
@@ -5,7 +5,10 @@ import no.nav.mulighetsrommet.api.clients.norg2.*
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
-import no.nav.mulighetsrommet.api.domain.dto.*
+import no.nav.mulighetsrommet.api.domain.dto.EnhetSlug
+import no.nav.mulighetsrommet.api.domain.dto.FylkeRef
+import no.nav.mulighetsrommet.api.domain.dto.Mutation
+import no.nav.mulighetsrommet.api.domain.dto.SanityEnhet
 import no.nav.mulighetsrommet.api.repositories.NavEnhetRepository
 import no.nav.mulighetsrommet.api.utils.NavEnhetUtils
 import no.nav.mulighetsrommet.slack.SlackNotifier
@@ -18,8 +21,6 @@ class NavEnheterSyncService(
     private val slackNotifier: SlackNotifier,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val fylkerOgEnheterTyper = listOf(Norg2Type.FYLKE, Norg2Type.TILTAK, Norg2Type.LOKAL)
-    private val spesialEnheterTyper = listOf(Norg2Type.ALS)
 
     suspend fun synkroniserEnheter() {
         val enheter = norg2Client.hentEnheter()
@@ -42,16 +43,34 @@ class NavEnheterSyncService(
                     enhetsnummer = it.enhet.enhetNr,
                     status = NavEnhetStatus.valueOf(it.enhet.status.name),
                     type = Norg2Type.valueOf(it.enhet.type.name),
-                    overordnetEnhet = getOverordnetEnhet(it.enhet.enhetNr, it.enhet.type, it.enhet.status) ?: it.overordnetEnhet,
+                    overordnetEnhet = it.overordnetEnhet ?: tryResolveOverordnetEnhet(it.enhet),
                 ),
             )
         }
     }
 
     fun utledEnheterTilSanity(enheter: List<Norg2Response>): List<SanityEnhet> {
-        val spesialEnheterToSanity = spesialEnheterToSanityEnheter(enheter)
-        val fylkerOgEnheterToSanity = fylkeOgUnderenheterToSanity(enheter)
-        return spesialEnheterToSanity + fylkerOgEnheterToSanity
+        val relevanteEnheterMedJustertOverordnetEnhet = enheter
+            .filter { isRelevantEnhetForSanity(it) }
+            .map {
+                val overordnetEnhet = it.overordnetEnhet ?: tryResolveOverordnetEnhet(it.enhet)
+                it.copy(overordnetEnhet = overordnetEnhet)
+            }
+
+        val fylker = relevanteEnheterMedJustertOverordnetEnhet
+            .filter { it.enhet.type == Norg2Type.FYLKE }
+
+        return fylker.flatMap { fylke ->
+            val underliggendeEnheter = relevanteEnheterMedJustertOverordnetEnhet
+                .filter { NavEnhetUtils.isUnderliggendeEnhet(fylke.enhet, it) }
+                .map { toSanityEnhet(it.enhet, fylke.enhet) }
+
+            listOf(toSanityEnhet(fylke.enhet)) + underliggendeEnheter
+        }
+    }
+
+    private fun isRelevantEnhetForSanity(it: Norg2Response): Boolean {
+        return NavEnhetUtils.isRelevantEnhetStatus(it.enhet.status) && NavEnhetUtils.isRelevantEnhetType(it.enhet.type)
     }
 
     suspend fun lagreEnheterTilSanity(sanityEnheter: List<SanityEnhet>) {
@@ -68,27 +87,6 @@ class NavEnheterSyncService(
         }
     }
 
-    private fun spesialEnheterToSanityEnheter(enheter: List<Norg2Response>): List<SanityEnhet> {
-        return enheter
-            .filter { NavEnhetUtils.relevanteStatuser(it.enhet.status) && erSpesialenhet(it) }
-            .map { toSanityEnhet(it.enhet) }
-    }
-
-    private fun fylkeOgUnderenheterToSanity(enheter: List<Norg2Response>): List<SanityEnhet> {
-        val relevanteEnheter = enheter
-            .filter { erFylkeEllerUnderenhet(it) }
-
-        val fylker = relevanteEnheter
-            .filter { NavEnhetUtils.relevanteStatuser(it.enhet.status) && it.enhet.type == Norg2Type.FYLKE }
-
-        return fylker.flatMap { fylke ->
-            val underliggendeEnheter = relevanteEnheter
-                .filter { NavEnhetUtils.isUnderliggendeEnhet(fylke.enhet, it) }
-                .map { toSanityEnhet(it.enhet, fylke.enhet) }
-            listOf(toSanityEnhet(fylke.enhet)) + underliggendeEnheter
-        }
-    }
-
     private fun toSanityEnhet(enhet: Norg2EnhetDto, fylke: Norg2EnhetDto? = null): SanityEnhet {
         var fylkeTilEnhet: FylkeRef? = null
 
@@ -98,15 +96,6 @@ class NavEnheterSyncService(
                 _ref = NavEnhetUtils.toEnhetId(fylke),
                 _key = fylke.enhetNr,
             )
-        } else if (enhet.type == Norg2Type.ALS) {
-            val fylkesnummer = getOverordnetEnhet(enhet.enhetNr, enhet.type, enhet.status)
-            if (fylkesnummer != null) {
-                fylkeTilEnhet = FylkeRef(
-                    _type = "reference",
-                    _ref = "enhet.fylke.$fylkesnummer",
-                    _key = fylkesnummer,
-                )
-            }
         }
 
         return SanityEnhet(
@@ -123,8 +112,11 @@ class NavEnheterSyncService(
         )
     }
 
-    private fun getOverordnetEnhet(enhetNr: String, type: Norg2Type, status: Norg2EnhetStatus): String? {
-        if (!getWhitelistForStatus().contains(status) || !listOf(Norg2Type.ALS, Norg2Type.TILTAK).contains(type)) {
+    private fun tryResolveOverordnetEnhet(enhet: Norg2EnhetDto): String? {
+        if (!NavEnhetUtils.isRelevantEnhetStatus(enhet.status) || !listOf(Norg2Type.ALS, Norg2Type.TILTAK).contains(
+                enhet.type,
+            )
+        ) {
             return null
         }
 
@@ -154,23 +146,11 @@ class NavEnheterSyncService(
             "5771" to "5700", // NAV Tiltak Trøndelag
         )
 
-        val fantFylke = spesialEnheterTilFylkeMap[enhetNr]
+        val fantFylke = spesialEnheterTilFylkeMap[enhet.enhetNr]
         if (fantFylke == null) {
-            slackNotifier.sendMessage("Fant ikke fylke for spesialenhet med enhetsnummer: $enhetNr. En utvikler må sjekke om enheten skal mappe til et fylke.")
+            slackNotifier.sendMessage("Fant ikke fylke for spesialenhet med enhetsnummer: ${enhet.enhetNr}. En utvikler må sjekke om enheten skal mappe til et fylke.")
             return null
         }
         return fantFylke
-    }
-
-    private fun erSpesialenhet(enhet: Norg2Response): Boolean {
-        return enhet.enhet.type in spesialEnheterTyper && enhet.enhet.status in getWhitelistForStatus()
-    }
-
-    private fun erFylkeEllerUnderenhet(enhet: Norg2Response): Boolean {
-        return enhet.enhet.type in fylkerOgEnheterTyper && enhet.enhet.status in getWhitelistForStatus()
-    }
-
-    private fun getWhitelistForStatus(): List<Norg2EnhetStatus> {
-        return listOf(Norg2EnhetStatus.AKTIV, Norg2EnhetStatus.UNDER_AVVIKLING, Norg2EnhetStatus.UNDER_ETABLERING)
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/NavEnhetUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/NavEnhetUtils.kt
@@ -4,20 +4,28 @@ import io.ktor.server.plugins.*
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetDto
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetStatus
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Response
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 
 object NavEnhetUtils {
     fun isUnderliggendeEnhet(fylke: Norg2EnhetDto, enhet: Norg2Response): Boolean {
-        return relevanteStatuser(enhet.enhet.status) && enhet.overordnetEnhet == fylke.enhetNr
+        return isRelevantEnhetStatus(enhet.enhet.status) && enhet.overordnetEnhet == fylke.enhetNr
     }
 
-    fun relevanteStatuser(status: Norg2EnhetStatus): Boolean {
-        val relevanteStatuser =
-            listOf(
-                Norg2EnhetStatus.UNDER_ETABLERING.name,
-                Norg2EnhetStatus.UNDER_AVVIKLING.name,
-                Norg2EnhetStatus.AKTIV.name,
-            )
-        return relevanteStatuser.contains(status.name)
+    fun isRelevantEnhetStatus(status: Norg2EnhetStatus): Boolean {
+        return status in listOf(
+            Norg2EnhetStatus.UNDER_ETABLERING,
+            Norg2EnhetStatus.UNDER_AVVIKLING,
+            Norg2EnhetStatus.AKTIV,
+        )
+    }
+
+    fun isRelevantEnhetType(type: Norg2Type): Boolean {
+        return type in listOf(
+            Norg2Type.FYLKE,
+            Norg2Type.LOKAL,
+            Norg2Type.ALS,
+            Norg2Type.TILTAK,
+        )
     }
 
     fun toEnhetId(enhet: Norg2EnhetDto): String {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavEnheterSyncServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavEnheterSyncServiceTest.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.services
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.ktor.client.engine.mock.*
 import io.mockk.mockk
@@ -44,7 +45,7 @@ class NavEnheterSyncServiceTest : FunSpec({
                 overordnetEnhet = null,
             ),
             Norg2Response(
-                enhet = createEnhet("1300", Norg2Type.ALS),
+                enhet = createEnhet("1291", Norg2Type.ALS),
                 overordnetEnhet = null,
             ),
         )
@@ -52,9 +53,31 @@ class NavEnheterSyncServiceTest : FunSpec({
         val tilSanity = navEnheterSyncService.utledEnheterTilSanity(mockEnheter)
 
         tilSanity.size shouldBe 3
-        tilSanity[0]._id shouldBe "enhet.als.1300"
-        tilSanity[1]._id shouldBe "enhet.fylke.1200"
-        tilSanity[2]._id shouldBe "enhet.lokal.1001"
+        tilSanity[0]._id shouldBe "enhet.fylke.1200"
+        tilSanity[0].fylke.shouldBeNull()
+        tilSanity[1]._id shouldBe "enhet.lokal.1001"
+        tilSanity[1].fylke?._ref shouldBe "enhet.fylke.1200"
+        tilSanity[2]._id shouldBe "enhet.als.1291"
         tilSanity[2].fylke?._ref shouldBe "enhet.fylke.1200"
+    }
+
+    test("skal utlede TILTAK-enheter for synkronisering til sanity") {
+        val mockEnheter = listOf(
+            Norg2Response(
+                enhet = createEnhet("0300", Norg2Type.FYLKE),
+                overordnetEnhet = null,
+            ),
+            Norg2Response(
+                enhet = createEnhet("0387", Norg2Type.TILTAK),
+                overordnetEnhet = null,
+            ),
+        )
+
+        val tilSanity = navEnheterSyncService.utledEnheterTilSanity(mockEnheter)
+
+        tilSanity.size shouldBe 2
+        tilSanity[0]._id shouldBe "enhet.fylke.0300"
+        tilSanity[1]._id shouldBe "enhet.tiltak.0387"
+        tilSanity[1].fylke?._ref shouldBe "enhet.fylke.0300"
     }
 })

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtilsTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utils/SanityUtilsTest.kt
@@ -58,10 +58,10 @@ class SanityUtilsTest : FunSpec({
         }
 
         test("Relevante statuser") {
-            NavEnhetUtils.relevanteStatuser(Norg2EnhetStatus.AKTIV) shouldBe true
-            NavEnhetUtils.relevanteStatuser(Norg2EnhetStatus.UNDER_AVVIKLING) shouldBe true
-            NavEnhetUtils.relevanteStatuser(Norg2EnhetStatus.UNDER_ETABLERING) shouldBe true
-            NavEnhetUtils.relevanteStatuser(Norg2EnhetStatus.NEDLAGT) shouldBe false
+            NavEnhetUtils.isRelevantEnhetStatus(Norg2EnhetStatus.AKTIV) shouldBe true
+            NavEnhetUtils.isRelevantEnhetStatus(Norg2EnhetStatus.UNDER_AVVIKLING) shouldBe true
+            NavEnhetUtils.isRelevantEnhetStatus(Norg2EnhetStatus.UNDER_ETABLERING) shouldBe true
+            NavEnhetUtils.isRelevantEnhetStatus(Norg2EnhetStatus.NEDLAGT) shouldBe false
         }
 
         test("toType skal returnere typer med stor forbokstav") {


### PR DESCRIPTION
Det ser ut som at TILTAK-enhetene ikke har fått utledet overordnet enhet basert på manuell mapping i `NavEnheterSyncService`.

Dette skaper problemer for noen tiltaksgjennomføringer som kommer fra Arena fordi de har tiltaksenhetene som ansvarlig enhet og de blir ikke skrevet til Sanity.

Blir dette riktig? Er det en grunn til at TILTAK-enhetene har blitt utelatt tidligere?