### PR TITLE
Personlig intro for del med bruker

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.ts
+++ b/frontend/mulighetsrommet-veileder-flate/cypress/e2e/mulighetsrommet.cy.ts
@@ -1,144 +1,159 @@
-before('Start server', () => {
-  cy.visit('/arbeidsmarkedstiltak/oversikt');
-  cy.url().should('include', '/');
-  Cypress.on('uncaught:exception', err => {
+before("Start server", () => {
+  cy.visit("/arbeidsmarkedstiltak/oversikt");
+  cy.url().should("include", "/");
+  Cypress.on("uncaught:exception", (err) => {
     // eslint-disable-next-line no-console
     console.log(err);
     return false;
   });
 
-  cy.getByTestId('tiltakstype-oversikt').children().should('have.length.greaterThan', 1);
+  cy.getByTestId("tiltakstype-oversikt").children().should("have.length.greaterThan", 1);
 });
 
-describe('Tiltaksoversikt', () => {
+describe("Tiltaksoversikt", () => {
   let antallTiltak: number;
 
   beforeEach(() => {
     cy.clearLocalStorage();
-    cy.visit('/arbeidsmarkedstiltak/oversikt');
+    cy.visit("/arbeidsmarkedstiltak/oversikt");
     cy.skruAvJoyride();
   });
 
-  it('Sjekk at det er tiltaksgjennomføringer i oversikten', () => {
-    cy.getByTestId('oversikt_tiltaksgjennomforinger').children().should('have.length.greaterThan', 1);
+  it("Sjekk at det er tiltaksgjennomføringer i oversikten", () => {
+    cy.getByTestId("oversikt_tiltaksgjennomforinger")
+      .children()
+      .should("have.length.greaterThan", 1);
   });
 
-  it('Sjekk UU', () => {
+  it("Sjekk UU", () => {
     cy.checkPageA11y();
   });
 
-  it('Lagre antall tiltak uten filtrering', () => {
-    cy.getByTestId('antall-tiltak').then($navn => {
+  it("Lagre antall tiltak uten filtrering", () => {
+    cy.getByTestId("antall-tiltak").then(($navn) => {
       antallTiltak = Number.parseInt($navn.text());
     });
   });
 
-  it('Filtrer på Tiltakstyper', () => {
-    cy.apneLukketFilterAccordion('tiltakstyper', true);
-    cy.velgFilter('mentor');
+  it("Filtrer på Tiltakstyper", () => {
+    cy.apneLukketFilterAccordion("tiltakstyper", true);
+    cy.velgFilter("mentor");
 
-    cy.getByTestId('antall-tiltak').then($navn => {
+    cy.getByTestId("antall-tiltak").then(($navn) => {
       expect(antallTiltak).not.to.eq($navn.text());
     });
 
-    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
+    cy.getByTestId("knapp_tilbakestill-filter").should("exist").click();
 
-    cy.getByTestId('filter_checkbox_avklaring').should('not.be.checked');
-    cy.getByTestId('filter_checkbox_mentor').should('not.be.checked');
+    cy.getByTestId("filter_checkbox_avklaring").should("not.be.checked");
+    cy.getByTestId("filter_checkbox_mentor").should("not.be.checked");
 
-    cy.apneLukketFilterAccordion('tiltakstyper', false);
+    cy.apneLukketFilterAccordion("tiltakstyper", false);
   });
 
-  it('Filtrer på søkefelt', () => {
-    cy.getByTestId('filter_sokefelt').type('Yoda', { delay: 250 });
-    cy.getByTestId('lenke_tiltaksgjennomforing').contains('Yoda');
+  it("Filtrer på søkefelt", () => {
+    cy.getByTestId("filter_sokefelt").type("Yoda", { delay: 250 });
+    cy.getByTestId("lenke_tiltaksgjennomforing").contains("Yoda");
   });
 
-  it('Skal vise tilbakestill filter-knapp når filter utenfor normalen hvis brukeren har innsatsgruppe', () => {
-    cy.velgFilter('standard-innsats');
-    cy.getByTestId('knapp_tilbakestill-filter').should('exist');
+  it("Skal vise tilbakestill filter-knapp når filter utenfor normalen hvis brukeren har innsatsgruppe", () => {
+    cy.velgFilter("standard-innsats");
+    cy.getByTestId("knapp_tilbakestill-filter").should("exist");
   });
 
-  it('Skal legge løpende tiltaksgjennomføringer først i rekken ved sortering på oppstartsdato', () => {
-    cy.getByTestId('sortering-select').select('oppstart-ascending');
-    cy.getByTestId('lenke_tiltaksgjennomforing').eq(0).contains('Løpende oppstart');
+  it("Skal legge løpende tiltaksgjennomføringer først i rekken ved sortering på oppstartsdato", () => {
+    cy.getByTestId("sortering-select").select("oppstart-ascending");
+    cy.getByTestId("lenke_tiltaksgjennomforing").eq(0).contains("Løpende oppstart");
   });
 
-  it('Skal kunne navigere mellom sider via paginering', () => {
-    cy.getByTestId('paginering').should('exist');
-    cy.getByTestId('paginering').children().children().eq(1).should('not.have.attr', 'aria-current');
-    cy.getByTestId('paginering').children().children().eq(2).click();
-    cy.getByTestId('paginering').children().children().children().eq(2).should('have.attr', 'aria-current');
+  it("Skal kunne navigere mellom sider via paginering", () => {
+    cy.getByTestId("paginering").should("exist");
+    cy.getByTestId("paginering")
+      .children()
+      .children()
+      .eq(1)
+      .should("not.have.attr", "aria-current");
+    cy.getByTestId("paginering").children().children().eq(2).click();
+    cy.getByTestId("paginering")
+      .children()
+      .children()
+      .children()
+      .eq(2)
+      .should("have.attr", "aria-current");
   });
 
-  it('Skal ha ferdig utfylt brukers innsatsgruppe hvis bruker har innsatsgruppe', () => {
+  it("Skal ha ferdig utfylt brukers innsatsgruppe hvis bruker har innsatsgruppe", () => {
     cy.resetSide();
     // Situasjonsbestemt innsats er innsatsgruppen som returneres når testene kjører med mock-data
-    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
-    cy.getByTestId('knapp_tilbakestill-filter').should('not.exist');
+    cy.getByTestId("filter_checkbox_situasjonsbestemt-innsats").should("be.checked");
+    cy.getByTestId("knapp_tilbakestill-filter").should("not.exist");
 
-    cy.getByTestId('filtertag_situasjonsbestemt-innsats').then($value => {
-      expect($value.text()).to.eq('Situasjonsbestemt innsats');
+    cy.getByTestId("filtertag_situasjonsbestemt-innsats").then(($value) => {
+      expect($value.text()).to.eq("Situasjonsbestemt innsats");
     });
   });
 
-  it('Skal huske filtervalg mellom detaljvisning og listevisning', () => {
-    cy.getByTestId('filter_checkbox_standard-innsats').click();
+  it("Skal huske filtervalg mellom detaljvisning og listevisning", () => {
+    cy.getByTestId("filter_checkbox_standard-innsats").click();
     cy.forventetAntallFiltertags(2);
-    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').click();
+    cy.getByTestId("filter_checkbox_situasjonsbestemt-innsats").click();
 
-    cy.getByTestId('lenke_tiltaksgjennomforing').first().click();
+    cy.getByTestId("lenke_tiltaksgjennomforing").first().click();
     cy.tilbakeTilListevisning();
-    cy.getByTestId('filter_checkbox_situasjonsbestemt-innsats').should('be.checked');
+    cy.getByTestId("filter_checkbox_situasjonsbestemt-innsats").should("be.checked");
     cy.forventetAntallFiltertags(2);
   });
 
-  it('Skal vise korrekt feilmelding dersom ingen tiltaksgjennomføringer blir funnet', () => {
-    cy.getByTestId('filter_sokefelt').type('blablablablabla', { delay: 250 });
-    cy.getByTestId('feilmelding-container').should('be.visible');
-    cy.getByTestId('feilmelding-container').should('have.attr', 'aria-live');
-    cy.getByTestId('knapp_tilbakestill-filter').should('exist').click();
+  it("Skal vise korrekt feilmelding dersom ingen tiltaksgjennomføringer blir funnet", () => {
+    cy.getByTestId("filter_sokefelt").type("blablablablabla", { delay: 250 });
+    cy.getByTestId("feilmelding-container").should("be.visible");
+    cy.getByTestId("feilmelding-container").should("have.attr", "aria-live");
+    cy.getByTestId("knapp_tilbakestill-filter").should("exist").click();
   });
 });
 
-describe('Tiltaksgjennomføringsdetaljer', () => {
+describe("Tiltaksgjennomføringsdetaljer", () => {
   beforeEach(() => {
     cy.clearLocalStorage();
-    cy.visit('/arbeidsmarkedstiltak/oversikt');
+    cy.visit("/arbeidsmarkedstiltak/oversikt");
     cy.skruAvJoyride();
-    cy.getByTestId('lenke_tiltaksgjennomforing').first().click();
+    cy.getByTestId("lenke_tiltaksgjennomforing").first().click();
   });
 
-  it('Gå til en tiltaksgjennomføring', () => {
+  it("Gå til en tiltaksgjennomføring", () => {
     cy.checkPageA11y();
   });
 
-  it('Sjekk at tilgjengelighetsstatus er tilgjengelig på detaljsiden', () => {
-    cy.getByTestId('tilgjengelighetsstatus_detaljside').should('exist');
+  it("Sjekk at tilgjengelighetsstatus er tilgjengelig på detaljsiden", () => {
+    cy.getByTestId("tilgjengelighetsstatus_detaljside").should("exist");
   });
 
-  it('Sjekk at fanene fungerer som de skal', () => {
-    cy.getByTestId('tab1').should('be.visible');
-    cy.getByTestId('tab2').should('not.be.visible');
+  it("Sjekk at fanene fungerer som de skal", () => {
+    cy.getByTestId("tab1").should("be.visible");
+    cy.getByTestId("tab2").should("not.be.visible");
 
-    cy.getByTestId('fane_detaljer-og-innhold').click();
+    cy.getByTestId("fane_detaljer-og-innhold").click();
 
-    cy.getByTestId('tab1').should('not.be.visible');
-    cy.getByTestId('tab2').should('be.visible');
+    cy.getByTestId("tab1").should("not.be.visible");
+    cy.getByTestId("tab2").should("be.visible");
   });
 
   it("Sjekk 'Del med bruker'", () => {
-    cy.getByTestId('deleknapp').should('be.visible').click();
+    cy.getByTestId("deleknapp").should("be.visible").click();
 
-    cy.getByTestId('modal_header').should('be.visible');
-    cy.getByTestId('personlig_hilsen_btn').click();
+    cy.getByTestId("modal_header").should("be.visible");
+    cy.getByTestId("personlig_intro_btn").click();
+    cy.getByTestId("textarea_intro").type("En spennende tekst", { delay: 250 });
+    cy.get(".navds-error-message").should("not.exist");
 
-    cy.getByTestId('textarea_hilsen').type('Test', { delay: 250 });
-    cy.get('.navds-error-message').should('not.exist');
+    cy.getByTestId("personlig_hilsen_btn").click();
 
-    cy.getByTestId('modal_btn-send').should('not.be.disabled').click();
+    cy.getByTestId("textarea_hilsen").type("Test", { delay: 250 });
+    cy.get(".navds-error-message").should("not.exist");
 
-    cy.getByTestId('modal_header').should('contain', 'Tiltaket er delt med brukeren');
-    cy.getByTestId('modal_btn-cancel').last().click();
+    cy.getByTestId("modal_btn-send").should("not.be.disabled").click();
+
+    cy.getByTestId("modal_header").should("contain", "Tiltaket er delt med brukeren");
+    cy.getByTestId("modal_btn-cancel").last().click();
   });
 });

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -49,7 +49,7 @@ export function DelMedBrukerContent({
 
   const enablePersonligIntro = () => {
     dispatch({ type: "Skriv personlig intro", payload: true });
-    dispatch({ type: "Sett intro", payload: state.introtekst });
+    dispatch({ type: "Sett intro", payload: "" });
     logDelMedbrukerEvent("Sett intro");
   };
 

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -1,12 +1,12 @@
 import { Alert, BodyShort, Button, ErrorMessage, Textarea } from "@navikt/ds-react";
 import { DelMedBruker, VeilederflateTiltaksgjennomforing } from "mulighetsrommet-api-client";
-import React, { Dispatch, useEffect, useRef, useState } from "react";
+import React, { Dispatch, useEffect, useRef } from "react";
 import { erPreview, formaterDato } from "../../../utils/Utils";
 import { logDelMedbrukerEvent } from "./Delemodal";
 import delemodalStyles from "./Delemodal.module.scss";
 import { Actions, State } from "./DelemodalActions";
 
-const MAKS_ANTALL_TEGN_HILSEN = 300;
+const MAKS_ANTALL_TEGN = 500;
 
 interface Props {
   state: State;
@@ -25,44 +25,89 @@ export function DelMedBrukerContent({
   harDeltMedBruker,
   tiltaksgjennomforing,
 }: Props) {
-  const [visPersonligMelding, setVisPersonligMelding] = useState(false);
+  const { skrivPersonligMelding, skrivPersonligIntro } = state;
+  const personligIntroRef = useRef<HTMLTextAreaElement>(null);
   const personligHilsenRef = useRef<HTMLTextAreaElement>(null);
   const datoSidenSistDelt =
     harDeltMedBruker?.createdAt && formaterDato(new Date(harDeltMedBruker.createdAt));
 
   useEffect(() => {
-    personligHilsenRef?.current?.focus();
-  }, [visPersonligMelding]);
+    if (skrivPersonligIntro) {
+      personligIntroRef?.current?.focus();
+      return;
+    }
+    if (skrivPersonligMelding) {
+      personligHilsenRef?.current?.focus();
+    }
+  }, [skrivPersonligMelding, skrivPersonligIntro]);
 
   const enablePersonligMelding = () => {
+    dispatch({ type: "Skriv personlig melding", payload: true });
     dispatch({ type: "Sett hilsen", payload: state.originalHilsen });
-    setVisPersonligMelding(true);
     logDelMedbrukerEvent("Sett hilsen");
   };
 
+  const enablePersonligIntro = () => {
+    dispatch({ type: "Skriv personlig intro", payload: true });
+    dispatch({ type: "Sett intro", payload: state.introtekst });
+    logDelMedbrukerEvent("Sett intro");
+  };
+
   const handleError = () => {
-    if (state.hilsen.length > MAKS_ANTALL_TEGN_HILSEN) return "For mange tegn";
+    if (state.hilsen.length > MAKS_ANTALL_TEGN || state.introtekst.length > MAKS_ANTALL_TEGN)
+      return "For mange tegn";
   };
 
   const redigerHilsen = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     dispatch({ type: "Sett hilsen", payload: e.currentTarget.value });
   };
 
+  const redigerIntro = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    dispatch({ type: "Sett intro", payload: e.currentTarget.value });
+  };
   return (
     <>
       {harDeltMedBruker ? (
         <Alert variant="warning">{`Dette tiltaket ble delt med bruker ${datoSidenSistDelt}.`}</Alert>
       ) : null}
 
-      {visPersonligMelding && !state.deletekst ? null : (
+      {skrivPersonligIntro ? null : (
+        <Button
+          data-testid="personlig_intro_btn"
+          onClick={enablePersonligIntro}
+          variant="secondary"
+          className={delemodalStyles.personlig_melding_btn}
+        >
+          Legg til personlig introduksjon
+        </Button>
+      )}
+
+      {skrivPersonligIntro ? (
+        <Textarea
+          ref={personligIntroRef}
+          className={delemodalStyles.personligHilsen}
+          size="medium"
+          value={state.introtekst}
+          label=""
+          hideLabel
+          onChange={redigerIntro}
+          maxLength={MAKS_ANTALL_TEGN}
+          data-testid="textarea_intro"
+          error={handleError()}
+        />
+      ) : null}
+
+      {skrivPersonligMelding && skrivPersonligIntro && !state.deletekst ? null : (
         <BodyShort
           title="Teksten er hentet fra tiltakstypen og kan ikke redigeres."
           className={delemodalStyles.deletekst}
         >
-          {`${state.deletekst}${visPersonligMelding ? "" : `\n\n${state.hilsen}`}`}
+          {`${skrivPersonligIntro ? "" : `${state.introtekst}\n`}${state.deletekst}${
+            skrivPersonligMelding ? "" : `\n\n${state.hilsen}`
+          }`}
         </BodyShort>
       )}
-      {visPersonligMelding ? null : (
+      {skrivPersonligMelding ? null : (
         <Button
           data-testid="personlig_hilsen_btn"
           onClick={enablePersonligMelding}
@@ -73,7 +118,7 @@ export function DelMedBrukerContent({
         </Button>
       )}
 
-      {visPersonligMelding ? (
+      {skrivPersonligMelding ? (
         <>
           <Textarea
             ref={personligHilsenRef}
@@ -83,7 +128,7 @@ export function DelMedBrukerContent({
             label=""
             hideLabel
             onChange={redigerHilsen}
-            maxLength={MAKS_ANTALL_TEGN_HILSEN}
+            maxLength={MAKS_ANTALL_TEGN}
             data-testid="textarea_hilsen"
             error={handleError()}
           />

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelMedBrukerContent.tsx
@@ -6,7 +6,7 @@ import { logDelMedbrukerEvent } from "./Delemodal";
 import delemodalStyles from "./Delemodal.module.scss";
 import { Actions, State } from "./DelemodalActions";
 
-const MAKS_ANTALL_TEGN = 500;
+export const MAKS_ANTALL_TEGN_DEL_MED_BRUKER = 500;
 
 interface Props {
   state: State;
@@ -53,9 +53,12 @@ export function DelMedBrukerContent({
     logDelMedbrukerEvent("Sett intro");
   };
 
+  const forMangeTegn = (tekst: string): boolean => {
+    return tekst.length > MAKS_ANTALL_TEGN_DEL_MED_BRUKER;
+  };
+
   const handleError = () => {
-    if (state.hilsen.length > MAKS_ANTALL_TEGN || state.introtekst.length > MAKS_ANTALL_TEGN)
-      return "For mange tegn";
+    if (forMangeTegn(state.hilsen) || forMangeTegn(state.introtekst)) return "For mange tegn";
   };
 
   const redigerHilsen = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -91,7 +94,7 @@ export function DelMedBrukerContent({
           label=""
           hideLabel
           onChange={redigerIntro}
-          maxLength={MAKS_ANTALL_TEGN}
+          maxLength={MAKS_ANTALL_TEGN_DEL_MED_BRUKER}
           data-testid="textarea_intro"
           error={handleError()}
         />
@@ -128,7 +131,7 @@ export function DelMedBrukerContent({
             label=""
             hideLabel
             onChange={redigerHilsen}
-            maxLength={MAKS_ANTALL_TEGN}
+            maxLength={MAKS_ANTALL_TEGN_DEL_MED_BRUKER}
             data-testid="textarea_hilsen"
             error={handleError()}
           />

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -13,7 +13,7 @@ import { byttTilDialogFlate } from "../../../utils/DialogFlateUtils";
 import { erPreview } from "../../../utils/Utils";
 import modalStyles from "../Modal.module.scss";
 import { StatusModal } from "../StatusModal";
-import { DelMedBrukerContent } from "./DelMedBrukerContent";
+import { DelMedBrukerContent, MAKS_ANTALL_TEGN_DEL_MED_BRUKER } from "./DelMedBrukerContent";
 import delemodalStyles from "./Delemodal.module.scss";
 import { Actions, State } from "./DelemodalActions";
 
@@ -144,7 +144,6 @@ const Delemodal = ({
     tiltaksgjennomforingSanityId,
     brukerFnr,
   );
-  const MAKS_ANTALL_TEGN_HILSEN = 500;
 
   const clickCancel = (log = true) => {
     lukkModal();
@@ -157,8 +156,7 @@ const Delemodal = ({
   };
 
   const sySammenDeletekst = () => {
-    const tekst = `${state.introtekst}${state.deletekst}\n\n${state.hilsen}`;
-    return tekst;
+    return `${state.introtekst}${state.deletekst}\n\n${state.hilsen}`;
   };
 
   const handleSend = async () => {
@@ -242,9 +240,9 @@ const Delemodal = ({
                 disabled={
                   senderTilDialogen ||
                   state.hilsen.length === 0 ||
-                  state.hilsen.length > MAKS_ANTALL_TEGN_HILSEN ||
+                  state.hilsen.length > MAKS_ANTALL_TEGN_DEL_MED_BRUKER ||
                   state.introtekst.length === 0 ||
-                  state.introtekst.length > MAKS_ANTALL_TEGN_HILSEN ||
+                  state.introtekst.length > MAKS_ANTALL_TEGN_DEL_MED_BRUKER ||
                   erPreview
                 }
               >

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -144,7 +144,7 @@ const Delemodal = ({
     tiltaksgjennomforingSanityId,
     brukerFnr,
   );
-  const MAKS_ANTALL_TEGN_HILSEN = 300;
+  const MAKS_ANTALL_TEGN_HILSEN = 500;
 
   const clickCancel = (log = true) => {
     lukkModal();
@@ -243,6 +243,8 @@ const Delemodal = ({
                   senderTilDialogen ||
                   state.hilsen.length === 0 ||
                   state.hilsen.length > MAKS_ANTALL_TEGN_HILSEN ||
+                  state.introtekst.length === 0 ||
+                  state.introtekst.length > MAKS_ANTALL_TEGN_HILSEN ||
                   erPreview
                 }
               >

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/Delemodal.tsx
@@ -23,7 +23,8 @@ export const logDelMedbrukerEvent = (
     | "Delte med bruker"
     | "Del med bruker feilet"
     | "Avbrutt del med bruker"
-    | "Sett hilsen",
+    | "Sett hilsen"
+    | "Sett intro",
 ) => {
   logEvent("mulighetsrommet.del-med-bruker", { value: action });
 };
@@ -43,7 +44,15 @@ interface DelemodalProps {
 export function reducer(state: State, action: Actions): State {
   switch (action.type) {
     case "Avbryt":
-      return { ...state, sendtStatus: "IKKE_SENDT", hilsen: state.originalHilsen };
+      return {
+        ...state,
+        sendtStatus: "IKKE_SENDT",
+        hilsen: action.payload.tekster.originalHilsen,
+        skrivPersonligMelding: false,
+        skrivPersonligIntro: false,
+        deletekst: action.payload.tekster.deletekst,
+        introtekst: action.payload.tekster.introtekst,
+      };
     case "Send melding":
       return { ...state, sendtStatus: "SENDER" };
     case "Sendt ok":
@@ -52,21 +61,44 @@ export function reducer(state: State, action: Actions): State {
       return { ...state, sendtStatus: "SENDING_FEILET" };
     case "Sett hilsen":
       return { ...state, hilsen: action.payload, sendtStatus: "IKKE_SENDT" };
+    case "Sett intro":
+      return { ...state, introtekst: action.payload, sendtStatus: "IKKE_SENDT" };
+    case "Skriv personlig intro": {
+      return { ...state, skrivPersonligIntro: action.payload };
+    }
+    case "Skriv personlig melding":
+      return {
+        ...state,
+        skrivPersonligMelding: action.payload,
+      };
     case "Reset":
-      return initInitialState({ originalHilsen: state.originalHilsen, deletekst: state.deletekst });
-    default:
-      return state;
+      return initInitialState({
+        originalHilsen: state.originalHilsen,
+        deletekst: state.deletekst,
+        introtekst: state.introtekst,
+      });
   }
 }
 
-export function initInitialState(tekster: { deletekst: string; originalHilsen: string }): State {
+export function initInitialState(tekster: {
+  deletekst: string;
+  originalHilsen: string;
+  introtekst: string;
+}): State {
   return {
     deletekst: tekster.deletekst,
     originalHilsen: tekster.originalHilsen,
     hilsen: tekster.originalHilsen,
     sendtStatus: "IKKE_SENDT",
     dialogId: "",
+    introtekst: tekster.introtekst,
+    skrivPersonligIntro: false,
+    skrivPersonligMelding: false,
   };
+}
+
+function sySammenIntroTekst(brukernavn?: string) {
+  return `Hei ${brukernavn}\n`;
 }
 
 function sySammenBrukerTekst(
@@ -75,13 +107,12 @@ function sySammenBrukerTekst(
   brukernavn?: string,
 ) {
   return `${chattekst
-    .replaceAll(" <Fornavn>", brukernavn ? ` ${brukernavn}` : "")
+    .replaceAll("<Fornavn>", brukernavn ? `${brukernavn}` : "")
     .replaceAll("<tiltaksnavn>", tiltaksgjennomforingsnavn)}`;
 }
 
 function sySammenHilsenTekst(veiledernavn?: string) {
-  const interessant =
-    "Er dette aktuelt for deg? Gi meg tilbakemelding her i dialogen.\nSvaret ditt vil ikke endre din utbetaling fra NAV.";
+  const interessant = "Er dette aktuelt for deg? Gi meg tilbakemelding her i dialogen.";
   return veiledernavn
     ? `${interessant}\n\nVi holder kontakten!\nHilsen ${veiledernavn}`
     : `${interessant}\n\nVi holder kontakten!\nHilsen `;
@@ -98,9 +129,14 @@ const Delemodal = ({
   brukerdata,
   harDeltMedBruker,
 }: DelemodalProps) => {
+  const introtekst = sySammenIntroTekst(brukernavn);
   const deletekst = sySammenBrukerTekst(chattekst, tiltaksgjennomforing.navn, brukernavn);
   const originalHilsen = sySammenHilsenTekst(veiledernavn);
-  const [state, dispatch] = useReducer(reducer, { deletekst, originalHilsen }, initInitialState);
+  const [state, dispatch] = useReducer(
+    reducer,
+    { deletekst, originalHilsen, introtekst },
+    initInitialState,
+  );
 
   const senderTilDialogen = state.sendtStatus === "SENDER";
   const tiltaksgjennomforingSanityId = tiltaksgjennomforing.sanityId;
@@ -112,20 +148,26 @@ const Delemodal = ({
 
   const clickCancel = (log = true) => {
     lukkModal();
-    dispatch({ type: "Avbryt" });
+    dispatch({ type: "Avbryt", payload: { tekster: { introtekst, deletekst, originalHilsen } } });
     log && logDelMedbrukerEvent("Avbrutt del med bruker");
   };
 
-  const getAntallTegn = () => {
-    return state.hilsen.length;
+  const getAntallTegn = (tekst: string) => {
+    return tekst.length;
   };
 
   const sySammenDeletekst = () => {
-    return `${state.deletekst}\n\n${state.hilsen}`;
+    const tekst = `${state.introtekst}${state.deletekst}\n\n${state.hilsen}`;
+    return tekst;
   };
 
   const handleSend = async () => {
-    if (state.hilsen.trim().length > getAntallTegn()) return;
+    if (
+      state.hilsen.trim().length > getAntallTegn(state.hilsen) ||
+      state.introtekst.length > getAntallTegn(state.introtekst)
+    ) {
+      return;
+    }
     logDelMedbrukerEvent("Delte med bruker");
 
     dispatch({ type: "Send melding" });

--- a/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelemodalActions.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/modal/delemodal/DelemodalActions.tsx
@@ -1,9 +1,12 @@
 export interface State {
   deletekst: string;
   originalHilsen: string;
+  introtekst: string;
   hilsen: string;
   sendtStatus: Status;
   dialogId: string;
+  skrivPersonligMelding: boolean;
+  skrivPersonligIntro: boolean;
 }
 
 export type Status = "IKKE_SENDT" | "SENDER" | "SENDT_OK" | "SENDING_FEILET";
@@ -14,6 +17,7 @@ export interface SEND_MELDING_ACTION {
 
 export interface AVBRYT_ACTION {
   type: "Avbryt";
+  payload: { tekster: { introtekst: string; deletekst: string; originalHilsen: string } };
 }
 
 export interface SENDT_OK_ACTION {
@@ -34,10 +38,28 @@ export interface SETT_HILSEN_ACTION {
   payload: string;
 }
 
+export interface SETT_INTRO_ACTION {
+  type: "Sett intro";
+  payload: string;
+}
+
+export interface SKRIV_PERSONLIG_MELDING {
+  type: "Skriv personlig melding";
+  payload: boolean;
+}
+
+export interface SKRIV_PERSONLIG_INTRO {
+  type: "Skriv personlig intro";
+  payload: boolean;
+}
+
 export type Actions =
   | SEND_MELDING_ACTION
   | AVBRYT_ACTION
   | SENDT_OK_ACTION
   | RESET_ACTION
   | SENDING_FEILET_ACTION
-  | SETT_HILSEN_ACTION;
+  | SETT_HILSEN_ACTION
+  | SETT_INTRO_ACTION
+  | SKRIV_PERSONLIG_MELDING
+  | SKRIV_PERSONLIG_INTRO;

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltakstyper.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltakstyper.ts
@@ -546,7 +546,7 @@ export const mockTiltakstyper: { [name: string]: VeilederflateTiltakstype } = {
   jobbklubb: {
     sanityId: "31e72dd8-ad05-4e81-a7f9-fd4c8f295864",
     delingMedBruker:
-      "Hei <Fornavn>, \n\nVi har nå et arbeidsmarkedstiltak som jeg tenker kan passe deg godt. Det heter <tiltaksnavn> og er et kurs for de som er registrert som arbeidssøker hos NAV. \n\nJobbklubb er et kortvarig tiltak for deg som søker jobb. Når du deltar på jobbklubb, får du støtte og hjelp til å orientere deg på arbeidsmarkedet og være en aktiv jobbsøker.\n\nDu kan lese mer om kurset på www.nav.no/jobbklubb",
+      "Jobbklubb er et kortvarig tiltak for deg som søker jobb. Når du deltar på jobbklubb, får du støtte og hjelp til å orientere deg på arbeidsmarkedet og være en aktiv jobbsøker.\n\nDu kan lese mer om kurset på www.nav.no/jobbklubb",
     regelverkLenker: [
       {
         _id: "123",


### PR DESCRIPTION
Legger til rette for at veiledere kan legge til en personlig melding både før og etter 
"Del med bruker"-tekstene som Direktoratet er ansvarlig for. Dette vil føre til en endring i tekstene som ligger i Sanity.
Tekstendringene i Sanity må gjøres ca. samtidig som vi slipper ny funksjonalitet. Det ordner jeg. 

- Tillat personlig intro for Del med bruker
- Ingen Hei hvis veileder selv skriver i tekstfelt for intro
- Mindre refaktorering


![image](https://github.com/navikt/mulighetsrommet/assets/9053627/9454daac-3cdc-4121-9e3a-d6cd132d928e)
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/33f9c781-7071-4946-9d2b-bca2ff668c7a)
