### PR TITLE
fix forsokPaNyttLink

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/feilmelding/Feilmelding.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/feilmelding/Feilmelding.tsx
@@ -18,7 +18,7 @@ interface FeilmeldingProps {
 }
 
 export const forsokPaNyttLink = () => {
-  return <a href=".">forsøk på nytt</a>;
+  return <a href="/">forsøk på nytt</a>;
 };
 
 export const Feilmelding = ({


### PR DESCRIPTION
Ble samme feil lokalt, og dette fikset det. Da kommer man til oversikten igjen