### PR TITLE
Viser maks varighet inkl. opsjon for rammeavtaler

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
@@ -22,7 +22,7 @@ import { usePutAvtale } from "../../api/avtaler/usePutAvtale";
 import { useMutateUtkast } from "../../api/utkast/useMutateUtkast";
 import { useSokVirksomheter } from "../../api/virksomhet/useSokVirksomhet";
 import { useVirksomhet } from "../../api/virksomhet/useVirksomhet";
-import { addYear, formaterDatoSomYYYYMMDD } from "../../utils/Utils";
+import { addYear, formaterDato, formaterDatoSomYYYYMMDD } from "../../utils/Utils";
 import { AutoSaveUtkast } from "../autosave/AutoSaveUtkast";
 import { Separator } from "../detaljside/Metadata";
 import { ControlledMultiSelect } from "../skjema/ControlledMultiSelect";
@@ -121,7 +121,9 @@ export function AvtaleSkjemaContainer({
     inputProps: maksVarighetDatepickerInputProps,
   } = useDatepicker({
     fromDate: new Date(),
-    defaultSelected: addYear(watch("startOgSluttDato.startDato"), 5),
+    defaultSelected:
+      defaultValues?.startOgSluttDato?.startDato &&
+      addYear(defaultValues?.startOgSluttDato?.startDato, 5),
   });
 
   const watchedTiltakstype: EmbeddedTiltakstype | undefined = watch("tiltakstype");
@@ -288,13 +290,16 @@ export function AvtaleSkjemaContainer({
                     label: "Sluttdato",
                   }}
                 >
-                  {enableOpsjoner && watch("avtaletype") === Avtaletype.RAMMEAVTALE ? (
+                  {enableOpsjoner &&
+                  watch("avtaletype") === Avtaletype.RAMMEAVTALE &&
+                  !!watch("startOgSluttDato.startDato") ? (
                     <DatePicker {...maksVarighetDatepickerProps}>
                       <DatePicker.Input
                         {...maksVarighetDatepickerInputProps}
                         label="Maks varighet inkl. opsjon"
                         readOnly
                         size="small"
+                        value={formaterDato(addYear(watch("startOgSluttDato.startDato"), 5))}
                       />
                     </DatePicker>
                   ) : null}

--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
@@ -1,4 +1,4 @@
-import { Alert, Textarea, TextField } from "@navikt/ds-react";
+import { Alert, DatePicker, Textarea, TextField, useDatepicker } from "@navikt/ds-react";
 import {
   Avtale,
   AvtaleAvslutningsstatus,
@@ -10,6 +10,7 @@ import {
   NavEnhetType,
   Opphav,
   Tiltakskode,
+  Toggles,
 } from "mulighetsrommet-api-client";
 import { NavEnhet } from "mulighetsrommet-api-client/build/models/NavEnhet";
 import { Tiltakstype } from "mulighetsrommet-api-client/build/models/Tiltakstype";
@@ -21,7 +22,7 @@ import { usePutAvtale } from "../../api/avtaler/usePutAvtale";
 import { useMutateUtkast } from "../../api/utkast/useMutateUtkast";
 import { useSokVirksomheter } from "../../api/virksomhet/useSokVirksomhet";
 import { useVirksomhet } from "../../api/virksomhet/useVirksomhet";
-import { formaterDatoSomYYYYMMDD } from "../../utils/Utils";
+import { addYear, formaterDatoSomYYYYMMDD } from "../../utils/Utils";
 import { AutoSaveUtkast } from "../autosave/AutoSaveUtkast";
 import { Separator } from "../detaljside/Metadata";
 import { ControlledMultiSelect } from "../skjema/ControlledMultiSelect";
@@ -45,6 +46,7 @@ import { AvtaleSkjemaKnapperad } from "./AvtaleSkjemaKnapperad";
 import { PORTEN } from "mulighetsrommet-frontend-common/constants";
 import { resolveErrorMessage } from "../../api/errors";
 import { erAnskaffetTiltak } from "../../utils/tiltakskoder";
+import { useFeatureToggle } from "../../api/features/feature-toggles";
 
 interface Props {
   onClose: () => void;
@@ -67,6 +69,9 @@ export function AvtaleSkjemaContainer({
 }: Props) {
   const [navRegion, setNavRegion] = useState<string | undefined>(avtale?.navRegion?.enhetsnummer);
   const [sokLeverandor, setSokLeverandor] = useState(avtale?.leverandor?.organisasjonsnummer || "");
+  const { data: enableOpsjoner } = useFeatureToggle(
+    Toggles.MULIGHETSROMMET_ADMIN_FLATE_OPSJONER_FOR_AVTALER,
+  );
 
   const mutation = usePutAvtale();
   const { data: betabrukere } = useHentBetabrukere();
@@ -110,6 +115,14 @@ export function AvtaleSkjemaContainer({
     watch,
     setValue,
   } = form;
+
+  const {
+    datepickerProps: maksVarighetDatepickerProps,
+    inputProps: maksVarighetDatepickerInputProps,
+  } = useDatepicker({
+    fromDate: new Date(),
+    defaultSelected: addYear(watch("startOgSluttDato.startDato"), 5),
+  });
 
   const watchedTiltakstype: EmbeddedTiltakstype | undefined = watch("tiltakstype");
   const arenaKode = watchedTiltakstype?.arenaKode;
@@ -274,7 +287,18 @@ export function AvtaleSkjemaContainer({
                     ...register("startOgSluttDato.sluttDato"),
                     label: "Sluttdato",
                   }}
-                />
+                >
+                  {enableOpsjoner && watch("avtaletype") === Avtaletype.RAMMEAVTALE ? (
+                    <DatePicker {...maksVarighetDatepickerProps}>
+                      <DatePicker.Input
+                        {...maksVarighetDatepickerInputProps}
+                        label="Maks varighet inkl. opsjon"
+                        readOnly
+                        size="small"
+                      />
+                    </DatePicker>
+                  ) : null}
+                </FraTilDatoVelger>
                 {redigeringsModus ? <AvbrytAvtale onAvbryt={onClose} /> : null}
               </FormGroup>
               <Separator />

--- a/frontend/mr-admin-flate/src/components/skjema/FraTilDatoVelger.tsx
+++ b/frontend/mr-admin-flate/src/components/skjema/FraTilDatoVelger.tsx
@@ -1,19 +1,23 @@
 import styles from "./FraTilDatoVelger.module.scss";
 import { ControlledDateInput, DateInputProps } from "./ControlledDateInput";
+import { ReactNode } from "react";
 
 export function FraTilDatoVelger({
   fra,
   til,
   size,
+  children,
 }: {
   fra: DateInputProps;
   til: DateInputProps;
   size?: "small" | "medium";
+  children?: ReactNode;
 }) {
   return (
     <div className={styles.dato_container}>
       <ControlledDateInput size={size} {...fra} />
       <ControlledDateInput size={size} {...til} />
+      {children}
     </div>
   );
 }

--- a/frontend/mr-admin-flate/src/mocks/api/features.ts
+++ b/frontend/mr-admin-flate/src/mocks/api/features.ts
@@ -10,4 +10,5 @@ export const mockFeatures: Features = {
   "mulighetsrommet.admin-flate-vis-deltakerliste-fra-komet": false,
   "mulighetsrommet.enable-arbeidsflate": true,
   "mulighetsrommet-veilederflate-landingsside": true,
+  "mulighetsrommet.admin-flate.opsjoner-for-avtaler": true,
 };

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleInfo.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleInfo.tsx
@@ -1,5 +1,5 @@
 import { Alert, Heading } from "@navikt/ds-react";
-import { Avtalestatus } from "mulighetsrommet-api-client";
+import { Avtalestatus, Avtaletype, Toggles } from "mulighetsrommet-api-client";
 import { useState } from "react";
 import { useAvtale } from "../../api/avtaler/useAvtale";
 import AvbrytAvtaleModal from "../../components/modal/AvbrytAvtaleModal";
@@ -7,19 +7,23 @@ import { Bolk } from "../../components/detaljside/Bolk";
 import { Metadata, Separator } from "../../components/detaljside/Metadata";
 import { VisHvisVerdi } from "../../components/detaljside/VisHvisVerdi";
 import { Laster } from "../../components/laster/Laster";
-import { avtaletypeTilTekst, formaterDato } from "../../utils/Utils";
+import { addYear, avtaletypeTilTekst, formaterDato } from "../../utils/Utils";
 import styles from "../DetaljerInfo.module.scss";
 import { AvtaleKnapperad } from "./AvtaleKnapperad";
 import SlettAvtaleGjennomforingModal from "../../components/modal/SlettAvtaleGjennomforingModal";
 import { useDeleteAvtale } from "../../api/avtaler/useDeleteAvtale";
 import { ExternalLinkIcon } from "@navikt/aksel-icons";
 import { erAnskaffetTiltak } from "../../utils/tiltakskoder";
+import { useFeatureToggle } from "../../api/features/feature-toggles";
 
 export function AvtaleInfo() {
   const { data: avtale, isLoading, error, refetch } = useAvtale();
   const [slettModal, setSlettModal] = useState(false);
   const [avbrytModal, setAvbrytModal] = useState(false);
   const mutation = useDeleteAvtale();
+  const { data: enableOpsjoner } = useFeatureToggle(
+    Toggles.MULIGHETSROMMET_ADMIN_FLATE_OPSJONER_FOR_AVTALER,
+  );
 
   if (!avtale && isLoading) {
     return <Laster tekst="Laster avtaleinformasjon..." />;
@@ -84,6 +88,12 @@ export function AvtaleInfo() {
           <Bolk aria-label="Start- og sluttdato">
             <Metadata header="Startdato" verdi={formaterDato(avtale.startDato)} />
             <Metadata header="Sluttdato" verdi={formaterDato(avtale.sluttDato)} />
+            {enableOpsjoner && avtale.avtaletype === Avtaletype.RAMMEAVTALE ? (
+              <Metadata
+                header="Maks varighet inkl. opsjon"
+                verdi={formaterDato(addYear(new Date(avtale.startDato), 5))}
+              />
+            ) : null}
           </Bolk>
 
           <Separator />

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -152,3 +152,9 @@ export const validEmail = (email: string | undefined): Boolean => {
 };
 
 export const erProdMiljo = inneholderUrl("intern.nav.no");
+
+export function addYear(date: Date, numYears: number): Date {
+  const newDate = new Date(date);
+  newDate.setFullYear(date.getFullYear() + numYears);
+  return newDate;
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
@@ -10,4 +10,5 @@ export const mockFeatures: Features = {
   "mulighetsrommet.admin-flate-rediger-tiltaksgjennomforing": false,
   "mulighetsrommet.admin-flate-vis-deltakerliste-fra-komet": false,
   "mulighetsrommet-veilederflate-landingsside": false,
+  "mulighetsrommet.admin-flate.opsjoner-for-avtaler": true,
 };

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2898,3 +2898,4 @@ components:
         - mulighetsrommet.admin-flate-vis-deltakerliste-fra-komet
         - mulighetsrommet.enable-arbeidsflate
         - mulighetsrommet-veilederflate-landingsside
+        - mulighetsrommet.admin-flate.opsjoner-for-avtaler


### PR DESCRIPTION
Legger til felt for maks varighet inkl. opsjon for rammeavtaler.
I tillegg vises det som et readonly-felt i skjema for opprettelse av avtaler.

Funksjonaliteten ligger bak toggle https://team-mulighetsrommet-unleash-web.nav.cloud.nais.io/projects/default/features/mulighetsrommet.admin-flate.opsjoner-for-avtaler

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/6c10dacf-f852-456c-8509-3a2922c8440e)

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/ec52f2ee-dac4-4a92-8b34-a3729f00f095)

