### PR TITLE
KoinIsolated istedenfor Koin etter bump av versjon

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 common-java-modules = "3.2024.01.24_10.14-f70bae69bd65"
 flyway = "10.6.0"
 hoplite = "2.7.5"
-koin = "3.5.1"
+koin = "3.5.3"
 kotest = "5.8.0"
 kotest-testcontainers = "2.0.2"
 kotlin = "1.9.22"

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -62,14 +62,14 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.koin.core.module.Module
 import org.koin.dsl.module
-import org.koin.ktor.plugin.Koin
+import org.koin.ktor.plugin.KoinIsolated
 import org.koin.logger.SLF4JLogger
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
 
 fun Application.configureDependencyInjection(appConfig: AppConfig) {
-    install(Koin) {
+    install(KoinIsolated) {
         SLF4JLogger()
 
         modules(
@@ -279,7 +279,22 @@ private fun services(appConfig: AppConfig) = module {
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get()) }
     single { MicrosoftGraphService(get()) }
-    single { TiltaksgjennomforingService(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), appConfig.kafka.producers.arenaMigreringTiltaksgjennomforinger.tiltakstyper) }
+    single {
+        TiltaksgjennomforingService(
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            appConfig.kafka.producers.arenaMigreringTiltaksgjennomforinger.tiltakstyper,
+        )
+    }
     single { SanityTiltaksgjennomforingService(get(), get(), get()) }
     single { TiltakstypeService(get()) }
     single { NavEnheterSyncService(get(), get(), get(), get()) }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
@@ -28,7 +28,7 @@ import no.nav.mulighetsrommet.slack.SlackNotifierImpl
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.koin.core.module.Module
 import org.koin.dsl.module
-import org.koin.ktor.plugin.Koin
+import org.koin.ktor.plugin.KoinIsolated
 import org.koin.logger.SLF4JLogger
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPrivateKey
@@ -38,7 +38,7 @@ fun Application.configureDependencyInjection(
     appConfig: AppConfig,
 ) {
     val tokenClient = createM2mTokenClient(appConfig)
-    install(Koin) {
+    install(KoinIsolated) {
         SLF4JLogger()
         modules(
             db(appConfig.database),
@@ -144,7 +144,12 @@ private fun services(services: ServiceConfig, tokenClient: MachineToMachineToken
             SakEventProcessor(get()),
             AvtaleInfoEventProcessor(get(), get(), get()),
         )
-        ArenaEventService(config = services.arenaEventService, events = get(), processors = processors, entities = get())
+        ArenaEventService(
+            config = services.arenaEventService,
+            events = get(),
+            processors = processors,
+            entities = get(),
+        )
     }
     single { ArenaEntityService(get(), get(), get(), get(), get(), get()) }
 }


### PR DESCRIPTION
Det ble introdusert en breaking change (til tross for minor-bump) av Koin som gjorde at testene våre krasjer med beskjed om at det allerede fantes en Koin-instans. 
Her kan man lese issue fra GH: https://github.com/InsertKoinIO/koin/issues/1738. Denne PRen installerer `KoinIsolated` istedenfor `Koin` slik som det blir anbefalt i issuet og som gjør at tester og apper kjører som forventet.
