### PR TITLE
switch vis til veileder

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -49,7 +49,7 @@ data class TiltaksgjennomforingAdminDto(
     val createdAt: LocalDateTime,
     @Serializable(with = LocalDateTimeSerializer::class)
     val updatedAt: LocalDateTime,
-    val tilgjengeligForVeileder: Boolean
+    val tilgjengeligForVeileder: Boolean,
 ) {
     @Serializable
     data class Tiltakstype(

--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -49,6 +49,7 @@ data class TiltaksgjennomforingAdminDto(
     val createdAt: LocalDateTime,
     @Serializable(with = LocalDateTimeSerializer::class)
     val updatedAt: LocalDateTime,
+    val tilgjengeligForVeileder: Boolean
 ) {
     @Serializable
     data class Tiltakstype(

--- a/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useMutateTilgjengeligForVeileder.ts
+++ b/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useMutateTilgjengeligForVeileder.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+import { mulighetsrommetClient } from "../clients";
+
+export function useMutateTilgjengeligForVeileder() {
+  return useMutation({
+    mutationFn: async (data: { id: string; tilgjengeligForVeileder: boolean }) => {
+      return mulighetsrommetClient.tiltaksgjennomforinger.setTilgjengeligForVeileder({
+        id: data.id,
+        requestBody: { tilgjengeligForVeileder: data.tilgjengeligForVeileder },
+      });
+    },
+    useErrorBoundary: true,
+  });
+}

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
@@ -40,6 +40,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     stedForGjennomforing: "Brummundal",
     kontaktpersoner: [petrusKontaktperson, nikolineKontaktperson],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee362",
@@ -60,6 +61,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.MR_ADMIN_FLATE,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee363",
@@ -80,6 +82,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.MR_ADMIN_FLATE,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee364",
@@ -100,6 +103,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.MR_ADMIN_FLATE,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee365",
@@ -119,6 +123,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.MR_ADMIN_FLATE,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee366",
@@ -139,6 +144,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.MR_ADMIN_FLATE,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee367",
@@ -158,6 +164,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.MR_ADMIN_FLATE,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee368",
@@ -178,6 +185,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.ARENA,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee369",
@@ -198,6 +206,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.ARENA,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee310",
@@ -218,6 +227,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.ARENA,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee311",
@@ -237,6 +247,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.ARENA,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee312",
@@ -257,6 +268,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     opphav: Opphav.ARENA,
     tilgjengelighet: Tilgjengelighetsstatus.LEDIG,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
     stengtFra: "2022-01-01",
     stengtTil: "2022-12-12",
   },
@@ -279,6 +291,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     status: TiltaksgjennomforingStatus.GJENNOMFORES,
     opphav: Opphav.ARENA,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
     stengtFra: "2022-01-01",
     stengtTil: "2022-12-12",
   },
@@ -301,6 +314,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     status: TiltaksgjennomforingStatus.GJENNOMFORES,
     opphav: Opphav.ARENA,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee315",
@@ -321,6 +335,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     status: TiltaksgjennomforingStatus.GJENNOMFORES,
     opphav: Opphav.ARENA,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee316",
@@ -341,6 +356,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     status: TiltaksgjennomforingStatus.GJENNOMFORES,
     opphav: Opphav.ARENA,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee317",
@@ -361,6 +377,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     status: TiltaksgjennomforingStatus.GJENNOMFORES,
     opphav: Opphav.ARENA,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
   {
     id: "a7d63fb0-4366-412c-84b7-7c15518ee318",
@@ -381,6 +398,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     status: TiltaksgjennomforingStatus.APENT_FOR_INNSOK,
     opphav: Opphav.ARENA,
     kontaktpersoner: [],
+    tilgjengeligForVeileder: true,
   },
 ];
 

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingKnapperad.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingKnapperad.tsx
@@ -1,6 +1,8 @@
-import { Button } from "@navikt/ds-react";
+import { Button, Switch } from "@navikt/ds-react";
 import { Toggles } from "mulighetsrommet-api-client";
 import { useFeatureToggle } from "../../api/features/feature-toggles";
+import { useMutateTilgjengeligForVeileder } from "../../api/tiltaksgjennomforing/useMutateTilgjengeligForVeileder";
+import { useTiltaksgjennomforing } from "../../api/tiltaksgjennomforing/useTiltaksgjennomforing";
 import { Lenkeknapp } from "../../components/lenkeknapp/Lenkeknapp";
 import styles from "../DetaljerInfo.module.scss";
 
@@ -10,12 +12,27 @@ interface Props {
 }
 
 export function TiltaksgjennomforingKnapperad({ handleSlett, style }: Props) {
+  const { mutate } = useMutateTilgjengeligForVeileder();
+  const { data, refetch } = useTiltaksgjennomforing();
+
   const { data: slettGjennomforingIsEnabled } = useFeatureToggle(
     Toggles.MULIGHETSROMMET_ADMIN_FLATE_SLETT_TILTAKSGJENNOMFORING,
   );
 
+  function handleClick(e: React.MouseEvent<HTMLInputElement>) {
+    if (data?.id) {
+      mutate(
+        { id: data.id, tilgjengeligForVeileder: e.currentTarget.checked },
+        { onSettled: () => refetch() },
+      );
+    }
+  }
+
   return (
-    <div style={style}>
+    <div style={style} className={styles.knapperad}>
+      <Switch checked={!!data?.tilgjengeligForVeileder} onClick={handleClick}>
+        Tilgjengelig for veileder
+      </Switch>
       {slettGjennomforingIsEnabled ? (
         <Button
           style={{

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -62,14 +62,14 @@ fun Route.tiltaksgjennomforingRoutes() {
         }
 
         put("{id}") {
-            val gjennomforingId = call.parameters.getOrFail<UUID>("id")
+            val id = call.parameters.getOrFail<UUID>("id")
             val request = call.receive<GjennomforingTilAvtaleRequest>()
-            call.respond(tiltaksgjennomforingService.kobleGjennomforingTilAvtale(gjennomforingId, request.avtaleId))
+            call.respond(tiltaksgjennomforingService.kobleGjennomforingTilAvtale(id, request.avtaleId))
         }
 
         put("{id}/avbryt") {
-            val gjennomforingId = call.parameters.getOrFail<UUID>("id")
-            call.respondWithStatusResponse(tiltaksgjennomforingService.avbrytGjennomforing(gjennomforingId))
+            val id = call.parameters.getOrFail<UUID>("id")
+            call.respondWithStatusResponse(tiltaksgjennomforingService.avbrytGjennomforing(id))
         }
 
         get("{id}/nokkeltall") {
@@ -80,6 +80,17 @@ fun Route.tiltaksgjennomforingRoutes() {
         delete("{id}") {
             val id = call.parameters.getOrFail<UUID>("id")
             call.respondWithStatusResponse(tiltaksgjennomforingService.delete(id))
+        }
+
+        put("{id}/tilgjengeligForVeileder") {
+            val id = call.parameters.getOrFail<UUID>("id")
+            val request = call.receive<TilgjengeligForVeilederRequest>()
+            call.respond(
+                tiltaksgjennomforingService.setTilgjengeligForVeileder(
+                    id,
+                    request.tilgjengeligForVeileder,
+                ),
+            )
         }
     }
 }
@@ -183,4 +194,9 @@ data class GjennomforingTilAvtaleRequest(
 data class NavKontaktpersonForGjennomforing(
     val navIdent: String,
     val navEnheter: List<String>,
+)
+
+@Serializable
+data class TilgjengeligForVeilederRequest(
+    val tilgjengeligForVeileder: Boolean,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.services
 
 import arrow.core.Either
 import arrow.core.right
+import io.ktor.server.plugins.*
 import kotliquery.Session
 import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingNokkeltallDto
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
@@ -206,7 +207,11 @@ class TiltaksgjennomforingService(
         }.right()
     }
 
-    private fun dispatchSattSomAdministratorNotification(gjennomforingNavn: String, administrator: String, tx: Session) {
+    private fun dispatchSattSomAdministratorNotification(
+        gjennomforingNavn: String,
+        administrator: String,
+        tx: Session,
+    ) {
         val notification = ScheduledNotification(
             type = NotificationType.NOTIFICATION,
             title = "Du har blitt satt som administrator på gjennomføringen \"${gjennomforingNavn}\"",
@@ -214,5 +219,10 @@ class TiltaksgjennomforingService(
             createdAt = Instant.now(),
         )
         notificationRepository.insert(notification, tx)
+    }
+
+    fun setTilgjengeligForVeileder(id: UUID, tilgjengeligForVeileder: Boolean) {
+        val updatedRows = tiltaksgjennomforingRepository.setTilgjengeligForVeileder(id, tilgjengeligForVeileder)
+        if (updatedRows != 1) throw NotFoundException("Fant ingen gjennomføring med id: $id")
     }
 }

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -56,7 +56,8 @@ select tg.id::uuid,
        tg.faneinnhold,
        tg.beskrivelse,
        tg.created_at,
-       tg.updated_at
+       tg.updated_at,
+       tg.tilgjengelig_for_veileder
 from tiltaksgjennomforing tg
          inner join tiltakstype t on tg.tiltakstype_id = t.id
          left join tiltaksgjennomforing_administrator tg_a on tg_a.tiltaksgjennomforing_id = tg.id

--- a/mulighetsrommet-api/src/main/resources/db/migration/V91__tiltaksgjennomforing_vis_for_veileder.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V91__tiltaksgjennomforing_vis_for_veileder.sql
@@ -1,0 +1,1 @@
+alter table tiltaksgjennomforing add column tilgjengelig_for_veileder boolean not null default false;

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -682,6 +682,23 @@ paths:
               schema:
                 type: string
 
+  /api/v1/internal/tiltaksgjennomforinger/{id}/tilgjengeligForVeileder:
+    parameters:
+      - $ref: "#/components/parameters/ID"
+    put:
+      tags:
+        - Tiltaksgjennomforinger
+      operationId: setTilgjengeligForVeileder
+      requestBody:
+        $ref: "#/components/schemas/TilgjengeligForVeilederRequest"
+      responses:
+        200:
+          description: Update for 'tilgjengelig for veileder' was successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tiltaksgjennomforing"
+
   /api/v1/internal/tiltaksgjennomforinger/enhet/{enhet}:
     parameters:
       - in: path
@@ -1901,6 +1918,8 @@ components:
           $ref: "#/components/schemas/SanityFaneinnhold"
         beskrivelse:
           type: string
+        tilgjengeligForVeileder:
+          type: boolean
       required:
         - status
         - id
@@ -1912,6 +1931,7 @@ components:
         - opphav
         - midlertidigStengt
         - tilgjengelighet
+        - tilgjengeligForVeileder
 
     TiltaksgjennomforingRequest:
       type: object
@@ -2926,3 +2946,11 @@ components:
         - mulighetsrommet.admin-flate-faneinnhold
         - mulighetsrommet.admin-flate.opsjoner-for-avtaler
         - mulighetsrommet.admin-flate.rediger-oppstart
+
+    TilgjengeligForVeilederRequest:
+      type: object
+      properties:
+        tilgjengeligForVeileder:
+          type: boolean
+      required:
+        - tilgjengeligForVeileder

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1993,11 +1993,14 @@ components:
         stedForGjennomforing:
           type: string
         opphav:
-          $ref: "#/components/schemas/Opphav"
+          anyOf:
+            - type: "null"
+            - $ref: "#/components/schemas/Opphav"
           nullable: true
         faneinnhold:
-          $ref: "#/components/schemas/SanityFaneinnhold"
-          nullable: true
+          anyOf:
+            - type: "null"
+            - $ref: "#/components/schemas/SanityFaneinnhold"
         beskrivelse:
           type: string
           nullable: true

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -1135,4 +1135,17 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             it!!.faneinnhold!!.forHvem!![0] shouldBe faneinnhold.forHvem!![0]
         }
     }
+
+    test("Tilgjengelig for veileder") {
+        val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
+        val gjennomforing = Oppfolging1.copy(id = UUID.randomUUID())
+        tiltaksgjennomforinger.upsert(gjennomforing)
+        tiltaksgjennomforinger.get(gjennomforing.id).should {
+            it!!.tilgjengeligForVeileder shouldBe false
+        }
+        tiltaksgjennomforinger.setTilgjengeligForVeileder(gjennomforing.id, true)
+        tiltaksgjennomforinger.get(gjennomforing.id).should {
+            it!!.tilgjengeligForVeileder shouldBe true
+        }
+    }
 })

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
@@ -126,6 +126,7 @@ class VeilederflateServiceTest : FunSpec({
         beskrivelse = null,
         createdAt = LocalDateTime.now(),
         updatedAt = LocalDateTime.now(),
+        tilgjengeligForVeileder = false,
     )
 
     test("Tom enhetsliste fra db overskriver ikke sanity enheter") {


### PR DESCRIPTION
Legger til Switch som administrator kan bruke for å tilgjengeliggjøre 
gjennomføring til veileder.

MERK at denne PRen ikke gjør noe med verdien annet enn å oppdatere i database og visning i frontend.
Selve filtrering ut til veileder i veilederflate må fikses separat.

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/e78e76e4-249d-4647-9c22-9c4f955cbf70)


- Sett korrekt mock-data
- Trailing comma
