### PR TITLE
BUGFIX Modal kan åpnes og lukkes som forventet

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -151,7 +151,7 @@ const Delemodal = ({
           manuellStatus={manuellStatus}
         />
       ) : (
-        <Modal open={modalOpen} className={delemodalStyles.delemodal} aria-label="modal">
+        <Modal open={modalOpen} onClose={() => clickCancel()} className={delemodalStyles.delemodal} aria-label="modal">
           <Modal.Header closeButton data-testid="modal_header">
             <Heading size="xsmall">Del med bruker</Heading>
             <Heading size="large" level="1" className={delemodalStyles.heading}>


### PR DESCRIPTION
Det manglet en onClose-prop på modalen vi bruker for del med bruker-funksjonaliteten i 
veilederflaten.
