### PR TITLE
more extensive test of authentication

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -41,7 +41,7 @@ fun Application.configure(config: AppConfig) {
 
     routing {
         swaggerUI(path = "/swagger-ui/internal", swaggerFile = "web/openapi.yaml")
-        authenticate(AuthProvider.AzureAdNavIdent.name) {
+        authenticate(AuthProvider.AZURE_AD_NAV_IDENT.name) {
             tiltakstypeRoutes()
             tiltaksgjennomforingRoutes()
             avtaleRoutes()
@@ -59,12 +59,12 @@ fun Application.configure(config: AppConfig) {
             featureTogglesRoute()
         }
 
-        authenticate(AuthProvider.AzureAdDefaultApp.name) {
+        authenticate(AuthProvider.AZURE_AD_DEFAULT_APP.name) {
             arenaAdapterRoutes()
         }
 
         swaggerUI(path = "/swagger-ui/external", swaggerFile = "web/openapi-external.yaml")
-        authenticate(AuthProvider.AzureAdTiltaksgjennomforingApp.name) {
+        authenticate(AuthProvider.AZURE_AD_TILTAKSGJENNOMFORING_APP.name) {
             externalRoutes()
         }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -2,7 +2,7 @@ package no.nav.mulighetsrommet.api
 
 import no.nav.mulighetsrommet.api.clients.brreg.BrregClientImpl
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
-import no.nav.mulighetsrommet.api.services.AdGruppeNavAnsattRolleMapping
+import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
 import no.nav.mulighetsrommet.api.tasks.*
 import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
@@ -11,6 +11,7 @@ import no.nav.mulighetsrommet.kafka.producers.TiltaksgjennomforingKafkaProducer
 import no.nav.mulighetsrommet.kafka.producers.TiltakstypeKafkaProducer
 import no.nav.mulighetsrommet.ktor.ServerConfig
 import no.nav.mulighetsrommet.unleash.UnleashService
+import java.util.*
 
 data class Config(
     val server: ServerConfig,
@@ -31,7 +32,6 @@ data class AppConfig(
     val amtEnhetsregister: ServiceClientConfig,
     val arenaAdapter: ServiceClientConfig,
     val msGraphConfig: ServiceClientConfig,
-    val navAnsattService: NavAnsattServiceConfig,
     val tasks: TaskConfig,
     val norg2: Norg2Config,
     val slack: SlackConfig,
@@ -42,6 +42,12 @@ data class AppConfig(
 
 data class AuthConfig(
     val azure: AuthProvider,
+    val roles: List<AdGruppeNavAnsattRolleMapping>,
+)
+
+data class AdGruppeNavAnsattRolleMapping(
+    val adGruppeId: UUID,
+    val rolle: NavAnsattRolle,
 )
 
 data class KafkaConfig(
@@ -95,8 +101,4 @@ data class SlackConfig(
     val token: String,
     val channel: String,
     val enable: Boolean,
-)
-
-data class NavAnsattServiceConfig(
-    val roller: List<AdGruppeNavAnsattRolleMapping>,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -260,7 +260,7 @@ private fun services(appConfig: AppConfig) = module {
     single { ArrangorService(get()) }
     single { BrukerService(get(), get(), get()) }
     single { DialogService(get()) }
-    single { NavAnsattService(get(), get(), appConfig.navAnsattService.roller, get()) }
+    single { NavAnsattService(appConfig.auth.roles, get(), get(), get()) }
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get()) }
     single { MicrosoftGraphService(get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
@@ -7,6 +7,7 @@ import arrow.core.right
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.api.AdGruppeNavAnsattRolleMapping
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
@@ -23,9 +24,9 @@ import java.time.LocalDate
 import java.util.*
 
 class NavAnsattService(
+    private val roles: List<AdGruppeNavAnsattRolleMapping>,
     private val microsoftGraphService: MicrosoftGraphService,
     private val ansatte: NavAnsattRepository,
-    private val roles: List<AdGruppeNavAnsattRolleMapping>,
     private val sanityClient: SanityClient,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -213,11 +214,6 @@ class NavAnsattService(
         }
     }
 }
-
-data class AdGruppeNavAnsattRolleMapping(
-    val adGruppeId: UUID,
-    val rolle: NavAnsattRolle,
-)
 
 @Serializable
 data class SanityNavKontaktperson(

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -40,6 +40,16 @@ app:
       jwksUri: ${AZURE_OPENID_CONFIG_JWKS_URI}
       audience: ${AZURE_APP_CLIENT_ID}
       tokenEndpointUrl: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+    roles:
+      # team-mulighetsrommet
+      - adGruppeId: 639e2806-4cc2-484c-a72a-51b4308c52a1
+        rolle: TEAM_MULIGHETSROMMET
+      # 0000-GA-mr-admin-flate_betabruker
+      - adGruppeId: ee45478c-57a5-4ee6-b28d-b65f8c1733fe
+        rolle: BETABRUKER
+      # (GRP) mr-nav_kontaktperson
+      - adGruppeId: 7b1d209a-f6c1-4c6e-84f2-02a1bb4c92ba
+        rolle: KONTAKTPERSON
 
   sanity:
     dataset: ${SANITY_DATASET}
@@ -85,15 +95,6 @@ app:
   axsys:
     url: https://axsys.dev-fss-pub.nais.io
     scope: api://dev-fss.org.axsys/.default
-
-  navAnsattService:
-    roller:
-      - adGruppeId: 639e2806-4cc2-484c-a72a-51b4308c52a1 # team-mulighetsrommet
-        rolle: TEAM_MULIGHETSROMMET
-      - adGruppeId: ee45478c-57a5-4ee6-b28d-b65f8c1733fe # 0000-GA-mr-admin-flate_betabruker
-        rolle: BETABRUKER
-      - adGruppeId: 7b1d209a-f6c1-4c6e-84f2-02a1bb4c92ba # (GRP) mr-nav_kontaktperson
-        rolle: KONTAKTPERSON
 
   tasks:
     deleteExpiredTiltakshistorikk:

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -39,6 +39,10 @@ app:
       jwksUri: http://localhost:8081/azure/jwks
       audience: mulighetsrommet-api
       tokenEndpointUrl: http://localhost:8081/azure/token
+    roles:
+      # Mocket AD-gruppe for lokal utvikling
+      - adGruppeId: ee45478c-57a5-4ee6-b28d-b65f8c1733fe
+        rolle: BETABRUKER
 
   sanity:
     dataset: test
@@ -85,11 +89,6 @@ app:
   axsys:
     url: https://axsys.dev-fss-pub.nais.io # TODO Url for wiremock for axsys
     scope: default # TODO scope for wiremock for axsys
-
-  navAnsattService:
-    roller:
-      - adGruppeId: ee45478c-57a5-4ee6-b28d-b65f8c1733fe
-        rolle: BETABRUKER
 
   tasks:
     deleteExpiredTiltakshistorikk:

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -40,6 +40,16 @@ app:
       jwksUri: ${AZURE_OPENID_CONFIG_JWKS_URI}
       audience: ${AZURE_APP_CLIENT_ID}
       tokenEndpointUrl: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+    roles:
+      # team-mulighetsrommet
+      - adGruppeId: debefa6e-1865-446d-b22b-9579fc735de3
+        rolle: TEAM_MULIGHETSROMMET
+      # 0000-GA-mr-admin-flate_betabruker
+      - adGruppeId: dde41c4b-42af-401f-bedf-9e537bcbdd37
+        rolle: BETABRUKER
+      # (GRP) mr-nav_kontaktperson
+      - adGruppeId: 0fdd133a-f47f-4b95-9a5e-f3a5ec87a472
+        rolle: KONTAKTPERSON
 
   sanity:
     dataset: ${SANITY_DATASET}
@@ -87,13 +97,6 @@ app:
     scope: api://prod-fss.org.axsys/.default
 
   navAnsattService:
-    roller:
-      - adGruppeId: debefa6e-1865-446d-b22b-9579fc735de3 # team-mulighetsrommet
-        rolle: TEAM_MULIGHETSROMMET
-      - adGruppeId: dde41c4b-42af-401f-bedf-9e537bcbdd37 # 0000-GA-mr-admin-flate_betabruker
-        rolle: BETABRUKER
-      - adGruppeId: 0fdd133a-f47f-4b95-9a5e-f3a5ec87a472 # (GRP) mr-nav_kontaktperson
-        rolle: KONTAKTPERSON
 
   tasks:
     deleteExpiredTiltakshistorikk:
@@ -131,5 +134,3 @@ app:
     token: ${UNLEASH_SERVER_API_TOKEN}
     instanceId: ${NAIS_CLIENT_ID}
     environment: production
-
-

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/AuthenticationTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/AuthenticationTest.kt
@@ -1,15 +1,24 @@
 package no.nav.mulighetsrommet.api
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.*
 import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
+import no.nav.mulighetsrommet.api.plugins.AppRoles
+import no.nav.mulighetsrommet.api.plugins.AuthProvider
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import java.util.*
 
 class AuthenticationTest : FunSpec({
 
     val oauth = MockOAuth2Server()
-    val apiUrl = "/api/v1/internal/tiltakstyper"
 
     beforeSpec {
         oauth.start()
@@ -19,50 +28,180 @@ class AuthenticationTest : FunSpec({
         oauth.shutdown()
     }
 
-    context("protected endpoints") {
-        test("should respond with 401 when request is not authenticated") {
-            withTestApplication(oauth) {
-                val response = client.get(apiUrl)
+    fun Application.configureTestAuthentationRoutes() {
+        routing {
+            authenticate(AuthProvider.AZURE_AD_NAV_IDENT.name) {
+                get("AZURE_AD_NAV_IDENT") { call.respond(HttpStatusCode.OK) }
+            }
 
-                response.status shouldBe HttpStatusCode.Unauthorized
+            authenticate(AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
+                get("AZURE_AD_TEAM_MULIGHETSROMMET") { call.respond(HttpStatusCode.OK) }
+            }
+
+            authenticate(AuthProvider.AZURE_AD_DEFAULT_APP.name) {
+                get("AZURE_AD_DEFAULT_APP") { call.respond(HttpStatusCode.OK) }
+            }
+
+            authenticate(AuthProvider.AZURE_AD_TILTAKSGJENNOMFORING_APP.name) {
+                get("AZURE_AD_TILTAKSGJENNOMFORING_APP") { call.respond(HttpStatusCode.OK) }
             }
         }
+    }
 
-        test("should respond with 401 when the token has the wrong audience") {
-            withTestApplication(oauth) {
-                val response = client.get(apiUrl) {
-                    bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
-                }
-                response.status shouldBe HttpStatusCode.Unauthorized
-            }
+    test("verify provider AZURE_AD_NAV_IDENT") {
+        val requestWithoutBearerToken = { _: HttpRequestBuilder -> }
+        val requestWithWrongAudience = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
+        }
+        val requestWithWrongIssuer = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(issuerId = "skatteetaten").serialize())
+        }
+        val requestWithoutNAVident = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken().serialize())
+        }
+        val requestWithNAVident = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(claims = mapOf(Pair("NAVident", "ABC123"))).serialize())
         }
 
-        test("should respond with 401 when the token has the wrong issuer") {
-            withTestApplication(oauth) {
+        val config = createTestApplicationConfig().copy(
+            auth = createAuthConfig(oauth, roles = listOf()),
+        )
+        withTestApplication(config, additionalConfiguration = Application::configureTestAuthentationRoutes) {
+            forAll(
+                row(requestWithoutBearerToken, HttpStatusCode.Unauthorized),
+                row(requestWithWrongAudience, HttpStatusCode.Unauthorized),
+                row(requestWithWrongIssuer, HttpStatusCode.Unauthorized),
+                row(requestWithoutNAVident, HttpStatusCode.Unauthorized),
+                row(requestWithNAVident, HttpStatusCode.OK),
+            ) { buildRequest, responseStatusCode ->
+                val response = client.get("/AZURE_AD_NAV_IDENT") { buildRequest(this) }
 
-                val response = client.get(apiUrl) {
-                    bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
-                }
-                response.status shouldBe HttpStatusCode.Unauthorized
+                response.status shouldBe responseStatusCode
             }
         }
+    }
 
-        test("should respond with 401 when the token is missing the NAVident claim") {
-            withTestApplication(oauth) {
+    test("verify provider AZURE_AD_TEAM_MULIGHETSROMMET") {
+        val wrongRole = AdGruppeNavAnsattRolleMapping(UUID.randomUUID(), NavAnsattRolle.KONTAKTPERSON)
+        val correctRole = AdGruppeNavAnsattRolleMapping(UUID.randomUUID(), NavAnsattRolle.TEAM_MULIGHETSROMMET)
 
-                val response = client.get(apiUrl) {
-                    bearerAuth(oauth.issueToken().serialize())
-                }
-                response.status shouldBe HttpStatusCode.Unauthorized
-            }
+        val requestWithoutBearerToken = { _: HttpRequestBuilder -> }
+        val requestWithWrongAudience = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
+        }
+        val requestWithWrongIssuer = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(issuerId = "skatteetaten").serialize())
+        }
+        val requestWithoutNAVident = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken().serialize())
+        }
+        val requestWithoutGroup = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(claims = mapOf(Pair("NAVident", "ABC123"))).serialize())
+        }
+        val requestWithWrongGroup = { request: HttpRequestBuilder ->
+            val claims = mapOf(
+                "NAVident" to "ABC123",
+                "groups" to listOf(wrongRole.adGruppeId),
+            )
+            request.bearerAuth(oauth.issueToken(claims = claims).serialize())
+        }
+        val requestWithCorrectGroup = { request: HttpRequestBuilder ->
+            val claims = mapOf(
+                "NAVident" to "ABC123",
+                "groups" to listOf(correctRole.adGruppeId),
+            )
+            request.bearerAuth(oauth.issueToken(claims = claims).serialize())
         }
 
-        test("should respond with 200 when request is authenticated") {
-            withTestApplication(oauth) {
-                val response = client.get(apiUrl) {
-                    bearerAuth(oauth.issueToken(claims = mapOf(Pair("NAVident", "ABC123"))).serialize())
-                }
-                response.status shouldBe HttpStatusCode.OK
+        val config = createTestApplicationConfig().copy(
+            auth = createAuthConfig(oauth, roles = listOf(correctRole)),
+        )
+        withTestApplication(config, additionalConfiguration = Application::configureTestAuthentationRoutes) {
+            forAll(
+                row(requestWithoutBearerToken, HttpStatusCode.Unauthorized),
+                row(requestWithWrongAudience, HttpStatusCode.Unauthorized),
+                row(requestWithWrongIssuer, HttpStatusCode.Unauthorized),
+                row(requestWithoutNAVident, HttpStatusCode.Unauthorized),
+                row(requestWithoutGroup, HttpStatusCode.Unauthorized),
+                row(requestWithWrongGroup, HttpStatusCode.Unauthorized),
+                row(requestWithCorrectGroup, HttpStatusCode.OK),
+            ) { buildRequest, responseStatusCode ->
+                val response = client.get("/AZURE_AD_TEAM_MULIGHETSROMMET") { buildRequest(this) }
+
+                response.status shouldBe responseStatusCode
+            }
+        }
+    }
+
+    test("verify provider AZURE_AD_DEFAULT_APP") {
+        val requestWithoutBearerToken = { _: HttpRequestBuilder -> }
+        val requestWithWrongAudience = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
+        }
+        val requestWithWrongIssuer = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(issuerId = "skatteetaten").serialize())
+        }
+        val requestWithoutClaimAccessAsApplication = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken().serialize())
+        }
+        val requestWithClaimAccessAsApplication = { request: HttpRequestBuilder ->
+            val claims = mapOf("roles" to listOf(AppRoles.ACCESS_AS_APPLICATION))
+            request.bearerAuth(oauth.issueToken(claims = claims).serialize())
+        }
+
+        val config = createTestApplicationConfig().copy(
+            auth = createAuthConfig(oauth, roles = listOf()),
+        )
+        withTestApplication(config, additionalConfiguration = Application::configureTestAuthentationRoutes) {
+            forAll(
+                row(requestWithoutBearerToken, HttpStatusCode.Unauthorized),
+                row(requestWithWrongAudience, HttpStatusCode.Unauthorized),
+                row(requestWithWrongIssuer, HttpStatusCode.Unauthorized),
+                row(requestWithoutClaimAccessAsApplication, HttpStatusCode.Unauthorized),
+                row(requestWithClaimAccessAsApplication, HttpStatusCode.OK),
+            ) { buildRequest, responseStatusCode ->
+                val response = client.get("/AZURE_AD_DEFAULT_APP") { buildRequest(this) }
+
+                response.status shouldBe responseStatusCode
+            }
+        }
+    }
+
+    test("verify provider AZURE_AD_TILTAKSGJENNOMFORING_APP") {
+        val requestWithoutBearerToken = { _: HttpRequestBuilder -> }
+        val requestWithWrongAudience = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
+        }
+        val requestWithWrongIssuer = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken(issuerId = "skatteetaten").serialize())
+        }
+        val requestWithoutClaimAccessAsApplication = { request: HttpRequestBuilder ->
+            request.bearerAuth(oauth.issueToken().serialize())
+        }
+        val requestWithClaimAccessAsApplication = { request: HttpRequestBuilder ->
+            val claims = mapOf("roles" to listOf(AppRoles.ACCESS_AS_APPLICATION))
+            request.bearerAuth(oauth.issueToken(claims = claims).serialize())
+        }
+        val requestWithClaimsReadTiltaksgjennomforing = { request: HttpRequestBuilder ->
+            val claims = mapOf("roles" to listOf(AppRoles.ACCESS_AS_APPLICATION, AppRoles.READ_TILTAKSGJENNOMFORING))
+            request.bearerAuth(oauth.issueToken(claims = claims).serialize())
+        }
+
+        val config = createTestApplicationConfig().copy(
+            auth = createAuthConfig(oauth, roles = listOf()),
+        )
+        withTestApplication(config, additionalConfiguration = Application::configureTestAuthentationRoutes) {
+            forAll(
+                row(requestWithoutBearerToken, HttpStatusCode.Unauthorized),
+                row(requestWithWrongAudience, HttpStatusCode.Unauthorized),
+                row(requestWithWrongIssuer, HttpStatusCode.Unauthorized),
+                row(requestWithoutClaimAccessAsApplication, HttpStatusCode.Unauthorized),
+                row(requestWithClaimAccessAsApplication, HttpStatusCode.Unauthorized),
+                row(requestWithClaimsReadTiltaksgjennomforing, HttpStatusCode.OK),
+            ) { buildRequest, responseStatusCode ->
+                val response = client.get("/AZURE_AD_TILTAKSGJENNOMFORING_APP") { buildRequest(this) }
+
+                response.status shouldBe responseStatusCode
             }
         }
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
@@ -16,6 +16,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
+import no.nav.mulighetsrommet.api.AdGruppeNavAnsattRolleMapping
 import no.nav.mulighetsrommet.api.clients.msgraph.AzureAdNavAnsatt
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig


### PR DESCRIPTION
- Lagt til en ny custom "auth provider" som kan benyttes til å låse ned endepunkter som kun er tilgjengelig for team-mulighetsrommet (ikke i bruk enda, annet enn i tester)
  - Kan bli benyttet som basis etter hvert som vi implmenterer mer fingranulert tilgangskontroll basert på ad-grupper
- Implementert tester for alle custom auth providers