### PR TITLE
Navigerer mellom tabs og erstatter url

### DIFF
--- a/frontend/mr-admin-flate/src/hooks/useNavigateWithoutReplacingUrl.ts
+++ b/frontend/mr-admin-flate/src/hooks/useNavigateWithoutReplacingUrl.ts
@@ -1,0 +1,11 @@
+import { useNavigate } from "react-router-dom";
+
+export function useNavigateAndReplaceUrl() {
+  const navigate = useNavigate();
+
+  function navigateAndReplaceUrl(to: string) {
+    navigate(to, { replace: true });
+  }
+
+  return { navigateAndReplaceUrl };
+}

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
@@ -1,22 +1,23 @@
 import { Alert, Heading, Tabs } from "@navikt/ds-react";
-import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Toggles } from "mulighetsrommet-api-client";
+import { useTitle } from "mulighetsrommet-frontend-common";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import { useAvtale } from "../../api/avtaler/useAvtale";
+import { useFeatureToggle } from "../../api/features/feature-toggles";
 import { Header } from "../../components/detaljside/Header";
+import headerStyles from "../../components/detaljside/Header.module.scss";
 import { Laster } from "../../components/laster/Laster";
 import { AvtalestatusTag } from "../../components/statuselementer/AvtalestatusTag";
 import { useGetAvtaleIdFromUrlOrThrow } from "../../hooks/useGetAvtaleIdFromUrl";
-import commonStyles from "../Page.module.scss";
-import headerStyles from "../../components/detaljside/Header.module.scss";
-import styles from "./DetaljerAvtalePage.module.scss";
+import { useNavigateAndReplaceUrl } from "../../hooks/useNavigateWithoutReplacingUrl";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
-import { useTitle } from "mulighetsrommet-frontend-common";
-import { Toggles } from "mulighetsrommet-api-client";
-import { useFeatureToggle } from "../../api/features/feature-toggles";
+import commonStyles from "../Page.module.scss";
+import styles from "./DetaljerAvtalePage.module.scss";
 
 export function AvtalePage() {
   const avtaleId = useGetAvtaleIdFromUrlOrThrow();
   const { pathname } = useLocation();
-  const navigate = useNavigate();
+  const { navigateAndReplaceUrl } = useNavigateAndReplaceUrl();
   const { data: showNotater } = useFeatureToggle(Toggles.MULIGHETSROMMET_ADMIN_FLATE_SHOW_NOTATER);
   const { data: avtale, isPending } = useAvtale();
   useTitle(`Avtale ${avtale?.navn ? `- ${avtale.navn}` : ""}`);
@@ -65,14 +66,14 @@ export function AvtalePage() {
           <Tabs.Tab
             value="info"
             label="Avtaleinfo"
-            onClick={() => navigate(`/avtaler/${avtaleId}`)}
+            onClick={() => navigateAndReplaceUrl(`/avtaler/${avtaleId}`)}
             aria-controls="panel"
           />
           {showNotater && (
             <Tabs.Tab
               value="notater"
               label="Notater"
-              onClick={() => navigate(`/avtaler/${avtaleId}/notater`)}
+              onClick={() => navigateAndReplaceUrl(`/avtaler/${avtaleId}/notater`)}
               aria-controls="panel"
               data-testid="notater-tab"
             />
@@ -80,7 +81,7 @@ export function AvtalePage() {
           <Tabs.Tab
             value="tiltaksgjennomforinger"
             label="Gjennomføringer"
-            onClick={() => navigate(`/avtaler/${avtaleId}/tiltaksgjennomforinger`)}
+            onClick={() => navigateAndReplaceUrl(`/avtaler/${avtaleId}/tiltaksgjennomforinger`)}
             aria-controls="panel"
             data-testid="gjennomforinger-tab"
           />

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
@@ -1,21 +1,22 @@
 import { Alert, Heading, Tabs } from "@navikt/ds-react";
+import classNames from "classnames";
 import { Toggles } from "mulighetsrommet-api-client";
-import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import { useFeatureToggle } from "../../api/features/feature-toggles";
 import { useTiltaksgjennomforingById } from "../../api/tiltaksgjennomforing/useTiltaksgjennomforingById";
 import { Header } from "../../components/detaljside/Header";
-import { Laster } from "../../components/laster/Laster";
-import { TiltaksgjennomforingstatusTag } from "../../components/statuselementer/TiltaksgjennomforingstatusTag";
-import { ContainerLayout } from "../../layouts/ContainerLayout";
-import commonStyles from "../Page.module.scss";
 import headerStyles from "../../components/detaljside/Header.module.scss";
-import { erProdMiljo } from "../../utils/Utils";
+import { Laster } from "../../components/laster/Laster";
 import { Lenkeknapp } from "../../components/lenkeknapp/Lenkeknapp";
-import classNames from "classnames";
+import { TiltaksgjennomforingstatusTag } from "../../components/statuselementer/TiltaksgjennomforingstatusTag";
+import { useNavigateAndReplaceUrl } from "../../hooks/useNavigateWithoutReplacingUrl";
+import { ContainerLayout } from "../../layouts/ContainerLayout";
+import { erProdMiljo } from "../../utils/Utils";
+import commonStyles from "../Page.module.scss";
 
 export function TiltaksgjennomforingPage() {
   const { pathname } = useLocation();
-  const navigate = useNavigate();
+  const { navigateAndReplaceUrl } = useNavigateAndReplaceUrl();
   const { data: tiltaksgjennomforing, isLoading } = useTiltaksgjennomforingById();
   const forhandsvisningMiljo = import.meta.env.dev || erProdMiljo ? "nav.no" : "dev.nav.no";
 
@@ -86,14 +87,18 @@ export function TiltaksgjennomforingPage() {
           <Tabs.Tab
             value="info"
             label="Info"
-            onClick={() => navigate(`/tiltaksgjennomforinger/${tiltaksgjennomforing.id}`)}
+            onClick={() =>
+              navigateAndReplaceUrl(`/tiltaksgjennomforinger/${tiltaksgjennomforing.id}`)
+            }
             aria-controls="panel"
           />
           {showNotater && (
             <Tabs.Tab
               value="notater"
               label="Notater"
-              onClick={() => navigate(`/tiltaksgjennomforinger/${tiltaksgjennomforing.id}/notater`)}
+              onClick={() =>
+                navigateAndReplaceUrl(`/tiltaksgjennomforinger/${tiltaksgjennomforing.id}/notater`)
+              }
               aria-controls="panel"
             />
           )}
@@ -102,7 +107,9 @@ export function TiltaksgjennomforingPage() {
               value="poc"
               label="Deltakerliste"
               onClick={() =>
-                navigate(`/tiltaksgjennomforinger/${tiltaksgjennomforing.id}/deltakere`)
+                navigateAndReplaceUrl(
+                  `/tiltaksgjennomforinger/${tiltaksgjennomforing.id}/deltakere`,
+                )
               }
               aria-controls="panel"
             />

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
@@ -1,16 +1,17 @@
 import { Alert, Heading, Tabs } from "@navikt/ds-react";
-import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
+import { useTitle } from "mulighetsrommet-frontend-common";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import { useTiltakstypeById } from "../../api/tiltakstyper/useTiltakstypeById";
 import { Header } from "../../components/detaljside/Header";
 import { Laster } from "../../components/laster/Laster";
 import { TiltakstypestatusTag } from "../../components/statuselementer/TiltakstypestatusTag";
+import { useNavigateAndReplaceUrl } from "../../hooks/useNavigateWithoutReplacingUrl";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
 import commonStyles from "../Page.module.scss";
-import { useTitle } from "mulighetsrommet-frontend-common";
 
 export function DetaljerTiltakstypePage() {
   const { pathname } = useLocation();
-  const navigate = useNavigate();
+  const { navigateAndReplaceUrl } = useNavigateAndReplaceUrl();
   const { data: tiltakstype, isLoading } = useTiltakstypeById();
   useTitle(`Tiltakstyper ${tiltakstype?.navn ? `- ${tiltakstype.navn}` : ""}`);
 
@@ -43,13 +44,13 @@ export function DetaljerTiltakstypePage() {
           <Tabs.Tab
             value="arenainfo"
             label="Arenainfo"
-            onClick={() => navigate(`/tiltakstyper/${tiltakstype.id}`)}
+            onClick={() => navigateAndReplaceUrl(`/tiltakstyper/${tiltakstype.id}`)}
             aria-controls="panel"
           />
           <Tabs.Tab
             value="avtaler"
             label="Avtaler"
-            onClick={() => navigate(`/tiltakstyper/${tiltakstype.id}/avtaler`)}
+            onClick={() => navigateAndReplaceUrl(`/tiltakstyper/${tiltakstype.id}/avtaler`)}
             aria-controls="panel"
           />
         </Tabs.List>


### PR DESCRIPTION
Ved å erstatte url når man navigerer mellom tabs så 
vil man kunne bruke nettleseren sine piler frem og tilbake 
slik de er ment å brukes uten å hoppe mellom faner frem og tilbake hele tiden.
