### PR TITLE
FEAT: Mulighet for å duplisere tiltak

### DIFF
--- a/frontend/mr-admin-flate/src/components/detaljside/Header.module.scss
+++ b/frontend/mr-admin-flate/src/components/detaljside/Header.module.scss
@@ -48,6 +48,7 @@
       display: flex;
       justify-content: flex-start;
       gap: 1.5rem;
+      align-items: center;
     }
   }
 

--- a/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -13,6 +13,7 @@ import { PagineringsOversikt } from "../paginering/PagineringOversikt";
 import { TiltaksgjennomforingstatusTag } from "../statuselementer/TiltaksgjennomforingstatusTag";
 import styles from "./Tabell.module.scss";
 import { useAdminTiltaksgjennomforinger } from "../../api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger";
+import { DupliserTiltak } from "../tiltaksgjennomforinger/DupliserTiltak";
 
 interface ColumnHeader {
   sortKey: Kolonne;
@@ -22,6 +23,12 @@ interface ColumnHeader {
 }
 
 const headers: ColumnHeader[] = [
+  {
+    sortKey: "dupliser",
+    tittel: "",
+    sortable: false,
+    width: "0.5fr",
+  },
   {
     sortKey: "navn",
     tittel: "Tiltaksnavn",
@@ -79,6 +86,7 @@ const headers: ColumnHeader[] = [
 ];
 
 type Kolonne =
+  | "dupliser"
   | "navn"
   | "enhet"
   | "tiltaksnummer"
@@ -172,7 +180,7 @@ export const TiltaksgjennomforingsTabell = ({ skjulKolonner, filterAtom }: Props
           data-testid="tiltaksgjennomforing-tabell"
         >
           <Table.Header>
-            <Table.Row className={styles.tiltaksgjennomforing_tabellrad}>
+            <Table.Row>
               {headers
                 .filter((header) => {
                   return skjulKolonner ? !skjulKolonner[header.sortKey] : true;
@@ -195,7 +203,10 @@ export const TiltaksgjennomforingsTabell = ({ skjulKolonner, filterAtom }: Props
             <Table.Body>
               {tiltaksgjennomforinger.map((tiltaksgjennomforing, index) => {
                 return (
-                  <Table.Row key={index} className={styles.tiltaksgjennomforing_tabellrad}>
+                  <Table.Row key={index}>
+                    <Table.DataCell>
+                      <DupliserTiltak tiltaksgjennomforing={tiltaksgjennomforing} />
+                    </Table.DataCell>
                     <SkjulKolonne skjul={!!skjulKolonner?.navn}>
                       <Table.DataCell
                         aria-label={`Navn på tiltaksgjennomforing: ${tiltaksgjennomforing.navn}`}

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.module.scss
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.module.scss
@@ -1,0 +1,8 @@
+.button {
+  background-color: var(--a-surface-action);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  max-height: 2rem;
+  max-width: 2rem;
+}

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.tsx
@@ -1,8 +1,9 @@
 import { LayersPlusIcon } from "@navikt/aksel-icons";
 import styles from "./DupliserTiltak.module.scss";
 import { Button } from "@navikt/ds-react";
-import { Tiltaksgjennomforing } from "mulighetsrommet-api-client";
+import { Tiltaksgjennomforing, Toggles } from "mulighetsrommet-api-client";
 import { useNavigate } from "react-router-dom";
+import { useFeatureToggle } from "../../api/features/feature-toggles";
 
 interface Props {
   tiltaksgjennomforing: Tiltaksgjennomforing;
@@ -10,6 +11,11 @@ interface Props {
 
 export function DupliserTiltak({ tiltaksgjennomforing }: Props) {
   const navigate = useNavigate();
+  const { data: kanDuplisereTiltak } = useFeatureToggle(
+    Toggles.MR_ADMIN_FLATE_KAN_DUPLISERE_TILTAK,
+  );
+
+  if (!kanDuplisereTiltak) return null;
 
   function apneRedigeringForDupliseringAvTiltak() {
     navigate(`/tiltaksgjennomforinger/${tiltaksgjennomforing.id}/skjema`, {

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.tsx
@@ -1,0 +1,41 @@
+import { LayersPlusIcon } from "@navikt/aksel-icons";
+import styles from "./DupliserTiltak.module.scss";
+import { Button } from "@navikt/ds-react";
+import { Tiltaksgjennomforing } from "mulighetsrommet-api-client";
+import { useNavigate } from "react-router-dom";
+
+interface Props {
+  tiltaksgjennomforing: Tiltaksgjennomforing;
+}
+
+export function DupliserTiltak({ tiltaksgjennomforing }: Props) {
+  const navigate = useNavigate();
+
+  function apneRedigeringForDupliseringAvTiltak() {
+    navigate(`/tiltaksgjennomforinger/${tiltaksgjennomforing.id}/skjema`, {
+      state: {
+        tiltaksgjennomforing: {
+          ...tiltaksgjennomforing,
+          id: window.crypto.randomUUID(),
+          tiltaksnummer: "",
+          startDato: undefined,
+          sluttDato: undefined,
+        },
+      },
+    });
+  }
+
+  return (
+    <Button
+      title="Dupliser tiltaksgjennomføring"
+      className={styles.button}
+      onClick={apneRedigeringForDupliseringAvTiltak}
+    >
+      <LayersPlusIcon
+        style={{ margin: "0 auto", display: "block" }}
+        color="white"
+        fontSize="1.5rem"
+      />
+    </Button>
+  );
+}

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.tsx
@@ -41,6 +41,7 @@ export function DupliserTiltak({ tiltaksgjennomforing }: Props) {
         style={{ margin: "0 auto", display: "block" }}
         color="white"
         fontSize="1.5rem"
+        aria-label="Ikon for duplisering av dokument"
       />
     </Button>
   );

--- a/frontend/mr-admin-flate/src/mocks/api/features.ts
+++ b/frontend/mr-admin-flate/src/mocks/api/features.ts
@@ -6,4 +6,5 @@ export const mockFeatures: Features = {
   "mulighetsrommet-veilederflate-arena-oppskrifter": true,
   "mulighetsrommet.admin-flate.show-notater": false,
   "mulighetsrommet.admin-flate.midlertidig-stengt": false,
+  "mr-admin-flate.kan-duplisere-tiltak": true,
 };

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
@@ -13,6 +13,7 @@ import { useNavigateAndReplaceUrl } from "../../hooks/useNavigateWithoutReplacin
 import { ContainerLayout } from "../../layouts/ContainerLayout";
 import { erProdMiljo } from "../../utils/Utils";
 import commonStyles from "../Page.module.scss";
+import { DupliserTiltak } from "../../components/tiltaksgjennomforinger/DupliserTiltak";
 
 export function TiltaksgjennomforingPage() {
   const { pathname } = useLocation();
@@ -62,6 +63,7 @@ export function TiltaksgjennomforingPage() {
               {tiltaksgjennomforing?.navn ?? "..."}
             </Heading>
             <TiltaksgjennomforingstatusTag tiltaksgjennomforing={tiltaksgjennomforing} />
+            <DupliserTiltak tiltaksgjennomforing={tiltaksgjennomforing} />
           </div>
           {tiltaksgjennomforing?.id && (
             <div className={headerStyles.forhandsvisningsknapp}>

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
@@ -1,5 +1,5 @@
 import { Alert, Heading } from "@navikt/ds-react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useAvtale } from "../../api/avtaler/useAvtale";
 import { useTiltaksgjennomforingById } from "../../api/tiltaksgjennomforing/useTiltaksgjennomforingById";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
@@ -18,6 +18,7 @@ const TiltaksgjennomforingSkjemaPage = () => {
     useTiltaksgjennomforingById();
   const { data: avtale, isLoading: avtaleIsLoading } = useAvtale(tiltaksgjennomforing?.avtaleId);
   const { data: ansatt, isPending: isPendingAnsatt } = useHentAnsatt();
+  const location = useLocation();
 
   const redigeringsModus = tiltaksgjennomforing && inneholderUrl(tiltaksgjennomforing?.id);
 
@@ -43,7 +44,11 @@ const TiltaksgjennomforingSkjemaPage = () => {
         onSuccess={(id) => navigate(`/tiltaksgjennomforinger/${id}`)}
         avtale={avtale}
         ansatt={ansatt}
-        tiltaksgjennomforing={tiltaksgjennomforing}
+        tiltaksgjennomforing={
+          location.state?.tiltaksgjennomforing
+            ? location.state.tiltaksgjennomforing
+            : tiltaksgjennomforing
+        }
       />
     );
   }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
@@ -6,4 +6,5 @@ export const mockFeatures: Features = {
   "mulighetsrommet-veilederflate-arena-oppskrifter": true,
   "mulighetsrommet.admin-flate.show-notater": true,
   "mulighetsrommet.admin-flate.midlertidig-stengt": false,
+  "mr-admin-flate.kan-duplisere-tiltak": true,
 };

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -3361,6 +3361,7 @@ components:
         - mulighetsrommet-veilederflate-arena-oppskrifter
         - mulighetsrommet.admin-flate.show-notater
         - mulighetsrommet.admin-flate.midlertidig-stengt
+        - mr-admin-flate.kan-duplisere-tiltak
 
     TilgjengeligForVeilederRequest:
       type: object


### PR DESCRIPTION
Gir bruker av admin-flate en enkel mulighet for å duplisere tiltak
via tabellvisning eller detaljvisning for tiltak.

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/ce82dac8-6112-4e06-92e9-fd5c3fbe81f0)
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/20377493-bc59-44c0-96d0-3a71c1f64d7a)

