### PR TITLE
Mulighet for å synkronisere kontakter med en gang via MaaM

### DIFF
--- a/frontend/arena-adapter-manager/src/core/api.tsx
+++ b/frontend/arena-adapter-manager/src/core/api.tsx
@@ -89,7 +89,7 @@ export const deleteEvents = async (arenaTable: string, arenaIds: string) => {
     .catch((error) => toastError("Klarte ikke slette events", error));
 };
 
-export type MrApiTask = "generate-validation-report" | "initial-load-tiltaksgjennomforinger";
+export type MrApiTask = "generate-validation-report" | "initial-load-tiltaksgjennomforinger" | "sync-navansatte";
 
 export function runTask(task: MrApiTask) {
   return fetch(`/mulighetsrommet-api/api/v1/internal/tasks/${task}`, {

--- a/frontend/arena-adapter-manager/src/pages/MrApiManagement.tsx
+++ b/frontend/arena-adapter-manager/src/pages/MrApiManagement.tsx
@@ -10,6 +10,7 @@ export function MrApiManagement() {
         <UpdateVirksomhet />
         <RunTask task={"generate-validation-report"} />
         <RunTask task={"initial-load-tiltaksgjennomforinger"} />
+        <RunTask task={"sync-navansatte"} />
       </VStack>
     </Box>
   );

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -41,9 +41,9 @@ fun Application.configure(config: AppConfig) {
     configureStatusPagesForStatusException()
 
     routing {
-        authenticate(AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
-            tasks()
-        }
+   /*     authenticate(AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
+        }*/
+        tasks()
 
         authenticate(AuthProvider.AZURE_AD_BETABRUKER.name, AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
             veilederflatePreviewRoutes()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -41,9 +41,9 @@ fun Application.configure(config: AppConfig) {
     configureStatusPagesForStatusException()
 
     routing {
-   /*     authenticate(AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
-        }*/
-        tasks()
+        authenticate(AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
+            tasks()
+        }
 
         authenticate(AuthProvider.AZURE_AD_BETABRUKER.name, AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
             veilederflatePreviewRoutes()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -295,6 +295,7 @@ private fun services(appConfig: AppConfig) = module {
 private fun tasks(config: TaskConfig) = module {
     single { GenerateValidationReport(config.generateValidationReport, get(), get(), get(), get(), get()) }
     single { InitialLoadTiltaksgjennomforinger(get(), get(), get()) }
+    single { SynchronizeNavAnsatte(config.synchronizeNavAnsatte, get(), get(), get()) }
     single {
         val deleteExpiredTiltakshistorikk = DeleteExpiredTiltakshistorikk(
             config.deleteExpiredTiltakshistorikk,
@@ -307,7 +308,6 @@ private fun tasks(config: TaskConfig) = module {
         )
         val synchronizeTiltakstypestatuserToKafka = SynchronizeTiltakstypestatuserToKafka(get(), get())
         val synchronizeNorgEnheterTask = SynchronizeNorgEnheter(config.synchronizeNorgEnheter, get(), get())
-        val synchronizeNavAnsatte = SynchronizeNavAnsatte(config.synchronizeNavAnsatte, get(), get())
         val notifySluttdatoForGjennomforingerNarmerSeg = NotifySluttdatoForGjennomforingerNarmerSeg(
             config.notifySluttdatoForGjennomforingerNarmerSeg,
             get(),
@@ -337,6 +337,7 @@ private fun tasks(config: TaskConfig) = module {
         val notificationService: NotificationService by inject()
         val generateValidationReport: GenerateValidationReport by inject()
         val initialLoadTiltaksgjennomforinger: InitialLoadTiltaksgjennomforinger by inject()
+        val synchronizeNavAnsatte: SynchronizeNavAnsatte by inject()
 
         val db: Database by inject()
 
@@ -346,6 +347,7 @@ private fun tasks(config: TaskConfig) = module {
                 notificationService.getScheduledNotificationTask(),
                 generateValidationReport.task,
                 initialLoadTiltaksgjennomforinger.task,
+                synchronizeNavAnsatte.task,
             )
             .startTasks(
                 deleteExpiredTiltakshistorikk.task,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -347,7 +347,6 @@ private fun tasks(config: TaskConfig) = module {
                 notificationService.getScheduledNotificationTask(),
                 generateValidationReport.task,
                 initialLoadTiltaksgjennomforinger.task,
-                synchronizeNavAnsatte.task,
             )
             .startTasks(
                 deleteExpiredTiltakshistorikk.task,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/Tasks.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/Tasks.kt
@@ -7,6 +7,7 @@ import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.tasks.GenerateValidationReport
 import no.nav.mulighetsrommet.api.tasks.InitialLoadTiltaksgjennomforinger
+import no.nav.mulighetsrommet.api.tasks.SynchronizeNavAnsatte
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import org.koin.ktor.ext.inject
 import java.util.*
@@ -14,6 +15,7 @@ import java.util.*
 fun Route.tasks() {
     val generateValidationReport: GenerateValidationReport by inject()
     val initialLoadTiltaksgjennomforinger: InitialLoadTiltaksgjennomforinger by inject()
+    val synchronizeNavAnsatte: SynchronizeNavAnsatte by inject()
 
     route("api/v1/internal/tasks") {
         post("generate-validation-report") {
@@ -25,6 +27,11 @@ fun Route.tasks() {
         post("initial-load-tiltaksgjennomforinger") {
             val taskId = initialLoadTiltaksgjennomforinger.schedule()
 
+            call.respond(HttpStatusCode.Accepted, ScheduleTaskResponse(id = taskId))
+        }
+
+        post("sync-navansatte") {
+            val taskId = synchronizeNavAnsatte.schedule()
             call.respond(HttpStatusCode.Accepted, ScheduleTaskResponse(id = taskId))
         }
     }

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -98,6 +98,7 @@ app:
       delayOfMinutes: 360 # Hver 6. time
     synchronizeNavAnsatte:
       disabled: true
+      cronPattern: "0 */1 * * * *" # Hvert 1 minutt
     notifySluttdatoForGjennomforingerNarmerSeg:
       disabled: false
       cronPattern: "0 */1 * * * *" # Hvert 1 minutt


### PR DESCRIPTION
Fikser en mulighet for å manuelt trigge synkronisering av
nav-ansatte via MaaM. 

Fjerner også en cache som ikke egentlig var i bruk siden den ble
invalidert hver time og vi bare gjør kall til den cachede funksjonen
når vi kjører tasken.
