### PR TITLE
WIP Feature/json audit table

### DIFF
--- a/frontend/mr-admin-flate/src/api/QueryKeys.ts
+++ b/frontend/mr-admin-flate/src/api/QueryKeys.ts
@@ -15,13 +15,16 @@ export const QueryKeys = {
     tiltaksgjennomforingfilter?: TiltaksgjennomforingfilterProps,
   ) => ["tiltaksgjennomforinger", page, { ...tiltaksgjennomforingfilter }] as const,
   tiltaksgjennomforing: (id?: string) => ["tiltaksgjennomforing", id] as const,
+  tiltaksgjennomforingHistorikk: (id?: string) =>
+    ["tiltaksgjennomforing", id, "historikk"] as const,
   tiltaksgjennomforingerByEnhet: (enhet: string = "enhet", page?: number) =>
     [enhet, page, "tiltaksgjennomforinger"] as const,
   veilederflateTiltaksgjennomforing: (id: string) => [id, "tiltaksgjennomforing"] as const,
   ansatt: () => ["ansatt"] as const,
-  avtaler: (avtaleFilter: AvtaleFilterProps, page: number) =>
-    ["avtaler", page, { ...avtaleFilter }] as const,
-  avtale: (avtaleId: string) => ["avtale", avtaleId],
+  avtaler: (mine?: boolean, page?: number, avtaleFilter?: AvtaleFilterProps) =>
+    ["avtaler", mine, page, { ...avtaleFilter }] as const,
+  avtale: (id: string) => ["avtale", id],
+  avtaleHistorikk: (id?: string) => ["avtale", id, "historikk"] as const,
   enheter: () => ["enheter"],
   virksomheter: (til?: VirksomhetTil) => ["virksomheter", til],
   antallUlesteNotifikasjoner: () => ["antallUlesteNotifikasjoner"],

--- a/frontend/mr-admin-flate/src/api/avtaler/useAvbrytAvtale.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useAvbrytAvtale.ts
@@ -1,17 +1,25 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { mulighetsrommetClient } from "../clients";
 import { ApiError } from "mulighetsrommet-api-client";
+import { QueryKeys } from "../QueryKeys";
 
 export function useAvbrytAvtale() {
   const client = useQueryClient();
+
   return useMutation<unknown, ApiError, string>({
     mutationFn: (id: string) => {
       return mulighetsrommetClient.avtaler.avbrytAvtale({ id });
     },
-    onSuccess: () => {
-      client.invalidateQueries({
-        queryKey: ["avtale"],
-      });
+    onSuccess: (_, id) => {
+      return Promise.all([
+        client.invalidateQueries({
+          queryKey: QueryKeys.avtale(id),
+        }),
+
+        client.invalidateQueries({
+          queryKey: QueryKeys.avtaler(),
+        }),
+      ]);
     },
   });
 }

--- a/frontend/mr-admin-flate/src/api/avtaler/useAvtaleEndringshistorikk.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useAvtaleEndringshistorikk.ts
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { QueryKeys } from "../QueryKeys";
+import { mulighetsrommetClient } from "../clients";
+
+export function useAvtaleEndringshistorikk(id: string) {
+  return useSuspenseQuery({
+    queryKey: QueryKeys.avtaleHistorikk(id),
+    queryFn() {
+      return mulighetsrommetClient.avtaler.getAvtaleEndringshistorikk({
+        id,
+      });
+    },
+  });
+}

--- a/frontend/mr-admin-flate/src/api/avtaler/useAvtaler.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useAvtaler.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { WritableAtom, useAtom } from "jotai";
+import { useAtom, WritableAtom } from "jotai";
 import { useDebounce } from "mulighetsrommet-frontend-common";
 import { QueryKeys } from "../QueryKeys";
 import { AvtaleFilterProps, avtalePaginationAtomAtom } from "../atoms";
@@ -24,7 +24,7 @@ export function useAvtaler(
   };
 
   return useQuery({
-    queryKey: QueryKeys.avtaler({ ...filter, sok: debouncedSok }, page),
+    queryKey: QueryKeys.avtaler(filter.visMineAvtaler, page, { ...filter, sok: debouncedSok }),
 
     queryFn: () => {
       return filter.visMineAvtaler

--- a/frontend/mr-admin-flate/src/api/avtaler/useUpsertAvtale.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useUpsertAvtale.ts
@@ -1,10 +1,25 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ApiError, Avtale, AvtaleRequest } from "mulighetsrommet-api-client";
 import { mulighetsrommetClient } from "../clients";
+import { QueryKeys } from "../QueryKeys";
 
 export function useUpsertAvtale() {
+  const queryClient = useQueryClient();
+
   return useMutation<Avtale, ApiError, AvtaleRequest>({
     mutationFn: (requestBody: AvtaleRequest) =>
       mulighetsrommetClient.avtaler.upsertAvtale({ requestBody }),
+
+    onSuccess(_, request) {
+      return Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: QueryKeys.avtale(request.id),
+        }),
+
+        queryClient.invalidateQueries({
+          queryKey: QueryKeys.avtaler(),
+        }),
+      ]);
+    },
   });
 }

--- a/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useTiltaksgjennomforingEndringshistorikk.ts
+++ b/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useTiltaksgjennomforingEndringshistorikk.ts
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { QueryKeys } from "../QueryKeys";
+import { mulighetsrommetClient } from "../clients";
+
+export function useTiltaksgjennomforingEndringshistorikk(id: string) {
+  return useSuspenseQuery({
+    queryKey: QueryKeys.tiltaksgjennomforingHistorikk(id),
+    queryFn() {
+      return mulighetsrommetClient.tiltaksgjennomforinger.getTiltaksgjennomforingEndringshistorikk({
+        id,
+      });
+    },
+  });
+}

--- a/frontend/mr-admin-flate/src/components/endringshistorikk/EndringshistorikkPopover.tsx
+++ b/frontend/mr-admin-flate/src/components/endringshistorikk/EndringshistorikkPopover.tsx
@@ -1,0 +1,43 @@
+import React, { ReactElement, useRef, useState } from "react";
+import { ClockDashedIcon } from "@navikt/aksel-icons";
+import { Button, Loader, Popover } from "@navikt/ds-react";
+import { ErrorBoundary } from "react-error-boundary";
+import { ErrorFallback } from "../../main";
+
+export interface EndringshistorikkPopoverProps {
+  children: ReactElement;
+}
+
+export function EndringshistorikkPopover({ children }: EndringshistorikkPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <Button
+        ref={buttonRef}
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        variant="tertiary-neutral"
+        type="button"
+        size="small"
+        title="Trykk for å se endringshistorikk"
+      >
+        <ClockDashedIcon height={25} width={25} title="Endringshistorikk" />
+      </Button>
+
+      <Popover
+        open={open}
+        onClose={() => setOpen(false)}
+        anchorEl={buttonRef.current}
+        placement="bottom-end"
+      >
+        <Popover.Content>
+          <React.Suspense fallback={<Loader title="Laster endringshistorikk" />}>
+            <ErrorBoundary FallbackComponent={ErrorFallback}>{children}</ErrorBoundary>
+          </React.Suspense>
+        </Popover.Content>
+      </Popover>
+    </>
+  );
+}

--- a/frontend/mr-admin-flate/src/components/endringshistorikk/ViewEndringshistorikk.module.scss
+++ b/frontend/mr-admin-flate/src/components/endringshistorikk/ViewEndringshistorikk.module.scss
@@ -1,0 +1,5 @@
+.endringshistorikkList {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}

--- a/frontend/mr-admin-flate/src/components/endringshistorikk/ViewEndringshistorikk.tsx
+++ b/frontend/mr-admin-flate/src/components/endringshistorikk/ViewEndringshistorikk.tsx
@@ -1,0 +1,41 @@
+import type {
+  Endringshistorikk,
+  EndringshistorikkNavAnsatt,
+  EndringshistorikkUser,
+} from "mulighetsrommet-api-client";
+import { formaterDatoTid } from "../../utils/Utils";
+import styles from "./ViewEndringshistorikk.module.scss";
+
+export interface ViewEndringshistorikkProps {
+  historikk: Endringshistorikk;
+
+  operationToDescription(operation: string): string;
+}
+
+export function ViewEndringshistorikk(props: ViewEndringshistorikkProps) {
+  const { historikk, operationToDescription } = props;
+
+  if (historikk.entries.length === 0) {
+    return <div>Endringshistorikken er tom</div>;
+  }
+
+  return (
+    <ul className={styles.endringshistorikkList}>
+      {historikk.entries.map(({ operation, editedAt, editedBy }) => {
+        const user = isNavAnsatt(editedBy)
+          ? `${editedBy.navn} (${editedBy.navIdent})`
+          : editedBy.navn;
+
+        return (
+          <li key={editedAt}>
+            {formaterDatoTid(editedAt)} - <b>{operationToDescription(operation)}</b> - {user}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function isNavAnsatt(user: EndringshistorikkUser): user is EndringshistorikkNavAnsatt {
+  return "navIdent" in user;
+}

--- a/frontend/mr-admin-flate/src/components/endringshistorikk/ViewEndringshistorikk.tsx
+++ b/frontend/mr-admin-flate/src/components/endringshistorikk/ViewEndringshistorikk.tsx
@@ -8,12 +8,10 @@ import styles from "./ViewEndringshistorikk.module.scss";
 
 export interface ViewEndringshistorikkProps {
   historikk: Endringshistorikk;
-
-  operationToDescription(operation: string): string;
 }
 
 export function ViewEndringshistorikk(props: ViewEndringshistorikkProps) {
-  const { historikk, operationToDescription } = props;
+  const { historikk } = props;
 
   if (historikk.entries.length === 0) {
     return <div>Endringshistorikken er tom</div>;
@@ -28,7 +26,7 @@ export function ViewEndringshistorikk(props: ViewEndringshistorikkProps) {
 
         return (
           <li key={editedAt}>
-            {formaterDatoTid(editedAt)} - <b>{operationToDescription(operation)}</b> - {user}
+            {formaterDatoTid(editedAt)} - <b>{operation}</b> - {user}
           </li>
         );
       })}

--- a/frontend/mr-admin-flate/src/components/skjema/ValideringsfeilOppsummering.tsx
+++ b/frontend/mr-admin-flate/src/components/skjema/ValideringsfeilOppsummering.tsx
@@ -1,6 +1,5 @@
 import { ExclamationmarkTriangleFillIcon } from "@navikt/aksel-icons";
 import { Button, ErrorSummary, Popover } from "@navikt/ds-react";
-import PopoverContent from "@navikt/ds-react/esm/popover/PopoverContent";
 import { useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import styles from "./ValideringsfeilOppsummering.module.scss";
@@ -51,7 +50,7 @@ export function ValideringsfeilOppsummering() {
         onClose={() => setVisValideringsfeil(false)}
         anchorEl={visValideringsFeilTrekantRef.current}
       >
-        <PopoverContent>
+        <Popover.Content>
           <ErrorSummary
             className={styles.valideringsfeil}
             heading="Det er valideringsfeil i skjema"
@@ -64,7 +63,7 @@ export function ValideringsfeilOppsummering() {
               );
             })}
           </ErrorSummary>
-        </PopoverContent>
+        </Popover.Content>
       </Popover>
     </>
   );

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleKnapperad.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleKnapperad.tsx
@@ -26,18 +26,5 @@ export function AvtaleKnapperad({ avtale }: Props) {
 function AvtaleEndringshistorikk({ id }: { id: string }) {
   const historikk = useAvtaleEndringshistorikk(id);
 
-  function operationToDescription(operation: string): string {
-    const descriptions: { [operation: string]: string } = {
-      OPPDATERT: "Redigerte avtale",
-      AVBRUTT: "Avbrutt",
-    };
-    return descriptions[operation] ?? operation;
-  }
-
-  return (
-    <ViewEndringshistorikk
-      historikk={historikk.data}
-      operationToDescription={operationToDescription}
-    />
-  );
+  return <ViewEndringshistorikk historikk={historikk.data} />;
 }

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleKnapperad.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleKnapperad.tsx
@@ -1,6 +1,9 @@
 import { Avtale } from "mulighetsrommet-api-client";
 import { Lenkeknapp } from "../../components/lenkeknapp/Lenkeknapp";
 import styles from "../DetaljerInfo.module.scss";
+import { useAvtaleEndringshistorikk } from "../../api/avtaler/useAvtaleEndringshistorikk";
+import { ViewEndringshistorikk } from "../../components/endringshistorikk/ViewEndringshistorikk";
+import { EndringshistorikkPopover } from "../../components/endringshistorikk/EndringshistorikkPopover";
 
 interface Props {
   avtale: Avtale;
@@ -9,9 +12,32 @@ interface Props {
 export function AvtaleKnapperad({ avtale }: Props) {
   return (
     <div className={styles.knapperad}>
+      <EndringshistorikkPopover>
+        <AvtaleEndringshistorikk id={avtale.id} />
+      </EndringshistorikkPopover>
+
       <Lenkeknapp size="small" to={`/avtaler/${avtale.id}/skjema`} variant="primary">
         Rediger avtale
       </Lenkeknapp>
     </div>
+  );
+}
+
+function AvtaleEndringshistorikk({ id }: { id: string }) {
+  const historikk = useAvtaleEndringshistorikk(id);
+
+  function operationToDescription(operation: string): string {
+    const descriptions: { [operation: string]: string } = {
+      OPPDATERT: "Redigerte avtale",
+      AVBRUTT: "Avbrutt",
+    };
+    return descriptions[operation] ?? operation;
+  }
+
+  return (
+    <ViewEndringshistorikk
+      historikk={historikk.data}
+      operationToDescription={operationToDescription}
+    />
   );
 }

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingKnapperad.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingKnapperad.tsx
@@ -4,6 +4,9 @@ import { useMutateTilgjengeligForVeileder } from "../../api/tiltaksgjennomforing
 import { Lenkeknapp } from "../../components/lenkeknapp/Lenkeknapp";
 import styles from "../DetaljerInfo.module.scss";
 import { Tiltaksgjennomforing } from "mulighetsrommet-api-client";
+import { useTiltaksgjennomforingEndringshistorikk } from "../../api/tiltaksgjennomforing/useTiltaksgjennomforingEndringshistorikk";
+import { EndringshistorikkPopover } from "../../components/endringshistorikk/EndringshistorikkPopover";
+import { ViewEndringshistorikk } from "../../components/endringshistorikk/ViewEndringshistorikk";
 
 interface Props {
   style?: React.CSSProperties;
@@ -23,9 +26,35 @@ export function TiltaksgjennomforingKnapperad({ style, tiltaksgjennomforing }: P
         Tilgjengelig for veileder
       </Switch>
 
+      <EndringshistorikkPopover>
+        <TiltaksgjennomforingEndringshistorikk id={tiltaksgjennomforing.id} />
+      </EndringshistorikkPopover>
+
       <Lenkeknapp size="small" to={`skjema`} variant="primary">
         Rediger
       </Lenkeknapp>
     </div>
+  );
+}
+
+function TiltaksgjennomforingEndringshistorikk({ id }: { id: string }) {
+  const historikk = useTiltaksgjennomforingEndringshistorikk(id);
+
+  function operationToDescription(operation: string): string {
+    const descriptions: { [operation: string]: string } = {
+      OPPDATERT: "Redigerte tiltaksgjennomføring",
+      TILGJENGELIG_FOR_VEILEDER: "Tilgjengelig for veileder",
+      IKKE_TILGJENGELIG_FOR_VEILEDER: "Ikke tilgjengelig for veileder",
+      AVTALE_ENDRET: "Avtale endret",
+      AVBRUTT: "Avbrutt",
+    };
+    return descriptions[operation] ?? operation;
+  }
+
+  return (
+    <ViewEndringshistorikk
+      historikk={historikk.data}
+      operationToDescription={operationToDescription}
+    />
   );
 }

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingKnapperad.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingKnapperad.tsx
@@ -40,21 +40,5 @@ export function TiltaksgjennomforingKnapperad({ style, tiltaksgjennomforing }: P
 function TiltaksgjennomforingEndringshistorikk({ id }: { id: string }) {
   const historikk = useTiltaksgjennomforingEndringshistorikk(id);
 
-  function operationToDescription(operation: string): string {
-    const descriptions: { [operation: string]: string } = {
-      OPPDATERT: "Redigerte tiltaksgjennomføring",
-      TILGJENGELIG_FOR_VEILEDER: "Tilgjengelig for veileder",
-      IKKE_TILGJENGELIG_FOR_VEILEDER: "Ikke tilgjengelig for veileder",
-      AVTALE_ENDRET: "Avtale endret",
-      AVBRUTT: "Avbrutt",
-    };
-    return descriptions[operation] ?? operation;
-  }
-
-  return (
-    <ViewEndringshistorikk
-      historikk={historikk.data}
-      operationToDescription={operationToDescription}
-    />
-  );
+  return <ViewEndringshistorikk historikk={historikk.data} />;
 }

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -43,7 +43,7 @@ export function formaterDatoTid(dato: string | Date, fallback = ""): string {
     return fallback;
   }
 
-  return result.replace(",", " -");
+  return result.replace(",", " ");
 }
 
 export function formaterDatoSomYYYYMMDD(dato?: Date | null, fallback = ""): string {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/EndringshistorikkDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/EndringshistorikkDto.kt
@@ -18,6 +18,20 @@ data class EndringshistorikkDto(
         val operation: String,
         @Serializable(with = LocalDateTimeSerializer::class)
         val editedAt: LocalDateTime,
-        val editedBy: String,
+        val editedBy: User,
     )
+
+    @Serializable
+    sealed class User
+
+    @Serializable
+    data class Systembruker(
+        val navn: String,
+    ) : User()
+
+    @Serializable
+    data class NavAnsatt(
+        val navIdent: String,
+        val navn: String?,
+    ) : User()
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/EndringshistorikkDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/EndringshistorikkDto.kt
@@ -1,0 +1,23 @@
+package no.nav.mulighetsrommet.api.domain.dto
+
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.domain.serializers.LocalDateTimeSerializer
+import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
+import java.time.LocalDateTime
+import java.util.*
+
+@Serializable
+data class EndringshistorikkDto(
+    val entries: List<Entry>,
+) {
+
+    @Serializable
+    data class Entry(
+        @Serializable(with = UUIDSerializer::class)
+        val id: UUID,
+        val operation: String,
+        @Serializable(with = LocalDateTimeSerializer::class)
+        val editedAt: LocalDateTime,
+        val editedBy: String,
+    )
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -261,6 +261,7 @@ private fun services(appConfig: AppConfig) = module {
     single<BrregClient> {
         BrregClientImpl(baseUrl = appConfig.brreg.baseUrl)
     }
+    single { EndringshistorikkService(get()) }
     single {
         ArenaAdapterService(
             get(),
@@ -276,9 +277,10 @@ private fun services(appConfig: AppConfig) = module {
             get(),
             get(),
             get(),
+            get(),
         )
     }
-    single { AvtaleService(get(), get(), get(), get(), get(), get(), get()) }
+    single { AvtaleService(get(), get(), get(), get(), get(), get(), get(), get()) }
     single { TiltakshistorikkService(get(), get()) }
     single { VeilederflateService(get(), get(), get(), get()) }
     single { ArrangorService(get()) }
@@ -288,7 +290,7 @@ private fun services(appConfig: AppConfig) = module {
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get()) }
     single { MicrosoftGraphService(get()) }
-    single { TiltaksgjennomforingService(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    single { TiltaksgjennomforingService(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     single { SanityTiltaksgjennomforingService(get(), get(), get()) }
     single { TiltakstypeService(get()) }
     single { NavEnheterSyncService(get(), get(), get(), get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -19,7 +19,6 @@ import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
 import no.nav.mulighetsrommet.domain.dto.Tiltaksgjennomforingsstatus
 import no.nav.mulighetsrommet.domain.dto.Tiltaksgjennomforingsstatus.*
 import org.intellij.lang.annotations.Language
-import org.postgresql.util.PSQLException
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.util.*
@@ -269,64 +268,6 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         """.trimIndent()
 
         queryOf(query, tiltaksgjennomforing.toSqlParameters()).asExecute.let { tx.run(it) }
-    }
-
-    fun updateEnheter(tiltaksnummer: String, navEnheter: List<String>): Int {
-        @Language("PostgreSQL")
-        val findId = """
-            select id from tiltaksgjennomforing
-                where (:aar::text is null and split_part(tiltaksnummer, '#', 2) = :lopenr)
-                or (
-                    :aar::text is not null and split_part(tiltaksnummer, '#', 1) = :aar
-                    and split_part(tiltaksnummer, '#', 2) = :lopenr
-                )
-        """.trimIndent()
-
-        @Language("PostgreSQL")
-        val upsertEnhet = """
-            insert into tiltaksgjennomforing_nav_enhet (tiltaksgjennomforing_id, enhetsnummer)
-                values (:id::uuid, :enhetsnummer)
-                on conflict (tiltaksgjennomforing_id, enhetsnummer) do nothing
-        """.trimIndent()
-
-        @Language("PostgreSQL")
-        val deleteEnheter = """
-            delete from tiltaksgjennomforing_nav_enhet
-            where tiltaksgjennomforing_id = :id::uuid and not (enhetsnummer = any (:enhetsnummere))
-        """.trimIndent()
-
-        val (aar, lopenr) = tiltaksnummer.split("#").let {
-            if (it.size == 2) {
-                (it.first() to it[1])
-            } else {
-                (null to it.first())
-            }
-        }
-
-        return db.transaction { tx ->
-            val ider = queryOf(findId, mapOf("aar" to aar, "lopenr" to lopenr))
-                .map { it.string("id") }
-                .asList
-                .let { db.run(it) }
-            if (ider.size > 1) {
-                throw PSQLException("Fant flere enn én tiltaksgjennomforing_id for tiltaksnummer: $tiltaksnummer", null)
-            }
-            if (ider.isEmpty()) {
-                return@transaction 0
-            }
-            val id = ider[0]
-
-            navEnheter.forEach { enhetsnummer ->
-                tx.run(
-                    queryOf(upsertEnhet, mapOf("id" to id, "enhetsnummer" to enhetsnummer)).asExecute,
-                )
-            }
-            tx.run(
-                queryOf(deleteEnheter, mapOf("id" to id, "enhetsnummere" to db.createTextArray(navEnheter))).asExecute,
-            )
-
-            1
-        }
     }
 
     fun get(id: UUID): TiltaksgjennomforingAdminDto? =
@@ -830,7 +771,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             .let { db.run(it) }
     }
 
-    fun setAvtaleId(gjennomforingId: UUID, avtaleId: UUID?) {
+    fun setAvtaleId(tx: Session, gjennomforingId: UUID, avtaleId: UUID?) {
         @Language("PostgreSQL")
         val query = """
             update tiltaksgjennomforing

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -551,6 +551,10 @@ class TiltaksgjennomforingRepository(private val db: Database) {
     }
 
     fun setTilgjengeligForVeileder(id: UUID, tilgjengeligForVeileder: Boolean): Int {
+        return db.transaction { setTilgjengeligForVeileder(it, id, tilgjengeligForVeileder) }
+    }
+
+    fun setTilgjengeligForVeileder(tx: Session, id: UUID, tilgjengeligForVeileder: Boolean): Int {
         logger.info("Setter tilgjengelig for veileder '$tilgjengeligForVeileder' for gjennomføring med id: $id")
         @Language("PostgreSQL")
         val query = """
@@ -559,11 +563,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
            where id = ?::uuid
         """.trimIndent()
 
-        return queryOf(
-            query,
-            tilgjengeligForVeileder,
-            id,
-        ).asUpdate.let { db.run(it) }
+        return queryOf(query, tilgjengeligForVeileder, id).asUpdate.let { tx.run(it) }
     }
 
     private fun TiltaksgjennomforingDbo.toSqlParameters() = mapOf(
@@ -779,7 +779,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             where id = ?
         """.trimIndent()
 
-        return queryOf(query, avtaleId, gjennomforingId).asUpdate.let { db.run(it) }
+        return queryOf(query, avtaleId, gjennomforingId).asUpdate.let { tx.run(it) }
     }
 
     fun getAllMidlertidigStengteGjennomforingerSomNarmerSegSluttdato(currentDate: LocalDate = LocalDate.now()): List<TiltaksgjennomforingNotificationDto> {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -81,6 +81,12 @@ fun Route.avtaleRoutes() {
                 ?: call.respond(HttpStatusCode.NotFound, "Det finnes ikke noen avtale med id $id")
         }
 
+        get("{id}/historikk") {
+            val id: UUID by call.parameters
+            val historikk = avtaler.getEndringshistorikk(id)
+            call.respond(historikk)
+        }
+
         put("{id}/avbryt") {
             val id = call.parameters.getOrFail<UUID>("id")
             val navIdent = getNavIdent()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -83,7 +83,8 @@ fun Route.avtaleRoutes() {
 
         put("{id}/avbryt") {
             val id = call.parameters.getOrFail<UUID>("id")
-            val response = avtaler.avbrytAvtale(id)
+            val navIdent = getNavIdent()
+            val response = avtaler.avbrytAvtale(id, navIdent)
             call.respondWithStatusResponse(response)
         }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -65,21 +65,24 @@ fun Route.tiltaksgjennomforingRoutes() {
 
         put("{id}/avtale") {
             val id = call.parameters.getOrFail<UUID>("id")
+            val navIdent = getNavIdent()
             val request = call.receive<SetAvtaleForGjennomforingRequest>()
-            val response = service.setAvtale(id, request.avtaleId)
+            val response = service.setAvtale(id, request.avtaleId, navIdent)
             call.respondWithStatusResponse(response)
         }
 
         put("{id}/avbryt") {
             val id = call.parameters.getOrFail<UUID>("id")
-            val response = service.avbrytGjennomforing(id)
+            val navIdent = getNavIdent()
+            val response = service.avbrytGjennomforing(id, navIdent)
             call.respondWithStatusResponse(response)
         }
 
         put("{id}/tilgjengelig-for-veileder") {
             val id = call.parameters.getOrFail<UUID>("id")
+            val navIdent = getNavIdent()
             val request = call.receive<TilgjengeligForVeilederRequest>()
-            service.setTilgjengeligForVeileder(id, request.tilgjengeligForVeileder)
+            service.setTilgjengeligForVeileder(id, request.tilgjengeligForVeileder, navIdent)
             call.respond(HttpStatusCode.OK)
         }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -63,6 +63,12 @@ fun Route.tiltaksgjennomforingRoutes() {
                 ?: call.respond(HttpStatusCode.NotFound, "Ingen tiltaksgjennomføring med id=$id")
         }
 
+        get("{id}/historikk") {
+            val id: UUID by call.parameters
+            val historikk = service.getEndringshistorikk(id)
+            call.respond(historikk)
+        }
+
         put("{id}/avtale") {
             val id = call.parameters.getOrFail<UUID>("id")
             val navIdent = getNavIdent()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterService.kt
@@ -238,7 +238,7 @@ class ArenaAdapterService(
         endringshistorikk.logEndring(
             tx,
             documentClass,
-            "OPPDATERT",
+            "Endret i Arena",
             "Arena",
             id,
         ) { Json.encodeToJsonElement(value) }
@@ -252,7 +252,7 @@ class ArenaAdapterService(
         endringshistorikk.logEndring(
             tx,
             documentClass,
-            "SLETTET",
+            "Slettet i Arena",
             "Arena",
             id,
         ) { JsonNull }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
@@ -53,7 +53,7 @@ class AvtaleService(
                     dispatchNotificationToNewAdministrators(tx, dbo, navIdent)
 
                     val dto = getOrError(dbo.id, tx)
-                    logEndring("OPPDATERT", dto, navIdent, tx)
+                    logEndring("Redigerte avtale", dto, navIdent, tx)
                     dto
                 }
             }
@@ -117,7 +117,7 @@ class AvtaleService(
         db.transaction { tx ->
             avtaler.setAvslutningsstatus(tx, id, Avslutningsstatus.AVBRUTT)
             val dto = getOrError(id, tx)
-            logEndring("AVBRUTT", dto, navIdent, tx)
+            logEndring("Avtale ble avbrutt", dto, navIdent, tx)
         }
 
         return Either.Right(Unit)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
@@ -2,11 +2,14 @@ package no.nav.mulighetsrommet.api.services
 
 import arrow.core.Either
 import arrow.core.toNonEmptyListOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
 import kotliquery.TransactionalSession
 import no.nav.mulighetsrommet.api.avtaler.AvtaleValidator
 import no.nav.mulighetsrommet.api.domain.dbo.AvtaleDbo
 import no.nav.mulighetsrommet.api.domain.dto.AvtaleAdminDto
 import no.nav.mulighetsrommet.api.domain.dto.AvtaleNotificationDto
+import no.nav.mulighetsrommet.api.domain.dto.EndringshistorikkDto
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.UtkastRepository
@@ -31,6 +34,7 @@ class AvtaleService(
     private val notificationRepository: NotificationRepository,
     private val utkastRepository: UtkastRepository,
     private val validator: AvtaleValidator,
+    private val endringshistorikkService: EndringshistorikkService,
     private val db: Database,
 ) {
     fun get(id: UUID): AvtaleAdminDto? {
@@ -48,7 +52,9 @@ class AvtaleService(
 
                     dispatchNotificationToNewAdministrators(tx, dbo, navIdent)
 
-                    avtaler.get(dbo.id, tx)!!
+                    val dto = getOrError(dbo.id, tx)
+                    logEndring("OPPDATERT", dto, navIdent, tx)
+                    dto
                 }
             }
     }
@@ -83,8 +89,8 @@ class AvtaleService(
         return avtaler.getAllAvtalerSomNarmerSegSluttdato()
     }
 
-    fun avbrytAvtale(avtaleId: UUID): StatusResponse<Unit> {
-        val avtale = avtaler.get(avtaleId)
+    fun avbrytAvtale(id: UUID, navIdent: String): StatusResponse<Unit> {
+        val avtale = avtaler.get(id)
             ?: return Either.Left(NotFound("Avtalen finnes ikke"))
 
         if (avtale.opphav == Opphav.ARENA) {
@@ -95,7 +101,7 @@ class AvtaleService(
             return Either.Left(BadRequest(message = "Avtalen er allerede avsluttet og kan derfor ikke avbrytes."))
         }
 
-        val (antallGjennomforinger) = tiltaksgjennomforinger.getAll(avtaleId = avtaleId)
+        val (antallGjennomforinger) = tiltaksgjennomforinger.getAll(avtaleId = id)
         if (antallGjennomforinger > 0) {
             return Either.Left(
                 BadRequest(
@@ -108,7 +114,22 @@ class AvtaleService(
             )
         }
 
-        return Either.Right(avtaler.setAvslutningsstatus(avtaleId, Avslutningsstatus.AVBRUTT))
+        db.transaction { tx ->
+            avtaler.setAvslutningsstatus(tx, id, Avslutningsstatus.AVBRUTT)
+            val dto = getOrError(id, tx)
+            logEndring("AVBRUTT", dto, navIdent, tx)
+        }
+
+        return Either.Right(Unit)
+    }
+
+    fun getEndringshistorikk(id: UUID): EndringshistorikkDto {
+        return endringshistorikkService.getEndringshistorikk(DocumentClass.AVTALE, id)
+    }
+
+    private fun getOrError(id: UUID, tx: TransactionalSession): AvtaleAdminDto {
+        val dto = avtaler.get(id, tx)
+        return requireNotNull(dto) { "Avtale med id=$id finnes ikke" }
     }
 
     private fun dispatchNotificationToNewAdministrators(
@@ -128,5 +149,16 @@ class AvtaleService(
             createdAt = Instant.now(),
         )
         notificationRepository.insert(notification, tx)
+    }
+
+    private fun logEndring(
+        operation: String,
+        dto: AvtaleAdminDto,
+        navIdent: String,
+        tx: TransactionalSession,
+    ) {
+        endringshistorikkService.logEndring(tx, DocumentClass.AVTALE, operation, navIdent, dto.id) {
+            Json.encodeToJsonElement(dto)
+        }
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/EndringshistorikkService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/EndringshistorikkService.kt
@@ -1,0 +1,98 @@
+package no.nav.mulighetsrommet.api.services
+
+import kotlinx.serialization.json.JsonElement
+import kotliquery.TransactionalSession
+import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.domain.dto.EndringshistorikkDto
+import no.nav.mulighetsrommet.database.Database
+import org.intellij.lang.annotations.Language
+import java.time.LocalDateTime
+import java.util.*
+
+class EndringshistorikkService(
+    private val db: Database,
+) {
+
+    fun getEndringshistorikk(documentClass: DocumentClass, id: UUID): EndringshistorikkDto {
+        @Language("PostgreSQL")
+        val statement = """
+            select document_id,
+                   operation,
+                   lower(sys_period) as edited_at,
+                   case
+                       when na.nav_ident is not null then concat(na.fornavn, ' ', na.etternavn)
+                       else user_id
+                       end           as edited_by
+            from ${documentClass.table}
+                     left join nav_ansatt na on user_id = na.nav_ident
+            where document_id = :document_id
+            order by sys_period desc;
+        """.trimIndent()
+
+        val params = mapOf(
+            "document_id" to id,
+        )
+
+        val entries = queryOf(statement, params)
+            .map {
+                EndringshistorikkDto.Entry(
+                    id = it.uuid("document_id"),
+                    operation = it.string("operation"),
+                    editedAt = it.localDateTime("edited_at"),
+                    editedBy = it.string("edited_by"),
+                )
+            }
+            .asList
+            .let { db.run(it) }
+
+        return EndringshistorikkDto(entries = entries)
+    }
+
+
+    fun logEndring(
+        documentClass: DocumentClass,
+        operation: String,
+        userId: String,
+        documentId: UUID,
+        timestamp: LocalDateTime? = null,
+        valueProvider: () -> JsonElement,
+    ) = db.transaction {
+        logEndring(it, documentClass, operation, userId, documentId, timestamp, valueProvider)
+    }
+
+    fun logEndring(
+        tx: TransactionalSession,
+        documentClass: DocumentClass,
+        operation: String,
+        userId: String,
+        documentId: UUID,
+        timestamp: LocalDateTime? = null,
+        valueProvider: () -> JsonElement,
+    ) {
+        val statement = if (timestamp == null) {
+            """
+                select version_history(:table, :operation, :document_id::uuid, :value::jsonb, :user_id)
+            """.trimIndent()
+        } else {
+            """
+                select version_history(:table, :operation, :document_id::uuid, :value::jsonb, :user_id, :timestamp)
+            """.trimIndent()
+        }
+
+        val params = mapOf(
+            "operation" to operation,
+            "table" to documentClass.table,
+            "document_id" to documentId,
+            "value" to valueProvider.invoke().toString(),
+            "user_id" to userId,
+            "timestamp" to timestamp,
+        )
+
+        tx.run(queryOf(statement, params).asExecute)
+    }
+}
+
+enum class DocumentClass(val table: String) {
+    AVTALE("avtale_endringshistorikk"),
+    TILTAKSGJENNOMFORING("tiltaksgjennomforing_endringshistorikk"),
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -56,7 +56,7 @@ class TiltaksgjennomforingService(
                     dispatchNotificationToNewAdministrators(tx, dbo, navIdent)
 
                     val dto = getOrError(dbo.id, tx)
-                    logEndring("OPPDATERT", dto, navIdent, tx)
+                    logEndring("Redigerte gjennomføring", dto, navIdent, tx)
                     tiltaksgjennomforingKafkaProducer.publish(TiltaksgjennomforingDto.from(dto))
                     dto
                 }
@@ -153,9 +153,9 @@ class TiltaksgjennomforingService(
             tiltaksgjennomforinger.setTilgjengeligForVeileder(tx, id, tilgjengeligForVeileder)
             val dto = getOrError(id, tx)
             val operation = if (tilgjengeligForVeileder) {
-                "TILGJENGELIG_FOR_VEILEDER"
+                "Tilgjengelig for veileder"
             } else {
-                "IKKE_TILGJENGELIG_FOR_VEILEDER"
+                "Ikke tilgjengelig for veileder"
             }
             logEndring(operation, dto, navIdent, tx)
         }
@@ -178,7 +178,7 @@ class TiltaksgjennomforingService(
         db.transaction { tx ->
             tiltaksgjennomforinger.setAvtaleId(tx, id, avtaleId)
             val dto = getOrError(id, tx)
-            logEndring("AVTALE_ENDRET", dto, navIdent, tx)
+            logEndring("Endret avtale", dto, navIdent, tx)
         }
 
         return Either.Right(Unit)
@@ -203,7 +203,7 @@ class TiltaksgjennomforingService(
         db.transaction { tx ->
             tiltaksgjennomforinger.setAvslutningsstatus(tx, id, Avslutningsstatus.AVBRUTT)
             val dto = getOrError(id, tx)
-            logEndring("AVBRUTT", dto, navIdent, tx)
+            logEndring("Gjennomføring ble avbrutt", dto, navIdent, tx)
             tiltaksgjennomforingKafkaProducer.publish(TiltaksgjennomforingDto.from(dto))
         }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -3,14 +3,12 @@ package no.nav.mulighetsrommet.api.services
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.toNonEmptyListOrNull
-import io.ktor.server.plugins.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
 import kotliquery.TransactionalSession
 import no.nav.mulighetsrommet.api.clients.vedtak.Innsatsgruppe
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingAdminDto
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDto
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingNotificationDto
-import no.nav.mulighetsrommet.api.domain.dto.VeilederflateTiltaksgjennomforing
+import no.nav.mulighetsrommet.api.domain.dto.*
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
@@ -40,6 +38,7 @@ class TiltaksgjennomforingService(
     private val tiltaksgjennomforingKafkaProducer: TiltaksgjennomforingKafkaProducer,
     private val notificationRepository: NotificationRepository,
     private val validator: TiltaksgjennomforingValidator,
+    private val documentHistoryService: EndringshistorikkService,
     private val db: Database,
 ) {
     suspend fun upsert(
@@ -56,14 +55,17 @@ class TiltaksgjennomforingService(
 
                     dispatchNotificationToNewAdministrators(tx, dbo, navIdent)
 
-                    val dto = tiltaksgjennomforinger.get(dbo.id, tx)!!
+                    val dto = getOrError(dbo.id, tx)
+                    logEndring("OPPDATERT", dto, navIdent, tx)
                     tiltaksgjennomforingKafkaProducer.publish(TiltaksgjennomforingDto.from(dto))
                     dto
                 }
             }
     }
 
-    fun get(id: UUID): TiltaksgjennomforingAdminDto? = tiltaksgjennomforinger.get(id)
+    fun get(id: UUID): TiltaksgjennomforingAdminDto? {
+        return tiltaksgjennomforinger.get(id)
+    }
 
     fun getAllSkalMigreres(
         pagination: PaginationParams,
@@ -146,16 +148,21 @@ class TiltaksgjennomforingService(
         return tiltaksgjennomforinger.getAllMidlertidigStengteGjennomforingerSomNarmerSegSluttdato()
     }
 
-    fun setTilgjengeligForVeileder(id: UUID, tilgjengeligForVeileder: Boolean) {
-        val updatedRows = tiltaksgjennomforinger.setTilgjengeligForVeileder(id, tilgjengeligForVeileder)
-        if (updatedRows != 1) {
-            throw NotFoundException("Gjennomføringen finnes ikke")
+    fun setTilgjengeligForVeileder(id: UUID, tilgjengeligForVeileder: Boolean, navIdent: String) {
+        db.transaction { tx ->
+            tiltaksgjennomforinger.setTilgjengeligForVeileder(tx, id, tilgjengeligForVeileder)
+            val dto = getOrError(id, tx)
+            val operation = if (tilgjengeligForVeileder) {
+                "TILGJENGELIG_FOR_VEILEDER"
+            } else {
+                "IKKE_TILGJENGELIG_FOR_VEILEDER"
+            }
+            logEndring(operation, dto, navIdent, tx)
         }
     }
 
-    fun setAvtale(gjennomforingId: UUID, avtaleId: UUID?): StatusResponse<Unit> {
-        val gjennomforing = tiltaksgjennomforinger.get(gjennomforingId)
-            ?: return NotFound("Tiltaksgjennomføring med id=$gjennomforingId finnes ikke").left()
+    fun setAvtale(id: UUID, avtaleId: UUID?, navIdent: String): StatusResponse<Unit> {
+        val gjennomforing = get(id) ?: return NotFound("Gjennomføringen finnes ikke").left()
 
         if (!isTiltakMedAvtalerFraMulighetsrommet(gjennomforing.tiltakstype.arenaKode)) {
             return BadRequest("Avtale kan bare settes for tiltaksgjennomføringer av type AFT eller VTA").left()
@@ -168,14 +175,17 @@ class TiltaksgjennomforingService(
             }
         }
 
-        tiltaksgjennomforinger.setAvtaleId(gjennomforingId, avtaleId)
+        db.transaction { tx ->
+            tiltaksgjennomforinger.setAvtaleId(tx, id, avtaleId)
+            val dto = getOrError(id, tx)
+            logEndring("AVTALE_ENDRET", dto, navIdent, tx)
+        }
 
         return Either.Right(Unit)
     }
 
-    fun avbrytGjennomforing(gjennomforingId: UUID): StatusResponse<Unit> {
-        val gjennomforing = tiltaksgjennomforinger.get(gjennomforingId)
-            ?: return Either.Left(NotFound("Gjennomføringen finnes ikke"))
+    fun avbrytGjennomforing(id: UUID, navIdent: String): StatusResponse<Unit> {
+        val gjennomforing = get(id) ?: return Either.Left(NotFound("Gjennomføringen finnes ikke"))
 
         if (gjennomforing.opphav == ArenaMigrering.Opphav.ARENA) {
             return Either.Left(BadRequest(message = "Gjennomføringen har opprinnelse fra Arena og kan ikke bli avbrutt i admin-flate."))
@@ -185,18 +195,28 @@ class TiltaksgjennomforingService(
             return Either.Left(BadRequest(message = "Gjennomføringen kan ikke avbrytes fordi den allerede er avsluttet."))
         }
 
-        val antallDeltagere = deltakerRepository.getAll(gjennomforingId).size
+        val antallDeltagere = deltakerRepository.getAll(id).size
         if (antallDeltagere > 0) {
             return Either.Left(BadRequest(message = "Gjennomføringen kan ikke avbrytes fordi den har $antallDeltagere deltager(e) koblet til seg."))
         }
 
         db.transaction { tx ->
-            tiltaksgjennomforinger.setAvslutningsstatus(tx, gjennomforingId, Avslutningsstatus.AVBRUTT)
-            val dto = tiltaksgjennomforinger.get(gjennomforingId, tx)!!
+            tiltaksgjennomforinger.setAvslutningsstatus(tx, id, Avslutningsstatus.AVBRUTT)
+            val dto = getOrError(id, tx)
+            logEndring("AVBRUTT", dto, navIdent, tx)
             tiltaksgjennomforingKafkaProducer.publish(TiltaksgjennomforingDto.from(dto))
         }
 
         return Either.Right(Unit)
+    }
+
+    fun getEndringshistorikk(id: UUID): EndringshistorikkDto {
+        return documentHistoryService.getEndringshistorikk(DocumentClass.TILTAKSGJENNOMFORING, id)
+    }
+
+    private fun getOrError(id: UUID, tx: TransactionalSession): TiltaksgjennomforingAdminDto {
+        val gjennomforing = tiltaksgjennomforinger.get(id, tx)
+        return requireNotNull(gjennomforing) { "Gjennomføringen med id=$id finnes ikke" }
     }
 
     private fun dispatchNotificationToNewAdministrators(
@@ -216,5 +236,16 @@ class TiltaksgjennomforingService(
             createdAt = Instant.now(),
         )
         notificationRepository.insert(notification, tx)
+    }
+
+    private fun logEndring(
+        operation: String,
+        dto: TiltaksgjennomforingAdminDto,
+        navIdent: String,
+        tx: TransactionalSession,
+    ) {
+        documentHistoryService.logEndring(tx, DocumentClass.TILTAKSGJENNOMFORING, operation, navIdent, dto.id) {
+            Json.encodeToJsonElement<TiltaksgjennomforingAdminDto>(dto)
+        }
     }
 }

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__avtale_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__avtale_admin_view.sql
@@ -1,5 +1,4 @@
-drop view if exists avtale_admin_dto_view;
-create view avtale_admin_dto_view as
+create or replace view avtale_admin_dto_view as
 select a.id,
        a.navn,
        a.tiltakstype_id,
@@ -39,7 +38,7 @@ select a.id,
                    when aa.nav_ident is null then null::jsonb
                    else jsonb_build_object('navIdent', aa.nav_ident, 'navn', concat(na.fornavn, ' ', na.etternavn))
                    end
-       )                                                                        as administratorer
+           )                                                                    as administratorer
 from avtale a
          join tiltakstype t on t.id = a.tiltakstype_id
          left join avtale_administrator aa on a.id = aa.avtale_id

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -1,5 +1,4 @@
-drop view if exists tiltaksgjennomforing_admin_dto_view;
-create view tiltaksgjennomforing_admin_dto_view as
+create or replace view tiltaksgjennomforing_admin_dto_view as
 select tg.id::uuid,
        tg.navn,
        tg.tiltakstype_id,
@@ -12,14 +11,13 @@ select tg.id::uuid,
        t.navn                  as tiltakstype_navn,
        case
            when arena_nav_enhet.enhetsnummer is null then null::jsonb
-           else
-               jsonb_build_object(
-                       'enhetsnummer', arena_nav_enhet.enhetsnummer,
-                       'navn', arena_nav_enhet.navn,
-                       'type', arena_nav_enhet.type,
-                       'overordnetEnhet',
-                       arena_nav_enhet.overordnet_enhet) end
-                               as arena_ansvarlig_enhet,
+           else jsonb_build_object(
+                   'enhetsnummer', arena_nav_enhet.enhetsnummer,
+                   'navn', arena_nav_enhet.navn,
+                   'type', arena_nav_enhet.type,
+                   'overordnetEnhet',
+                   arena_nav_enhet.overordnet_enhet)
+           end                 as arena_ansvarlig_enhet,
        tg.avslutningsstatus,
        tg.apent_for_innsok,
        tg.sanity_id,

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__version_history.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__version_history.sql
@@ -1,0 +1,53 @@
+/**
+ * Utility for å dumpe snaphots av et dokument til en tabell spesifisert i [versioning_table].
+ *
+ * versioning_table: tabell som skal skrives til
+ * operation: fritekst som beskriver endringen
+ * document_id: id til dokumentet/entiteten som blir endret
+ * value: en JSON dump av dokumentet/entiteten
+ * user_id: identifikator på den som gjør endringen (typisk NAVIdent).
+ * ts: timestamp for endringen. Utledes automatisk, men kan settes eksplisitt.
+ *     Må være etter (i tid) forrige rad med samme [document_id].
+ */
+create or replace function version_history(
+    versioning_table text,
+    operation text,
+    document_id uuid,
+    value jsonb,
+    user_id text,
+    ts timestamp with time zone default current_timestamp
+) returns void as
+$$
+declare
+    last_sys_period tstzrange;
+    sql_query       text;
+begin
+    -- Find the last sys_period for the given document_id
+    sql_query := 'SELECT sys_period FROM ' || versioning_table ||
+                 ' WHERE document_id = $1 ORDER BY sys_period DESC LIMIT 1';
+    execute sql_query into last_sys_period using document_id;
+
+    -- If a previous record for "id", validate
+    if last_sys_period is not null then
+        if lower(last_sys_period) > ts then
+            raise invalid_parameter_value using
+                message =
+                            'the "ts" parameter must be after the most recent "sys_period" for versions of record with document_id ' ||
+                            document_id,
+                hint = 'expected "ts" to be after ' || lower(last_sys_period);
+        end if;
+
+        -- Update the sys_period of the previous latest record
+        sql_query := 'UPDATE ' || versioning_table ||
+                     ' SET sys_period = tstzrange($1, $2, ''[)'')' ||
+                     ' WHERE document_id = $3 AND sys_period = $4';
+        execute sql_query using lower(last_sys_period), ts, document_id, last_sys_period;
+    end if;
+
+    -- Insert the new record with the updated sys_period
+    sql_query := 'INSERT INTO ' || versioning_table ||
+                 ' (operation, document_id, value, user_id, sys_period) VALUES ($1, $2, $3, $4, tstzrange($5, NULL, ''[)''))';
+    execute sql_query using operation, document_id, value, user_id, ts;
+end
+$$ language plpgsql;
+

--- a/mulighetsrommet-api/src/main/resources/db/migration/V101__endringshistorikk.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V101__endringshistorikk.sql
@@ -1,0 +1,23 @@
+create table if not exists tiltaksgjennomforing_endringshistorikk
+(
+    document_id uuid      not null,
+    value       jsonb     not null,
+    operation   text      not null,
+    user_id     text      not null,
+    sys_period  tstzrange not null
+);
+
+create index on tiltaksgjennomforing_endringshistorikk (document_id, sys_period);
+create index on tiltaksgjennomforing_endringshistorikk using gist (sys_period) include (document_id);
+
+create table if not exists avtale_endringshistorikk
+(
+    document_id uuid      not null,
+    value       jsonb     not null,
+    operation   text      not null,
+    user_id     text      not null,
+    sys_period  tstzrange not null
+);
+
+create index on avtale_endringshistorikk (document_id, sys_period);
+create index on avtale_endringshistorikk using gist (sys_period) include (document_id);

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -382,6 +382,48 @@ paths:
               schema:
                 $ref: "#/components/schemas/TiltaksgjennomforingNotat"
 
+  /api/v1/internal/avtaler/{id}/historikk:
+    get:
+      tags:
+        - Avtaler
+      operationId: getAvtaleEndringshistorikk
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID for avtalen
+      responses:
+        200:
+          description: Endringshistorikken for avtalen
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endringshistorikk"
+
+  /api/v1/internal/tiltaksgjennomforinger/{id}/historikk:
+    get:
+      tags:
+        - Tiltaksgjennomforinger
+      operationId: getTiltaksgjennomforingEndringshistorikk
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID for tiltaksgjennomføringen
+      responses:
+        200:
+          description: Endringshistorikken for tiltaksgjennomføringen
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endringshistorikk"
+
   /api/v1/internal/notater/tiltaksgjennomforinger/mine:
     get:
       tags:
@@ -675,10 +717,6 @@ paths:
       responses:
         200:
           description: Update for 'tilgjengelig for veileder' was successful
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Tiltaksgjennomforing"
 
   /api/v1/internal/tiltaksgjennomforinger/enhet/{enhet}:
     parameters:
@@ -3041,6 +3079,59 @@ components:
         - id
         - avtaleId
         - innhold
+
+    Endringshistorikk:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/EndringshistorikkEntry"
+      required:
+        - entries
+
+    EndringshistorikkEntry:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        operation:
+          type: string
+        editedAt:
+          type: string
+          format: date-time
+        editedBy:
+          $ref: "#/components/schemas/EndringshistorikkUser"
+      required:
+        - id
+        - operation
+        - editedAt
+        - editedBy
+
+    EndringshistorikkUser:
+      oneOf:
+        - $ref: "#/components/schemas/EndringshistorikkSystembruker"
+        - $ref: "#/components/schemas/EndringshistorikkNavAnsatt"
+
+    EndringshistorikkSystembruker:
+      type: object
+      properties:
+        navn:
+          type: string
+      required:
+        - navn
+
+    EndringshistorikkNavAnsatt:
+      type: object
+      properties:
+        navIdent:
+          type: string
+        navn:
+          type: string
+      required:
+        - navIdent
+        - navn
 
     TiltaksgjennomforingNotat:
       type: object

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.api.repositories
 
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
@@ -347,68 +346,6 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     hovedenhet = "2990",
                 ),
             )
-        }
-
-        test("Oppdater navEnheter fra Sanity-tiltaksgjennomføringer til database") {
-            val enhetRepository = NavEnhetRepository(database.db)
-            enhetRepository.upsert(
-                NavEnhetDbo(
-                    navn = "Navn1",
-                    enhetsnummer = "1",
-                    status = NavEnhetStatus.AKTIV,
-                    type = Norg2Type.LOKAL,
-                    overordnetEnhet = null,
-                ),
-            ).shouldBeRight()
-            enhetRepository.upsert(
-                NavEnhetDbo(
-                    navn = "Navn2",
-                    enhetsnummer = "2",
-                    status = NavEnhetStatus.AKTIV,
-                    type = Norg2Type.LOKAL,
-                    overordnetEnhet = null,
-                ),
-            ).shouldBeRight()
-
-            val gjennomforing = Oppfolging1.copy(navEnheter = emptyList())
-
-            tiltaksgjennomforinger.upsert(gjennomforing)
-            tiltaksgjennomforinger.get(gjennomforing.id).should {
-                it!!.navEnheter.shouldBeEmpty()
-            }
-            tiltaksgjennomforinger.updateEnheter("1", listOf("1", "2"))
-            tiltaksgjennomforinger.get(gjennomforing.id).should {
-                it!!.navEnheter shouldContainExactlyInAnyOrder listOf(
-                    EmbeddedNavEnhet(
-                        enhetsnummer = "1",
-                        navn = "Navn1",
-                        type = Norg2Type.LOKAL,
-                        overordnetEnhet = null,
-                    ),
-                    EmbeddedNavEnhet(
-                        enhetsnummer = "2",
-                        navn = "Navn2",
-                        type = Norg2Type.LOKAL,
-                        overordnetEnhet = null,
-                    ),
-                )
-            }
-            database.assertThat("tiltaksgjennomforing_nav_enhet").hasNumberOfRows(2)
-
-            tiltaksgjennomforinger.updateEnheter("1", listOf("2"))
-            tiltaksgjennomforinger.get(gjennomforing.id).should {
-                it!!.navEnheter.shouldContainExactlyInAnyOrder(
-                    listOf(
-                        EmbeddedNavEnhet(
-                            enhetsnummer = "2",
-                            navn = "Navn2",
-                            type = Norg2Type.LOKAL,
-                            overordnetEnhet = null,
-                        ),
-                    ),
-                )
-            }
-            database.assertThat("tiltaksgjennomforing_nav_enhet").hasNumberOfRows(1)
         }
 
         test("update sanity_id") {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
@@ -144,6 +144,7 @@ class ArenaAdapterServiceTest : FunSpec({
             virksomhetService = mockk(relaxed = true),
             navEnhetService = mockk(relaxed = true),
             notificationService = mockk(relaxed = true),
+            endringshistorikk = EndringshistorikkService(database.db),
         )
 
         afterTest {
@@ -202,6 +203,7 @@ class ArenaAdapterServiceTest : FunSpec({
             virksomhetService = mockk(relaxed = true),
             navEnhetService = NavEnhetService(navEnheter),
             notificationService = notificationService,
+            endringshistorikk = EndringshistorikkService(database.db),
         )
 
         afterEach {
@@ -336,6 +338,7 @@ class ArenaAdapterServiceTest : FunSpec({
             virksomhetService = mockk(relaxed = true),
             navEnhetService = NavEnhetService(NavEnhetRepository(database.db)),
             notificationService = notificationService,
+            endringshistorikk = EndringshistorikkService(database.db),
         )
 
         afterEach {
@@ -538,6 +541,7 @@ class ArenaAdapterServiceTest : FunSpec({
             virksomhetService = mockk(relaxed = true),
             navEnhetService = NavEnhetService(NavEnhetRepository(database.db)),
             notificationService = mockk(relaxed = true),
+            endringshistorikk = EndringshistorikkService(database.db),
         )
 
         beforeTest {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/AvtaleServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/AvtaleServiceTest.kt
@@ -57,6 +57,7 @@ class AvtaleServiceTest : FunSpec({
             NotificationRepository(database.db),
             utkastRepository,
             validator,
+            EndringshistorikkService(database.db),
             database.db,
         )
 
@@ -82,6 +83,7 @@ class AvtaleServiceTest : FunSpec({
             NotificationRepository(database.db),
             utkastRepository,
             validator,
+            EndringshistorikkService(database.db),
             database.db,
         )
 
@@ -90,7 +92,7 @@ class AvtaleServiceTest : FunSpec({
             val avtaleIdSomIkkeFinnes = "3c9f3d26-50ec-45a7-a7b2-c2d8a3653945".toUUID()
             avtaleRepository.upsert(avtale)
 
-            avtaleService.avbrytAvtale(avtaleIdSomIkkeFinnes).shouldBeLeft(
+            avtaleService.avbrytAvtale(avtaleIdSomIkkeFinnes, "B123456").shouldBeLeft(
                 NotFound("Avtalen finnes ikke"),
             )
         }
@@ -104,7 +106,7 @@ class AvtaleServiceTest : FunSpec({
             )
             avtaleRepository.upsert(avtale)
 
-            avtaleService.avbrytAvtale(avtale.id).shouldBeLeft(
+            avtaleService.avbrytAvtale(avtale.id, "B123456").shouldBeLeft(
                 BadRequest("Avtalen har opprinnelse fra Arena og kan ikke bli avbrutt fra admin-flate."),
             )
         }
@@ -118,7 +120,7 @@ class AvtaleServiceTest : FunSpec({
             )
             avtaleRepository.upsert(avtale)
 
-            avtaleService.avbrytAvtale(avtale.id).shouldBeLeft(
+            avtaleService.avbrytAvtale(avtale.id, "B123456").shouldBeLeft(
                 BadRequest(message = "Avtalen er allerede avsluttet og kan derfor ikke avbrytes."),
             )
         }
@@ -160,7 +162,7 @@ class AvtaleServiceTest : FunSpec({
             tiltaksgjennomforinger.upsert(arbeidstrening)
             tiltaksgjennomforinger.upsert(oppfolging2)
 
-            avtaleService.avbrytAvtale(avtale.id).shouldBeLeft(
+            avtaleService.avbrytAvtale(avtale.id, "B123456").shouldBeLeft(
                 BadRequest("Avtalen har 2 tiltaksgjennomføringer koblet til seg. Du må frikoble gjennomføringene før du kan avbryte avtalen."),
             )
         }
@@ -172,7 +174,7 @@ class AvtaleServiceTest : FunSpec({
             )
             avtaleRepository.upsert(avtale).right()
 
-            avtaleService.avbrytAvtale(avtale.id)
+            avtaleService.avbrytAvtale(avtale.id, "B123456")
         }
     }
 
@@ -186,6 +188,7 @@ class AvtaleServiceTest : FunSpec({
             NotificationRepository(database.db),
             utkastRepository,
             validator,
+            EndringshistorikkService(database.db),
             database.db,
         )
         val navAnsattRepository = NavAnsattRepository(database.db)
@@ -283,6 +286,7 @@ class AvtaleServiceTest : FunSpec({
             NotificationRepository(database.db),
             utkastRepository,
             validator,
+            EndringshistorikkService(database.db),
             database.db,
         )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/EndringshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/EndringshistorikkServiceTest.kt
@@ -1,0 +1,115 @@
+package no.nav.mulighetsrommet.api.services
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import no.nav.mulighetsrommet.api.createDatabaseTestConfig
+import no.nav.mulighetsrommet.api.domain.dto.EndringshistorikkDto
+import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
+import no.nav.mulighetsrommet.api.fixtures.NavAnsattFixture
+import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import java.time.LocalDateTime
+import java.util.*
+
+class EndringshistorikkServiceTest : FunSpec({
+    val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
+
+    test("opprett og les endringshistorikk sortert med nyeste endringer først") {
+        val id = UUID.randomUUID()
+
+        val endringshistorikk = EndringshistorikkService(database.db)
+
+        endringshistorikk.logEndring(
+            DocumentClass.AVTALE,
+            operation = "OPPRETTET",
+            userId = "Arena",
+            documentId = id,
+            timestamp = LocalDateTime.of(2023, 1, 1, 9, 0, 0),
+        ) { Json.parseToJsonElement("""{ "navn": "Ny avtale" }""") }
+
+        endringshistorikk.logEndring(
+            DocumentClass.AVTALE,
+            operation = "ENDRET",
+            userId = "Ola",
+            documentId = id,
+            timestamp = LocalDateTime.of(2023, 1, 2, 9, 0, 0),
+        ) { Json.parseToJsonElement("""{ "navn": "Endret avtale" }""") }
+
+        endringshistorikk.logEndring(
+            DocumentClass.AVTALE,
+            operation = "SLETTET",
+            userId = "Arena",
+            documentId = id,
+            timestamp = LocalDateTime.of(2023, 1, 3, 9, 0, 0),
+        ) { JsonNull }
+
+        endringshistorikk.getEndringshistorikk(DocumentClass.AVTALE, id) shouldBe EndringshistorikkDto(
+            entries = listOf(
+                EndringshistorikkDto.Entry(
+                    id = id,
+                    operation = "SLETTET",
+                    editedAt = LocalDateTime.of(2023, 1, 3, 9, 0, 0),
+                    editedBy = "Arena",
+                ),
+                EndringshistorikkDto.Entry(
+                    id = id,
+                    operation = "ENDRET",
+                    editedAt = LocalDateTime.of(2023, 1, 2, 9, 0, 0),
+                    editedBy = "Ola",
+                ),
+                EndringshistorikkDto.Entry(
+                    id = id,
+                    operation = "OPPRETTET",
+                    editedAt = LocalDateTime.of(2023, 1, 1, 9, 0, 0),
+                    editedBy = "Arena",
+                ),
+            ),
+        )
+    }
+
+    test("bruker i endringshistorikk blir utledet fra kjente NAV-ansatte") {
+        val id = UUID.randomUUID()
+
+        val ansatt1 = NavAnsattFixture.ansatt1
+        val ansatt2 = NavAnsattFixture.ansatt2
+
+        val domain = MulighetsrommetTestDomain(ansatte = listOf(ansatt1, ansatt2))
+        domain.initialize(database.db)
+
+        val endringshistorikk = EndringshistorikkService(database.db)
+
+        endringshistorikk.logEndring(
+            DocumentClass.AVTALE,
+            operation = "OPPRETTET",
+            userId = ansatt1.navIdent,
+            documentId = id,
+            timestamp = LocalDateTime.of(2023, 1, 1, 9, 0, 0),
+        ) { Json.parseToJsonElement("""{ "navn": "Ny avtale" }""") }
+
+        endringshistorikk.logEndring(
+            DocumentClass.AVTALE,
+            operation = "ENDRET",
+            userId = ansatt2.navIdent,
+            documentId = id,
+            timestamp = LocalDateTime.of(2023, 1, 2, 9, 0, 0),
+        ) { Json.parseToJsonElement("""{ "navn": "Endret avtale" }""") }
+
+        endringshistorikk.getEndringshistorikk(DocumentClass.AVTALE, id) shouldBe EndringshistorikkDto(
+            entries = listOf(
+                EndringshistorikkDto.Entry(
+                    id = id,
+                    operation = "ENDRET",
+                    editedAt = LocalDateTime.of(2023, 1, 2, 9, 0, 0),
+                    editedBy = "${ansatt2.fornavn} ${ansatt2.etternavn}",
+                ),
+                EndringshistorikkDto.Entry(
+                    id = id,
+                    operation = "OPPRETTET",
+                    editedAt = LocalDateTime.of(2023, 1, 1, 9, 0, 0),
+                    editedBy = "${ansatt1.fornavn} ${ansatt1.etternavn}",
+                ),
+            ),
+        )
+    }
+})

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/EndringshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/EndringshistorikkServiceTest.kt
@@ -50,19 +50,19 @@ class EndringshistorikkServiceTest : FunSpec({
                     id = id,
                     operation = "SLETTET",
                     editedAt = LocalDateTime.of(2023, 1, 3, 9, 0, 0),
-                    editedBy = "Arena",
+                    editedBy = EndringshistorikkDto.Systembruker(navn = "Arena"),
                 ),
                 EndringshistorikkDto.Entry(
                     id = id,
                     operation = "ENDRET",
                     editedAt = LocalDateTime.of(2023, 1, 2, 9, 0, 0),
-                    editedBy = "Ola",
+                    editedBy = EndringshistorikkDto.Systembruker(navn = "Ola"),
                 ),
                 EndringshistorikkDto.Entry(
                     id = id,
                     operation = "OPPRETTET",
                     editedAt = LocalDateTime.of(2023, 1, 1, 9, 0, 0),
-                    editedBy = "Arena",
+                    editedBy = EndringshistorikkDto.Systembruker(navn = "Arena"),
                 ),
             ),
         )
@@ -101,13 +101,13 @@ class EndringshistorikkServiceTest : FunSpec({
                     id = id,
                     operation = "ENDRET",
                     editedAt = LocalDateTime.of(2023, 1, 2, 9, 0, 0),
-                    editedBy = "${ansatt2.fornavn} ${ansatt2.etternavn}",
+                    editedBy = EndringshistorikkDto.NavAnsatt(navIdent = "DD2", navn = "Dolly Duck"),
                 ),
                 EndringshistorikkDto.Entry(
                     id = id,
                     operation = "OPPRETTET",
                     editedAt = LocalDateTime.of(2023, 1, 1, 9, 0, 0),
-                    editedBy = "${ansatt1.fornavn} ${ansatt1.etternavn}",
+                    editedBy = EndringshistorikkDto.NavAnsatt(navIdent = "DD1", navn = "Donald Duck"),
                 ),
             ),
         )

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
@@ -66,11 +66,12 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             tiltaksgjennomforingKafkaProducer,
             NotificationRepository(database.db),
             validator,
+            EndringshistorikkService(database.db),
             database.db,
         )
 
         test("Man skal ikke få avbryte dersom gjennomføringen ikke finnes") {
-            tiltaksgjennomforingService.avbrytGjennomforing(UUID.randomUUID()).shouldBeLeft(
+            tiltaksgjennomforingService.avbrytGjennomforing(UUID.randomUUID(), "B123456").shouldBeLeft(
                 NotFound(message = "Gjennomføringen finnes ikke"),
             )
         }
@@ -82,7 +83,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             )
             tiltaksgjennomforingRepository.upsert(gjennomforing)
 
-            tiltaksgjennomforingService.avbrytGjennomforing(gjennomforing.id).shouldBeLeft(
+            tiltaksgjennomforingService.avbrytGjennomforing(gjennomforing.id, "B123456").shouldBeLeft(
                 BadRequest(message = "Gjennomføringen har opprinnelse fra Arena og kan ikke bli avbrutt i admin-flate."),
             )
         }
@@ -98,7 +99,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             val deltager = DeltakerFixture.Deltaker.copy(tiltaksgjennomforingId = gjennomforing.id)
             deltagerRepository.upsert(deltager)
 
-            tiltaksgjennomforingService.avbrytGjennomforing(gjennomforing.id).shouldBeLeft(
+            tiltaksgjennomforingService.avbrytGjennomforing(gjennomforing.id, "B123456").shouldBeLeft(
                 BadRequest(message = "Gjennomføringen kan ikke avbrytes fordi den har 1 deltager(e) koblet til seg."),
             )
         }
@@ -111,7 +112,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             )
             tiltaksgjennomforingRepository.upsert(gjennomforing)
 
-            tiltaksgjennomforingService.avbrytGjennomforing(gjennomforing.id).shouldBeRight()
+            tiltaksgjennomforingService.avbrytGjennomforing(gjennomforing.id, "B123456").shouldBeRight()
         }
     }
 
@@ -129,6 +130,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             tiltaksgjennomforingKafkaProducer,
             NotificationRepository(database.db),
             validator,
+            EndringshistorikkService(database.db),
             database.db,
         )
 
@@ -161,6 +163,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             tiltaksgjennomforingKafkaProducer,
             NotificationRepository(database.db),
             validator,
+            EndringshistorikkService(database.db),
             database.db,
         )
         val navAnsattRepository = NavAnsattRepository(database.db)
@@ -278,6 +281,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
             tiltaksgjennomforingKafkaProducer,
             notificationRepository,
             validator,
+            EndringshistorikkService(database.db),
             database.db,
         )
 
@@ -337,7 +341,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
 
             every { tiltaksgjennomforingKafkaProducer.publish(any()) } throws Exception()
 
-            shouldThrow<Throwable> { tiltaksgjennomforingService.avbrytGjennomforing(gjennomforing.id) }
+            shouldThrow<Throwable> { tiltaksgjennomforingService.avbrytGjennomforing(gjennomforing.id, "B123456") }
 
             tiltaksgjennomforingService.get(gjennomforing.id) should {
                 it!!.status shouldBe Tiltaksgjennomforingsstatus.GJENNOMFORES


### PR DESCRIPTION
Gjenstår fortsatt noen greier, bl.a. design rundt visning av endringshistorikken.

Delvis inspirert av følgende blogpost, men endte opp med lagre en unormalisert dump av json-dokumentet i stedet for temporal tables. Fortsatt ikke helt overbevist over dette valget mtp. at endringer også kan skje fra andre steder enn fra adminflate (f.eks. arena) og hvis vi ønsker å ha en komplett endringshistorikk må vi selv huske å oppdatere denne på hvert sted vi gjør en endring..

https://clarkdave.net/2015/02/historical-records-with-postgresql-and-temporal-tables-and-sql-2011/