### PR TITLE
Ikke registrer endring når avtale/gjennomføring ikke har endret seg

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Faneinnhold.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Faneinnhold.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
 @Serializable
-class Faneinnhold(
+data class Faneinnhold(
     val forHvem: List<JsonObject>? = emptyList(),
     val forHvemInfoboks: String? = null,
     val detaljerOgInnhold: List<JsonObject>? = emptyList(),

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_avtaler.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_avtaler.ts
@@ -48,7 +48,6 @@ export const mockAvtaler: Avtale[] = [
         20 deltakere:
         Teori en uke: 56 771,- (55 117,-)                     Praksis en uke: 45 695,- (44 364,-)                       Kombinasjon en uke: 47 344,- (45 965,-)`,
     url: "https://www.websak.no",
-    updatedAt: new Date().toISOString(),
     kontorstruktur: [
       { region: mockEnheter._0300, kontorer: [mockEnheter._0313, mockEnheter._0318] },
       {
@@ -84,7 +83,6 @@ export const mockAvtaler: Avtale[] = [
     arenaAnsvarligEnhet: mockEnheter._0400,
     prisbetingelser: "Maskert prisbetingelser",
     url: null,
-    updatedAt: new Date().toISOString(),
     kontorstruktur: [
       { region: mockEnheter._0400, kontorer: [mockEnheter._0415, mockEnheter._0402] },
     ],
@@ -116,7 +114,6 @@ export const mockAvtaler: Avtale[] = [
     avtalestatus: Avtalestatus.AKTIV,
     arenaAnsvarligEnhet: mockEnheter._0313,
     prisbetingelser: "Maskert prisbetingelser",
-    updatedAt: new Date().toISOString(),
     kontorstruktur: [
       { region: mockEnheter._0400, kontorer: [mockEnheter._0415, mockEnheter._0402] },
       { region: mockEnheter._0300, kontorer: [mockEnheter._0313, mockEnheter._0318] },

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
@@ -8,7 +8,7 @@ import arrow.core.right
 import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.domain.dbo.AvtaleDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
-import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
+import no.nav.mulighetsrommet.api.domain.dto.AvtaleAdminDto
 import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.api.routes.v1.responses.ValidationError
@@ -19,11 +19,10 @@ import no.nav.mulighetsrommet.env.NaisEnv
 
 class AvtaleValidator(
     private val tiltakstyper: TiltakstypeRepository,
-    private val avtaler: AvtaleRepository,
     private val tiltaksgjennomforinger: TiltaksgjennomforingRepository,
     private val navEnheterService: NavEnhetService,
 ) {
-    fun validate(dbo: AvtaleDbo): Either<List<ValidationError>, AvtaleDbo> = either {
+    fun validate(dbo: AvtaleDbo, previous: AvtaleAdminDto?): Either<List<ValidationError>, AvtaleDbo> = either {
         val tiltakstype = tiltakstyper.get(dbo.tiltakstypeId)
             ?: raise(ValidationError.of(AvtaleDbo::tiltakstypeId, "Tiltakstypen finnes ikke").nel())
 
@@ -51,7 +50,7 @@ class AvtaleValidator(
                 )
             }
 
-            avtaler.get(dbo.id)?.also { avtale ->
+            previous?.also { avtale ->
                 if (dbo.opphav != avtale.opphav) {
                     add(ValidationError.of(AvtaleDbo::opphav, "Avtalens opphav kan ikke endres"))
                 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/AvtaleDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/AvtaleDbo.kt
@@ -4,7 +4,6 @@ import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dto.Avtaletype
 import no.nav.mulighetsrommet.domain.dto.Faneinnhold
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.*
 
 data class AvtaleDbo(
@@ -24,7 +23,6 @@ data class AvtaleDbo(
     val antallPlasser: Int?,
     val url: String?,
     val administratorer: List<String>,
-    val updatedAt: LocalDateTime,
     val beskrivelse: String?,
     val faneinnhold: Faneinnhold?,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -1,7 +1,6 @@
 package no.nav.mulighetsrommet.api.domain.dbo
 
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
-import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
 import no.nav.mulighetsrommet.domain.dto.Faneinnhold
 import java.time.LocalDate
@@ -17,7 +16,6 @@ data class TiltaksgjennomforingDbo(
     val arrangorKontaktpersonId: UUID?,
     val startDato: LocalDate,
     val sluttDato: LocalDate?,
-    val avslutningsstatus: Avslutningsstatus,
     val apentForInnsok: Boolean,
     val antallPlasser: Int,
     val avtaleId: UUID,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -1,7 +1,11 @@
 package no.nav.mulighetsrommet.api.domain.dto
 
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingKontaktpersonDbo
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
+import no.nav.mulighetsrommet.domain.dbo.ArenaTiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
 import no.nav.mulighetsrommet.domain.dto.Faneinnhold
 import no.nav.mulighetsrommet.domain.dto.Tiltaksgjennomforingsstatus
@@ -80,4 +84,64 @@ data class TiltaksgjennomforingAdminDto(
         val kontaktperson: VirksomhetKontaktperson?,
         val slettet: Boolean,
     )
+
+    fun toDbo() =
+        TiltaksgjennomforingDbo(
+            id = id,
+            navn = navn,
+            tiltakstypeId = tiltakstype.id,
+            tiltaksnummer = tiltaksnummer,
+            arrangorOrganisasjonsnummer = arrangor.organisasjonsnummer,
+            arrangorKontaktpersonId = arrangor.kontaktperson?.id,
+            startDato = startDato,
+            sluttDato = sluttDato,
+            apentForInnsok = apentForInnsok,
+            antallPlasser = antallPlasser ?: -1,
+            avtaleId = avtaleId ?: id,
+            administratorer = administratorer.map { it.navIdent },
+            navRegion = navRegion?.enhetsnummer ?: "",
+            navEnheter = navEnheter.map { it.enhetsnummer },
+            oppstart = oppstart,
+            opphav = opphav,
+            stengtFra = stengtFra,
+            stengtTil = stengtTil,
+            kontaktpersoner = kontaktpersoner.map {
+                TiltaksgjennomforingKontaktpersonDbo(
+                    navIdent = it.navIdent,
+                    navEnheter = it.navEnheter,
+                )
+            },
+            stedForGjennomforing = stedForGjennomforing,
+            faneinnhold = faneinnhold,
+            beskrivelse = beskrivelse,
+            fremmoteTidspunkt = fremmoteTidspunkt,
+            fremmoteSted = fremmoteSted,
+            deltidsprosent = deltidsprosent,
+        )
+
+    fun toArenaTiltaksgjennomforingDbo() =
+        ArenaTiltaksgjennomforingDbo(
+            id = id,
+            navn = navn,
+            tiltakstypeId = tiltakstype.id,
+            tiltaksnummer = tiltaksnummer ?: "",
+            arrangorOrganisasjonsnummer = arrangor.organisasjonsnummer,
+            startDato = startDato,
+            sluttDato = sluttDato,
+            arenaAnsvarligEnhet = arenaAnsvarligEnhet?.enhetsnummer,
+            avslutningsstatus = when (status) {
+                Tiltaksgjennomforingsstatus.PLANLAGT, Tiltaksgjennomforingsstatus.GJENNOMFORES -> Avslutningsstatus.IKKE_AVSLUTTET
+                Tiltaksgjennomforingsstatus.AVLYST -> Avslutningsstatus.AVLYST
+                Tiltaksgjennomforingsstatus.AVBRUTT -> Avslutningsstatus.AVBRUTT
+                Tiltaksgjennomforingsstatus.AVSLUTTET -> Avslutningsstatus.AVSLUTTET
+            },
+            apentForInnsok = apentForInnsok,
+            antallPlasser = antallPlasser,
+            avtaleId = avtaleId,
+            oppstart = oppstart,
+            opphav = opphav,
+            fremmoteTidspunkt = fremmoteTidspunkt,
+            fremmoteSted = fremmoteSted,
+            deltidsprosent = deltidsprosent,
+        )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -298,8 +298,8 @@ private fun services(appConfig: AppConfig) = module {
         UnleashService(appConfig.unleash, byEnhetStrategy, byNavidentStrategy)
     }
     single { AxsysService(appConfig.axsys) { m2mTokenProvider.createMachineToMachineToken(appConfig.axsys.scope) } }
-    single { AvtaleValidator(get(), get(), get(), get()) }
-    single { TiltaksgjennomforingValidator(get(), get(), get()) }
+    single { AvtaleValidator(get(), get(), get()) }
+    single { TiltaksgjennomforingValidator(get(), get()) }
 }
 
 private fun tasks(config: TaskConfig) = module {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -452,7 +452,6 @@ class AvtaleRepository(private val db: Database) {
             url = stringOrNull("url"),
             antallPlasser = intOrNull("antall_plasser"),
             opphav = ArenaMigrering.Opphav.valueOf(string("opphav")),
-            updatedAt = localDateTime("updated_at"),
             kontorstruktur = kontorstruktur,
             beskrivelse = stringOrNull("beskrivelse"),
             faneinnhold = stringOrNull("faneinnhold")?.let { Json.decodeFromString(it) },

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -592,7 +592,7 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "arrangor_kontaktperson_id" to arrangorKontaktpersonId,
         "start_dato" to startDato,
         "slutt_dato" to sluttDato,
-        "avslutningsstatus" to avslutningsstatus.name,
+        "avslutningsstatus" to Avslutningsstatus.IKKE_AVSLUTTET.name,
         "apent_for_innsok" to apentForInnsok,
         "antall_plasser" to antallPlasser,
         "avtale_id" to avtaleId,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -147,7 +147,6 @@ data class AvtaleRequest(
         prisbetingelser = prisbetingelser,
         navEnheter = navEnheter,
         opphav = opphav,
-        updatedAt = LocalDate.now().atStartOfDay(),
         beskrivelse = beskrivelse,
         faneinnhold = faneinnhold,
     )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -16,7 +16,6 @@ import no.nav.mulighetsrommet.api.services.TiltaksgjennomforingService
 import no.nav.mulighetsrommet.api.utils.getAdminTiltaksgjennomforingsFilter
 import no.nav.mulighetsrommet.api.utils.getPaginationParams
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
-import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
 import no.nav.mulighetsrommet.domain.dto.Faneinnhold
 import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
@@ -138,7 +137,6 @@ data class TiltaksgjennomforingRequest(
         avtaleId = avtaleId,
         startDato = startDato,
         sluttDato = sluttDato,
-        avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         antallPlasser = antallPlasser,
         apentForInnsok = apentForInnsok,
         tiltaksnummer = tiltaksnummer,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -47,17 +47,18 @@ class TiltaksgjennomforingService(
     ): Either<List<ValidationError>, TiltaksgjennomforingAdminDto> {
         virksomhetService.getOrSyncVirksomhet(request.arrangorOrganisasjonsnummer)
 
-        val previous = tiltaksgjennomforinger.get(request.id)
         return validator.validate(request.toDbo())
             .map { dbo ->
                 db.transactionSuspend { tx ->
+                    val previous = tiltaksgjennomforinger.get(request.id)
+                    if (previous?.toDbo() == dbo) {
+                        return@transactionSuspend previous
+                    }
+
                     tiltaksgjennomforinger.upsert(dbo, tx)
                     utkastRepository.delete(dbo.id, tx)
 
                     val dto = getOrError(dbo.id, tx)
-                    if (previous == dto) {
-                        return@transactionSuspend dto
-                    }
 
                     dispatchNotificationToNewAdministrators(tx, dbo, navIdent)
                     logEndring("Redigerte gjennomføring", dto, navIdent, tx)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -47,10 +47,10 @@ class TiltaksgjennomforingService(
     ): Either<List<ValidationError>, TiltaksgjennomforingAdminDto> {
         virksomhetService.getOrSyncVirksomhet(request.arrangorOrganisasjonsnummer)
 
-        return validator.validate(request.toDbo())
+        val previous = tiltaksgjennomforinger.get(request.id)
+        return validator.validate(request.toDbo(), previous)
             .map { dbo ->
                 db.transactionSuspend { tx ->
-                    val previous = tiltaksgjennomforinger.get(request.id)
                     if (previous?.toDbo() == dbo) {
                         return@transactionSuspend previous
                     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/GenerateValidationReport.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/GenerateValidationReport.kt
@@ -131,7 +131,7 @@ class GenerateValidationReport(
     private suspend fun validateAvtaler() = buildMap {
         paginateFanOut({ pagination -> avtaler.getAll(pagination).second }) {
             val dbo = it.toDbo()
-            avtaleValidator.validate(dbo)
+            avtaleValidator.validate(dbo, it)
                 .onLeft { validationErrors ->
                     put(it, validationErrors)
                 }
@@ -156,7 +156,7 @@ class GenerateValidationReport(
     private suspend fun validateGjennomforinger() = buildMap {
         paginateFanOut({ pagination -> gjennomforinger.getAll(pagination).second }) {
             val dbo = it.toDbo()
-            gjennomforingValidator.validate(dbo)
+            gjennomforingValidator.validate(dbo, it)
                 .onLeft { validationErrors ->
                     put(it, validationErrors)
                 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
@@ -6,9 +6,9 @@ import arrow.core.nel
 import arrow.core.raise.either
 import arrow.core.right
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingAdminDto
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
-import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.routes.v1.responses.ValidationError
 import no.nav.mulighetsrommet.domain.Tiltakskoder
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
@@ -17,10 +17,12 @@ import java.time.LocalTime
 
 class TiltaksgjennomforingValidator(
     private val avtaler: AvtaleRepository,
-    private val tiltaksgjennomforinger: TiltaksgjennomforingRepository,
     private val deltakere: DeltakerRepository,
 ) {
-    fun validate(dbo: TiltaksgjennomforingDbo): Either<List<ValidationError>, TiltaksgjennomforingDbo> = either {
+    fun validate(
+        dbo: TiltaksgjennomforingDbo,
+        previousDto: TiltaksgjennomforingAdminDto?,
+    ): Either<List<ValidationError>, TiltaksgjennomforingDbo> = either {
         val avtale = avtaler.get(dbo.avtaleId)
             ?: raise(ValidationError.of(TiltaksgjennomforingDbo::avtaleId, "Avtalen finnes ikke").nel())
 
@@ -120,7 +122,7 @@ class TiltaksgjennomforingValidator(
                 )
             }
 
-            tiltaksgjennomforinger.get(dbo.id)?.also { gjennomforing ->
+            previousDto?.also { gjennomforing ->
                 if (!gjennomforing.isAktiv()) {
                     add(
                         ValidationError.of(

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1870,9 +1870,6 @@ components:
           $ref: "#/components/schemas/NavKontorStruktur"
         opphav:
           $ref: "#/components/schemas/Opphav"
-        updatedAt:
-          type: string
-          format: date-time
         beskrivelse:
           type: string
         faneinnhold:
@@ -1891,7 +1888,6 @@ components:
         - prisbetingelser
         - kontorstruktur
         - opphav
-        - updatedAt
 
     AvtaleRequest:
       type: object

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
@@ -27,7 +27,6 @@ import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dto.Avtaletype
 import no.nav.mulighetsrommet.env.NaisEnv
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.*
 
 class AvtaleValidatorTest : FunSpec({
@@ -50,7 +49,6 @@ class AvtaleValidatorTest : FunSpec({
         navEnheter = listOf("0400", "0502"),
         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
         antallPlasser = null,
-        updatedAt = LocalDateTime.now(),
         beskrivelse = null,
         faneinnhold = null,
     )
@@ -214,7 +212,6 @@ class AvtaleValidatorTest : FunSpec({
                 navEnheter = listOf("0300"),
                 opphav = ArenaMigrering.Opphav.ARENA,
                 antallPlasser = null,
-                updatedAt = avtaleDbo.updatedAt,
                 beskrivelse = null,
                 faneinnhold = null,
             )

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
@@ -100,7 +100,7 @@ class AvtaleValidatorTest : FunSpec({
     }
 
     test("should accumulate errors when dbo has multiple issues") {
-        val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+        val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
 
         val dbo = avtaleDbo.copy(
             startDato = LocalDate.of(2023, 1, 1),
@@ -109,7 +109,7 @@ class AvtaleValidatorTest : FunSpec({
             leverandorUnderenheter = emptyList(),
         )
 
-        validator.validate(dbo).shouldBeLeft().shouldContainAll(
+        validator.validate(dbo, null).shouldBeLeft().shouldContainAll(
             listOf(
                 ValidationError("startDato", "Startdato må være før sluttdato"),
                 ValidationError("navEnheter", "Minst én NAV-region må være valgt"),
@@ -119,9 +119,9 @@ class AvtaleValidatorTest : FunSpec({
     }
 
     test("Avtalenavn må være minst 5 tegn når avtalen er opprettet i Admin-flate") {
-        val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+        val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
         val dbo = avtaleDbo.copy(navn = "Avt", opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE)
-        validator.validate(dbo).shouldBeLeft().shouldContainExactlyInAnyOrder(
+        validator.validate(dbo, null).shouldBeLeft().shouldContainExactlyInAnyOrder(
             listOf(
                 ValidationError("navn", "Avtalenavn må være minst 5 tegn langt"),
             ),
@@ -129,13 +129,13 @@ class AvtaleValidatorTest : FunSpec({
     }
 
     test("skal validere at ") {
-        val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+        val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
 
         val dbo = avtaleDbo.copy(
             navEnheter = listOf("0300", "0502"),
         )
 
-        validator.validate(dbo).shouldBeLeft().shouldContainExactlyInAnyOrder(
+        validator.validate(dbo, null).shouldBeLeft().shouldContainExactlyInAnyOrder(
             listOf(
                 ValidationError("navEnheter", "NAV-enheten 0502 passer ikke i avtalens kontorstruktur"),
             ),
@@ -144,13 +144,13 @@ class AvtaleValidatorTest : FunSpec({
 
     context("når avtalen ikke allerede eksisterer") {
         test("skal feile når tiltakstypen ikke er VTA eller AFT og miljø er produksjon") {
-            val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+            val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
             mockkObject(NaisEnv.current())
             coEvery { NaisEnv.current().isProdGCP() } returns true
 
             val dbo = avtaleDbo.copy(tiltakstypeId = TiltakstypeFixtures.Oppfolging.id)
 
-            validator.validate(dbo).shouldBeLeft().shouldContain(
+            validator.validate(dbo, null).shouldBeLeft().shouldContain(
                 ValidationError(
                     "tiltakstypeId",
                     "Avtaler kan bare opprettes når de gjelder for tiltakstypene AFT eller VTA",
@@ -159,23 +159,23 @@ class AvtaleValidatorTest : FunSpec({
         }
 
         test("skal ikke feile når tiltakstypen ikke er VTA eller AFT og miljø ikke er produksjon") {
-            val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+            val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
             mockkObject(NaisEnv.current())
             coEvery { NaisEnv.current().isProdGCP() } returns false
 
             val dbo = avtaleDbo.copy(tiltakstypeId = TiltakstypeFixtures.Oppfolging.id)
 
-            validator.validate(dbo).shouldBeRight {
+            validator.validate(dbo, null).shouldBeRight {
                 dbo.tiltakstypeId.toString() shouldBe TiltakstypeFixtures.Oppfolging.id.toString()
             }
         }
 
         test("skal feile når opphav ikke er MR_ADMIN_FLATE") {
-            val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+            val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
 
             val dbo = avtaleDbo.copy(opphav = ArenaMigrering.Opphav.ARENA)
 
-            validator.validate(dbo).shouldBeLeft().shouldContain(
+            validator.validate(dbo, null).shouldBeLeft().shouldContain(
                 ValidationError("opphav", "Opphav må være MR_ADMIN_FLATE"),
             )
         }
@@ -185,11 +185,12 @@ class AvtaleValidatorTest : FunSpec({
         test("skal ikke kunne endre opphav") {
             avtaler.upsert(avtaleDbo.copy(opphav = ArenaMigrering.Opphav.ARENA, administratorer = listOf()))
 
-            val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+            val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
 
             val dbo = avtaleDbo.copy(opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE)
 
-            validator.validate(dbo).shouldBeLeft().shouldContain(
+            val previous = avtaler.get(avtaleDbo.id)
+            validator.validate(dbo, previous).shouldBeLeft().shouldContain(
                 ValidationError("opphav", "Avtalens opphav kan ikke endres"),
             )
         }
@@ -223,9 +224,10 @@ class AvtaleValidatorTest : FunSpec({
                 ),
             )
 
-            val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+            val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
 
-            validator.validate(avtaleMedEndringer).shouldBeLeft().shouldContainExactlyInAnyOrder(
+            val previous = avtaler.get(avtaleDbo.id)
+            validator.validate(avtaleMedEndringer, previous).shouldBeLeft().shouldContainExactlyInAnyOrder(
                 listOf(
                     ValidationError("navn", "Navn kan ikke endres utenfor Arena"),
                     ValidationError("tiltakstypeId", "Tiltakstype kan ikke endres utenfor Arena"),
@@ -255,7 +257,7 @@ class AvtaleValidatorTest : FunSpec({
             }
 
             test("skal validere at data samsvarer med avtalens gjennomføringer") {
-                val validator = AvtaleValidator(tiltakstyper, avtaler, gjennomforinger, navEnheterService)
+                val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService)
 
                 val dbo = avtaleDbo.copy(
                     tiltakstypeId = TiltakstypeFixtures.VTA.id,
@@ -263,7 +265,8 @@ class AvtaleValidatorTest : FunSpec({
                     navEnheter = listOf("0400"),
                 )
 
-                validator.validate(dbo).shouldBeLeft().shouldContainExactlyInAnyOrder(
+                val previous = avtaler.get(avtaleDbo.id)
+                validator.validate(dbo, previous).shouldBeLeft().shouldContainExactlyInAnyOrder(
                     listOf(
                         ValidationError(
                             "tiltakstypeId",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -31,7 +31,6 @@ object AvtaleFixtures {
         leverandorKontaktpersonId = null,
         antallPlasser = null,
         url = null,
-        updatedAt = LocalDate.now().atStartOfDay(),
         beskrivelse = null,
         faneinnhold = null,
     )
@@ -87,7 +86,6 @@ object AvtaleFixtures {
         url = null,
         antallPlasser = null,
         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-        updatedAt = avtale1.updatedAt,
         kontorstruktur = listOf(
             Kontorstruktur(
                 region = EmbeddedNavEnhet(
@@ -137,7 +135,6 @@ object AvtaleFixtures {
         url = null,
         antallPlasser = null,
         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-        updatedAt = avtale1.updatedAt,
         kontorstruktur = listOf(
             Kontorstruktur(
                 region = EmbeddedNavEnhet(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -1,13 +1,11 @@
 package no.nav.mulighetsrommet.api.fixtures
 
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
-import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingAdminDto
 import no.nav.mulighetsrommet.api.routes.v1.TiltaksgjennomforingRequest
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.ArenaTiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
-import no.nav.mulighetsrommet.domain.dto.Tiltaksgjennomforingsstatus
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -41,7 +39,6 @@ object TiltaksgjennomforingFixtures {
         arrangorOrganisasjonsnummer = "976663934",
         startDato = LocalDate.of(2023, 1, 1),
         sluttDato = LocalDate.of(2023, 2, 1),
-        avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         apentForInnsok = true,
         antallPlasser = 12,
         administratorer = listOf(),
@@ -90,48 +87,6 @@ object TiltaksgjennomforingFixtures {
         deltidsprosent = 100.0,
     )
 
-    val Oppfolging1AdminDto = TiltaksgjennomforingAdminDto(
-        id = Oppfolging1.id,
-        tiltakstype = TiltaksgjennomforingAdminDto.Tiltakstype(
-            id = TiltakstypeFixtures.Oppfolging.id,
-            navn = TiltakstypeFixtures.Oppfolging.navn,
-            arenaKode = TiltakstypeFixtures.Oppfolging.tiltakskode,
-        ),
-        navn = Oppfolging1.navn,
-        tiltaksnummer = Oppfolging1.tiltaksnummer,
-        arrangor = TiltaksgjennomforingAdminDto.Arrangor(
-            organisasjonsnummer = Oppfolging1.arrangorOrganisasjonsnummer,
-            navn = "Bedrift",
-            kontaktperson = null,
-            slettet = false,
-        ),
-        startDato = Oppfolging1.startDato,
-        sluttDato = Oppfolging1.sluttDato,
-        arenaAnsvarligEnhet = null,
-        status = Tiltaksgjennomforingsstatus.GJENNOMFORES,
-        apentForInnsok = Oppfolging1.apentForInnsok,
-        antallPlasser = Oppfolging1.antallPlasser,
-        avtaleId = Oppfolging1.avtaleId,
-        administratorer = emptyList(),
-        navEnheter = emptyList(),
-        navRegion = null,
-        sanityId = null,
-        oppstart = Oppfolging1.oppstart,
-        opphav = Oppfolging1.opphav,
-        stengtFra = Oppfolging1.stengtFra,
-        stengtTil = Oppfolging1.stengtTil,
-        kontaktpersoner = emptyList(),
-        stedForGjennomforing = Oppfolging1.stedForGjennomforing,
-        faneinnhold = Oppfolging1.faneinnhold,
-        beskrivelse = Oppfolging1.beskrivelse,
-        createdAt = Oppfolging1.startDato.atStartOfDay(),
-        tilgjengeligForVeileder = true,
-        visesForVeileder = true,
-        fremmoteTidspunkt = null,
-        fremmoteSted = null,
-        deltidsprosent = 100.0,
-    )
-
     val Oppfolging2 = TiltaksgjennomforingDbo(
         id = UUID.randomUUID(),
         navn = "Oppfølging 2",
@@ -140,7 +95,6 @@ object TiltaksgjennomforingFixtures {
         arrangorOrganisasjonsnummer = "111111111",
         startDato = LocalDate.of(2023, 1, 1),
         sluttDato = LocalDate.of(2023, 2, 1),
-        avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         apentForInnsok = true,
         antallPlasser = 12,
         administratorer = emptyList(),
@@ -169,7 +123,6 @@ object TiltaksgjennomforingFixtures {
         arrangorOrganisasjonsnummer = "222222222",
         startDato = LocalDate.of(2023, 1, 1),
         sluttDato = LocalDate.of(2023, 2, 1),
-        avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         apentForInnsok = true,
         antallPlasser = 12,
         administratorer = emptyList(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -611,24 +611,24 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         val dagensDato = LocalDate.of(2023, 2, 1)
 
         val tiltaksgjennomforingAktiv = Arbeidstrening1
-        val tiltaksgjennomforingAvsluttetStatus = Oppfolging1.copy(
+        val tiltaksgjennomforingAvsluttetStatus = ArenaOppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.AVSLUTTET,
         )
-        val tiltaksgjennomforingAvsluttetDato = Oppfolging1.copy(
+        val tiltaksgjennomforingAvsluttetDato = ArenaOppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
             sluttDato = LocalDate.of(2023, 1, 31),
         )
-        val tiltaksgjennomforingAvbrutt = Oppfolging1.copy(
+        val tiltaksgjennomforingAvbrutt = ArenaOppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.AVBRUTT,
         )
-        val tiltaksgjennomforingAvlyst = Oppfolging1.copy(
+        val tiltaksgjennomforingAvlyst = ArenaOppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.AVLYST,
         )
-        val tiltaksgjennomforingPlanlagt = Oppfolging1.copy(
+        val tiltaksgjennomforingPlanlagt = ArenaOppfolging1.copy(
             id = UUID.randomUUID(),
             avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
             startDato = LocalDate.of(2023, 2, 2),
@@ -637,11 +637,11 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
         beforeAny {
             val tiltaksgjennomforingRepository = TiltaksgjennomforingRepository(database.db)
             tiltaksgjennomforingRepository.upsert(tiltaksgjennomforingAktiv)
-            tiltaksgjennomforingRepository.upsert(tiltaksgjennomforingAvsluttetStatus)
-            tiltaksgjennomforingRepository.upsert(tiltaksgjennomforingAvsluttetDato)
-            tiltaksgjennomforingRepository.upsert(tiltaksgjennomforingAvbrutt)
-            tiltaksgjennomforingRepository.upsert(tiltaksgjennomforingPlanlagt)
-            tiltaksgjennomforingRepository.upsert(tiltaksgjennomforingAvlyst)
+            tiltaksgjennomforingRepository.upsertArenaTiltaksgjennomforing(tiltaksgjennomforingAvsluttetStatus)
+            tiltaksgjennomforingRepository.upsertArenaTiltaksgjennomforing(tiltaksgjennomforingAvsluttetDato)
+            tiltaksgjennomforingRepository.upsertArenaTiltaksgjennomforing(tiltaksgjennomforingAvbrutt)
+            tiltaksgjennomforingRepository.upsertArenaTiltaksgjennomforing(tiltaksgjennomforingPlanlagt)
+            tiltaksgjennomforingRepository.upsertArenaTiltaksgjennomforing(tiltaksgjennomforingAvlyst)
         }
 
         test("filtrer på avbrutt") {
@@ -840,7 +840,6 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                         tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                         tiltaksnummer = "$it",
                         arrangorOrganisasjonsnummer = "123456789",
-                        avslutningsstatus = Avslutningsstatus.AVSLUTTET,
                         startDato = LocalDate.of(2022, 1, 1),
                         apentForInnsok = true,
                         oppstart = TiltaksgjennomforingOppstartstype.FELLES,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/VirksomhetRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/VirksomhetRepositoryTest.kt
@@ -14,7 +14,6 @@ import no.nav.mulighetsrommet.api.utils.VirksomhetTil
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.database.utils.getOrThrow
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
-import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
 import no.nav.mulighetsrommet.domain.dbo.TiltakstypeDbo
 import no.nav.mulighetsrommet.domain.dto.Avtaletype
@@ -241,7 +240,6 @@ class VirksomhetRepositoryTest : FunSpec({
                 antallPlasser = null,
                 url = null,
                 administratorer = emptyList(),
-                updatedAt = LocalDate.now().atStartOfDay(),
                 beskrivelse = null,
                 faneinnhold = null,
             )
@@ -253,7 +251,6 @@ class VirksomhetRepositoryTest : FunSpec({
                 tiltaksnummer = null,
                 arrangorOrganisasjonsnummer = "112254604",
                 startDato = LocalDate.now(),
-                avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
                 apentForInnsok = true,
                 antallPlasser = 12,
                 administratorer = emptyList(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/AvtaleServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/AvtaleServiceTest.kt
@@ -42,7 +42,7 @@ class AvtaleServiceTest : FunSpec({
     beforeEach {
         domain.initialize(database.db)
 
-        every { validator.validate(any()) } answers {
+        every { validator.validate(any(), any()) } answers {
             firstArg<AvtaleDbo>().right()
         }
     }
@@ -64,7 +64,7 @@ class AvtaleServiceTest : FunSpec({
         test("Man skal ikke få lov til å opprette avtale dersom det oppstår valideringsfeil") {
             val request = AvtaleFixtures.avtaleRequest
 
-            every { validator.validate(request.toDbo()) } returns listOf(ValidationError("navn", "Dårlig navn")).left()
+            every { validator.validate(request.toDbo(), any()) } returns listOf(ValidationError("navn", "Dårlig navn")).left()
 
             avtaleService.upsert(request, "B123456").shouldBeLeft(
                 listOf(ValidationError("navn", "Dårlig navn")),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingServiceTest.kt
@@ -46,7 +46,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
     beforeEach {
         domain.initialize(database.db)
 
-        every { validator.validate(any()) } answers {
+        every { validator.validate(any(), any()) } answers {
             firstArg<TiltaksgjennomforingDbo>().right()
         }
     }
@@ -140,7 +140,7 @@ class TiltaksgjennomforingServiceTest : FunSpec({
         test("Man skal ikke få lov til å opprette gjennomføring dersom det oppstår valideringsfeil") {
             val gjennomforing = TiltaksgjennomforingFixtures.Oppfolging1Request
 
-            every { validator.validate(gjennomforing.toDbo()) } returns listOf(
+            every { validator.validate(gjennomforing.toDbo(), any()) } returns listOf(
                 ValidationError("navn", "Dårlig navn"),
             ).left()
 


### PR DESCRIPTION
 - Fjernet updatedAt fra AvtaleAdminDto da denne brekker equality (updated_at endres uavhenging om noe endret seg på upsert)
 - Faneinnhold må være data class for at equality skal funke