### PR TITLE
Stopp opprettelse av tiltak når tiltakstype ikke er skrudd på

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ExclamationmarkTriangleFillIcon } from "@navikt/aksel-icons";
-import { Alert, Button, Tabs } from "@navikt/ds-react";
+import { Button, Tabs } from "@navikt/ds-react";
 import { useAtom } from "jotai";
 import {
   Avtale,
@@ -8,16 +8,18 @@ import {
   Tiltaksgjennomforing,
   TiltaksgjennomforingRequest,
 } from "mulighetsrommet-api-client";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { v4 as uuidv4 } from "uuid";
 import { gjennomforingDetaljerTabAtom } from "../../api/atoms";
 import { useHandleApiUpsertResponse } from "../../api/effects";
 import { useUpsertTiltaksgjennomforing } from "../../api/tiltaksgjennomforing/useUpsertTiltaksgjennomforing";
 import { formaterDatoSomYYYYMMDD } from "../../utils/Utils";
+import { HarSkrivetilgang } from "../authActions/HarSkrivetilgang";
 import { Separator } from "../detaljside/Metadata";
 import { AvbrytTiltaksgjennomforingModal } from "../modal/AvbrytTiltaksgjennomforingModal";
 import skjemastyles from "../skjema/Skjema.module.scss";
+import { TiltakgjennomforingRedaksjoneltInnholdForm } from "./TiltaksgjennomforingRedaksjoneltInnholdForm";
 import {
   InferredTiltaksgjennomforingSchema,
   TiltaksgjennomforingSchema,
@@ -25,8 +27,6 @@ import {
 import { defaultTiltaksgjennomforingData, erArenaOpphav } from "./TiltaksgjennomforingSkjemaConst";
 import { TiltaksgjennomforingSkjemaDetaljer } from "./TiltaksgjennomforingSkjemaDetaljer";
 import { TiltaksgjennomforingSkjemaKnapperad } from "./TiltaksgjennomforingSkjemaKnapperad";
-import { TiltakgjennomforingRedaksjoneltInnholdForm } from "./TiltaksgjennomforingRedaksjoneltInnholdForm";
-import { HarSkrivetilgang } from "../authActions/HarSkrivetilgang";
 
 interface Props {
   onClose: () => void;
@@ -46,7 +46,6 @@ export const TiltaksgjennomforingSkjemaContainer = ({
   const redigeringsModus = !!tiltaksgjennomforing;
   const mutation = useUpsertTiltaksgjennomforing();
   const [activeTab, setActiveTab] = useAtom(gjennomforingDetaljerTabAtom);
-  const [error, setError] = useState("");
 
   const avbrytModalRef = useRef<HTMLDialogElement>(null);
 
@@ -115,10 +114,6 @@ export const TiltaksgjennomforingSkjemaContainer = ({
         form.setError(name, { type: "custom", message: error.message });
       });
 
-      if (validation?.message) {
-        setError(validation.message);
-      }
-
       function mapErrorToSchemaPropertyName(name: string) {
         const mapping: { [name: string]: string } = {
           startDato: "startOgSluttDato.startDato",
@@ -141,16 +136,6 @@ export const TiltaksgjennomforingSkjemaContainer = ({
 
   return (
     <FormProvider {...form}>
-      {!redigeringsModus ? (
-        <Alert variant="warning" style={{ margin: "1rem 0" }}>
-          Opprettelse av gjennomføring her vil ikke opprette gjennomføringen i Arena.
-        </Alert>
-      ) : null}
-      {error ? (
-        <Alert variant="error" style={{ margin: "1rem 0" }}>
-          {error}
-        </Alert>
-      ) : null}
       <form onSubmit={handleSubmit(postData)}>
         <Tabs defaultValue={activeTab}>
           <Tabs.List className={skjemastyles.tabslist}>

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
@@ -8,7 +8,7 @@ import {
   Tiltaksgjennomforing,
   TiltaksgjennomforingRequest,
 } from "mulighetsrommet-api-client";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { v4 as uuidv4 } from "uuid";
 import { gjennomforingDetaljerTabAtom } from "../../api/atoms";
@@ -46,6 +46,7 @@ export const TiltaksgjennomforingSkjemaContainer = ({
   const redigeringsModus = !!tiltaksgjennomforing;
   const mutation = useUpsertTiltaksgjennomforing();
   const [activeTab, setActiveTab] = useAtom(gjennomforingDetaljerTabAtom);
+  const [error, setError] = useState("");
 
   const avbrytModalRef = useRef<HTMLDialogElement>(null);
 
@@ -114,6 +115,10 @@ export const TiltaksgjennomforingSkjemaContainer = ({
         form.setError(name, { type: "custom", message: error.message });
       });
 
+      if (validation?.message) {
+        setError(validation.message);
+      }
+
       function mapErrorToSchemaPropertyName(name: string) {
         const mapping: { [name: string]: string } = {
           startDato: "startOgSluttDato.startDato",
@@ -139,6 +144,11 @@ export const TiltaksgjennomforingSkjemaContainer = ({
       {!redigeringsModus ? (
         <Alert variant="warning" style={{ margin: "1rem 0" }}>
           Opprettelse av gjennomføring her vil ikke opprette gjennomføringen i Arena.
+        </Alert>
+      ) : null}
+      {error ? (
+        <Alert variant="error" style={{ margin: "1rem 0" }}>
+          {error}
         </Alert>
       ) : null}
       <form onSubmit={handleSubmit(postData)}>

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon, XMarkIcon } from "@navikt/aksel-icons";
-import { Button, Checkbox, HStack, TextField } from "@navikt/ds-react";
+import { Alert, Button, Checkbox, HStack, TextField } from "@navikt/ds-react";
 import { Avtale, Tiltaksgjennomforing, Toggles } from "mulighetsrommet-api-client";
 import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
 import { useFieldArray, useFormContext } from "react-hook-form";
@@ -113,7 +113,14 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
               readOnly
               label={`Avtale (tiltakstype: ${avtale.tiltakstype.navn})`}
               value={avtale.navn || ""}
+              error={errors.avtale?.message as string}
             />
+            {/**
+             * // TODO Kan fjerne alert under når Aksel har fikset readonly + error
+             * */}
+            {errors.avtale?.message ? (
+              <Alert variant="warning">{errors.avtale.message as string}</Alert>
+            ) : null}
           </FormGroup>
           <Separator />
           <FormGroup>

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -57,7 +57,7 @@ fun Application.configure(config: AppConfig) {
 
         authenticate(AuthProvider.AZURE_AD_NAV_IDENT.name, AuthProvider.AZURE_AD_TILTAKSADMINISTRASJON_GENERELL.name) {
             tiltakstypeRoutes()
-            tiltaksgjennomforingRoutes()
+            tiltaksgjennomforingRoutes(config)
             avtaleRoutes()
             veilederflateRoutes()
             brukerRoutes()

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -37,7 +37,7 @@ fun Route.tiltaksgjennomforingRoutes(appConfig: AppConfig) {
     route("/api/v1/internal/tiltaksgjennomforinger") {
         authenticate(
             AuthProvider.AZURE_AD_TILTAKSJENNOMFORINGER_SKRIV.name,
-            strategy = AuthenticationStrategy.Required
+            strategy = AuthenticationStrategy.Required,
         ) {
             put {
                 val request = call.receive<TiltaksgjennomforingRequest>()
@@ -52,9 +52,9 @@ fun Route.tiltaksgjennomforingRoutes(appConfig: AppConfig) {
                         Either.Left(
                             BadRequest(
                                 message = "Opprettelse av tiltaksgjennomføring for tiltakstype: '${tiltakstype.navn}' er ikke skrudd på enda.",
-                                errors = emptyList()
-                            )
-                        )
+                                errors = emptyList(),
+                            ),
+                        ),
                     )
                 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -15,8 +15,8 @@ import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingKontaktpersonDbo
 import no.nav.mulighetsrommet.api.plugins.AuthProvider
 import no.nav.mulighetsrommet.api.plugins.getNavIdent
-import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
+import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.api.routes.v1.responses.BadRequest
 import no.nav.mulighetsrommet.api.routes.v1.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.services.TiltaksgjennomforingService

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -18,6 +18,7 @@ import no.nav.mulighetsrommet.api.plugins.getNavIdent
 import no.nav.mulighetsrommet.api.repositories.DeltakerRepository
 import no.nav.mulighetsrommet.api.repositories.TiltakstypeRepository
 import no.nav.mulighetsrommet.api.routes.v1.responses.BadRequest
+import no.nav.mulighetsrommet.api.routes.v1.responses.ValidationError
 import no.nav.mulighetsrommet.api.routes.v1.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.services.TiltaksgjennomforingService
 import no.nav.mulighetsrommet.api.utils.getAdminTiltaksgjennomforingsFilter
@@ -53,8 +54,12 @@ fun Route.tiltaksgjennomforingRoutes(appConfig: AppConfig) {
                     call.respondWithStatusResponse(
                         Either.Left(
                             BadRequest(
-                                message = "Opprettelse av tiltaksgjennomføring for tiltakstype: '${tiltakstype.navn}' er ikke skrudd på enda.",
-                                errors = emptyList(),
+                                errors = listOf(
+                                    ValidationError(
+                                        name = "avtale",
+                                        message = "Opprettelse av tiltaksgjennomføring for tiltakstype: '${tiltakstype.navn}' er ikke skrudd på enda."
+                                    )
+                                ),
                             ),
                         ),
                     )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -57,8 +57,8 @@ fun Route.tiltaksgjennomforingRoutes(appConfig: AppConfig) {
                                 errors = listOf(
                                     ValidationError(
                                         name = "avtale",
-                                        message = "Opprettelse av tiltaksgjennomføring for tiltakstype: '${tiltakstype.navn}' er ikke skrudd på enda."
-                                    )
+                                        message = "Opprettelse av tiltaksgjennomføring for tiltakstype: '${tiltakstype.navn}' er ikke skrudd på enda.",
+                                    ),
                                 ),
                             ),
                         ),

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -23,7 +23,19 @@ app:
     producers:
       arenaMigreringTiltaksgjennomforinger:
         topic: arena-migrering-tiltaksgjennomforinger-v1
-        tiltakstyper: []
+        tiltakstyper:
+          - ARBFORB
+          - ARBRRHDAG
+          - AVKLARAG
+          - DIGIOPPARB
+          - GRUFAGYRKE
+          - GRUPPEAMO
+          - INDJOBSTOT
+          - INDOPPFAG
+          - IPSUNG
+          - JOBBK
+          - UTVAOONAV
+          - VASV
       tiltaksgjennomforinger:
         topic: siste-tiltaksgjennomforinger-v1
       tiltakstyper:

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1606,6 +1606,8 @@ components:
     ValidationErrorResponse:
       type: object
       properties:
+        message:
+          type: string
         errors:
           type: array
           items:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -104,7 +104,7 @@ fun createKafkaConfig(): KafkaConfig {
             tiltakstyper = TiltakstypeKafkaProducer.Config(topic = "siste-tiltakstyper-v1"),
             arenaMigreringTiltaksgjennomforinger = ArenaMigreringTiltaksgjennomforingKafkaProducer.Config(
                 topic = "arena-migrering-tiltaksgjennomforinger-v1",
-                tiltakstyper = emptyList(),
+                tiltakstyper = listOf("INDOPPFAG"),
             ),
         ),
         consumerGroupId = "mulighetsrommet-api-consumer",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -35,6 +35,27 @@ object AvtaleFixtures {
         faneinnhold = null,
     )
 
+    val avtaleForVta = AvtaleDbo(
+        id = UUID.randomUUID(),
+        navn = "Avtalenavn for VTA",
+        avtalenummer = "2024#1",
+        tiltakstypeId = TiltakstypeFixtures.VTA.id,
+        leverandorOrganisasjonsnummer = "123456789",
+        leverandorUnderenheter = emptyList(),
+        startDato = LocalDate.of(2023, 1, 1),
+        sluttDato = LocalDate.of(2023, 2, 28),
+        avtaletype = Avtaletype.Rammeavtale,
+        prisbetingelser = null,
+        opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
+        administratorer = emptyList(),
+        navEnheter = listOf("2990"),
+        leverandorKontaktpersonId = null,
+        antallPlasser = null,
+        url = null,
+        beskrivelse = null,
+        faneinnhold = null,
+    )
+
     val avtaleRequest = AvtaleRequest(
         id = UUID.randomUUID(),
         navn = "Avtalenavn",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -17,7 +17,7 @@ data class MulighetsrommetTestDomain(
     val tiltakstyper: List<TiltakstypeDbo> = listOf(
         TiltakstypeFixtures.Oppfolging,
         TiltakstypeFixtures.Arbeidstrening,
-        TiltakstypeFixtures.VTA
+        TiltakstypeFixtures.VTA,
     ),
     val avtaler: List<AvtaleDbo> = listOf(AvtaleFixtures.avtale1, AvtaleFixtures.avtaleForVta),
 ) {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -17,8 +17,9 @@ data class MulighetsrommetTestDomain(
     val tiltakstyper: List<TiltakstypeDbo> = listOf(
         TiltakstypeFixtures.Oppfolging,
         TiltakstypeFixtures.Arbeidstrening,
+        TiltakstypeFixtures.VTA
     ),
-    val avtaler: List<AvtaleDbo> = listOf(AvtaleFixtures.avtale1),
+    val avtaler: List<AvtaleDbo> = listOf(AvtaleFixtures.avtale1, AvtaleFixtures.avtaleForVta),
 ) {
     fun initialize(database: FlywayDatabaseAdapter) {
         NavEnhetRepository(database).also { repository ->

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
@@ -559,7 +559,7 @@ class AvtaleRepositoryTest : FunSpec({
             avtaler.upsert(avtale5)
             val result = avtaler.getAll(sortering = "navn-ascending")
 
-            result.second shouldHaveSize 5
+            result.second shouldHaveSize 6
             result.second[0].navn shouldBe "Avtale hos Anders"
             result.second[1].navn shouldBe "Avtale hos Kjetil"
             result.second[2].navn shouldBe "Avtale hos Ærfuglen Ærle"
@@ -594,12 +594,13 @@ class AvtaleRepositoryTest : FunSpec({
             avtaler.upsert(avtale5)
             val result = avtaler.getAll(sortering = "navn-descending")
 
-            result.second shouldHaveSize 5
-            result.second[0].navn shouldBe "Avtale hos Åse"
-            result.second[1].navn shouldBe "Avtale hos Øyvind"
-            result.second[2].navn shouldBe "Avtale hos Ærfuglen Ærle"
-            result.second[3].navn shouldBe "Avtale hos Kjetil"
-            result.second[4].navn shouldBe "Avtale hos Anders"
+            result.second shouldHaveSize 6
+            result.second[0].navn shouldBe "Avtalenavn for VTA"
+            result.second[1].navn shouldBe "Avtale hos Åse"
+            result.second[2].navn shouldBe "Avtale hos Øyvind"
+            result.second[3].navn shouldBe "Avtale hos Ærfuglen Ærle"
+            result.second[4].navn shouldBe "Avtale hos Kjetil"
+            result.second[5].navn shouldBe "Avtale hos Anders"
         }
 
         test("Filtrer på tiltakstype og nav-region forholder seg til korrekt logikk i filter-spørring") {
@@ -693,7 +694,7 @@ class AvtaleRepositoryTest : FunSpec({
 
             val ascending = avtaler.getAll(sortering = "leverandor-ascending")
 
-            ascending.second shouldHaveSize 2
+            ascending.second shouldHaveSize 3
             ascending.second[0].leverandor shouldBe AvtaleAdminDto.Leverandor(
                 organisasjonsnummer = "987654321",
                 navn = "alvdal",
@@ -704,16 +705,26 @@ class AvtaleRepositoryTest : FunSpec({
                 navn = "bjarne",
                 slettet = false,
             )
+            ascending.second[2].leverandor shouldBe AvtaleAdminDto.Leverandor(
+                organisasjonsnummer = "123456789",
+                navn = "bjarne",
+                slettet = false,
+            )
 
             val descending = avtaler.getAll(sortering = "leverandor-descending")
 
-            descending.second shouldHaveSize 2
+            descending.second shouldHaveSize 3
             descending.second[0].leverandor shouldBe AvtaleAdminDto.Leverandor(
                 organisasjonsnummer = "123456789",
                 navn = "bjarne",
                 slettet = false,
             )
             descending.second[1].leverandor shouldBe AvtaleAdminDto.Leverandor(
+                organisasjonsnummer = "123456789",
+                navn = "bjarne",
+                slettet = false,
+            )
+            descending.second[2].leverandor shouldBe AvtaleAdminDto.Leverandor(
                 organisasjonsnummer = "987654321",
                 navn = "alvdal",
                 slettet = false,
@@ -759,19 +770,21 @@ class AvtaleRepositoryTest : FunSpec({
 
             val result = avtaler.getAll(sortering = "sluttdato-descending")
 
-            result.second shouldHaveSize 6
-            result.second[0].sluttDato shouldBe LocalDate.of(2023, 1, 1)
-            result.second[0].navn shouldBe "Avtale hos Benny"
+            result.second shouldHaveSize 7
+            result.second[0].sluttDato shouldBe LocalDate.of(2023, 2, 28)
+            result.second[0].navn shouldBe "Avtalenavn for VTA"
             result.second[1].sluttDato shouldBe LocalDate.of(2023, 1, 1)
-            result.second[1].navn shouldBe "Avtale hos Christina"
-            result.second[2].sluttDato shouldBe LocalDate.of(2011, 1, 1)
-            result.second[2].navn shouldBe "Avtale hos Kjetil"
-            result.second[3].sluttDato shouldBe LocalDate.of(2010, 1, 31)
-            result.second[3].navn shouldBe "Avtale hos Anders"
-            result.second[4].sluttDato shouldBe LocalDate.of(2010, 1, 1)
-            result.second[4].navn shouldBe "Avtale hos Øyvind"
-            result.second[5].sluttDato shouldBe LocalDate.of(2009, 1, 1)
-            result.second[5].navn shouldBe "Avtale hos Åse"
+            result.second[1].navn shouldBe "Avtale hos Benny"
+            result.second[2].sluttDato shouldBe LocalDate.of(2023, 1, 1)
+            result.second[2].navn shouldBe "Avtale hos Christina"
+            result.second[3].sluttDato shouldBe LocalDate.of(2011, 1, 1)
+            result.second[3].navn shouldBe "Avtale hos Kjetil"
+            result.second[4].sluttDato shouldBe LocalDate.of(2010, 1, 31)
+            result.second[4].navn shouldBe "Avtale hos Anders"
+            result.second[5].sluttDato shouldBe LocalDate.of(2010, 1, 1)
+            result.second[5].navn shouldBe "Avtale hos Øyvind"
+            result.second[6].sluttDato shouldBe LocalDate.of(2009, 1, 1)
+            result.second[6].navn shouldBe "Avtale hos Åse"
         }
 
         test("Sortering på sluttdato fra å-a sorterer korrekt") {
@@ -813,7 +826,7 @@ class AvtaleRepositoryTest : FunSpec({
 
             val result = avtaler.getAll(sortering = "sluttdato-ascending")
 
-            result.second shouldHaveSize 6
+            result.second shouldHaveSize 7
             result.second[0].sluttDato shouldBe LocalDate.of(2009, 1, 1)
             result.second[0].navn shouldBe "Avtale hos Åse"
             result.second[1].sluttDato shouldBe LocalDate.of(2010, 1, 1)
@@ -826,6 +839,8 @@ class AvtaleRepositoryTest : FunSpec({
             result.second[4].navn shouldBe "Avtale hos Benny"
             result.second[5].sluttDato shouldBe LocalDate.of(2023, 1, 1)
             result.second[5].navn shouldBe "Avtale hos Christina"
+            result.second[6].sluttDato shouldBe LocalDate.of(2023, 2, 28)
+            result.second[6].navn shouldBe "Avtalenavn for VTA"
         }
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/routes/TiltaksgjennomforingRoutesTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/routes/TiltaksgjennomforingRoutesTest.kt
@@ -137,7 +137,7 @@ class TiltaksgjennomforingRoutesTest : FunSpec({
                         avtaleId = AvtaleFixtures.avtale1.id,
                         navRegion = NavEnhetFixtures.Oslo.enhetsnummer,
                         navEnheter = listOf(NavEnhetFixtures.Sagene.enhetsnummer),
-                        tiltakstypeId = TiltakstypeFixtures.Oppfolging.id
+                        tiltakstypeId = TiltakstypeFixtures.Oppfolging.id,
                     ),
                 )
             }
@@ -183,7 +183,7 @@ class TiltaksgjennomforingRoutesTest : FunSpec({
                         avtaleId = AvtaleFixtures.avtale1.id,
                         navRegion = NavEnhetFixtures.Oslo.enhetsnummer,
                         navEnheter = listOf(NavEnhetFixtures.Sagene.enhetsnummer),
-                        tiltakstypeId = TiltakstypeFixtures.VTA.id
+                        tiltakstypeId = TiltakstypeFixtures.VTA.id,
                     ),
                 )
             }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/routes/TiltaksgjennomforingRoutesTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/routes/TiltaksgjennomforingRoutesTest.kt
@@ -2,8 +2,10 @@ package no.nav.mulighetsrommet.api.routes
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import no.nav.mulighetsrommet.api.*
@@ -11,10 +13,7 @@ import no.nav.mulighetsrommet.api.clients.brreg.BrregEmbeddedUnderenheter
 import no.nav.mulighetsrommet.api.clients.brreg.BrregEnhet
 import no.nav.mulighetsrommet.api.clients.brreg.BrregUnderenheter
 import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
-import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
-import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
-import no.nav.mulighetsrommet.api.fixtures.NavEnhetFixtures
-import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures
+import no.nav.mulighetsrommet.api.fixtures.*
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
 import no.nav.mulighetsrommet.ktor.createMockEngine
 import no.nav.mulighetsrommet.ktor.respondJson
@@ -138,10 +137,58 @@ class TiltaksgjennomforingRoutesTest : FunSpec({
                         avtaleId = AvtaleFixtures.avtale1.id,
                         navRegion = NavEnhetFixtures.Oslo.enhetsnummer,
                         navEnheter = listOf(NavEnhetFixtures.Sagene.enhetsnummer),
+                        tiltakstypeId = TiltakstypeFixtures.Oppfolging.id
                     ),
                 )
             }
             response.status shouldBe HttpStatusCode.OK
+        }
+    }
+
+    test("400 Bad request for autentisert kall for PUT av tiltaksgjennomføring når tiltakstypen ikke er skrudd på som master") {
+        val tiltaksgjennomforingSkrivRolle =
+            AdGruppeNavAnsattRolleMapping(UUID.randomUUID(), NavAnsattRolle.TILTAKSGJENNOMFORINGER_SKRIV)
+        val tiltaksadministrasjonGenerellRolle =
+            AdGruppeNavAnsattRolleMapping(UUID.randomUUID(), NavAnsattRolle.TILTAKADMINISTRASJON_GENERELL)
+        val engine = createMockEngine(
+            "/brreg/enheter/${TiltaksgjennomforingFixtures.Oppfolging1Request.arrangorOrganisasjonsnummer}" to {
+                respondJson(BrregEnhet(organisasjonsnummer = "123456789", navn = "Testvirksomhet"))
+            },
+            "/brreg/underenheter" to {
+                respondJson(BrregEmbeddedUnderenheter(_embedded = BrregUnderenheter(underenheter = emptyList())))
+            },
+        )
+        val config = createTestApplicationConfig().copy(
+            auth = createAuthConfig(oauth, roles = listOf(tiltaksgjennomforingSkrivRolle, tiltaksadministrasjonGenerellRolle)),
+            engine = engine,
+            database = databaseConfig,
+        )
+        withTestApplication(config) {
+            val client = createClient {
+                install(ContentNegotiation) {
+                    json()
+                }
+            }
+            val response = client.put("/api/v1/internal/tiltaksgjennomforinger") {
+                val claims = mapOf(
+                    "NAVident" to "ABC123",
+                    "groups" to listOf(tiltaksgjennomforingSkrivRolle.adGruppeId, tiltaksadministrasjonGenerellRolle.adGruppeId),
+                )
+                bearerAuth(
+                    oauth.issueToken(claims = claims).serialize(),
+                )
+                contentType(ContentType.Application.Json)
+                setBody(
+                    TiltaksgjennomforingFixtures.Oppfolging1Request.copy(
+                        avtaleId = AvtaleFixtures.avtale1.id,
+                        navRegion = NavEnhetFixtures.Oslo.enhetsnummer,
+                        navEnheter = listOf(NavEnhetFixtures.Sagene.enhetsnummer),
+                        tiltakstypeId = TiltakstypeFixtures.VTA.id
+                    ),
+                )
+            }
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "er ikke skrudd på enda"
         }
     }
 


### PR DESCRIPTION
Vi sjekker hvilke tiltakstype vi har skrudd på eierskap for og lar bare dem passere videre til lagring i databasen når bruker i admin-flate prøver å opprette tiltak.

- Blokkerer opprettelse av tiltak når tiltakstype ikke er skrudd på
![Skjermbilde 2024-01-25 kl  07 40 27](https://github.com/navikt/mulighetsrommet/assets/9053627/ffff085f-0840-4f7c-b314-b0ea27281d7f)


