### PR TITLE
Bort med 'tittel' fra header i admin-flate

### DIFF
--- a/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
@@ -178,7 +178,7 @@ export const AvtaleTabell = ({ avtalefilter, paginerteAvtaler, isLoading }: Prop
           <Table.Header>
             <Table.Row className={styles.avtale_tabellrad}>
               <Table.ColumnHeader sortKey="navn" sortable>
-                Tittel
+                Avtalenavn
               </Table.ColumnHeader>
               <Table.ColumnHeader>Avtalenummer</Table.ColumnHeader>
               <Table.ColumnHeader sortKey="leverandor" sortable>

--- a/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -27,7 +27,7 @@ interface ColumnHeader {
 const headers: ColumnHeader[] = [
   {
     sortKey: "navn",
-    tittel: "Tittel",
+    tittel: "Tiltaksnavn",
     sortable: true,
     width: "3fr",
   },

--- a/frontend/mr-admin-flate/src/components/tabell/TiltakstypeTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/TiltakstypeTabell.tsx
@@ -60,7 +60,7 @@ export const TiltakstypeTabell = () => {
         <Table.Header>
           <Table.Row className={styles.tiltakstype_tabellrad}>
             <Table.ColumnHeader sortKey="navn" sortable>
-              Tittel
+              Navn
             </Table.ColumnHeader>
             <Table.ColumnHeader sortKey="startdato" sortable>
               Startdato


### PR DESCRIPTION
Har brukt samme navn på headeren som vi har på input-feltene i skjema. For tiltakstype har jeg gått for bare "navn".