### PR TITLE
Ikke vis tiltakstyper for gruppetiltak ved opprettelse av gjennomføri…

### DIFF
--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -1,16 +1,15 @@
 import { GrDocumentPerformance } from "react-icons/gr";
 import { Rule, defineArrayMember, defineField, defineType } from "sanity";
 import { Information } from "../components/Information";
+import { VelgAlleEnheterForKontaktpersoner } from "../components/VelgAlleEnheterForKontaktpersoner";
 import { API_VERSION } from "../sanity.config";
 import {
   IKKE_I_ADMINFLATE_TILTAK_PROD,
-  TILTAK_I_EGEN_REGI_PROD,
   hasDuplicates,
   isEgenRegiTiltak,
   isInAdminFlate,
 } from "../utils/utils";
 import { EnhetType } from "./enhet";
-import { VelgAlleEnheterForKontaktpersoner } from "../components/VelgAlleEnheterForKontaktpersoner";
 
 export const tiltaksgjennomforing = defineType({
   name: "tiltaksgjennomforing",
@@ -58,7 +57,7 @@ export const tiltaksgjennomforing = defineType({
       to: [{ type: "tiltakstype" }],
       options: {
         filter: "_id in $ider",
-        filterParams: { ider: IKKE_I_ADMINFLATE_TILTAK_PROD.concat(TILTAK_I_EGEN_REGI_PROD) },
+        filterParams: { ider: IKKE_I_ADMINFLATE_TILTAK_PROD },
       },
       validation: (rule) =>
         rule.custom((currentValue) => {

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -2,7 +2,13 @@ import { GrDocumentPerformance } from "react-icons/gr";
 import { Rule, defineArrayMember, defineField, defineType } from "sanity";
 import { Information } from "../components/Information";
 import { API_VERSION } from "../sanity.config";
-import { hasDuplicates, isEgenRegiTiltak, isInAdminFlate } from "../utils/utils";
+import {
+  IKKE_I_ADMINFLATE_TILTAK_PROD,
+  TILTAK_I_EGEN_REGI_PROD,
+  hasDuplicates,
+  isEgenRegiTiltak,
+  isInAdminFlate,
+} from "../utils/utils";
 import { EnhetType } from "./enhet";
 import { VelgAlleEnheterForKontaktpersoner } from "../components/VelgAlleEnheterForKontaktpersoner";
 
@@ -50,6 +56,10 @@ export const tiltaksgjennomforing = defineType({
       title: "Tiltakstype",
       type: "reference",
       to: [{ type: "tiltakstype" }],
+      options: {
+        filter: "_id in $ider",
+        filterParams: { ider: IKKE_I_ADMINFLATE_TILTAK_PROD.concat(TILTAK_I_EGEN_REGI_PROD) },
+      },
       validation: (rule) =>
         rule.custom((currentValue) => {
           if (currentValue && isInAdminFlate(currentValue._ref)) {

--- a/frontend/mulighetsrommet-cms/utils/utils.tsx
+++ b/frontend/mulighetsrommet-cms/utils/utils.tsx
@@ -1,4 +1,4 @@
-const IKKE_I_ADMINFLATE_TILTAK_PROD = [
+export const IKKE_I_ADMINFLATE_TILTAK_PROD = [
   "18ff4bef-f62e-444a-920f-e30bde5c3950", // "Tilskudd til sommerjobb",
   "2ba9c085-3780-420a-a5d5-820788c74d29", //  Inkluderingstilskudd,
   "4457d760-81a4-4c16-8ab3-64c72d424db2", // Opplæring - Høyere utdanning",
@@ -24,7 +24,7 @@ const IKKE_I_ADMINFLATE_TILTAK_DEV = [
   "8d8abebd-3617-494a-a687-d44810e0a7ee", // "Varig tilrettelagt arbeids i ordinær virksomhet",
 ];
 
-const TILTAK_I_EGEN_REGI_PROD = [
+export const TILTAK_I_EGEN_REGI_PROD = [
   "f3faa5f2-ee9b-42da-9368-4749668144c0", // IPS UNG
   "9fbf9feb-aa4c-4e3c-bc0e-edee0ab957ad", // Arbeid med støtte
   "d322b7e7-0c68-44d6-a325-b12d71af63c6", // IPS


### PR DESCRIPTION
…ng i Sanity

Skjuler gruppetiltak fra dropdown i Sanity ved valg av tiltakstype når man oppretter individuelle tiltak i Sanity.
Tar også med visning av tiltak i egen regi siden de må de søkes opp i Sanity og så fylle ut tekstlig innhold.