### PR TITLE
Refactor/send fnr through post body

### DIFF
--- a/common/ktor-clients/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
+++ b/common/ktor-clients/src/main/kotlin/no/nav/mulighetsrommet/ktor/clients/HttpClients.kt
@@ -12,6 +12,7 @@ import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 import no.nav.mulighetsrommet.metrics.Metrikker
+import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 
 val ClientResponseMetricPlugin = createClientPlugin("ClientResponseMetricPlugin") {
@@ -25,6 +26,18 @@ fun httpJsonClient(engine: HttpClientEngine = CIO.create()) = HttpClient(engine)
 
     install(Logging) {
         level = LogLevel.INFO
+
+        logger = object : Logger {
+            private val logger = LoggerFactory.getLogger(HttpClient::class.java)
+
+            private val fnrRegex = "\\d{11}".toRegex()
+
+            override fun log(message: String) {
+                val maskedMessage = message.replace(fnrRegex, replacement = "***********")
+                logger.info(maskedMessage)
+            }
+        }
+
     }
 
     install(ContentNegotiation) {

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -124,8 +124,7 @@ const Delemodal = ({
     const tekst = sySammenDeletekst();
     try {
       const res = await mulighetsrommetClient.dialogen.delMedDialogen({
-        fnr: brukerFnr,
-        requestBody: { overskrift, tekst },
+        requestBody: { norskIdent: brukerFnr, overskrift, tekst },
       });
       if (tiltaksgjennomforingSanityId) {
         await lagreVeilederHarDeltTiltakMedBruker(res.id, tiltaksgjennomforingSanityId);

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
@@ -34,7 +34,7 @@ const ArrangorInfo = ({ data }: ArrangorInfoProps) => {
             {kontaktperson.navn}
           </BodyShort>
 
-          <BodyShort size="small">
+          <BodyShort as="div" size="small">
             <div className={styles.infofelt}>
               <div className={styles.kolonne}>
                 <span>Telefon:</span>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/NavKontaktpersonInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/NavKontaktpersonInfo.tsx
@@ -33,7 +33,7 @@ const NavKontaktpersonInfo = ({ data }: NavKontaktpersonInfoProps) => {
               {navn}
             </BodyShort>
 
-            <BodyShort size="small">
+            <BodyShort as="div" size="small">
               <div className={styles.infofelt}>
                 <div className={styles.kolonne}>
                   {telefonnummer && <span>Telefon:</span>}

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentBrukerdata.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentBrukerdata.ts
@@ -8,9 +8,11 @@ import { erPreview } from '../../../utils/Utils';
 export function useHentBrukerdata() {
   const fnr = useFnr();
 
+  const requestBody = { norskIdent: fnr };
+
   return useQuery<Bruker, Error>(
     [QueryKeys.Brukerdata, fnr],
-    () => mulighetsrommetClient.bruker.getBrukerdata({ fnr }),
+    () => mulighetsrommetClient.bruker.getBrukerdata({ requestBody }),
     { enabled: !erPreview }
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentDeltMedbrukerStatus.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentDeltMedbrukerStatus.ts
@@ -8,22 +8,28 @@ import { useHentVeilederdata } from './useHentVeilederdata';
 export function useHentDeltMedBrukerStatus(sanityId: string | undefined, norskIdent: string) {
   const { data: veilederData } = useHentVeilederdata();
 
+  const requestBody = {
+    norskIdent,
+    sanityId: sanityId ?? '',
+  };
+
   const { data: sistDeltMedBruker, refetch: refetchDelMedBruker } = useQuery<DelMedBruker>(
     [QueryKeys.DeltMedBrukerStatus, norskIdent, sanityId],
-    () =>
-      mulighetsrommetClient.delMedBruker.getDelMedBruker({
-        fnr: norskIdent,
-        sanityId: sanityId!!,
-      }),
+    () => mulighetsrommetClient.delMedBruker.getDelMedBruker({ requestBody }),
     { enabled: !erPreview && !!sanityId }
   );
 
   async function lagreVeilederHarDeltTiltakMedBruker(dialogId: string, sanityId: string) {
     if (!veilederData?.navIdent) return;
 
-    await mulighetsrommetClient.delMedBruker.postDelMedBruker({
-      requestBody: { norskIdent, navident: veilederData?.navIdent, sanityId, dialogId },
-    });
+    const requestBody = {
+      norskIdent,
+      navident: veilederData?.navIdent,
+      sanityId,
+      dialogId,
+    };
+
+    await mulighetsrommetClient.delMedBruker.delMedBruker({ requestBody });
 
     await refetchDelMedBruker();
   }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentHistorikk.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentHistorikk.ts
@@ -5,7 +5,14 @@ import { QueryKeys } from '../query-keys';
 
 export function useHentHistorikk(prefetch: boolean = true) {
   const fnr = useFnr();
-  return useQuery([QueryKeys.Historikk, fnr], () => mulighetsrommetClient.historikk.hentHistorikkForBruker({ fnr }), {
-    enabled: prefetch,
-  });
+
+  const requestBody = { norskIdent: fnr };
+
+  return useQuery(
+    [QueryKeys.Historikk, fnr],
+    () => mulighetsrommetClient.historikk.hentHistorikkForBruker({ requestBody }),
+    {
+      enabled: prefetch,
+    }
+  );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/usePreviewTiltaksgjennomforingById.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/usePreviewTiltaksgjennomforingById.ts
@@ -5,9 +5,7 @@ import { useGetTiltaksgjennomforingIdFraUrl } from './useGetTiltaksgjennomforing
 
 export default function usePreviewTiltaksgjennomforingById() {
   const id = useGetTiltaksgjennomforingIdFraUrl();
-  const response = useQuery(QueryKeys.sanity.tiltaksgjennomforingPreview(id), () =>
-    mulighetsrommetClient.sanity.getSanityTiltaksgjennomforingForPreview({ id })
+  return useQuery(QueryKeys.sanity.tiltaksgjennomforingPreview(id), () =>
+    mulighetsrommetClient.sanity.getTiltaksgjennomforingForPreview({ id })
   );
-
-  return response;
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforingById.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforingById.ts
@@ -7,9 +7,10 @@ import { useGetTiltaksgjennomforingIdFraUrl } from './useGetTiltaksgjennomforing
 export default function useTiltaksgjennomforingById() {
   const id = useGetTiltaksgjennomforingIdFraUrl();
   const fnr = useFnr();
-  const response = useQuery(QueryKeys.sanity.tiltaksgjennomforing(id), () =>
-    mulighetsrommetClient.sanity.getSanityTiltaksgjennomforing({ id, fnr })
-  );
 
-  return response;
+  const requestBody = { sanityId: id, norskIdent: fnr };
+
+  return useQuery(QueryKeys.sanity.tiltaksgjennomforing(id), () =>
+    mulighetsrommetClient.sanity.getTiltaksgjennomforingForBruker({ requestBody })
+  );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltaksgjennomforinger.ts
@@ -12,13 +12,15 @@ export default function useTiltaksgjennomforinger() {
   const brukerData = useHentBrukerdata();
   const fnr = useFnr();
 
+  const requestBody = {
+    norskIdent: fnr,
+    innsatsgruppe: filter.innsatsgruppe?.nokkel,
+    search: filter.search,
+    tiltakstypeIds: filter.tiltakstyper.map(({ id }) => id),
+  };
+
   return useQuery(QueryKeys.sanity.tiltaksgjennomforinger(brukerData.data, filter), () =>
-    mulighetsrommetClient.sanity.getTiltaksgjennomforingForBruker({
-      fnr,
-      innsatsgruppe: filter.innsatsgruppe?.nokkel,
-      sokestreng: filter.search,
-      tiltakstypeIder: filter.tiltakstyper.map(({ id }) => id),
-    })
+    mulighetsrommetClient.sanity.getRelevanteTiltaksgjennomforingerForBruker({ requestBody })
   );
 }
 

--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltakstyper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useTiltakstyper.ts
@@ -3,5 +3,5 @@ import { mulighetsrommetClient } from '../clients';
 import { QueryKeys } from '../query-keys';
 
 export function useTiltakstyper() {
-  return useQuery(QueryKeys.sanity.tiltakstyper, () => mulighetsrommetClient.sanity.getSanityTiltakstyper());
+  return useQuery(QueryKeys.sanity.tiltakstyper, () => mulighetsrommetClient.sanity.getVeilederflateTiltakstyper());
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/apiHandlers.ts
@@ -1,7 +1,6 @@
 import { RestHandler } from 'msw';
 import { brukerHandlers } from './endpoints/brukerHandlers';
 import { delMedBrukerHandlers } from './endpoints/delMedBrukerHandlers';
-import { historikkHandlers } from './endpoints/historikkHandlers';
 import { sanityHandlers } from './endpoints/sanityHandlers';
 import { veilederHandlers } from './endpoints/veilederHandlers';
 import { featureToggleHandlers } from './endpoints/featureToggleHandlers';
@@ -11,6 +10,5 @@ export const apiHandlers: RestHandler[] = [
   ...delMedBrukerHandlers,
   ...brukerHandlers,
   ...veilederHandlers,
-  ...historikkHandlers,
   ...featureToggleHandlers,
 ];

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/brukerHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/brukerHandlers.ts
@@ -1,20 +1,21 @@
 import { DefaultBodyType, PathParams, rest } from 'msw';
-import { Bruker, Innsatsgruppe } from 'mulighetsrommet-api-client';
+import { Bruker, GetBrukerRequest, HistorikkForBruker, Innsatsgruppe } from 'mulighetsrommet-api-client';
 import { ENHET_FREDRIKSTAD } from '../../mock_constants';
 import { badReq } from '../responses';
+import { historikk } from '../../fixtures/historikk';
 
 export const brukerHandlers = [
-  rest.get<DefaultBodyType, PathParams, Bruker>('*/api/v1/internal/bruker', (req, res, ctx) => {
-    const fnr = req.url.searchParams.get('fnr');
+  rest.post<DefaultBodyType, PathParams, Bruker>('*/api/v1/internal/bruker', async (req, res, ctx) => {
+    const { norskIdent } = await req.json<GetBrukerRequest>();
 
-    if (!fnr) {
+    if (!norskIdent) {
       return badReq("'fnr' must be specified");
     }
 
     return res(
       ctx.status(200),
       ctx.json({
-        fnr,
+        fnr: norskIdent,
         innsatsgruppe: Innsatsgruppe.SITUASJONSBESTEMT_INNSATS,
         oppfolgingsenhet: {
           navn: 'NAV Fredrikstad',
@@ -34,5 +35,9 @@ export const brukerHandlers = [
         },
       })
     );
+  }),
+
+  rest.post<DefaultBodyType, PathParams, HistorikkForBruker[]>('*/api/v1/internal/bruker/historikk', (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json(historikk));
   }),
 ];

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/delMedBrukerHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/delMedBrukerHandlers.ts
@@ -2,12 +2,12 @@ import { rest, DefaultBodyType, PathParams } from 'msw';
 import { DelMedBruker, DialogResponse } from 'mulighetsrommet-api-client';
 
 export const delMedBrukerHandlers = [
-  rest.post<DelMedBruker, PathParams, DelMedBruker>('*/api/v1/internal/delMedBruker', async (req, res, ctx) => {
+  rest.put<DelMedBruker, PathParams, DelMedBruker>('*/api/v1/internal/del-med-bruker', async (req, res, ctx) => {
     const data = await req.json<DelMedBruker>();
     return res(ctx.status(200), ctx.json(data));
   }),
 
-  rest.get<DefaultBodyType, PathParams, DelMedBruker>('*/api/v1/internal/delMedBruker/*', (req, res, ctx) => {
+  rest.post<DefaultBodyType, PathParams, DelMedBruker>('*/api/v1/internal/del-med-bruker', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/historikkHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/historikkHandlers.ts
@@ -1,9 +1,0 @@
-import { DefaultBodyType, PathParams, rest } from 'msw';
-import { HistorikkForBruker } from 'mulighetsrommet-api-client';
-import { historikk } from '../../fixtures/historikk';
-
-export const historikkHandlers = [
-  rest.get<DefaultBodyType, PathParams, HistorikkForBruker[]>('*/api/v1/internal/bruker/historikk', (_, res, ctx) => {
-    return res(ctx.status(200), ctx.json(historikk));
-  }),
-];

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/sanityHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/sanityHandlers.ts
@@ -1,5 +1,7 @@
 import { DefaultBodyType, PathParams, rest } from 'msw';
 import {
+  GetRelevanteTiltaksgjennomforingerForBrukerRequest,
+  GetTiltaksgjennomforingForBrukerRequest,
   VeilederflateInnsatsgruppe,
   VeilederflateTiltaksgjennomforing,
   VeilederflateTiltakstype,
@@ -24,21 +26,24 @@ export const sanityHandlers = [
     }
   ),
 
-  rest.get<DefaultBodyType, PathParams, any>('*/api/v1/internal/sanity/tiltaksgjennomforinger', async req => {
-    const innsatsgruppe = req.url.searchParams.get('innsatsgruppe') || '';
-    const tiltakstypeIder = req.url.searchParams.getAll('tiltakstypeIder');
-    const sokestreng = req.url.searchParams.get('sokestreng') || '';
+  rest.post<DefaultBodyType, PathParams, any>('*/api/v1/internal/sanity/tiltaksgjennomforinger', async req => {
+    const {
+      innsatsgruppe = '',
+      search = '',
+      tiltakstypeIds = [],
+    } = await req.json<GetRelevanteTiltaksgjennomforingerForBrukerRequest>();
+
     const results = mockTiltaksgjennomforinger
-      .filter(gj => filtrerFritekst(gj, sokestreng))
+      .filter(gj => filtrerFritekst(gj, search))
       .filter(gj => filtrerInnsatsgruppe(gj, innsatsgruppe))
-      .filter(gj => filtrerTiltakstyper(gj, tiltakstypeIder));
+      .filter(gj => filtrerTiltakstyper(gj, tiltakstypeIds));
 
     return ok(results);
   }),
 
-  rest.get<DefaultBodyType, PathParams, any>('*/api/v1/internal/sanity/tiltaksgjennomforing/:id', async req => {
-    const id = req.params.id;
-    const gjennomforing = mockTiltaksgjennomforinger.find(gj => gj.sanityId === id);
+  rest.post<DefaultBodyType, PathParams, any>('*/api/v1/internal/sanity/tiltaksgjennomforing', async req => {
+    const { sanityId } = await req.json<GetTiltaksgjennomforingForBrukerRequest>();
+    const gjennomforing = mockTiltaksgjennomforinger.find(gj => gj.sanityId === sanityId);
     return ok(gjennomforing);
   }),
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
@@ -101,14 +101,3 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getNavAnsattAzureId(): UUID {
         ?.let { UUID.fromString(it) }
         ?: throw StatusException(HttpStatusCode.Forbidden, "NavAnsattAzureId mangler i JWTPrincipal")
 }
-
-fun <T : Any> PipelineContext<T, ApplicationCall>.getNorskIdent(): String {
-    val fnr = call.request.queryParameters["fnr"] ?: throw StatusException(
-        HttpStatusCode.BadRequest,
-        "fnr mangler som queryparameter",
-    )
-
-    if (fnr.length != 11) throw BadRequestException("fnr må være 11 siffer")
-
-    return fnr
-}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DialogRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DialogRoutes.kt
@@ -5,13 +5,11 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.util.pipeline.*
 import no.nav.common.audit_log.cef.CefMessage
 import no.nav.common.audit_log.cef.CefMessageEvent
 import no.nav.common.audit_log.cef.CefMessageSeverity
 import no.nav.mulighetsrommet.api.plugins.getNavAnsattAzureId
 import no.nav.mulighetsrommet.api.plugins.getNavIdent
-import no.nav.mulighetsrommet.api.plugins.getNorskIdent
 import no.nav.mulighetsrommet.api.services.DialogRequest
 import no.nav.mulighetsrommet.api.services.DialogService
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
@@ -20,42 +18,50 @@ import no.nav.mulighetsrommet.auditlog.AuditLog
 import org.koin.ktor.ext.inject
 
 fun Route.dialogRoutes() {
-    val auditLog = AuditLog.auditLogger
     val dialogService: DialogService by inject()
     val poaoTilgangService: PoaoTilgangService by inject()
 
     route("/api/v1/internal/dialog") {
         post {
-            poaoTilgangService.verifyAccessToUserFromVeileder(getNavAnsattAzureId(), getNorskIdent())
-            val dialogRequest = call.receive<DialogRequest>()
+            val request = call.receive<DialogRequest>()
+            val norskIdent = request.norskIdent
+            val navIdent = getNavIdent()
+
+            poaoTilgangService.verifyAccessToUserFromVeileder(getNavAnsattAzureId(), norskIdent)
+
             val accessToken = call.getAccessToken()
-            val response = dialogService.sendMeldingTilDialogen(getNorskIdent(), accessToken, dialogRequest)
+            val response = dialogService.sendMeldingTilDialogen(norskIdent, accessToken, request)
             response?.let {
-                auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' har delt informasjon om tiltaket '${dialogRequest.overskrift}' til bruker med ident: '${getNorskIdent()}'."))
+                val message = createAuditMessage(
+                    msg = "NAV-ansatt med ident: '$navIdent' har delt informasjon om tiltaket '${request.overskrift}' til bruker med ident: '$norskIdent'.",
+                    navIdent = navIdent,
+                    norskIdent = norskIdent,
+                )
+                AuditLog.auditLogger.log(message)
                 call.respond(response)
             } ?: run {
-                auditLog.log(createAuditMessage("NAV-ansatt med ident: '${getNavIdent()}' fikke ikke delt informasjon om tiltaket '${dialogRequest.overskrift}' til bruker med ident: '${getNorskIdent()}'."))
+                val message = createAuditMessage(
+                    msg = "NAV-ansatt med ident: '$navIdent' fikk ikke delt informasjon om tiltaket '${request.overskrift}' til bruker med ident: '$norskIdent'.",
+                    navIdent = navIdent,
+                    norskIdent = norskIdent,
+                )
+                AuditLog.auditLogger.log(message)
                 call.respond(HttpStatusCode.Conflict)
             }
         }
     }
 }
 
-private fun PipelineContext<Unit, ApplicationCall>.createAuditMessage(
-    msg: String,
-): CefMessage? {
+private fun createAuditMessage(msg: String, navIdent: String, norskIdent: String): CefMessage {
     return CefMessage.builder()
         .applicationName("modia")
         .loggerName("mulighetsrommet-api")
         .event(CefMessageEvent.CREATE)
         .name("Arbeidsmarkedstiltak - Del med bruker")
         .severity(CefMessageSeverity.INFO)
-        .sourceUserId(getNavIdent())
-        .destinationUserId(getNorskIdent())
+        .sourceUserId(navIdent)
+        .destinationUserId(norskIdent)
         .timeEnded(System.currentTimeMillis())
-        .extension(
-            "msg",
-            msg,
-        )
+        .extension("msg", msg)
         .build()
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DialogService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/DialogService.kt
@@ -13,6 +13,7 @@ class DialogService(
 
 @Serializable
 data class DialogRequest(
+    val norskIdent: String,
     val overskrift: String,
     val tekst: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -57,7 +57,7 @@ data class EnhetFilter(
 data class TiltaksgjennomforingFilter(
     val innsatsgruppe: String? = null,
     val tiltakstypeIder: List<String> = emptyList(),
-    val sokestreng: String = "",
+    val sokestreng: String? = null,
 )
 
 data class NotificationFilter(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/FilterUtils.kt
@@ -54,12 +54,6 @@ data class EnhetFilter(
     val typer: List<Norg2Type>? = null,
 )
 
-data class TiltaksgjennomforingFilter(
-    val innsatsgruppe: String? = null,
-    val tiltakstypeIder: List<String> = emptyList(),
-    val sokestreng: String? = null,
-)
-
 data class NotificationFilter(
     val status: NotificationStatus? = null,
 )
@@ -181,17 +175,6 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getEnhetFilter(): EnhetFilter 
     return EnhetFilter(
         statuser = statuser,
         typer = typer,
-    )
-}
-
-fun <T : Any> PipelineContext<T, ApplicationCall>.getTiltaksgjennomforingsFilter(): TiltaksgjennomforingFilter {
-    val innsatsgruppe = call.parameters["innsatsgruppe"]
-    val tiltakstypeIder = call.parameters.getAll("tiltakstypeIder") ?: emptyList()
-    val sokestreng = call.parameters["sokestreng"] ?: ""
-    return TiltaksgjennomforingFilter(
-        innsatsgruppe = innsatsgruppe,
-        tiltakstypeIder = tiltakstypeIder,
-        sokestreng = sokestreng,
     )
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityFilters.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utils/SanityFilters.kt
@@ -10,8 +10,10 @@ fun byggTiltakstypeFilter(tiltakstyper: List<String>): String {
     """.trimIndent()
 }
 
-fun byggSokeFilter(sokestreng: String): String {
-    if (sokestreng.isBlank()) return ""
+fun byggSokeFilter(sokestreng: String?): String {
+    if (sokestreng.isNullOrBlank()) {
+        return ""
+    }
 
     return """
             && [tiltaksgjennomforingNavn, string(tiltaksnummer.current), tiltakstype->tiltakstypeNavn, lokasjon, oppstartsdato] match "*$sokestreng*"

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -9,12 +9,16 @@ security:
 
 paths:
   /api/v1/internal/bruker:
-    parameters:
-      - $ref: "#/components/parameters/Fnr"
-    get:
+    post:
       tags:
         - Bruker
       operationId: getBrukerdata
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetBrukerRequest"
+        required: true
       responses:
         200:
           description: Data about the 'bruker' in the context of 'veileder'
@@ -814,7 +818,7 @@ paths:
     get:
       tags:
         - Sanity
-      operationId: getSanityTiltakstyper
+      operationId: getVeilederflateTiltakstyper
       responses:
         200:
           description: Tiltakstyper definert i Sanity
@@ -826,30 +830,16 @@ paths:
                   $ref: "#/components/schemas/VeilederflateTiltakstype"
 
   /api/v1/internal/sanity/tiltaksgjennomforinger:
-    parameters:
-      - $ref: "#/components/parameters/Fnr"
-    get:
+    post:
       tags:
         - Sanity
-      operationId: getTiltaksgjennomforingForBruker
-      parameters:
-        - in: query
-          name: innsatsgruppe
-          schema:
-            type: string
-          description: Innsatsgruppe du ønsker å filtrere på
-        - in: query
-          name: tiltakstypeIder
-          schema:
-            type: array
-            items:
-              type: string
-          description: Liste med id'er for tiltakstyper man er interessert i
-        - in: query
-          name: sokestreng
-          schema:
-            type: string
-          description: Søkestreng for fritekstsøk etter tiltaksgjennomføringer
+      operationId: getRelevanteTiltaksgjennomforingerForBruker
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetRelevanteTiltaksgjennomforingerForBrukerRequest"
+        required: true
       responses:
         200:
           description: Hent tiltaksgjennomføringer som bruker har rett på
@@ -860,23 +850,17 @@ paths:
                 items:
                   $ref: "#/components/schemas/VeilederflateTiltaksgjennomforing"
 
-  /api/v1/internal/sanity/tiltaksgjennomforing/{id}:
-    get:
+  /api/v1/internal/sanity/tiltaksgjennomforing:
+    post:
       tags:
         - Sanity
-      operationId: getSanityTiltaksgjennomforing
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-          description: ID for tiltaksgjennomføring i Sanity
-        - in: query
-          name: fnr
-          schema:
-            type: string
-          description: FNR for bruker
+      operationId: getTiltaksgjennomforingForBruker
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetTiltaksgjennomforingForBrukerRequest"
+        required: true
       responses:
         200:
           description: Hent tiltaksgjennomføring for id
@@ -889,7 +873,7 @@ paths:
     get:
       tags:
         - Sanity
-      operationId: getSanityTiltaksgjennomforingForPreview
+      operationId: getTiltaksgjennomforingForPreview
       parameters:
         - in: path
           name: id
@@ -899,15 +883,13 @@ paths:
           description: ID for tiltaksgjennomføring i Sanity
       responses:
         200:
-          description: Hent tiltaksgjennomføring for id uavhengig av fnr i kontekst
+          description: Hent tiltaksgjennomføring for id uavhengig av bruker i kontekst
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/VeilederflateTiltaksgjennomforing"
 
   /api/v1/internal/dialog:
-    parameters:
-      - $ref: "#/components/parameters/Fnr"
     post:
       tags:
         - dialogen
@@ -932,12 +914,16 @@ paths:
                 type: string
 
   /api/v1/internal/bruker/historikk:
-    parameters:
-      - $ref: "#/components/parameters/Fnr"
-    get:
+    post:
       tags:
         - Historikk
       operationId: hentHistorikkForBruker
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetHistorikkForBrukerRequest"
+        required: true
       responses:
         200:
           description: Historical data about the user
@@ -1027,24 +1013,17 @@ paths:
               schema:
                 type: string
 
-  /api/v1/internal/delMedBruker:
-    get:
+  /api/v1/internal/del-med-bruker:
+    post:
       tags:
         - Del med bruker
       operationId: getDelMedBruker
-      parameters:
-        - in: query
-          name: fnr
-          description: "Brukers fnr"
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: sanityId
-          description: "ID fra Sanity-dokument"
-          required: true
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetDelMedBrukerRequest"
+        required: true
       responses:
         200:
           description: "Last entry in database about share with user"
@@ -1059,10 +1038,10 @@ paths:
               schema:
                 type: string
 
-    post:
+    put:
       tags:
         - Del med bruker
-      operationId: postDelMedBruker
+      operationId: delMedBruker
       requestBody:
         content:
           application/json:
@@ -1418,13 +1397,6 @@ components:
       required: true
       schema:
         type: string
-    Fnr:
-      name: fnr
-      in: query
-      description: Fødselsnummer
-      required: true
-      schema:
-        type: string
     Utkasttype:
       in: query
       name: utkasttype
@@ -1444,6 +1416,63 @@ components:
         type: string
 
   schemas:
+    GetBrukerRequest:
+      type: object
+      properties:
+        norskIdent:
+          type: string
+      required:
+        - norskIdent
+
+    GetHistorikkForBrukerRequest:
+      type: object
+      properties:
+        norskIdent:
+          type: string
+      required:
+        - norskIdent
+
+    GetDelMedBrukerRequest:
+      type: object
+      properties:
+        norskIdent:
+          type: string
+        sanityId:
+          type: string
+          format: uuid
+      required:
+        - norskIdent
+        - sanityId
+
+    GetRelevanteTiltaksgjennomforingerForBrukerRequest:
+      type: object
+      properties:
+        norskIdent:
+          type: string
+        innsatsgruppe:
+          $ref: "#/components/schemas/Innsatsgruppe"
+        tiltakstypeIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        search:
+          type: string
+      required:
+        - norskIdent
+
+    GetTiltaksgjennomforingForBrukerRequest:
+      type: object
+      properties:
+        sanityId:
+          type: string
+          format: uuid
+        norskIdent:
+          type: string
+      required:
+        - sanityId
+        - norskIdent
+
     ManuellStatus:
       type: object
       properties:
@@ -2106,11 +2135,14 @@ components:
     DialogRequest:
       type: object
       properties:
+        norskIdent:
+          type: string
         overskrift:
           type: string
         tekst:
           type: string
       required:
+        - norskIdent
         - overskrift
         - tekst
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
@@ -12,7 +12,7 @@ import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
 import no.nav.mulighetsrommet.api.domain.dto.SanityResponse
-import no.nav.mulighetsrommet.api.utils.TiltaksgjennomforingFilter
+import no.nav.mulighetsrommet.api.routes.v1.GetRelevanteTiltaksgjennomforingerForBrukerRequest
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingTilgjengelighetsstatus
@@ -122,7 +122,7 @@ class VeilederflateServiceTest : FunSpec({
     )
 
     test("Tom enhetsliste fra db overskriver ikke sanity enheter") {
-        val fnr = "01010199999"
+        val norskIdent = "01010199999"
         val veilederFlateService = VeilederflateService(
             sanityClient,
             brukerService,
@@ -135,7 +135,7 @@ class VeilederflateServiceTest : FunSpec({
         )
         coEvery { virksomhetService.getOrSyncVirksomhet(any()) } returns null
         coEvery { brukerService.hentBrukerdata(any(), any()) } returns BrukerService.Brukerdata(
-            fnr,
+            norskIdent,
             geografiskEnhet = Enhet(navn = "A", enhetsnummer = "0430"),
             innsatsgruppe = null,
             oppfolgingsenhet = null,
@@ -146,9 +146,8 @@ class VeilederflateServiceTest : FunSpec({
         coEvery { sanityClient.query(any()) } returns sanityResult
 
         val gjennomforinger = veilederFlateService.hentTiltaksgjennomforingerForBrukerBasertPaEnhetOgFylke(
-            fnr,
+            GetRelevanteTiltaksgjennomforingerForBrukerRequest(norskIdent = norskIdent),
             "accessToken",
-            TiltaksgjennomforingFilter(),
         )
         gjennomforinger.size shouldBe 2
         gjennomforinger.find { it.sanityId == "f21d1e35-d63b-4de7-a0a5-589e57111527" }!!.enheter!!.size shouldBe 1
@@ -186,9 +185,8 @@ class VeilederflateServiceTest : FunSpec({
         coEvery { sanityClient.query(any()) } returns sanityResult
 
         val gjennomforinger = veilederFlateService.hentTiltaksgjennomforingerForBrukerBasertPaEnhetOgFylke(
-            fnr,
+            GetRelevanteTiltaksgjennomforingerForBrukerRequest(norskIdent = fnr),
             "accessToken",
-            TiltaksgjennomforingFilter(),
         )
         gjennomforinger.size shouldBe 2
         gjennomforinger.find { it.sanityId == "f21d1e35-d63b-4de7-a0a5-589e57111527" }!!.enheter!!.size shouldBe 1
@@ -219,9 +217,8 @@ class VeilederflateServiceTest : FunSpec({
         coEvery { sanityClient.query(any()) } returns sanityResult
 
         val gjennomforinger = veilederFlateService.hentTiltaksgjennomforingerForBrukerBasertPaEnhetOgFylke(
-            fnr,
+            GetRelevanteTiltaksgjennomforingerForBrukerRequest(norskIdent = fnr),
             "accessToken",
-            TiltaksgjennomforingFilter(),
         )
         gjennomforinger.size shouldBe 1
         gjennomforinger.find { it.sanityId == "f21d1e35-d63b-4de7-a0a5-589e57111527" } shouldBe null


### PR DESCRIPTION
Gjør om alle våre requests som inneholdt GET med fnr i url til en POST med fnr (norskIdent) i body.
Legger også til en enkel maskeringsmekanisme for fnr i loggeren til ktor-klientene som vi kan ha inntil veilarbtjenestene blir oppdatert med alternative endepunkter som ikke krever fnr i url.
Endringene er gjort litt raskt, vi kan evt. ta noen  omstruktureringer etc. i etterkant.