### PR TITLE
Add 30 sec delay when rescheduling syncAnsatte

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
@@ -74,7 +74,7 @@ class SynchronizeNavAnsatte(
             throw BadRequestException("Synkronisering av ansatte kjører allerede.")
         }
 
-        client.reschedule(task.instance(existingTaskId), startTime)
+        client.reschedule(task.instance(existingTaskId), startTime.plusSeconds(30))
         return UUID.randomUUID()
     }
 }


### PR DESCRIPTION
Legger til 30 sek delay for reschedulering for synkronisering av ansatte så db-scheduler får med seg at tasken er reschedulert.
