### PR TITLE
Flytter kontaktinfo under arrangør i kontaktinfo-fanen

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/ArrangorInfo.tsx
@@ -1,12 +1,14 @@
-import { BodyShort, Heading } from "@navikt/ds-react";
+import { BodyLong, BodyShort, Heading } from "@navikt/ds-react";
 import { VeilderflateArrangor, VirksomhetKontaktperson } from "mulighetsrommet-api-client";
 import styles from "./Kontaktinfo.module.scss";
+import { RedaksjoneltInnhold } from "../../RedaksjoneltInnhold";
 
 interface ArrangorInfoProps {
   arrangor?: VeilderflateArrangor;
+  faneinnhold: any;
 }
 
-const ArrangorInfo = ({ arrangor }: ArrangorInfoProps) => {
+const ArrangorInfo = ({ arrangor, faneinnhold }: ArrangorInfoProps) => {
   if (!arrangor) {
     return null;
   }
@@ -54,6 +56,11 @@ const ArrangorInfo = ({ arrangor }: ArrangorInfoProps) => {
           </BodyShort>
         </div>
       ))}
+      {faneinnhold && (
+        <BodyLong as="div" textColor="subtle" size="small">
+          <RedaksjoneltInnhold value={faneinnhold} />
+        </BodyLong>
+      )}
     </div>
   );
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/tabs/kontaktinfofane/KontaktinfoFane.tsx
@@ -1,10 +1,9 @@
+import { Alert } from "@navikt/ds-react";
 import { VeilederflateTiltaksgjennomforing } from "mulighetsrommet-api-client";
 import FaneTiltaksinformasjon from "../FaneTiltaksinformasjon";
 import ArrangorInfo from "./ArrangorInfo";
 import styles from "./Kontaktinfo.module.scss";
 import NavKontaktpersonInfo from "./NavKontaktpersonInfo";
-import { Alert, BodyLong } from "@navikt/ds-react";
-import { RedaksjoneltInnhold } from "../../RedaksjoneltInnhold";
 
 interface Props {
   tiltaksgjennomforing: VeilederflateTiltaksgjennomforing;
@@ -21,13 +20,11 @@ const KontaktinfoFane = ({ tiltaksgjennomforing }: Props) => {
           {tiltaksgjennomforing.faneinnhold.kontaktinfoInfoboks}
         </Alert>
       )}
-      {tiltaksgjennomforing.faneinnhold?.kontaktinfo && (
-        <BodyLong as="div" textColor="subtle" size="small">
-          <RedaksjoneltInnhold value={tiltaksgjennomforing.faneinnhold?.kontaktinfo} />
-        </BodyLong>
-      )}
       <div className={styles.grid_container}>
-        <ArrangorInfo arrangor={tiltaksgjennomforing.arrangor} />
+        <ArrangorInfo
+          arrangor={tiltaksgjennomforing.arrangor}
+          faneinnhold={tiltaksgjennomforing.faneinnhold?.kontaktinfo}
+        />
         <NavKontaktpersonInfo kontaktinfo={tiltaksgjennomforing.kontaktinfo} />
       </div>
     </FaneTiltaksinformasjon>

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
@@ -17,6 +17,19 @@ export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
     tiltakstype: mockTiltakstyper.avklaring,
     sluttdato: "2025-07-09",
     apentForInnsok: true,
+    arrangor: {
+      selskapsnavn: "JOBLEARN AS AVD 813201 ØST-VIKEN KURS",
+      kontaktpersoner: [
+        {
+          id: "1",
+          navn: "Ole Testesen",
+          telefon: "12345678",
+          epost: "test@example.com",
+          organisasjonsnummer: "987654321",
+          beskrivelse: null,
+        },
+      ],
+    },
     kontaktinfo: {
       tiltaksansvarlige: [
         {
@@ -42,6 +55,28 @@ export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
           children: [
             {
               text: "Tiltaket er for deltakere som er synshemmet eller døve/hørselshemmet.",
+              _type: "span",
+            },
+          ],
+          _type: "block",
+        },
+      ],
+      kontaktinfo: [
+        {
+          style: "normal",
+          children: [
+            {
+              text: "Oppmøtested er Andeby 1, 0669 Donald-Pocketby",
+              _type: "span",
+            },
+          ],
+          _type: "block",
+        },
+        {
+          style: "normal",
+          children: [
+            {
+              text: "Postadresse er Fyrstikkalleen 1, 0101 Oslo",
               _type: "span",
             },
           ],


### PR DESCRIPTION
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/524ecf45-8c5e-45fe-8a4a-87063c235aab)
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/a137c6e0-40d4-4152-9023-5d13abf92dba)

Flytter redaksjonelt innhold for kontaktpersoner under arrangør i denne omgang. Beholder infoboks i toppen.