### PR TITLE
Fix wrong zIndex in SokeSelect clearIndicator

### DIFF
--- a/frontend/frontend-common/components/SokeSelect.tsx
+++ b/frontend/frontend-common/components/SokeSelect.tsx
@@ -145,7 +145,6 @@ const customStyles = (readOnly: boolean, isError: boolean) => ({
   }),
   clearIndicator: (provided: any) => ({
     ...provided,
-    zIndex: "100",
   }),
   indicatorSeparator: () => ({
     display: "none",


### PR DESCRIPTION
Reverter en tidligere zIndex fiks. Lurer på om det ble fiksa i biblioteket når vi har oppgradert.

Before
<img width="676" alt="Screenshot 2023-11-23 at 08 52 29" src="https://github.com/navikt/mulighetsrommet/assets/3830767/ffee22ef-9c71-4459-9ffd-9894056c5a2c">

After
<img width="650" alt="Screenshot 2023-11-23 at 08 52 38" src="https://github.com/navikt/mulighetsrommet/assets/3830767/fa47e8a4-bbbe-4bdf-8806-84cc31e32948">

