### PR TITLE
filter enheter db

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -448,11 +448,13 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         search: String? = null,
         sanityTiltakstypeIds: List<UUID>? = null,
         innsatsgrupper: List<Innsatsgruppe> = emptyList(),
+        brukersEnheter: List<String>,
     ): List<VeilederflateTiltaksgjennomforing> {
         val parameters = mapOf(
             "search" to search?.let { "%${it.replace("/", "#").trim()}%" },
             "sanityTiltakstypeIds" to sanityTiltakstypeIds?.let { db.createUuidArray(it) },
             "innsatsgrupper" to db.createTextArray(innsatsgrupper.map { it.name }),
+            "brukersEnheter" to db.createTextArray(brukersEnheter)
         )
 
         val where = DatabaseUtils.andWhereParameterNotNull(
@@ -505,6 +507,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             and tg.tilgjengelig_for_veileder
             and t.skal_migreres
             group by tg.id, t.id, v.navn, vk.id
+            having array_agg(tg_e.enhetsnummer) && :brukersEnheter
         """.trimIndent()
 
         return queryOf(query, parameters)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -454,7 +454,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             "search" to search?.let { "%${it.replace("/", "#").trim()}%" },
             "sanityTiltakstypeIds" to sanityTiltakstypeIds?.let { db.createUuidArray(it) },
             "innsatsgrupper" to db.createTextArray(innsatsgrupper.map { it.name }),
-            "brukersEnheter" to db.createTextArray(brukersEnheter)
+            "brukersEnheter" to db.createTextArray(brukersEnheter),
         )
 
         val where = DatabaseUtils.andWhereParameterNotNull(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -101,10 +101,12 @@ class TiltaksgjennomforingService(
         search: String?,
         sanityTiltakstypeIds: List<UUID>?,
         innsatsgrupper: List<Innsatsgruppe>,
+        brukersEnheter: List<String>,
     ): List<VeilederflateTiltaksgjennomforing> = tiltaksgjennomforinger.getAllVeilederflateTiltaksgjennomforing(
         search,
         sanityTiltakstypeIds,
         innsatsgrupper,
+        brukersEnheter,
     )
 
     fun getAll(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateService.kt
@@ -178,6 +178,7 @@ class VeilederflateService(
             innsatsgrupper = innsatsgruppe?.let {
                 utledInnsatsgrupper(innsatsgruppe).map { Innsatsgruppe.valueOf(it) }
             } ?: emptyList(),
+            brukersEnheter = brukersEnheter,
         )
 
         val gruppeSanityIds = gruppeGjennomforinger.map { it.sanityId }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -12,7 +12,7 @@ import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 
 data class MulighetsrommetTestDomain(
-    val enheter: List<NavEnhetDbo> = listOf(NavEnhetFixtures.IT),
+    val enheter: List<NavEnhetDbo> = listOf(NavEnhetFixtures.IT, NavEnhetFixtures.Innlandet, NavEnhetFixtures.Oslo),
     val ansatte: List<NavAnsattDbo> = listOf(NavAnsattFixture.ansatt1, NavAnsattFixture.ansatt2),
     val tiltakstyper: List<TiltakstypeDbo> = listOf(
         TiltakstypeFixtures.Oppfolging,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -12,7 +12,7 @@ import no.nav.mulighetsrommet.database.FlywayDatabaseAdapter
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 
 data class MulighetsrommetTestDomain(
-    val enheter: List<NavEnhetDbo> = listOf(NavEnhetFixtures.IT, NavEnhetFixtures.Innlandet, NavEnhetFixtures.Oslo),
+    val enheter: List<NavEnhetDbo> = listOf(NavEnhetFixtures.IT),
     val ansatte: List<NavAnsattDbo> = listOf(NavAnsattFixture.ansatt1, NavAnsattFixture.ansatt2),
     val tiltakstyper: List<TiltakstypeDbo> = listOf(
         TiltakstypeFixtures.Oppfolging,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -1137,7 +1137,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             search = null,
             sanityTiltakstypeIds = listOf(tiltakstypeSanityId),
             innsatsgrupper = listOf(Innsatsgruppe.STANDARD_INNSATS),
-            brukersEnheter = listOf("2990")
+            brukersEnheter = listOf("2990"),
         ).should {
             it shouldHaveSize 1
             it[0].navn shouldBe Oppfolging1.navn
@@ -1172,7 +1172,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             search = null,
             sanityTiltakstypeIds = null,
             innsatsgrupper = listOf(Innsatsgruppe.STANDARD_INNSATS),
-            brukersEnheter = listOf("2990")
+            brukersEnheter = listOf("2990"),
         ).should {
             it shouldHaveSize 1
             it[0].navn shouldBe Oppfolging1.navn
@@ -1202,7 +1202,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             search = "rik",
             sanityTiltakstypeIds = listOf(tiltakstypeSanityId),
             innsatsgrupper = listOf(Innsatsgruppe.STANDARD_INNSATS),
-            brukersEnheter = listOf("2990")
+            brukersEnheter = listOf("2990"),
         ).should {
             it shouldHaveSize 1
             it.get(0).navn shouldBe "erik"
@@ -1241,7 +1241,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             search = null,
             sanityTiltakstypeIds = listOf(tiltakstypeSanityId),
             innsatsgrupper = listOf(Innsatsgruppe.STANDARD_INNSATS),
-            brukersEnheter = listOf("2990", "0400")
+            brukersEnheter = listOf("2990", "0400"),
         ).should {
             it shouldHaveSize 2
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -21,6 +21,7 @@ import no.nav.mulighetsrommet.api.domain.dto.*
 import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures.avtale1
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture
+import no.nav.mulighetsrommet.api.fixtures.NavEnhetFixtures
 import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures.Arbeidstrening1
 import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures.ArenaOppfolging1
 import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures.Oppfolging1
@@ -1226,6 +1227,10 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         Query("update tiltakstype set innsatsgruppe = '${Innsatsgruppe.STANDARD_INNSATS}' where id = '${TiltakstypeFixtures.Arbeidstrening.id}'")
             .asUpdate
             .let { database.db.run(it) }
+
+        val enheter = NavEnhetRepository(database.db)
+        enheter.upsert(NavEnhetFixtures.Oslo)
+        enheter.upsert(NavEnhetFixtures.Innlandet)
 
         val tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
         tiltaksgjennomforinger.upsert(Oppfolging1.copy(navn = "erik"))

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateServiceTest.kt
@@ -131,6 +131,7 @@ class VeilederflateServiceTest : FunSpec({
                 any(),
                 any(),
                 any(),
+                any(),
             )
         } returns listOf(
             dbGjennomforing.copy(enheter = listOf("0430")),
@@ -157,6 +158,7 @@ class VeilederflateServiceTest : FunSpec({
 
         every {
             tiltaksgjennomforingService.getAllVeilederflateTiltaksgjennomforing(
+                any(),
                 any(),
                 any(),
                 any(),
@@ -188,6 +190,7 @@ class VeilederflateServiceTest : FunSpec({
                 any(),
                 any(),
                 any(),
+                any(),
             )
         } returns listOf(
             dbGjennomforing.copy(faneinnhold = Faneinnhold(forHvemInfoboks = "123")),
@@ -214,6 +217,7 @@ class VeilederflateServiceTest : FunSpec({
         )
         every {
             tiltaksgjennomforingService.getAllVeilederflateTiltaksgjennomforing(
+                any(),
                 any(),
                 any(),
                 any(),


### PR DESCRIPTION
Filtrer på brukers enhet i database så vi ikke henter alle gjennomføringer til servicen før vi gjør filtrering mot brukers enheter.
Beholder fortsatt filtrering i service for individuelle gjennomføringer, men nå vil det bli et subset som returneres fra databasen for gruppetiltak.
