### PR TITLE
Viser korrekt feilmelding dersom admin mangler

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
@@ -51,7 +51,10 @@ export const TiltaksgjennomforingSchema = z
       .min(1, "Du må velge en underenhet for tiltaksarrangør"),
     stedForGjennomforing: z.string().nullable(),
     arrangorKontaktpersonId: z.string().nullable().optional(),
-    administratorer: z.string().array().min(1, "Du må velge minst én administrator"),
+    administratorer: z
+      .string({ required_error: "Du må velge minst én administrator" })
+      .array()
+      .min(1, "Du må velge minst én administrator"),
     fremmoteDato: z.string().optional(),
     fremmoteTid: z.string().optional(),
     fremmoteSted: z.string().optional(),


### PR DESCRIPTION
Dersom administrator ikke er satt så viser vi nå en korrekt feilmelding.
Dette bør være et relativt sjeldent scenario nå siden vi automatisk setter
administrator til innlogget bruker når man oppretter tiltak.
