### PR TITLE
Skjul gjennomføringer som administreres i admin-flate (gruppetiltak)

### DIFF
--- a/frontend/mulighetsrommet-cms/deskStructures/commonStructure.ts
+++ b/frontend/mulighetsrommet-cms/deskStructures/commonStructure.ts
@@ -2,8 +2,22 @@ import { GrDocumentPerformance, GrLocation, GrUserAdmin } from "react-icons/gr";
 import { FaWpforms } from "react-icons/fa";
 import { ImOffice } from "react-icons/im";
 import { API_VERSION } from "../sanity.config";
+import {
+  IKKE_I_ADMINFLATE_TILTAK_DEV,
+  IKKE_I_ADMINFLATE_TILTAK_PROD,
+  TILTAK_I_EGEN_REGI_PROD,
+} from "../utils/utils";
 
 const ORDER_BY_CREATEDAT_FIELD = [{ field: "_createdAt", direction: "desc" }];
+
+const notInAdminFlateFilter = `
+  tiltakstype._ref in [
+  ${IKKE_I_ADMINFLATE_TILTAK_PROD.concat(IKKE_I_ADMINFLATE_TILTAK_DEV)
+    .concat(TILTAK_I_EGEN_REGI_PROD)
+    .map((d) => `"${d}"`)
+    .join(",")}
+]
+  `;
 
 export function commonStructure(S, Context) {
   return [
@@ -21,7 +35,7 @@ export function commonStructure(S, Context) {
                 S.documentList()
                   .title("Alle tiltaksgjennomføringer")
                   .apiVersion(API_VERSION)
-                  .filter('_type == "tiltaksgjennomforing"')
+                  .filter(`_type == "tiltaksgjennomforing" && ${notInAdminFlateFilter}`)
                   .defaultOrdering([{ field: "_createdAt", direction: "desc" }]),
               ),
             S.divider(),
@@ -45,7 +59,7 @@ export function commonStructure(S, Context) {
                       .apiVersion(API_VERSION)
                       .defaultOrdering(ORDER_BY_CREATEDAT_FIELD)
                       .title("Tiltaksgjennomføringer")
-                      .filter('_type == "tiltaksgjennomforing" && $enhet in enheter[]._ref')
+                      .filter(`_type == "tiltaksgjennomforing" && $enhet in enheter[]._ref && ${notInAdminFlateFilter}`)
                       .params({ enhet })
                       .menuItems([...S.documentTypeList("tiltaksgjennomforing").getMenuItems()]),
                   ),
@@ -73,7 +87,7 @@ export function commonStructure(S, Context) {
                           .defaultOrdering(ORDER_BY_CREATEDAT_FIELD)
                           .title("Tiltaksgjennomføringer")
                           .filter(
-                            '_type == "tiltaksgjennomforing" && ($enhet == fylke._ref) && $tiltakstype == tiltakstype._ref',
+                            `_type == "tiltaksgjennomforing" && ($enhet == fylke._ref) && $tiltakstype == tiltakstype._ref && ${notInAdminFlateFilter}`,
                           )
                           .params({ enhet, tiltakstype })
                           .menuItems([
@@ -93,7 +107,9 @@ export function commonStructure(S, Context) {
                     S.documentList()
                       .apiVersion(API_VERSION)
                       .title("Per administrator")
-                      .filter('_type == "tiltaksgjennomforing" && $redaktorId in redaktor[]._ref')
+                      .filter(
+                        `_type == "tiltaksgjennomforing" && $redaktorId in redaktor[]._ref && ${notInAdminFlateFilter}`,
+                      )
                       .params({ redaktorId })
                       .defaultOrdering(ORDER_BY_CREATEDAT_FIELD)
                       .menuItems([...S.documentTypeList("tiltaksgjennomforing").getMenuItems()]),
@@ -117,7 +133,9 @@ export function commonStructure(S, Context) {
                       .apiVersion(API_VERSION)
                       .defaultOrdering(ORDER_BY_CREATEDAT_FIELD)
                       .title("Tiltaksgjennomføringer")
-                      .filter('_type == "tiltaksgjennomforing" && $tiltakstype == tiltakstype._ref')
+                      .filter(
+                        `_type == "tiltaksgjennomforing" && $tiltakstype == tiltakstype._ref && ${notInAdminFlateFilter}`,
+                      )
                       .params({ tiltakstype }),
                   ),
               ),

--- a/frontend/mulighetsrommet-cms/utils/utils.tsx
+++ b/frontend/mulighetsrommet-cms/utils/utils.tsx
@@ -1,4 +1,4 @@
-const IKKE_I_ADMINFLATE_TILTAK_PROD = [
+export const IKKE_I_ADMINFLATE_TILTAK_PROD = [
   "18ff4bef-f62e-444a-920f-e30bde5c3950", // "Tilskudd til sommerjobb",
   "2ba9c085-3780-420a-a5d5-820788c74d29", //  Inkluderingstilskudd,
   "4457d760-81a4-4c16-8ab3-64c72d424db2", // Opplæring - Høyere utdanning",
@@ -14,7 +14,7 @@ const IKKE_I_ADMINFLATE_TILTAK_PROD = [
   "d322b7e7-0c68-44d6-a325-b12d71af63c6", // IPS
 ];
 
-const IKKE_I_ADMINFLATE_TILTAK_DEV = [
+export const IKKE_I_ADMINFLATE_TILTAK_DEV = [
   "ad998fc6-310e-45d4-a056-57732fed87b4", // "Mentor",
   "50878ad5-90d0-496d-a0d0-a53091800760", // "Opplæring - Høyere utdanning",
   "bbb8d042-b30e-4e4a-8cd0-210019b19de3", // "Opplæring - Enkeltplass AMO",
@@ -24,7 +24,7 @@ const IKKE_I_ADMINFLATE_TILTAK_DEV = [
   "8d8abebd-3617-494a-a687-d44810e0a7ee", // "Varig tilrettelagt arbeids i ordinær virksomhet",
 ];
 
-const TILTAK_I_EGEN_REGI_PROD = [
+export const TILTAK_I_EGEN_REGI_PROD = [
   "f3faa5f2-ee9b-42da-9368-4749668144c0", // IPS UNG
   "9fbf9feb-aa4c-4e3c-bc0e-edee0ab957ad", // Arbeid med støtte
   "d322b7e7-0c68-44d6-a325-b12d71af63c6", // IPS


### PR DESCRIPTION
For å ikke kunne endre gruppetiltak mens vi migrerer (og i etterkant).

Jeg provde forst readOnly på dokumentet men fikk ikke det til å funke 🤔 