### PR TITLE
Helptekst for varsel om endring av oppstartstype

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/SelectOppstartstype.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/SelectOppstartstype.tsx
@@ -68,13 +68,11 @@ function OppstartstypeWarning({ gjennomforingId }: OppstartstypePropsWarning) {
             Statusen vises i aktivitetsplanen og Deltakeroversikten.
           </li>
           <li>
-            Dersom oppstartstypen blir endret så vil også den avsluttende statusen endres, og
-            aktivitetskortet i aktivitetsplanen vil kunne bli flyttet til enten fullført eller
-            avbrutt.
+            Dersom oppstartstypen blir endret, så endres også den avsluttende statusen, og
+            aktiviteten i aktivitetsplanen kan flyttes til enten fullført eller avbrutt.
           </li>
           <li>
-            Når statusen endres vil det komme en visuell markering i form av en blå prikk på det
-            aktuelle aktivitetskortet.
+            En blå prikk vises på aktiviteten for å synliggjøre at det er en endring siden sist.
           </li>
         </ul>
       </HelpText>

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/SelectOppstartstype.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/SelectOppstartstype.tsx
@@ -1,4 +1,4 @@
-import { Alert } from "@navikt/ds-react";
+import { Alert, HelpText } from "@navikt/ds-react";
 import { TiltaksgjennomforingOppstartstype } from "mulighetsrommet-api-client";
 import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
 import { useController } from "react-hook-form";
@@ -59,7 +59,31 @@ function OppstartstypeWarning({ gjennomforingId }: OppstartstypePropsWarning) {
   return isError || summary.antallDeltakere > 0 ? (
     <Alert variant="warning">
       Deltakerstatus påvirkes av oppstartstypen. Hvis du endrer oppstartstypen så kan deltakelser
-      som er avsluttet få en ny status. Statusen vises i aktivitetsplanen og deltakeroversikten.
+      som er avsluttet få en ny status. Statusen vises i aktivitetsplanen og deltakeroversikten.{" "}
+      <HelpText title="Hvilke konsekvenser får dette?">
+        <ul>
+          <li>
+            På tiltak med <code>løpende inntak</code> vil avsluttede deltakere ha statusen &quot;Har
+            sluttet&quot; i aktivitetsplanen og Deltakeroversikten. Dersom gjennomføringen blir
+            endret til <code>felles oppstart</code> så vil statusen endres til enten
+            &quot;Fullført&quot; eller &quot;Avbrutt&quot;. Aktivitetskortet i aktivitetsplanen til
+            bruker vil flyttes til statuskolonnen &quot;Avbrutt&quot; dersom statusen på
+            tiltaksdeltakelsen endres til dette.
+          </li>
+          <li>
+            På tiltak med <code>felles oppstart</code> vil avsluttede deltakere ha status
+            &quot;Fullført&quot; eller &quot;Avbrutt&quot;. Dersom gjennomføringen blir endret til{" "}
+            <code>løpende inntak</code> så vil disse statusene blir endret til &quot;Har
+            sluttet&quot; (og aktivitetskortet i aktivitetsplanen vil ligge i statuskolonnen
+            &quot;Fullført&quot;).
+          </li>
+          <li>
+            Dersom statusen endres vil det være synlig i aktivitetsplanen at det er en endring på
+            det aktuelle aktivitetskortet (en visuell markering i form av en blå prikk som betyr at
+            det er en endring siden sist du var inne på planen)
+          </li>
+        </ul>
+      </HelpText>
     </Alert>
   ) : null;
 }

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/SelectOppstartstype.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/SelectOppstartstype.tsx
@@ -63,24 +63,18 @@ function OppstartstypeWarning({ gjennomforingId }: OppstartstypePropsWarning) {
       <HelpText title="Hvilke konsekvenser får dette?">
         <ul>
           <li>
-            På tiltak med <code>løpende inntak</code> vil avsluttede deltakere ha statusen &quot;Har
-            sluttet&quot; i aktivitetsplanen og Deltakeroversikten. Dersom gjennomføringen blir
-            endret til <code>felles oppstart</code> så vil statusen endres til enten
-            &quot;Fullført&quot; eller &quot;Avbrutt&quot;. Aktivitetskortet i aktivitetsplanen til
-            bruker vil flyttes til statuskolonnen &quot;Avbrutt&quot; dersom statusen på
-            tiltaksdeltakelsen endres til dette.
+            Avsluttende deltakere vil ha statusen &quot;Har sluttet&quot; på tiltak med løpende
+            inntak, og &quot;Fullført&quot; eller &quot;Avbrutt&quot; på tiltak med felles oppstart.
+            Statusen vises i aktivitetsplanen og Deltakeroversikten.
           </li>
           <li>
-            På tiltak med <code>felles oppstart</code> vil avsluttede deltakere ha status
-            &quot;Fullført&quot; eller &quot;Avbrutt&quot;. Dersom gjennomføringen blir endret til{" "}
-            <code>løpende inntak</code> så vil disse statusene blir endret til &quot;Har
-            sluttet&quot; (og aktivitetskortet i aktivitetsplanen vil ligge i statuskolonnen
-            &quot;Fullført&quot;).
+            Dersom oppstartstypen blir endret så vil også den avsluttende statusen endres, og
+            aktivitetskortet i aktivitetsplanen vil kunne bli flyttet til enten fullført eller
+            avbrutt.
           </li>
           <li>
-            Dersom statusen endres vil det være synlig i aktivitetsplanen at det er en endring på
-            det aktuelle aktivitetskortet (en visuell markering i form av en blå prikk som betyr at
-            det er en endring siden sist du var inne på planen)
+            Når statusen endres vil det komme en visuell markering i form av en blå prikk på det
+            aktuelle aktivitetskortet.
           </li>
         </ul>
       </HelpText>


### PR DESCRIPTION
Viser et spm.tegn som bruker av admin-flate kan trykke på for å forstå hva det betyr å endre oppstartstype når det finnes deltakere på tiltaket.
Det er mye tekst og kanskje litt rotete, men tror det kan skape litt mindre forvirring.

Implementert etter forslag fra Komet-Lars.

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/7faf97c5-63f4-4bc2-afc3-ccf13302acf0)

