### PR TITLE
Redigerbar Del med bruker tekst på Avtale/gjennomføring

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Faneinnhold.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Faneinnhold.kt
@@ -13,4 +13,5 @@ data class Faneinnhold(
     val pameldingOgVarighetInfoboks: String? = null,
     val kontaktinfo: List<JsonObject>? = null,
     val kontaktinfoInfoboks: String? = null,
+    val delMedBruker: String? = null,
 )

--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSchema.ts
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSchema.ts
@@ -53,6 +53,8 @@ export const AvtaleSchema = z.object({
         pameldingOgVarighetInfoboks: z.string().nullable().optional(),
         pameldingOgVarighet: z.any().nullable(),
         kontaktinfo: z.any().nullable(),
+        kontaktinfoInfoboks: z.string().nullable().optional(),
+        delMedBruker: z.string().nullable().optional(),
       },
       { required_error: "Det redaksjonelle innholdet må settes på avtalen" },
     )

--- a/frontend/mr-admin-flate/src/components/redaksjonelt-innhold/RedaksjoneltInnholdForm.tsx
+++ b/frontend/mr-admin-flate/src/components/redaksjonelt-innhold/RedaksjoneltInnholdForm.tsx
@@ -7,8 +7,9 @@ import { Separator } from "../detaljside/Metadata";
 import { PortableTextEditor } from "../portableText/PortableTextEditor";
 import skjemastyles from "../skjema/Skjema.module.scss";
 import { Laster } from "../laster/Laster";
-import React from "react";
+import React, { useState } from "react";
 import { InlineErrorBoundary } from "../../ErrorBoundary";
+import { FileTextIcon, PaperplaneIcon } from "@navikt/aksel-icons";
 
 interface RedaksjoneltInnholdFormProps {
   tiltakstype: EmbeddedTiltakstype;
@@ -52,11 +53,46 @@ function RedaksjoneltInnhold({ tiltakstype }: { tiltakstype: EmbeddedTiltakstype
         <Heading size="medium">Faneinnhold</Heading>
         <Tabs size="small" defaultValue="for_hvem">
           <Tabs.List>
-            <Tabs.Tab value="for_hvem" label="For hvem" />
-            <Tabs.Tab value="detaljer_og_innhold" label="Detaljer og innhold" />
-            <Tabs.Tab value="pamelding_og_varighet" label="Påmelding og varighet" />
-            <Tabs.Tab value="kontaktinfo" label="Kontaktinfo" />
-            <Tabs.Tab value="alle" label="Alle faner" />
+            <Tabs.Tab
+              value="for_hvem"
+              label={
+                <div className={skjemastyles.red_tab_title}>
+                  <FileTextIcon /> For hvem
+                </div>
+              }
+            />
+            <Tabs.Tab
+              value="detaljer_og_innhold"
+              label={
+                <div className={skjemastyles.red_tab_title}>
+                  <FileTextIcon /> Detaljer og innhold
+                </div>
+              }
+            />
+            <Tabs.Tab
+              value="pamelding_og_varighet"
+              label={
+                <div className={skjemastyles.red_tab_title}>
+                  <FileTextIcon /> Påmelding og varighet
+                </div>
+              }
+            />
+            <Tabs.Tab
+              value="kontaktinfo"
+              label={
+                <div className={skjemastyles.red_tab_title}>
+                  <FileTextIcon /> Kontaktinfo
+                </div>
+              }
+            />
+            <Tabs.Tab
+              value="del_med_bruker"
+              label={
+                <div className={skjemastyles.red_tab_title}>
+                  <PaperplaneIcon /> Del med bruker
+                </div>
+              }
+            />
           </Tabs.List>
           <Tabs.Panel value="for_hvem">
             <ForHvem tiltakstype={tiltakstypeSanityData} />
@@ -70,13 +106,8 @@ function RedaksjoneltInnhold({ tiltakstype }: { tiltakstype: EmbeddedTiltakstype
           <Tabs.Panel value="kontaktinfo">
             <Kontaktinfo />
           </Tabs.Panel>
-          <Tabs.Panel value="alle">
-            <>
-              <ForHvem tiltakstype={tiltakstypeSanityData} />
-              <DetaljerOgInnhold tiltakstype={tiltakstypeSanityData} />
-              <PameldingOgVarighet tiltakstype={tiltakstypeSanityData} />
-              <Kontaktinfo />
-            </>
+          <Tabs.Panel value="del_med_bruker">
+            <DelMedBruker tiltakstype={tiltakstypeSanityData} />
           </Tabs.Panel>
         </Tabs>
       </div>
@@ -181,6 +212,34 @@ const Kontaktinfo = () => {
         {...register("faneinnhold.kontaktinfo")}
         label="Kontaktinfo"
         description="Ekstra tekst om kontaktinfo."
+      />
+    </div>
+  );
+};
+
+const DelMedBruker = ({ tiltakstype }: { tiltakstype?: VeilederflateTiltakstype }) => {
+  const { watch, setValue } = useFormContext();
+
+  const [tekst, setTekst] = useState<string>(
+    watch("faneinnhold.delMedBruker") ?? tiltakstype?.delingMedBruker ?? "",
+  );
+
+  function onChange(value: string) {
+    if (value !== tiltakstype?.delingMedBruker) {
+      setValue("faneinnhold.delMedBruker", value);
+    }
+  }
+
+  return (
+    <div className={skjemastyles.faneinnhold_container}>
+      <Textarea
+        onChange={(e) => {
+          onChange(e.target.value);
+          setTekst(e.target.value);
+        }}
+        value={tekst}
+        label="Del med bruker"
+        description="Bruk denne tekstboksen for å redigere default teksten som sendes til bruker når man deler et tiltak."
       />
     </div>
   );

--- a/frontend/mr-admin-flate/src/components/redaksjonelt-innhold/RedaksjoneltInnholdPreview.tsx
+++ b/frontend/mr-admin-flate/src/components/redaksjonelt-innhold/RedaksjoneltInnholdPreview.tsx
@@ -67,6 +67,10 @@ function RedaksjoneltInnhold(props: RedaksjoneltInnholdPreviewProps) {
         tiltaksgjennomforing={faneinnhold?.kontaktinfo}
         tiltaksgjennomforingAlert={faneinnhold?.kontaktinfoInfoboks}
       />
+      <Heading size="medium">Del med bruker</Heading>
+      <BodyLong as="div" size="small">
+        {faneinnhold?.delMedBruker ?? tiltakstypeSanityData.delingMedBruker}
+      </BodyLong>
     </div>
   );
 }

--- a/frontend/mr-admin-flate/src/components/skjema/Skjema.module.scss
+++ b/frontend/mr-admin-flate/src/components/skjema/Skjema.module.scss
@@ -172,3 +172,10 @@
   justify-content: space-between;
   align-items: center;
 }
+
+.red_tab_title {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.125rem;
+}

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
@@ -101,6 +101,7 @@ export const TiltaksgjennomforingSchema = z
         pameldingOgVarighet: z.any().nullable(),
         kontaktinfo: z.any().nullable(),
         kontaktinfoInfoboks: z.string().nullable().optional(),
+        delMedBruker: z.string().nullable().optional(),
       })
       .nullable(),
     opphav: z.nativeEnum(Opphav),

--- a/frontend/mulighetsrommet-veileder-flate/src/components/delMedBruker/DelMedBruker.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/delMedBruker/DelMedBruker.tsx
@@ -26,13 +26,16 @@ export const DelMedBruker = ({
   tiltaksgjennomforing,
   delMedBrukerInfo,
 }: Props) => {
-  const originaldeletekstFraTiltakstypen = tiltaksgjennomforing.tiltakstype.delingMedBruker ?? "";
+  const delMedBrukerTekst =
+    tiltaksgjennomforing.faneinnhold?.delMedBruker ??
+    tiltaksgjennomforing.tiltakstype.delingMedBruker ??
+    "";
 
   const { logEvent } = useLogEvent();
   const { reservert } = erBrukerReservertMotElektroniskKommunikasjon(brukerdata);
 
   const deletekst = utledDelMedBrukerTekst(
-    originaldeletekstFraTiltakstypen,
+    delMedBrukerTekst,
     tiltaksgjennomforing.navn,
     brukerdata.fornavn,
   );

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2821,6 +2821,8 @@ components:
           type: object
         kontaktinfoInfoboks:
           type: string
+        delMedBruker:
+          type: string
 
     SanityFaneinnholdRequest:
       type: object
@@ -2843,6 +2845,9 @@ components:
         kontaktinfo:
           type: object
         kontaktinfoInfoboks:
+          type: string
+          nullable: true
+        delMedBruker:
           type: string
           nullable: true
 


### PR DESCRIPTION
<img width="988" alt="Screenshot 2024-01-26 at 15 33 41" src="https://github.com/navikt/mulighetsrommet/assets/3830767/8b60a9d1-effe-4720-9547-357379a0b71f">

Var enklere å slenge på både avtale og gjennomføring siden de bruker samme faneinnhold komponent. Kopier fra avtale og sånn fungerer da ut av boksen