### PR TITLE
Stigende og synkende datosortering

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
@@ -85,29 +85,10 @@ const Tiltaksgjennomforingsoversikt = (props: Props) => {
     });
   };
 
-  const lopendeGjennomforinger = tiltaksgjennomforinger.filter(
-    (gj) => gj.oppstart === TiltaksgjennomforingOppstartstype.LOPENDE,
+  const gjennomforingerForSide = sorter(tiltaksgjennomforinger).slice(
+    (page - 1) * elementsPerPage,
+    page * elementsPerPage,
   );
-  const gjennomforingerMedOppstartIFremtiden = tiltaksgjennomforinger.filter(
-    (gj) =>
-      gj.oppstart !== TiltaksgjennomforingOppstartstype.LOPENDE &&
-      new Date(gj.oppstartsdato!!) >= new Date(),
-  );
-  const gjennomforingerMedOppstartHarVaert = tiltaksgjennomforinger.filter(
-    (gj) =>
-      gj.oppstart !== TiltaksgjennomforingOppstartstype.LOPENDE &&
-      new Date(gj.oppstartsdato!!) <= new Date(),
-  );
-
-  const gjennomforingerForSide = (
-    getSort(sortValue).orderBy === "oppstart"
-      ? [
-          ...lopendeGjennomforinger,
-          ...sorter(gjennomforingerMedOppstartIFremtiden),
-          ...sorter(gjennomforingerMedOppstartHarVaert).reverse(),
-        ]
-      : sorter(tiltaksgjennomforinger)
-  ).slice((page - 1) * elementsPerPage, page * elementsPerPage);
 
   return (
     <>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
@@ -85,10 +85,18 @@ const Tiltaksgjennomforingsoversikt = (props: Props) => {
     });
   };
 
-  const gjennomforingerForSide = sorter(tiltaksgjennomforinger).slice(
-    (page - 1) * elementsPerPage,
-    page * elementsPerPage,
+  const lopendeGjennomforinger = tiltaksgjennomforinger.filter(
+    (gj) => gj.oppstart === TiltaksgjennomforingOppstartstype.LOPENDE,
   );
+  const gjennomforingerMedFellesOppstart = tiltaksgjennomforinger.filter(
+    (gj) => gj.oppstart !== TiltaksgjennomforingOppstartstype.LOPENDE,
+  );
+
+  const gjennomforingerForSide = (
+    getSort(sortValue).orderBy === "oppstart"
+      ? [...sorter(gjennomforingerMedFellesOppstart), ...lopendeGjennomforinger]
+      : sorter(tiltaksgjennomforinger)
+  ).slice((page - 1) * elementsPerPage, page * elementsPerPage);
 
   return (
     <>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sorteringmeny/Sorteringsmeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sorteringmeny/Sorteringsmeny.tsx
@@ -18,7 +18,8 @@ export const Sorteringsmeny = ({ sortValue, setSortValue }: Props) => {
       data-testid="sortering-select"
     >
       <option value="tiltakstype-ascending">Sorter etter:</option>
-      <option value="oppstart-ascending">Oppstartsdato</option>
+      <option value="oppstart-ascending">Oppstartsdato synkende</option>
+      <option value="oppstart-descending">Oppstartsdato stigende</option>
       <option value="navn-ascending">Tittel a-å</option>
       <option value="navn-descending">Tittel å-a</option>
     </Select>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sorteringmeny/Sorteringsmeny.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sorteringmeny/Sorteringsmeny.tsx
@@ -18,8 +18,8 @@ export const Sorteringsmeny = ({ sortValue, setSortValue }: Props) => {
       data-testid="sortering-select"
     >
       <option value="tiltakstype-ascending">Sorter etter:</option>
-      <option value="oppstart-ascending">Oppstartsdato synkende</option>
-      <option value="oppstart-descending">Oppstartsdato stigende</option>
+      <option value="oppstart-descending">Oppstartsdato synkende</option>
+      <option value="oppstart-ascending">Oppstartsdato stigende</option>
       <option value="navn-ascending">Tittel a-å</option>
       <option value="navn-descending">Tittel å-a</option>
     </Select>

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
@@ -61,7 +61,7 @@ export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
     stedForGjennomforing: "2050 JESSHEIM",
     apentForInnsok: true,
     tiltakstype: mockTiltakstyper.gruppe_amo,
-    oppstart: TiltaksgjennomforingOppstartstype.LOPENDE,
+    oppstart: TiltaksgjennomforingOppstartstype.FELLES,
     oppstartsdato: "2023-11-01",
     sluttdato: "2023-11-30",
     arrangor: {


### PR DESCRIPTION
Legger til støtte for å sortere faste datoer stigende eller synkende. 
Ved sortering på dato så blir de tiltakene med løpende oppstart lagt bakerst i listen over tiltak. 
