### PR TITLE
Arrangør orgnummer er readonly på arena opphav

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -296,7 +296,9 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
                 onClearValue={() => {
                   setValue("tiltaksArrangorUnderenhetOrganisasjonsnummer", "");
                 }}
-                readOnly={!avtale.leverandor.organisasjonsnummer}
+                readOnly={
+                  !avtale.leverandor.organisasjonsnummer || arenaOpphav(tiltaksgjennomforing)
+                }
                 options={arrangorUnderenheterOptions(avtale, virksomhet)}
               />
               {watch("tiltaksArrangorUnderenhetOrganisasjonsnummer") &&


### PR DESCRIPTION
Dette er vel bare en glipp at ikke har vært readonly på Arena gjennomforinger? Ref bug som komet hadde

Hvis underenheten ikke er i avtalens liste med underenheter går det fortsatt fint å endre når denne er readonly. Men man ser ikke verdien da. Men tenker det er et annet problem hva vi gjor når avtalen sine lister (arrangor, nav enhet) ikke samsvarer med gjennomforingens. Lager en oppgave på det.