### PR TITLE
BUGFIX Ikke avbryt redigering ved Enter-tast

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaKnapperad.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaKnapperad.tsx
@@ -15,6 +15,7 @@ export function AvtaleSkjemaKnapperad({ redigeringsModus, onClose }: Props) {
         onClick={onClose}
         variant="tertiary"
         data-testid="avtaleskjema-avbrytknapp"
+        type="button"
       >
         Avbryt
       </Button>


### PR DESCRIPTION
Avbryt-knappen var av `type=submit` by default, så når man trykket enter så trykket man i praksis på avbryt-knappen som dermed avbrøt redigering. Fikset ved å legge på `type=button` for avbryt-knappen.

