### PR TITLE
Fallbacker til orgnr hvis vi ikke finner virksomhet i Brreg

### DIFF
--- a/frontend/mr-admin-flate/src/api/virksomhet/useVirksomhet.ts
+++ b/frontend/mr-admin-flate/src/api/virksomhet/useVirksomhet.ts
@@ -5,7 +5,14 @@ import { mulighetsrommetClient } from "../clients";
 export function useVirksomhet(orgnr: string) {
   return useQuery({
     queryKey: QueryKeys.virksomhetOppslag(orgnr),
-    queryFn: () => mulighetsrommetClient.virksomhet.hentVirksomhet({ orgnr }),
+    queryFn: async () => {
+      const response = await mulighetsrommetClient.virksomhet.hentVirksomhet({ orgnr });
+      if (!response) {
+        // Fallback for organisasjoner som ikke finnes i Brreg, men som må vi støtte i løsningen
+        return { organisasjonsnummer: orgnr, navn: orgnr };
+      }
+      return response;
+    },
     enabled: !!orgnr,
   });
 }

--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
@@ -9,25 +9,25 @@ import {
   Opphav,
   Tiltakstype,
 } from "mulighetsrommet-api-client";
+import { ControlledSokeSelect } from "mulighetsrommet-frontend-common/components/ControlledSokeSelect";
+import { SelectOption } from "mulighetsrommet-frontend-common/components/SokeSelect";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
+import { MultiValue } from "react-select";
 import { useHentBetabrukere } from "../../api/ansatt/useHentBetabrukere";
 import { useSokVirksomheter } from "../../api/virksomhet/useSokVirksomhet";
 import { useVirksomhet } from "../../api/virksomhet/useVirksomhet";
+import { erAnskaffetTiltak } from "../../utils/tiltakskoder";
 import { addYear } from "../../utils/Utils";
 import { Separator } from "../detaljside/Metadata";
+import { AdministratorOptions } from "../skjema/AdministratorOptions";
 import { ControlledMultiSelect } from "../skjema/ControlledMultiSelect";
+import { FormGroup } from "../skjema/FormGroup";
 import { FraTilDatoVelger } from "../skjema/FraTilDatoVelger";
 import skjemastyles from "../skjema/Skjema.module.scss";
 import { VirksomhetKontaktpersoner } from "../virksomhet/VirksomhetKontaktpersoner";
-import { ControlledSokeSelect } from "mulighetsrommet-frontend-common/components/ControlledSokeSelect";
-import { SelectOption } from "mulighetsrommet-frontend-common/components/SokeSelect";
-import { MultiValue } from "react-select";
-import { erAnskaffetTiltak } from "../../utils/tiltakskoder";
-import { AdministratorOptions } from "../skjema/AdministratorOptions";
-import { FormGroup } from "../skjema/FormGroup";
-import { getLokaleUnderenheterAsSelectOptions, underenheterOptions } from "./AvtaleSkjemaConst";
 import { InferredAvtaleSchema } from "./AvtaleSchema";
+import { getLokaleUnderenheterAsSelectOptions, underenheterOptions } from "./AvtaleSkjemaConst";
 
 const minStartdato = new Date(2000, 0, 1);
 
@@ -40,7 +40,6 @@ interface Props {
 
 export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: Props) {
   const [sokLeverandor, setSokLeverandor] = useState(avtale?.leverandor?.organisasjonsnummer || "");
-  const [valgtLeverandor, setValgtLeverandor] = useState<{ name?: string; value?: any }>({});
   const { data: leverandorVirksomheter = [] } = useSokVirksomheter(sokLeverandor);
 
   const { data: betabrukere } = useHentBetabrukere();
@@ -80,18 +79,12 @@ export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: 
     }));
 
     if (leverandorData) {
-      options.push({ label: leverandorData?.navn, value: leverandorData?.organisasjonsnummer });
+      options.push({
+        label: `${leverandorData.navn} - ${leverandorData.organisasjonsnummer}`,
+        value: leverandorData?.organisasjonsnummer,
+      });
     } else {
       options.push({ label: watchedLeverandor, value: watchedLeverandor });
-    }
-
-    // Fordi leverandør søk nulles ut når man velger leverandør legger vi til
-    // den valgte leverandøren manuelt i lista her.
-    if (valgtLeverandor?.name && valgtLeverandor?.value) {
-      options.push({
-        label: valgtLeverandor?.name,
-        value: valgtLeverandor?.value,
-      });
     }
 
     return options;
@@ -257,9 +250,6 @@ export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: 
                 placeholder="Skriv for å søke etter tiltaksarrangør"
                 label={"Tiltaksarrangør hovedenhet"}
                 {...register("leverandor")}
-                onChange={(v) => {
-                  setValgtLeverandor(v.target);
-                }}
                 onInputChange={(value) => {
                   setSokLeverandor(value);
                 }}

--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
@@ -79,6 +79,12 @@ export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: 
       label: `${enhet.navn} - ${enhet.organisasjonsnummer}`,
     }));
 
+    if (leverandorData) {
+      options.push({ label: leverandorData?.navn, value: leverandorData?.organisasjonsnummer });
+    } else {
+      options.push({ label: watchedLeverandor, value: watchedLeverandor });
+    }
+
     // Fordi leverandør søk nulles ut når man velger leverandør legger vi til
     // den valgte leverandøren manuelt i lista her.
     if (valgtLeverandor?.name && valgtLeverandor?.value) {

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
@@ -204,13 +204,13 @@ export function AvtaleDetaljer() {
             header="Arrangører underenheter"
             verdi={
               <ul>
-                {leverandorUnderenheter
-                  .filter((enhet) => enhet.navn)
-                  .map((enhet) => (
-                    <li key={enhet.organisasjonsnummer}>
-                      {enhet.navn} - {enhet.organisasjonsnummer}
-                    </li>
-                  ))}
+                {leverandorUnderenheter.map((enhet) => (
+                  <li key={enhet.organisasjonsnummer}>
+                    {enhet?.navn
+                      ? `${enhet.navn} - ${enhet.organisasjonsnummer}`
+                      : `${enhet.organisasjonsnummer}`}
+                  </li>
+                ))}
               </ul>
             }
           />

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -29,7 +29,6 @@ data class AppConfig(
     val veilarbdialogConfig: ServiceClientConfig,
     val veilarbveilederConfig: ServiceClientConfig,
     val poaoTilgang: ServiceClientConfig,
-    val amtEnhetsregister: ServiceClientConfig,
     val arenaAdapter: ServiceClientConfig,
     val msGraphConfig: ServiceClientConfig,
     val tasks: TaskConfig,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/VirksomhetRoutes.kt
@@ -38,7 +38,7 @@ fun Route.virksomhetRoutes() {
 
             val enhet = virksomhetService.getOrSyncVirksomhet(orgnr)
             if (enhet == null) {
-                call.respond(HttpStatusCode.NotFound, "Fant ikke enhet med orgnr: $orgnr")
+                call.respond(HttpStatusCode.NoContent, "Fant ikke enhet med orgnr: $orgnr")
             } else {
                 call.respond(enhet)
             }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -50,7 +50,6 @@ fun createTestApplicationConfig() = AppConfig(
     veilarbveilederConfig = createServiceClientConfig("veilarbveileder"),
     veilarbdialogConfig = createServiceClientConfig("veilarbdialog"),
     poaoTilgang = createServiceClientConfig("poaotilgang"),
-    amtEnhetsregister = createServiceClientConfig("amtenhetsregister"),
     msGraphConfig = createServiceClientConfig("ms-graph"),
     arenaAdapter = createServiceClientConfig("arena-adapter"),
     tasks = TaskConfig(


### PR DESCRIPTION
Returnerer bare orgnr som organisasjonsnummer og navn på virksomhet dersom vi ikke får treff i Brreg. Dette er en liten "hack" for å støtte blant annet svenske virksomheter som holder tiltak for NAV.