### PR TITLE
Sett lopende oppstart på gjennomforinger fra Sanity

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/sanityHandlers.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/endpoints/sanityHandlers.ts
@@ -72,6 +72,10 @@ function filtrerInnsatsgruppe(
   gjennomforing: VeilederflateTiltaksgjennomforing,
   innsatsgruppe?: Innsatsgruppe,
 ): boolean {
+  if (!gjennomforing.tiltakstype.innsatsgruppe) {
+    return true;
+  }
+
   switch (innsatsgruppe) {
     case Innsatsgruppe.STANDARD_INNSATS: {
       return gjennomforing.tiltakstype.innsatsgruppe.nokkel === innsatsgruppe;

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
@@ -284,6 +284,7 @@ export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
     tiltakstype: mockTiltakstyper.OpplaringEnkeltplassFagOgYrke,
     oppstart: TiltaksgjennomforingOppstartstype.LOPENDE,
     oppstartsdato: "2022-11-01",
+    kontaktinfoTiltaksansvarlige: [],
     sluttdato: "2030-11-30",
     estimertVentetid: "",
   },

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/SanityResponseDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/SanityResponseDto.kt
@@ -36,7 +36,7 @@ data class SanityTiltakstype(
 @Serializable
 data class SanityTiltaksgjennomforing(
     val _id: String,
-    val tiltakstype: SanityTiltakstype? = null,
+    val tiltakstype: SanityTiltakstype,
     val tiltaksgjennomforingNavn: String,
     val tiltaksnummer: String? = null,
     val beskrivelse: String? = null,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/SanityResponseDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/SanityResponseDto.kt
@@ -24,8 +24,8 @@ data class SanityInnsatsgruppe(
 
 @Serializable
 data class SanityTiltakstype(
-    val _id: String? = null,
-    val tiltakstypeNavn: String? = null,
+    val _id: String,
+    val tiltakstypeNavn: String,
     val beskrivelse: String? = null,
     val innsatsgruppe: SanityInnsatsgruppe? = null,
     val regelverkLenker: List<RegelverkLenke>? = emptyList(),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/VeilederflateTiltaksgjennomforing.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/VeilederflateTiltaksgjennomforing.kt
@@ -48,8 +48,8 @@ data class VeilederflateTiltaksgjennomforing(
 
 @Serializable
 data class VeilederflateTiltakstype(
-    val sanityId: String? = null,
-    val navn: String? = null,
+    val sanityId: String,
+    val navn: String,
     val beskrivelse: String? = null,
     val innsatsgruppe: SanityInnsatsgruppe? = null,
     val regelverkLenker: List<RegelverkLenke>? = emptyList(),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/VeilederflateTiltaksgjennomforing.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/VeilederflateTiltaksgjennomforing.kt
@@ -23,12 +23,12 @@ data class VeilederflateTiltaksgjennomforing(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID? = null,
     val sanityId: String? = null,
-    val tiltakstype: VeilederflateTiltakstype? = null,
+    val tiltakstype: VeilederflateTiltakstype,
     val navn: String,
     val stedForGjennomforing: String? = null,
     val tilgjengelighet: TiltaksgjennomforingTilgjengelighetsstatus? = null,
     val tiltaksnummer: String? = null,
-    val oppstart: TiltaksgjennomforingOppstartstype? = null,
+    val oppstart: TiltaksgjennomforingOppstartstype,
     @Serializable(with = LocalDateSerializer::class)
     val oppstartsdato: LocalDate? = null,
     @Serializable(with = LocalDateSerializer::class)
@@ -39,7 +39,7 @@ data class VeilederflateTiltaksgjennomforing(
     val stengtFra: LocalDate? = null,
     @Serializable(with = LocalDateSerializer::class)
     val stengtTil: LocalDate? = null,
-    val kontaktinfoTiltaksansvarlige: List<KontaktinfoTiltaksansvarlige>? = emptyList(),
+    val kontaktinfoTiltaksansvarlige: List<KontaktinfoTiltaksansvarlige>,
     val fylke: String? = null,
     val enheter: List<String>? = emptyList(),
     val beskrivelse: String? = null,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -478,7 +478,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         innsatsgrupper: List<Innsatsgruppe> = emptyList(),
     ): List<VeilederflateTiltaksgjennomforing> {
         val parameters = mapOf(
-            "search" to search?.let { "%${it.replace("/", "#")?.trim()}%" },
+            "search" to search?.let { "%${it.replace("/", "#").trim()}%" },
             "sanityTiltakstypeIds" to sanityTiltakstypeIds?.let { db.createUuidArray(it) },
             "innsatsgrupper" to db.createTextArray(innsatsgrupper.map { it.name }),
         )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltakstypeRoutes.kt
@@ -47,7 +47,7 @@ fun Route.tiltakstypeRoutes() {
             )
 
             val veilederflateTiltakstype: VeilederflateTiltakstype = veilederflateService.hentTiltakstyper()
-                .find { it.sanityId != null && UUID.fromString(it.sanityId) == tiltakstype.sanityId }
+                .find { UUID.fromString(it.sanityId) == tiltakstype.sanityId }
                 ?: return@get call.respondText(
                     "Det finnes ikke noe faneinnhold for tiltakstype med id $id",
                     status = HttpStatusCode.NotFound,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -177,8 +177,6 @@ class TiltaksgjennomforingService(
             return Either.Left(BadRequest(message = "Gjennomføringen kan ikke slettes fordi den har $antallDeltagere deltager(e) koblet til seg."))
         }
 
-        val sanityId = gjennomforing.sanityId
-
         return db.transactionSuspend { tx ->
             tiltaksgjennomforingRepository.delete(id, tx)
             tiltaksgjennomforingKafkaProducer.retract(id)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateService.kt
@@ -124,6 +124,7 @@ class VeilederflateService(
             ] {
               _id,
               tiltakstype->{
+                _id,
                 tiltakstypeNavn
               },
               tiltaksgjennomforingNavn,

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2536,7 +2536,6 @@ components:
       required:
         - sanityId
         - navn
-        - innsatsgruppe
 
     VeilederflateTiltaksgjennomforing:
       type: object

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2582,6 +2582,7 @@ components:
         - navn
         - tiltakstype
         - oppstart
+        - kontaktinfoTiltaksansvarlige
 
     SanityRegelverkLenke:
       type: object

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
@@ -53,6 +53,7 @@ class VeilederflateServiceTest : FunSpec({
                 "stedForGjennomforing": null,
                 "tiltaksnummer": "2023#176408",
                 "tiltakstype": {
+                    "_id": "${UUID.randomUUID()}",
                     "tiltakstypeNavn": "Oppl\u00e6ring - Gruppe AMO"
                 },
                 "fylke": null
@@ -63,6 +64,7 @@ class VeilederflateServiceTest : FunSpec({
                 "tiltaksnummer": "2023#199282",
                 "stedForGjennomforing": "Oslo",
                 "tiltakstype": {
+                    "_id": "${UUID.randomUUID()}",
                     "tiltakstypeNavn": "Individuelt Tiltak"
                 },
                 "fylke": "0400",
@@ -79,6 +81,7 @@ class VeilederflateServiceTest : FunSpec({
                 "tiltaksnummer": "2022#116075",
                 "fylke": "0400",
                 "tiltakstype": {
+                    "_id": "${UUID.randomUUID()}",
                     "tiltakstypeNavn": "Oppf\u00f8lging"
                 },
                 "enheter": ["0430"],
@@ -93,6 +96,7 @@ class VeilederflateServiceTest : FunSpec({
         sanityId = "f21d1e35-d63b-4de7-a0a5-589e57111527",
         tiltakstype = VeilederflateTiltakstype(
             sanityId = UUID.randomUUID().toString(),
+            navn = "Oppfølging",
         ),
         navn = "Navn",
         tiltaksnummer = null,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
@@ -113,6 +113,7 @@ class VeilederflateServiceTest : FunSpec({
         stedForGjennomforing = null,
         faneinnhold = null,
         beskrivelse = null,
+        kontaktinfoTiltaksansvarlige = emptyList(),
     )
 
     test("Samme enhet overskrevet fra admin flate skal fungere") {


### PR DESCRIPTION
Feltet har blitt fjernet fra Sanity, og alle som hentes derfra nå er individuelle eller egen regi

Her mangler 'lopende oppstart' fra en individuell gjennomforing fra sanity
![Screenshot 2023-10-18 at 14 27 32](https://github.com/navikt/mulighetsrommet/assets/3830767/6b1c449c-cf6a-4ebf-a34c-e70290b6334b)
