### PR TITLE
Fjerner tekst som ble feil

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -177,7 +177,6 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
               readOnly
               size="small"
               label="Tilgjengelighetsstatus"
-              description="Statusen vises til veileder i Modia"
               value={tilgjengelighetsstatusTilTekst(tiltaksgjennomforing?.tilgjengelighet)}
             />
           </FormGroup>


### PR DESCRIPTION
Denne teksten er fake news så vi tar den bort for å ikke skape forvirring til redaktørene i admin-flate.
