### PR TITLE
Vise tiltaktype bak avtale-label

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -107,7 +107,12 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
           </FormGroup>
           <Separator />
           <FormGroup>
-            <TextField size="small" readOnly label={"Avtale"} value={avtale.navn || ""} />
+            <TextField
+              size="small"
+              readOnly
+              label={`Avtale (tiltakstype: ${avtale.tiltakstype.navn})`}
+              value={avtale.navn || ""}
+            />
           </FormGroup>
           <Separator />
           <FormGroup>


### PR DESCRIPTION
Legger tiltakstypen bak avtale-label i skjema for redigering av gjennomføring så 
bruker har tiltakstypen i kontekst.

Tar gjerne innspill dersom dere ser at tiltakstypen burde ligge et annet sted i skjema.
