### PR TITLE
Hent bare gjennomforinger som 'skal_migreres' fra db

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -478,7 +478,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         innsatsgrupper: List<Innsatsgruppe> = emptyList(),
     ): List<VeilederflateTiltaksgjennomforing> {
         val parameters = mapOf(
-            "search" to search?.let { "%${it.replace("/", "#")?.trim()}%" },
+            "search" to search?.let { "%${it.replace("/", "#").trim()}%" },
             "sanityTiltakstypeIds" to sanityTiltakstypeIds?.let { db.createUuidArray(it) },
             "innsatsgrupper" to db.createTextArray(innsatsgrupper.map { it.name }),
         )
@@ -533,6 +533,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                      left join virksomhet_kontaktperson vk on vk.id = tg.arrangor_kontaktperson_id
             $where
             and tg.tilgjengelig_for_veileder
+            and t.skal_migreres
             group by tg.id, t.id, v.navn, avtale_ne.navn, vk.id, avtale_ne.enhetsnummer
         """.trimIndent()
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -1154,6 +1154,9 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
 
     test("getAllVeilederflateTiltaksgjennomforing by tiltakstype sanity Id") {
         val tiltakstypeSanityId = UUID.randomUUID()
+        Query("update tiltakstype set skal_migreres = true")
+            .asUpdate
+            .let { database.db.run(it) }
         Query("update tiltakstype set sanity_id = '$tiltakstypeSanityId' where id = '${TiltakstypeFixtures.Oppfolging.id}'")
             .asUpdate
             .let { database.db.run(it) }
@@ -1184,8 +1187,45 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         }
     }
 
+    test("getAllVeilederflateTiltaksgjennomforing returnerer bare skal_migreres") {
+        Query("update tiltakstype set sanity_id = '${UUID.randomUUID()}'")
+            .asUpdate
+            .let { database.db.run(it) }
+        Query("update tiltakstype set skal_migreres = true where id = '${TiltakstypeFixtures.Oppfolging.id}'")
+            .asUpdate
+            .let { database.db.run(it) }
+        Query("update tiltakstype set innsatsgruppe = '${Innsatsgruppe.STANDARD_INNSATS}' where id = '${TiltakstypeFixtures.Oppfolging.id}'")
+            .asUpdate
+            .let { database.db.run(it) }
+        Query("update tiltakstype set skal_migreres = false where id = '${TiltakstypeFixtures.Arbeidstrening.id}'")
+            .asUpdate
+            .let { database.db.run(it) }
+        Query("update tiltakstype set innsatsgruppe = '${Innsatsgruppe.STANDARD_INNSATS}' where id = '${TiltakstypeFixtures.Arbeidstrening.id}'")
+            .asUpdate
+            .let { database.db.run(it) }
+
+        val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
+        tiltaksgjennomforinger.upsert(Oppfolging1)
+        tiltaksgjennomforinger.setTilgjengeligForVeileder(Oppfolging1.id, true)
+
+        tiltaksgjennomforinger.upsert(Arbeidstrening1)
+        tiltaksgjennomforinger.setTilgjengeligForVeileder(Arbeidstrening1.id, true)
+
+        tiltaksgjennomforinger.getAllVeilederflateTiltaksgjennomforing(
+            search = null,
+            sanityTiltakstypeIds = null,
+            innsatsgrupper = listOf(Innsatsgruppe.STANDARD_INNSATS),
+        ).should {
+            it shouldHaveSize 1
+            it[0].navn shouldBe Oppfolging1.navn
+        }
+    }
+
     test("getAllVeilederflateTiltaksgjennomforing by search") {
         val tiltakstypeSanityId = UUID.randomUUID()
+        Query("update tiltakstype set skal_migreres = true")
+            .asUpdate
+            .let { database.db.run(it) }
         Query("update tiltakstype set sanity_id = '$tiltakstypeSanityId' where id = '${TiltakstypeFixtures.Oppfolging.id}'")
             .asUpdate
             .let { database.db.run(it) }


### PR DESCRIPTION
Jeg tror det blir feil om vi ikke slenger på denne. For ellers vil egen regi tiltakene også hentes fra db (og filtreres vekk fra de individuelle), men de har all data i sanity.