### PR TITLE
Egne filter for ulike kontekster

### DIFF
--- a/frontend/mr-admin-flate/src/App.tsx
+++ b/frontend/mr-admin-flate/src/App.tsx
@@ -1,5 +1,6 @@
 import { initializeFaro } from "@grafana/faro-web-sdk";
 import { Alert, BodyShort } from "@navikt/ds-react";
+import { useAtom } from "jotai";
 import { NavAnsattRolle, UtkastRequest as Utkast } from "mulighetsrommet-api-client";
 import { Route, Routes } from "react-router-dom";
 import { Forside } from "./Forside";
@@ -30,6 +31,7 @@ import { DetaljerTiltakstypePage } from "./pages/tiltakstyper/DetaljerTiltakstyp
 import { TiltakstypeInfo } from "./pages/tiltakstyper/TiltakstypeInfo";
 import { TiltakstyperPage } from "./pages/tiltakstyper/TiltakstyperPage";
 import { AvtalerForTiltakstype } from "./pages/tiltakstyper/avtaler/AvtalerForTiltakstype";
+import { avtaleFilterForTiltakstype, tiltaksgjennomforingfilterForAvtale } from "./api/atoms";
 
 if (import.meta.env.PROD) {
   initializeFaro({
@@ -42,6 +44,10 @@ if (import.meta.env.PROD) {
 
 export function App() {
   const { data: ansatt, isLoading: ansattIsLoading, error } = useHentAnsatt();
+  const [filter, setFilter] = useAtom(tiltaksgjennomforingfilterForAvtale);
+  const [filterForAvtaleTiltakstype, setFilterForAvtaleTiltakstype] = useAtom(
+    avtaleFilterForTiltakstype,
+  );
 
   if (error) {
     return (
@@ -87,7 +93,10 @@ export function App() {
           index
           element={
             <>
-              <Avtalefilter />
+              <Avtalefilter
+                filter={filterForAvtaleTiltakstype}
+                setFilter={setFilterForAvtaleTiltakstype}
+              />
               <AvtaleTabell />
             </>
           }
@@ -111,6 +120,8 @@ export function App() {
             element={
               <>
                 <Tiltaksgjennomforingfilter
+                  filter={filter}
+                  setFilter={setFilter}
                   skjulFilter={{
                     tiltakstype: true,
                   }}

--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -25,8 +25,8 @@ if (version !== "0.1.0") {
 function atomWithStorage<Value>(key: string, initialValue: Value, storage = localStorage) {
   const baseAtom = atom(storage.getItem(key) ?? JSON.stringify(initialValue));
   return atom(
-    (get) => JSON.parse(get(baseAtom)),
-    (get, set, nextValue: Value) => {
+    (get) => JSON.parse(get(baseAtom)) as Value,
+    (_, set, nextValue: Value) => {
       const str = JSON.stringify(nextValue);
       set(baseAtom, str);
       storage.setItem(key, str);
@@ -113,6 +113,12 @@ export const tiltaksgjennomforingfilter = atomWithHashAndStorage<Tiltaksgjennomf
   defaultTiltaksgjennomforingfilter,
 );
 
+export const tiltaksgjennomforingfilterForAvtale =
+  atomWithHashAndStorage<Tiltaksgjennomforingfilter>(
+    "tiltaksgjennomforingFilterForAvtale",
+    defaultTiltaksgjennomforingfilter,
+  );
+
 export const tiltaksgjennomforingTilAvtaleFilter = atom<Pick<Tiltaksgjennomforingfilter, "search">>(
   { search: "" },
 );
@@ -141,6 +147,11 @@ export const defaultAvtaleFilter: AvtaleFilterProps = {
 
 export const avtaleFilter = atomWithHashAndStorage<AvtaleFilterProps>(
   "avtalefilter",
+  defaultAvtaleFilter,
+);
+
+export const avtaleFilterForTiltakstype = atomWithHashAndStorage<AvtaleFilterProps>(
+  "avtalefilterForTiltakstype",
   defaultAvtaleFilter,
 );
 

--- a/frontend/mr-admin-flate/src/components/filter/Avtalefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/Avtalefilter.tsx
@@ -1,15 +1,16 @@
 import { faro } from "@grafana/faro-web-sdk";
 import { Button, Search } from "@navikt/ds-react";
 import { useAtom } from "jotai";
-import { NavEnhetType, Tiltakstypestatus, VirksomhetTil } from "mulighetsrommet-api-client";
+import {
+  Avtalestatus,
+  NavEnhetType,
+  Tiltakstypestatus,
+  VirksomhetTil,
+} from "mulighetsrommet-api-client";
+import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
 import { useEffect, useRef } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import {
-  avtaleFilter,
-  AvtaleFilterProps,
-  avtalePaginationAtom,
-  defaultAvtaleFilter,
-} from "../../api/atoms";
+import { AvtaleFilterProps, avtalePaginationAtom, defaultAvtaleFilter } from "../../api/atoms";
 import { useAvtaler } from "../../api/avtaler/useAvtaler";
 import { useNavEnheter } from "../../api/enhet/useNavEnheter";
 import { useTiltakstyper } from "../../api/tiltakstyper/useTiltakstyper";
@@ -18,16 +19,17 @@ import { resetPaginering, valueOrDefault } from "../../utils/Utils";
 import { Lenkeknapp } from "../lenkeknapp/Lenkeknapp";
 import styles from "./Filter.module.scss";
 import { FilterTag } from "./FilterTag";
-import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
 
 type Filters = "tiltakstype";
 
 interface Props {
   skjulFilter?: Record<Filters, boolean>;
+  filter: AvtaleFilterProps;
+  setFilter: (value: AvtaleFilterProps) => void;
 }
 
 export function Avtalefilter(props: Props) {
-  const [filter, setFilter] = useAtom(avtaleFilter);
+  const { filter, setFilter } = props;
   const form = useForm<AvtaleFilterProps>({
     defaultValues: {
       ...filter,
@@ -129,7 +131,10 @@ export function Avtalefilter(props: Props) {
               onChange={(e) => {
                 setFilter({
                   ...filter,
-                  status: valueOrDefault(e.target.value, defaultAvtaleFilter.status),
+                  status: valueOrDefault(
+                    e.target.value as Avtalestatus,
+                    defaultAvtaleFilter.status,
+                  ),
                 });
               }}
               options={[

--- a/frontend/mr-admin-flate/src/components/filter/Tiltaksgjennomforingfilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/Tiltaksgjennomforingfilter.tsx
@@ -1,3 +1,4 @@
+import { faro } from "@grafana/faro-web-sdk";
 import { Button, Search } from "@navikt/ds-react";
 import classNames from "classnames";
 import { useAtom } from "jotai";
@@ -10,26 +11,24 @@ import {
   Toggles,
   VirksomhetTil,
 } from "mulighetsrommet-api-client";
+import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
 import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import {
+  Tiltaksgjennomforingfilter as TiltaksgjennomforingAtomFilter,
   defaultTiltaksgjennomforingfilter,
   paginationAtom,
-  Tiltaksgjennomforingfilter as TiltaksgjennomforingAtomFilter,
-  tiltaksgjennomforingfilter,
 } from "../../api/atoms";
+import { useAvtale } from "../../api/avtaler/useAvtale";
 import { useNavEnheter } from "../../api/enhet/useNavEnheter";
 import { useFeatureToggle } from "../../api/features/feature-toggles";
 import { useTiltakstyper } from "../../api/tiltakstyper/useTiltakstyper";
 import { useVirksomheter } from "../../api/virksomhet/useVirksomheter";
 import { inneholderUrl, resetPaginering, valueOrDefault } from "../../utils/Utils";
+import { Lenkeknapp } from "../lenkeknapp/Lenkeknapp";
 import { LeggTilGjennomforingModal } from "../modal/LeggTilGjennomforingModal";
 import styles from "./Filter.module.scss";
 import { FilterTag } from "./FilterTag";
-import { Lenkeknapp } from "../lenkeknapp/Lenkeknapp";
-import { faro } from "@grafana/faro-web-sdk";
-import { useAvtale } from "../../api/avtaler/useAvtale";
-import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
 
 type Filters = "tiltakstype";
 
@@ -58,11 +57,12 @@ const statusOptions: { label: string; value: TiltaksgjennomforingStatus | "" }[]
 
 interface Props {
   skjulFilter?: Record<Filters, boolean>;
+  filter: TiltaksgjennomforingAtomFilter;
+  setFilter: (value: TiltaksgjennomforingAtomFilter) => void;
 }
 
-export function Tiltaksgjennomforingfilter({ skjulFilter }: Props) {
+export function Tiltaksgjennomforingfilter({ skjulFilter, filter, setFilter }: Props) {
   const { data: avtale } = useAvtale();
-  const [filter, setFilter] = useAtom(tiltaksgjennomforingfilter);
   const [, setPage] = useAtom(paginationAtom);
   const { data: enheter } = useNavEnheter();
   const { data: virksomheter } = useVirksomheter(VirksomhetTil.TILTAKSGJENNOMFORING);

--- a/frontend/mr-admin-flate/src/components/filter/Tiltakstypefilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/Tiltakstypefilter.tsx
@@ -11,6 +11,7 @@ import { resetPaginering, valueOrDefault } from "../../utils/Utils";
 import styles from "./Filter.module.scss";
 import { FilterTag } from "./FilterTag";
 import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
+import { Tiltakstypekategori, Tiltakstypestatus } from "mulighetsrommet-api-client";
 
 export function Tiltakstypefilter() {
   const [filter, setFilter] = useAtom(tiltakstypeFilter);
@@ -92,7 +93,10 @@ export function Tiltakstypefilter() {
                 resetPaginering(setPage);
                 setFilter({
                   ...filter,
-                  status: valueOrDefault(e.target.value, defaultTiltakstypeFilter.status),
+                  status: valueOrDefault(
+                    e.target.value as Tiltakstypestatus,
+                    defaultTiltakstypeFilter.status,
+                  ),
                 });
               }}
               options={statusOptions()}
@@ -107,7 +111,10 @@ export function Tiltakstypefilter() {
                 resetPaginering(setPage);
                 setFilter({
                   ...filter,
-                  kategori: valueOrDefault(e.target.value, defaultTiltakstypeFilter.kategori),
+                  kategori: valueOrDefault(
+                    e.target.value as Tiltakstypekategori,
+                    defaultTiltakstypeFilter.kategori,
+                  ),
                 });
               }}
               options={kategoriOptions()}

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
@@ -6,15 +6,18 @@ import { ErrorBoundary } from "react-error-boundary";
 import { ErrorFallback } from "../../main";
 import { HeaderBanner } from "../../layouts/HeaderBanner";
 import { useTitle } from "mulighetsrommet-frontend-common";
+import { useAtom } from "jotai";
+import { tiltaksgjennomforingfilter } from "../../api/atoms";
 
 export function TiltaksgjennomforingerPage() {
   useTitle("Tiltaksgjennomføringer");
+  const [filter, setFilter] = useAtom(tiltaksgjennomforingfilter);
   return (
     <>
       <HeaderBanner heading="Oversikt over tiltaksgjennomføringer" />
       <MainContainer>
         <ContainerLayout>
-          <Tiltaksgjennomforingfilter />
+          <Tiltaksgjennomforingfilter filter={filter} setFilter={setFilter} />
           <ErrorBoundary FallbackComponent={ErrorFallback}>
             <TiltaksgjennomforingsTabell />
           </ErrorBoundary>

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/avtaler/AvtalerForTiltakstype.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/avtaler/AvtalerForTiltakstype.tsx
@@ -31,6 +31,8 @@ export function AvtalerForTiltakstype() {
   return (
     <ContainerLayout>
       <Avtalefilter
+        filter={filter}
+        setFilter={setFilter}
         skjulFilter={{
           tiltakstype: true,
         }}


### PR DESCRIPTION
Lager to nye filtre i atoms.ts, et for filtrering på avtaler under en tiltakstype, og et for tiltaksgjennomføringer under en avtale.
Nå vil vi i hvert fall redusere forvirring når man navigerer seg rundt.

Utfordringen med at filter for tiltaksgjennomføringens avtaler fortsatt følger brukeren uavhengig av hvilken avtale de navigerer til står fortsatt.
