### PR TITLE
FEAT Estimert ventetid

### DIFF
--- a/frontend/mr-admin-flate/src/components/skjema/Skjema.module.scss
+++ b/frontend/mr-admin-flate/src/components/skjema/Skjema.module.scss
@@ -167,3 +167,12 @@
   align-items: center;
   gap: 0.125rem;
 }
+
+.fieldset_no_styling {
+  border: none;
+  padding: 0;
+  legend {
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+  }
+}

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
@@ -112,7 +112,7 @@ export const TiltaksgjennomforingSchema = z
           required_error: "Du må sette en verdi for estimert ventetid",
           invalid_type_error: "Du må sette en verdi for estimert ventetid",
         }),
-        enhet: z.string({
+        enhet: z.enum(["uke", "maned"], {
           required_error: "Du må sette en enhet for estimert ventetid",
           invalid_type_error: "Du må sette en enhet for estimert ventetid",
         }),

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
@@ -105,9 +105,19 @@ export const TiltaksgjennomforingSchema = z
       })
       .nullable(),
     opphav: z.nativeEnum(Opphav),
-    visEstimertVentetid: z.boolean().default(false),
-    estimertVentetidVerdi: z.number().nullable(),
-    estimertVentetidEnhet: z.string().nullable(),
+    visEstimertVentetid: z.boolean(),
+    estimertVentetid: z
+      .object({
+        verdi: z.number({
+          required_error: "Du må sette en verdi for estimert ventetid",
+          invalid_type_error: "Du må sette en verdi for estimert ventetid",
+        }),
+        enhet: z.string({
+          required_error: "Du må sette en enhet for estimert ventetid",
+          invalid_type_error: "Du må sette en enhet for estimert ventetid",
+        }),
+      })
+      .nullable(),
   })
   .superRefine((data, ctx) => {
     if (
@@ -152,21 +162,6 @@ export const TiltaksgjennomforingSchema = z
           path: ["startOgSluttDato.sluttDato"],
         });
       }
-    }
-    if (data.visEstimertVentetid && !data.estimertVentetidEnhet) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Du må registrere enhet for estimert ventetid",
-        path: ["estimertVentetidEnhet"],
-      });
-    }
-
-    if (data.visEstimertVentetid && !data.estimertVentetidVerdi) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Du må registrere verdi for estimert ventetid",
-        path: ["estimertVentetidVerdi"],
-      });
     }
   });
 

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSchema.ts
@@ -105,6 +105,9 @@ export const TiltaksgjennomforingSchema = z
       })
       .nullable(),
     opphav: z.nativeEnum(Opphav),
+    visEstimertVentetid: z.boolean().default(false),
+    estimertVentetidVerdi: z.number().nullable(),
+    estimertVentetidEnhet: z.string().nullable(),
   })
   .superRefine((data, ctx) => {
     if (
@@ -119,6 +122,7 @@ export const TiltaksgjennomforingSchema = z
         path: ["midlertidigStengt.stengtTil"],
       });
     }
+
     if (data.opphav === Opphav.MR_ADMIN_FLATE && !data.startOgSluttDato.sluttDato) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -148,6 +152,21 @@ export const TiltaksgjennomforingSchema = z
           path: ["startOgSluttDato.sluttDato"],
         });
       }
+    }
+    if (data.visEstimertVentetid && !data.estimertVentetidEnhet) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Du må registrere enhet for estimert ventetid",
+        path: ["estimertVentetidEnhet"],
+      });
+    }
+
+    if (data.visEstimertVentetid && !data.estimertVentetidVerdi) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Du må registrere verdi for estimert ventetid",
+        path: ["estimertVentetidVerdi"],
+      });
     }
   });
 

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaConst.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaConst.tsx
@@ -138,5 +138,8 @@ export function defaultTiltaksgjennomforingData(
     faneinnhold: tiltaksgjennomforing?.faneinnhold ?? avtale.faneinnhold,
     opphav: tiltaksgjennomforing?.opphav ?? Opphav.MR_ADMIN_FLATE,
     deltidsprosent: tiltaksgjennomforing?.deltidsprosent ?? 100,
+    visEstimertVentetid: !!tiltaksgjennomforing?.estimertVentetid?.verdi ?? false,
+    estimertVentetidEnhet: tiltaksgjennomforing?.estimertVentetid?.enhet ?? null,
+    estimertVentetidVerdi: tiltaksgjennomforing?.estimertVentetid?.verdi ?? null,
   };
 }

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaConst.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaConst.tsx
@@ -139,7 +139,6 @@ export function defaultTiltaksgjennomforingData(
     opphav: tiltaksgjennomforing?.opphav ?? Opphav.MR_ADMIN_FLATE,
     deltidsprosent: tiltaksgjennomforing?.deltidsprosent ?? 100,
     visEstimertVentetid: !!tiltaksgjennomforing?.estimertVentetid?.verdi ?? false,
-    estimertVentetidEnhet: tiltaksgjennomforing?.estimertVentetid?.enhet ?? null,
-    estimertVentetidVerdi: tiltaksgjennomforing?.estimertVentetid?.verdi ?? null,
+    estimertVentetid: tiltaksgjennomforing?.estimertVentetid ?? null,
   };
 }

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
@@ -100,13 +100,7 @@ export const TiltaksgjennomforingSkjemaContainer = ({
       faneinnhold: data.faneinnhold ?? null,
       opphav: data.opphav,
       deltidsprosent: data.deltidsprosent,
-      estimertVentetid:
-        data.visEstimertVentetid && data.estimertVentetidEnhet && data.estimertVentetidVerdi
-          ? {
-              verdi: data.estimertVentetidVerdi,
-              enhet: data.estimertVentetidEnhet,
-            }
-          : null,
+      estimertVentetid: data.estimertVentetid ?? null,
     };
 
     mutation.mutate(body);

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
@@ -100,6 +100,13 @@ export const TiltaksgjennomforingSkjemaContainer = ({
       faneinnhold: data.faneinnhold ?? null,
       opphav: data.opphav,
       deltidsprosent: data.deltidsprosent,
+      estimertVentetid:
+        data.visEstimertVentetid && data.estimertVentetidEnhet && data.estimertVentetidVerdi
+          ? {
+              verdi: data.estimertVentetidVerdi,
+              enhet: data.estimertVentetidEnhet,
+            }
+          : null,
     };
 
     mutation.mutate(body);

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -1,13 +1,24 @@
 import { PlusIcon, XMarkIcon } from "@navikt/aksel-icons";
-import { Alert, Button, Checkbox, HStack, TextField } from "@navikt/ds-react";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  HStack,
+  HelpText,
+  Select,
+  Switch,
+  TextField,
+} from "@navikt/ds-react";
 import { Avtale, Tiltaksgjennomforing, Toggles } from "mulighetsrommet-api-client";
 import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
+import { useEffect, useRef } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { useHentAnsatt } from "../../api/ansatt/useHentAnsatt";
 import { useHentKontaktpersoner } from "../../api/ansatt/useHentKontaktpersoner";
 import { useTiltaksgjennomforingAdministratorer } from "../../api/ansatt/useTiltaksgjennomforingAdministratorer";
 import { useFeatureToggle } from "../../api/features/feature-toggles";
 import { useVirksomhet } from "../../api/virksomhet/useVirksomhet";
+import { useVirksomhetKontaktpersoner } from "../../api/virksomhet/useVirksomhetKontaktpersoner";
 import { addYear } from "../../utils/Utils";
 import { isTiltakMedFellesOppstart } from "../../utils/tiltakskoder";
 import { Separator } from "../detaljside/Metadata";
@@ -16,11 +27,10 @@ import { ControlledMultiSelect } from "../skjema/ControlledMultiSelect";
 import { FormGroup } from "../skjema/FormGroup";
 import { FraTilDatoVelger } from "../skjema/FraTilDatoVelger";
 import skjemastyles from "../skjema/Skjema.module.scss";
-import { arrangorUnderenheterOptions, erArenaOpphav } from "./TiltaksgjennomforingSkjemaConst";
-import { SelectOppstartstype } from "./SelectOppstartstype";
 import { VirksomhetKontaktpersonerModal } from "../virksomhet/VirksomhetKontaktpersonerModal";
-import { useRef } from "react";
-import { useVirksomhetKontaktpersoner } from "../../api/virksomhet/useVirksomhetKontaktpersoner";
+import { SelectOppstartstype } from "./SelectOppstartstype";
+import { arrangorUnderenheterOptions, erArenaOpphav } from "./TiltaksgjennomforingSkjemaConst";
+import { InferredTiltaksgjennomforingSchema } from "./TiltaksgjennomforingSchema";
 
 interface Props {
   tiltaksgjennomforing?: Tiltaksgjennomforing;
@@ -30,19 +40,18 @@ interface Props {
 export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtale }: Props) => {
   const { data: virksomhet } = useVirksomhet(avtale.leverandor.organisasjonsnummer);
   const { data: administratorer } = useTiltaksgjennomforingAdministratorer();
-
   const { data: ansatt, isLoading: isLoadingAnsatt } = useHentAnsatt();
-
   const { data: kontaktpersoner, isLoading: isLoadingKontaktpersoner } = useHentKontaktpersoner();
+
   const virksomhetKontaktpersonerModalRef = useRef<HTMLDialogElement>(null);
 
   const kontaktpersonerOption = (selectedIndex: number) => {
     const excludedKontaktpersoner = watch("kontaktpersoner")
-      .filter((_: any, i: number) => i !== selectedIndex)
+      ?.filter((_: any, i: number) => i !== selectedIndex)
       .map((k: any) => k["navIdent"]);
 
     const options = kontaktpersoner
-      ?.filter((kontaktperson) => !excludedKontaktpersoner.includes(kontaktperson.navIdent))
+      ?.filter((kontaktperson) => !excludedKontaktpersoner?.includes(kontaktperson.navIdent))
       ?.map((kontaktperson) => ({
         label: `${kontaktperson.fornavn} ${kontaktperson.etternavn} - ${kontaktperson.navIdent}`,
         value: kontaktperson.navIdent,
@@ -57,7 +66,7 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
     formState: { errors },
     setValue,
     watch,
-  } = useFormContext();
+  } = useFormContext<InferredTiltaksgjennomforingSchema>();
   const {
     fields: kontaktpersonFields,
     append: appendKontaktperson,
@@ -73,6 +82,18 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
   } = useVirksomhetKontaktpersoner(watch("tiltaksArrangorUnderenhetOrganisasjonsnummer"));
 
   const watchErMidlertidigStengt = watch("midlertidigStengt.erMidlertidigStengt");
+  const watchVisEstimertVentetid = watch("visEstimertVentetid");
+
+  useEffect(() => {
+    const resetEstimertVentetid = () => {
+      if (!watchVisEstimertVentetid) {
+        setValue("estimertVentetidEnhet", null);
+        setValue("estimertVentetidVerdi", null);
+      }
+    };
+
+    resetEstimertVentetid();
+  }, [watchVisEstimertVentetid]);
 
   const regionerOptions = avtale.kontorstruktur
     .map((struk) => struk.region)
@@ -121,13 +142,9 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
               readOnly
               label={`Avtale (tiltakstype: ${avtale.tiltakstype.navn})`}
               value={avtale.navn || ""}
-              error={errors.avtale?.message as string}
             />
-            {/**
-             * // TODO Kan fjerne alert under når Aksel har fikset readonly + error
-             * */}
-            {errors.avtale?.message ? (
-              <Alert variant="warning">{errors.avtale.message as string}</Alert>
+            {errors.avtaleId?.message ? (
+              <Alert variant="warning">{errors.avtaleId.message as string}</Alert>
             ) : null}
           </FormGroup>
           <Separator />
@@ -212,6 +229,43 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
                 />
               )}
             </HStack>
+            <Separator />
+            <fieldset className={skjemastyles.fieldset_no_styling}>
+              <HStack gap="1">
+                <legend>Estimert ventetid </legend>
+                <HelpText title="Hva er estimert ventetid?">
+                  Estimert ventetid er et felt som kan brukes hvis dere sitter på informasjon om
+                  estimert ventetid for tiltaket. Hvis dere legger inn en verdi i feltene her blir
+                  det synlig for alle ansatte i NAV.
+                </HelpText>
+              </HStack>
+              <Switch checked={watch("visEstimertVentetid")} {...register("visEstimertVentetid")}>
+                Registrer estimert ventetid
+              </Switch>
+              {watch("visEstimertVentetid") ? (
+                <HStack justify="start" gap="10" columns={2}>
+                  <TextField
+                    size="small"
+                    type="number"
+                    min={1}
+                    label="Antall"
+                    error={errors.estimertVentetidVerdi?.message as string}
+                    {...register("estimertVentetidVerdi", {
+                      valueAsNumber: true,
+                    })}
+                  />
+                  <Select
+                    size="small"
+                    label="Måleenhet"
+                    error={errors.estimertVentetidEnhet?.message as string}
+                    {...register("estimertVentetidEnhet")}
+                  >
+                    <option value="uke">Uker</option>
+                    <option value="maned">Måneder</option>
+                  </Select>
+                </HStack>
+              ) : null}
+            </fieldset>
           </FormGroup>
           <Separator />
           <FormGroup>
@@ -239,7 +293,7 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
                 placeholder="Velg en"
                 {...register("navRegion")}
                 onChange={() => {
-                  setValue("navEnheter", []);
+                  setValue("navEnheter", [] as any);
                 }}
                 options={regionerOptions}
               />

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -87,8 +87,7 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
   useEffect(() => {
     const resetEstimertVentetid = () => {
       if (!watchVisEstimertVentetid) {
-        setValue("estimertVentetidEnhet", null);
-        setValue("estimertVentetidVerdi", null);
+        setValue("estimertVentetid", null);
       }
     };
 
@@ -243,22 +242,22 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
                 Registrer estimert ventetid
               </Switch>
               {watch("visEstimertVentetid") ? (
-                <HStack justify="start" gap="10" columns={2}>
+                <HStack justify="start" gap="10" columns={4}>
                   <TextField
                     size="small"
                     type="number"
                     min={1}
                     label="Antall"
-                    error={errors.estimertVentetidVerdi?.message as string}
-                    {...register("estimertVentetidVerdi", {
+                    error={errors.estimertVentetid?.verdi?.message as string}
+                    {...register("estimertVentetid.verdi", {
                       valueAsNumber: true,
                     })}
                   />
                   <Select
                     size="small"
                     label="Måleenhet"
-                    error={errors.estimertVentetidEnhet?.message as string}
-                    {...register("estimertVentetidEnhet")}
+                    error={errors.estimertVentetid?.enhet?.message as string}
+                    {...register("estimertVentetid.enhet")}
                   >
                     <option value="uke">Uker</option>
                     <option value="maned">Måneder</option>

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
@@ -1,4 +1,5 @@
 import {
+  EstimertVentetid,
   Opphav,
   PaginertTiltaksgjennomforing,
   Tiltaksgjennomforing,
@@ -16,6 +17,10 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     id: "a7d63fb0-4366-412c-84b7-7c15518ee361",
     navn: "Yrkesnorsk med praksis med en veldig lang tittel som ikke er helt utenkelig at de skriver inn",
     tiltaksnummer: "123456",
+    estimertVentetid: {
+      verdi: 3,
+      enhet: EstimertVentetid.enhet.MANED,
+    },
     antallPlasser: 50,
     arrangor: {
       ...mockVirksomheter.fretex.underenheter!![0],

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingDetaljer.tsx
@@ -9,7 +9,7 @@ import {
 import { NOM_ANSATT_SIDE } from "mulighetsrommet-frontend-common/constants";
 import { Bolk } from "../../components/detaljside/Bolk";
 import { Metadata, Separator } from "../../components/detaljside/Metadata";
-import { formaterDato } from "../../utils/Utils";
+import { formaterDato, formatertVentetid } from "../../utils/Utils";
 import styles from "../DetaljerInfo.module.scss";
 import { Kontaktperson } from "./Kontaktperson";
 import { Link } from "react-router-dom";
@@ -148,6 +148,21 @@ export function TiltaksgjennomforingDetaljer(props: Props) {
           </Bolk>
 
           <Separator />
+
+          {tiltaksgjennomforing?.estimertVentetid ? (
+            <>
+              <Bolk aria-label="Estimert ventetid">
+                <Metadata
+                  header="Estimert ventetid"
+                  verdi={formatertVentetid(
+                    tiltaksgjennomforing.estimertVentetid.verdi,
+                    tiltaksgjennomforing.estimertVentetid.enhet,
+                  )}
+                />
+              </Bolk>
+              <Separator />
+            </>
+          ) : null}
 
           <Bolk aria-label="Administratorer for gjennomføringen">
             <Metadata

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -216,5 +216,7 @@ export function formatertVentetid(verdi: number, enhet: EstimertVentetid.enhet):
       return `${verdi} ${verdi > 1 ? "uker" : "uke"}`;
     case EstimertVentetid.enhet.MANED:
       return `${verdi} ${verdi > 1 ? "måneder" : "måned"}`;
+    default:
+      return "Ukjent enhet for ventetid";
   }
 }

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -1,4 +1,9 @@
-import { Avtale, Avtaletype, TiltaksgjennomforingStatus } from "mulighetsrommet-api-client";
+import {
+  Avtale,
+  Avtaletype,
+  EstimertVentetid,
+  TiltaksgjennomforingStatus,
+} from "mulighetsrommet-api-client";
 import { AvtaleFilter } from "../api/atoms";
 
 export function capitalize(text?: string): string {
@@ -203,4 +208,13 @@ export function createQueryParamsForExcelDownload(filter: AvtaleFilter): URLSear
 
   queryParams.set("size", "10000");
   return queryParams;
+}
+
+export function formatertVentetid(verdi: number, enhet: EstimertVentetid.enhet): string {
+  switch (enhet) {
+    case EstimertVentetid.enhet.UKE:
+      return `${verdi} ${verdi > 1 ? "uker" : "uke"}`;
+    case EstimertVentetid.enhet.MANED:
+      return `${verdi} ${verdi > 1 ? "måneder" : "måned"}`;
+  }
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/EstimertVentetid.module.scss
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/EstimertVentetid.module.scss
@@ -1,0 +1,9 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ikon {
+  color: var(--a-data-surface-3-subtle);
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/EstimertVentetid.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/EstimertVentetid.tsx
@@ -1,0 +1,31 @@
+import { TimerPauseIcon } from "@navikt/aksel-icons";
+import { BodyShort } from "@navikt/ds-react";
+import { VeilederflateTiltaksgjennomforing } from "mulighetsrommet-api-client";
+import styles from "./EstimertVentetid.module.scss";
+import { formatertVentetid } from "../../utils/Utils";
+
+interface Props {
+  tiltaksgjennomforing: VeilederflateTiltaksgjennomforing;
+}
+
+export function EstimertVentetid({ tiltaksgjennomforing }: Props) {
+  if (!tiltaksgjennomforing?.estimertVentetid) {
+    return null;
+  }
+
+  return (
+    <>
+      <BodyShort className={styles.container}>
+        <TimerPauseIcon
+          className={styles.ikon}
+          aria-label="Stoppeklokkeikon for å indikere estimert ventetid for tiltaket"
+        />{" "}
+        Estimert ventetid for tiltaket:{" "}
+        {formatertVentetid(
+          tiltaksgjennomforing.estimertVentetid.verdi,
+          tiltaksgjennomforing.estimertVentetid.enhet,
+        )}
+      </BodyShort>
+    </>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -7,6 +7,7 @@ import {
 } from "mulighetsrommet-api-client";
 import { formaterDato, utledLopenummerFraTiltaksnummer } from "../../utils/Utils";
 import Kopiknapp from "../kopiknapp/Kopiknapp";
+import { EstimertVentetid } from "./EstimertVentetid";
 import Regelverksinfo from "./Regelverksinfo";
 import styles from "./Sidemenydetaljer.module.scss";
 
@@ -60,6 +61,7 @@ const SidemenyDetaljer = ({ tiltaksgjennomforing }: Props) => {
 
   return (
     <>
+      <EstimertVentetid tiltaksgjennomforing={tiltaksgjennomforing} />
       <Panel className={styles.panel} id="sidemeny">
         {tiltaksnummer && (
           <div className={styles.rad}>

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
@@ -6,6 +6,7 @@ import {
 } from "mulighetsrommet-api-client";
 import { mockTiltakstyper } from "./mockTiltakstyper";
 
+// TODO Mock estimert ventetid
 export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
   {
     sanityId: "f4cea25b-c372-4d4c-8106-535ab10cd586",

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
@@ -1,4 +1,5 @@
 import {
+  EstimertVentetid,
   NavEnhetStatus,
   NavEnhetType,
   TiltaksgjennomforingOppstartstype,
@@ -6,12 +7,15 @@ import {
 } from "mulighetsrommet-api-client";
 import { mockTiltakstyper } from "./mockTiltakstyper";
 
-// TODO Mock estimert ventetid
 export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
   {
     sanityId: "f4cea25b-c372-4d4c-8106-535ab10cd586",
     navn: "Avklaring - Fredrikstad",
     oppstart: TiltaksgjennomforingOppstartstype.LOPENDE,
+    estimertVentetid: {
+      verdi: 3,
+      enhet: EstimertVentetid.enhet.MANED,
+    },
     stedForGjennomforing:
       "Valpekullsveien 69, 1424" +
       " Taumatawhakatangi­hangakoauauotamatea­turipukakapikimaunga­horonukupokaiwhen­uakitanatahu",
@@ -89,6 +93,10 @@ export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
   {
     sanityId: "91205ff2-ec72-4a7f-80b8-1c99d8535a06",
     navn: "Sindres mentorordning med Yoda",
+    estimertVentetid: {
+      verdi: 5,
+      enhet: EstimertVentetid.enhet.UKE,
+    },
     oppstart: TiltaksgjennomforingOppstartstype.FELLES,
     oppstartsdato: new Date().toDateString(),
     stedForGjennomforing: "Oslo",

--- a/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
@@ -67,5 +67,7 @@ export function formatertVentetid(verdi: number, enhet: EstimertVentetid.enhet):
       return `${verdi} ${verdi > 1 ? "uker" : "uke"}`;
     case EstimertVentetid.enhet.MANED:
       return `${verdi} ${verdi > 1 ? "måneder" : "måned"}`;
+    default:
+      return "Ukjent enhet for ventetid";
   }
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/utils/Utils.ts
@@ -1,3 +1,5 @@
+import { EstimertVentetid } from "mulighetsrommet-api-client";
+
 export const inneholderUrl = (string: string) => {
   return window.location.href.indexOf(string) > -1;
 };
@@ -56,5 +58,14 @@ export function addOrRemove<T>(array: T[], item: T): T[] {
     const result = array;
     result.push(item);
     return result;
+  }
+}
+
+export function formatertVentetid(verdi: number, enhet: EstimertVentetid.enhet): string {
+  switch (enhet) {
+    case EstimertVentetid.enhet.UKE:
+      return `${verdi} ${verdi > 1 ? "uker" : "uke"}`;
+    case EstimertVentetid.enhet.MANED:
+      return `${verdi} ${verdi > 1 ? "måneder" : "måned"}`;
   }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/TiltaksgjennomforingDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/TiltaksgjennomforingDbo.kt
@@ -30,6 +30,8 @@ data class TiltaksgjennomforingDbo(
     val faneinnhold: Faneinnhold?,
     val beskrivelse: String?,
     val deltidsprosent: Double,
+    val estimertVentetidVerdi: Int?,
+    val estimertVentetidEnhet: String?,
 )
 
 data class TiltaksgjennomforingKontaktpersonDbo(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -55,6 +55,7 @@ data class TiltaksgjennomforingAdminDto(
     val tilgjengeligForVeileder: Boolean,
     val visesForVeileder: Boolean,
     val deltidsprosent: Double,
+    val estimertVentetid: EstimertVentetid?,
 ) {
     fun isAktiv(): Boolean = status in listOf(
         Tiltaksgjennomforingsstatus.PLANLAGT,
@@ -81,6 +82,12 @@ data class TiltaksgjennomforingAdminDto(
         val navn: String?,
         val kontaktpersoner: List<VirksomhetKontaktperson>,
         val slettet: Boolean,
+    )
+
+    @Serializable
+    data class EstimertVentetid(
+        val verdi: Int,
+        val enhet: String,
     )
 
     fun toDbo() =
@@ -114,6 +121,8 @@ data class TiltaksgjennomforingAdminDto(
             faneinnhold = faneinnhold,
             beskrivelse = beskrivelse,
             deltidsprosent = deltidsprosent,
+            estimertVentetidVerdi = estimertVentetid?.verdi,
+            estimertVentetidEnhet = estimertVentetid?.enhet,
         )
 
     fun toArenaTiltaksgjennomforingDbo() =

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/VeilederflateTiltaksgjennomforing.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/VeilederflateTiltaksgjennomforing.kt
@@ -44,6 +44,7 @@ data class VeilederflateTiltaksgjennomforing(
     val beskrivelse: String? = null,
     val faneinnhold: Faneinnhold? = null,
     val kontaktinfo: VeilederflateKontaktinfo? = null,
+    val estimertVentetid: EstimertVentetid? = null,
 )
 
 @Serializable
@@ -96,4 +97,10 @@ data class Oppskrift(
     val beskrivelse: String,
     val steg: List<JsonObject>,
     val _updatedAt: String,
+)
+
+@Serializable
+data class EstimertVentetid(
+    val verdi: Int,
+    val enhet: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -56,7 +56,9 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 faneinnhold,
                 beskrivelse,
                 nav_region,
-                deltidsprosent
+                deltidsprosent,
+                estimert_ventetid_verdi,
+                estimert_ventetid_enhet
             )
             values (
                 :id::uuid,
@@ -78,7 +80,9 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 :faneinnhold::jsonb,
                 :beskrivelse,
                 :nav_region,
-                :deltidsprosent
+                :deltidsprosent,
+                :estimert_ventetid_verdi,
+                :estimert_ventetid_enhet
             )
             on conflict (id)
                 do update set navn                         = excluded.navn,
@@ -99,7 +103,9 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                               faneinnhold                  = excluded.faneinnhold,
                               beskrivelse                  = excluded.beskrivelse,
                               nav_region                   = excluded.nav_region,
-                              deltidsprosent               = excluded.deltidsprosent
+                              deltidsprosent               = excluded.deltidsprosent,
+                              estimert_ventetid_verdi      = excluded.estimert_ventetid_verdi,
+                              estimert_ventetid_enhet      = excluded.estimert_ventetid_enhet
         """.trimIndent()
 
         @Language("PostgreSQL")
@@ -532,7 +538,9 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                         'epost', vk.epost,
                         'beskrivelse', vk.beskrivelse
                     ) end
-                ) as virksomhet_kontaktpersoner
+                ) as virksomhet_kontaktpersoner,
+                tg.estimert_ventetid_verdi,
+                tg.estimert_ventetid_enhet
             from tiltaksgjennomforing tg
                 inner join tiltakstype t on tg.tiltakstype_id = t.id
                 left join tiltaksgjennomforing_nav_enhet tg_e on tg_e.tiltaksgjennomforing_id = tg.id
@@ -639,6 +647,8 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "beskrivelse" to beskrivelse,
         "nav_region" to navRegion,
         "deltidsprosent" to deltidsprosent,
+        "estimert_ventetid_verdi" to estimertVentetidVerdi,
+        "estimert_ventetid_enhet" to estimertVentetidEnhet,
     )
 
     private fun ArenaTiltaksgjennomforingDbo.toSqlParameters() = mapOf(
@@ -690,6 +700,12 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             enheter = navEnheter,
             beskrivelse = stringOrNull("beskrivelse"),
             faneinnhold = stringOrNull("faneinnhold")?.let { Json.decodeFromString(it) },
+            estimertVentetid = intOrNull("estimert_ventetid_verdi")?.let {
+                EstimertVentetid(
+                    verdi = int("estimert_ventetid_verdi"),
+                    enhet = string("estimert_ventetid_enhet"),
+                )
+            },
         )
     }
 
@@ -762,6 +778,12 @@ class TiltaksgjennomforingRepository(private val db: Database) {
             tilgjengeligForVeileder = boolean("tilgjengelig_for_veileder"),
             visesForVeileder = boolean("vises_for_veileder"),
             deltidsprosent = double("deltidsprosent"),
+            estimertVentetid = intOrNull("estimert_ventetid_verdi")?.let {
+                TiltaksgjennomforingAdminDto.EstimertVentetid(
+                    verdi = int("estimert_ventetid_verdi"),
+                    enhet = string("estimert_ventetid_enhet"),
+                )
+            },
         )
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -149,6 +149,7 @@ data class TiltaksgjennomforingRequest(
     val faneinnhold: Faneinnhold?,
     val beskrivelse: String?,
     val deltidsprosent: Double,
+    val estimertVentetid: EstimertVentetid?,
 ) {
     fun toDbo() = TiltaksgjennomforingDbo(
         id = id,
@@ -180,6 +181,8 @@ data class TiltaksgjennomforingRequest(
         faneinnhold = faneinnhold,
         beskrivelse = beskrivelse,
         deltidsprosent = deltidsprosent,
+        estimertVentetidVerdi = estimertVentetid?.verdi,
+        estimertVentetidEnhet = estimertVentetid?.enhet,
     )
 }
 
@@ -199,4 +202,10 @@ data class NavKontaktpersonForGjennomforing(
 @Serializable
 data class TilgjengeligForVeilederRequest(
     val tilgjengeligForVeileder: Boolean,
+)
+
+@Serializable
+data class EstimertVentetid(
+    val verdi: Int,
+    val enhet: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateService.kt
@@ -357,6 +357,12 @@ class VeilederflateService(
                     varsler = emptyList(),
                     tiltaksansvarlige = kontaktpersoner,
                 ),
+                estimertVentetid = estimertVentetid?.let {
+                    EstimertVentetid(
+                        verdi = it.verdi,
+                        enhet = it.enhet,
+                    )
+                },
             )
         }
     }

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -89,7 +89,9 @@ select tg.id::uuid,
                            'beskrivelse', vk.beskrivelse
                        )
                     end
-       ) as virksomhet_kontaktpersoner
+       ) as virksomhet_kontaktpersoner,
+    tg.estimert_ventetid_verdi,
+    tg.estimert_ventetid_enhet
 from tiltaksgjennomforing tg
          inner join tiltakstype t on tg.tiltakstype_id = t.id
          left join tiltaksgjennomforing_administrator tg_a on tg_a.tiltaksgjennomforing_id = tg.id

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -1,3 +1,4 @@
+drop view if exists tiltaksgjennomforing_admin_dto_view;
 create or replace view tiltaksgjennomforing_admin_dto_view as
 select tg.id::uuid,
        tg.navn,

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -1,4 +1,3 @@
-drop view if exists tiltaksgjennomforing_admin_dto_view;
 create or replace view tiltaksgjennomforing_admin_dto_view as
 select tg.id::uuid,
        tg.navn,

--- a/mulighetsrommet-api/src/main/resources/db/migration/V113__add_column_for_estimert_ventetid_for_tiltaksgjennomforing.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V113__add_column_for_estimert_ventetid_for_tiltaksgjennomforing.sql
@@ -1,0 +1,2 @@
+alter table tiltaksgjennomforing add column estimert_ventetid_verdi int;
+alter table tiltaksgjennomforing add column estimert_ventetid_enhet text;

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2184,6 +2184,9 @@ components:
           type: boolean
         deltidsprosent:
           type: number
+        estimertVentetid:
+          $ref: "#/components/schemas/EstimertVentetid"
+          nullable: true
       required:
         - status
         - id
@@ -2272,6 +2275,16 @@ components:
           nullable: true
         deltidsprosent:
           type: number
+        estimertVentetid:
+          type: object
+          properties:
+            verdi:
+              type: number
+              nullable: true
+            enhet:
+              type: string
+              nullable: true
+          nullable: true
       required:
         - id
         - tiltakstypeId
@@ -2824,6 +2837,9 @@ components:
           type: string
         kontaktinfo:
           $ref: "#/components/schemas/VeilederflateKontaktInfo"
+        estimertVentetid:
+          $ref: "#/components/schemas/EstimertVentetid"
+          nullable: true
       required:
         - navn
         - tiltakstype
@@ -3413,3 +3429,17 @@ components:
         - OVERSIKT
         - DETALJER
         - HAR_VIST_OPPRETT_AVTALE
+
+    EstimertVentetid:
+      type: object
+      properties:
+        verdi:
+          type: number
+        enhet:
+          type: string
+          enum:
+            - uke
+            - maned
+      required:
+        - verdi
+        - enhet

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.fixtures
 
 import no.nav.mulighetsrommet.api.domain.dbo.TiltaksgjennomforingDbo
+import no.nav.mulighetsrommet.api.routes.v1.EstimertVentetid
 import no.nav.mulighetsrommet.api.routes.v1.TiltaksgjennomforingRequest
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.ArenaTiltaksgjennomforingDbo
@@ -52,6 +53,8 @@ object TiltaksgjennomforingFixtures {
         faneinnhold = null,
         beskrivelse = null,
         deltidsprosent = 100.0,
+        estimertVentetidVerdi = 3,
+        estimertVentetidEnhet = "dager",
     )
 
     val Oppfolging1Request = TiltaksgjennomforingRequest(
@@ -78,6 +81,10 @@ object TiltaksgjennomforingFixtures {
         faneinnhold = Oppfolging1.faneinnhold,
         beskrivelse = Oppfolging1.beskrivelse,
         deltidsprosent = 100.0,
+        estimertVentetid = EstimertVentetid(
+            verdi = 3,
+            enhet = "dager",
+        ),
     )
 
     val Oppfolging2 = TiltaksgjennomforingDbo(
@@ -104,6 +111,8 @@ object TiltaksgjennomforingFixtures {
         faneinnhold = null,
         beskrivelse = null,
         deltidsprosent = 100.0,
+        estimertVentetidVerdi = 3,
+        estimertVentetidEnhet = "dager",
     )
 
     val Arbeidstrening1 = TiltaksgjennomforingDbo(
@@ -130,5 +139,7 @@ object TiltaksgjennomforingFixtures {
         faneinnhold = null,
         beskrivelse = null,
         deltidsprosent = 100.0,
+        estimertVentetidVerdi = 3,
+        estimertVentetidEnhet = "dager",
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -54,7 +54,7 @@ object TiltaksgjennomforingFixtures {
         beskrivelse = null,
         deltidsprosent = 100.0,
         estimertVentetidVerdi = 3,
-        estimertVentetidEnhet = "dager",
+        estimertVentetidEnhet = "dag",
     )
 
     val Oppfolging1Request = TiltaksgjennomforingRequest(
@@ -83,7 +83,7 @@ object TiltaksgjennomforingFixtures {
         deltidsprosent = 100.0,
         estimertVentetid = EstimertVentetid(
             verdi = 3,
-            enhet = "dager",
+            enhet = "dag",
         ),
     )
 
@@ -112,7 +112,7 @@ object TiltaksgjennomforingFixtures {
         beskrivelse = null,
         deltidsprosent = 100.0,
         estimertVentetidVerdi = 3,
-        estimertVentetidEnhet = "dager",
+        estimertVentetidEnhet = "dag",
     )
 
     val Arbeidstrening1 = TiltaksgjennomforingDbo(
@@ -140,6 +140,6 @@ object TiltaksgjennomforingFixtures {
         beskrivelse = null,
         deltidsprosent = 100.0,
         estimertVentetidVerdi = 3,
-        estimertVentetidEnhet = "dager",
+        estimertVentetidEnhet = "dag",
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/VirksomhetRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/VirksomhetRepositoryTest.kt
@@ -268,6 +268,8 @@ class VirksomhetRepositoryTest : FunSpec({
                 faneinnhold = null,
                 beskrivelse = null,
                 deltidsprosent = 100.0,
+                estimertVentetidVerdi = 3,
+                estimertVentetidEnhet = "dager",
             )
             tiltaksgjennomforingRepository.upsert(tiltaksgjennomforing)
 


### PR DESCRIPTION
Legger til valgfrie felter for estimert ventetid.
Redaktør kan legge inn x antall uker eller måneder med estimert ventetid og så blir det synlig for alle NAVs ansatte via detaljvisningen til et tiltak.

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/049b085b-009b-4b57-8fb5-1eb0dcc63e15)
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/789d4e21-1710-4eff-827d-e65e1d08f843)
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/48bde584-28d4-40cc-8308-0b188822315c)
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/13fd5f7c-5863-462f-8b8b-c466ce68facd)
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/54d85428-f82e-4243-a1e5-7a04b04487f2)
