### PR TITLE
null hvis undefined fra queryFn for deltMedBrukerStatus

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentDeltMedbrukerStatus.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/core/api/queries/useHentDeltMedbrukerStatus.ts
@@ -14,11 +14,12 @@ export function useHentDeltMedBrukerStatus(
 
   const { data: sistDeltMedBruker, refetch: refetchDelMedBruker } = useQuery({
     queryKey: [QueryKeys.DeltMedBrukerStatus, norskIdent, id],
-    queryFn: () =>
-      mulighetsrommetClient.delMedBruker.getDelMedBruker({
+    queryFn: async () => {
+      const result = await mulighetsrommetClient.delMedBruker.getDelMedBruker({
         requestBody: { norskIdent, id: id!! },
-      }),
-    throwOnError: false,
+      });
+      return result || null; // Returner null hvis API returnerer 204 No Content = undefined;
+    },
     enabled: !erPreview() && !!id,
   });
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DelMedBrukerRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/DelMedBrukerRoutes.kt
@@ -47,7 +47,7 @@ fun Route.delMedBrukerRoutes() {
                 .onRight {
                     if (it == null) {
                         call.respondText(
-                            status = HttpStatusCode.NotFound,
+                            status = HttpStatusCode.NoContent,
                             text = "Fant ikke innslag om at veileder har delt tiltak med bruker tidligere",
                         )
                     } else {


### PR DESCRIPTION
Vi ønsker egentlig ikke returnere 404 fra delt med bruker-api'et hvis vi ikke har delt med bruker før, så jeg tar tilbake til 204 No Content og returnerer heller null fra queryFn så useQuery blir happy.
