### PR TITLE
Metrikker: Tiltakstype lagt til i fanevalg

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/TiltaksdetaljerFane.tsx
@@ -71,6 +71,7 @@ const TiltaksdetaljerFane = ({ tiltaksgjennomforing }: Props) => {
           name: "arbeidsmarkedstiltak.fanevalg",
           data: {
             faneValgt: getFaneValgt(value as TabsType),
+            tiltakstype: tiltaksgjennomforing.tiltakstype.navn,
           },
         });
       }}

--- a/frontend/mulighetsrommet-veileder-flate/src/logging/taxonomy.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/logging/taxonomy.ts
@@ -10,6 +10,7 @@ type KLIKK_PA_FANE_EVENT = {
   name: "arbeidsmarkedstiltak.fanevalg";
   data: {
     faneValgt: string;
+    tiltakstype: string;
   };
 };
 


### PR DESCRIPTION
Lagt til tiltakstype i fanevalg slik at vi kan få metrikker på hvilke tiltakstyper veilederne er inne i når de bytter fane på detaljvisningen