### PR TITLE
validere avtalenavn arena

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSchema.ts
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSchema.ts
@@ -7,7 +7,7 @@ const GyldigUrlHvisVerdi = z.union([
 ]);
 
 export const AvtaleSchema = z.object({
-  navn: z.string().min(5, "Et avtalenavn må minst være 5 tegn langt"),
+  navn: z.string(),
   tiltakstype: z.object(
     {
       navn: z.string(),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
@@ -28,6 +28,10 @@ class AvtaleValidator(
             ?: raise(ValidationError.of(AvtaleDbo::tiltakstypeId, "Tiltakstypen finnes ikke").nel())
 
         val errors = buildList {
+            if (dbo.navn.length < 5 && dbo.opphav == ArenaMigrering.Opphav.MR_ADMIN_FLATE) {
+                add(ValidationError.of(AvtaleDbo::navn, "Avtalenavn må være minst 5 tegn langt"))
+            }
+
             if (dbo.administratorer.isEmpty()) {
                 add(ValidationError.of(AvtaleDbo::administratorer, "Minst én administrator må være valgt"))
             }
@@ -59,7 +63,7 @@ class AvtaleValidator(
                  * så reglene for når en avtale er låst er foreløpig ganske naive og baserer seg kun på om det finnes
                  * gjennomføringer på avtalen eller ikke...
                  */
-                    val (numGjennomforinger, gjennomforinger) = tiltaksgjennomforinger.getAll(avtaleId = dbo.id)
+                val (numGjennomforinger, gjennomforinger) = tiltaksgjennomforinger.getAll(avtaleId = dbo.id)
                 if (numGjennomforinger > 0) {
                     if (dbo.tiltakstypeId != avtale.tiltakstype.id) {
                         add(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
@@ -63,7 +63,7 @@ class AvtaleValidator(
                  * så reglene for når en avtale er låst er foreløpig ganske naive og baserer seg kun på om det finnes
                  * gjennomføringer på avtalen eller ikke...
                  */
-                val (numGjennomforinger, gjennomforinger) = tiltaksgjennomforinger.getAll(avtaleId = dbo.id)
+                    val (numGjennomforinger, gjennomforinger) = tiltaksgjennomforinger.getAll(avtaleId = dbo.id)
                 if (numGjennomforinger > 0) {
                     if (dbo.tiltakstypeId != avtale.tiltakstype.id) {
                         add(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
@@ -120,6 +120,16 @@ class AvtaleValidatorTest : FunSpec({
         )
     }
 
+    test("Avtalenavn må være mer enn 5 tegn når avtalen er opprettet i Admin-flate") {
+        val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+        val dbo = avtaleDbo.copy(navn = "Avt", opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE)
+        validator.validate(dbo).shouldBeLeft().shouldContainExactlyInAnyOrder(
+            listOf(
+                ValidationError("navn", "Avtalenavn må være minst 5 tegn langt"),
+            ),
+        )
+    }
+
     test("skal validere at ") {
         val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
@@ -120,7 +120,7 @@ class AvtaleValidatorTest : FunSpec({
         )
     }
 
-    test("Avtalenavn må være mer enn 5 tegn når avtalen er opprettet i Admin-flate") {
+    test("Avtalenavn må være minst 5 tegn når avtalen er opprettet i Admin-flate") {
         val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
         val dbo = avtaleDbo.copy(navn = "Avt", opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE)
         validator.validate(dbo).shouldBeLeft().shouldContainExactlyInAnyOrder(


### PR DESCRIPTION
Validerer i backend at navn er minst 5 tegn langt hvis opphavet er Admin-flate. Hvis opphavet ikke er admin-flate så godtar vi kortere avtalenavn.
