### PR TITLE
Legger til støtte for OVERF fra Arena for avtaler

### DIFF
--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
@@ -13,6 +13,7 @@ import no.nav.mulighetsrommet.arena.adapter.models.ProcessingResult
 import no.nav.mulighetsrommet.arena.adapter.models.arena.ArenaAvtaleInfo
 import no.nav.mulighetsrommet.arena.adapter.models.arena.ArenaTable
 import no.nav.mulighetsrommet.arena.adapter.models.arena.Avtalekode
+import no.nav.mulighetsrommet.arena.adapter.models.arena.Avtalestatuskode
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Handled
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEntityMapping.Status.Ignored
 import no.nav.mulighetsrommet.arena.adapter.models.db.ArenaEvent
@@ -60,6 +61,10 @@ class AvtaleInfoEventProcessor(
 
         if (!isRecentAvtale(data)) {
             return@either ProcessingResult(Ignored, "Avtale har en til-dato som er før 2023")
+        }
+
+        if(data.AVTALESTATUSKODE === Avtalestatuskode.Overfort) {
+            return@either ProcessingResult(Ignored, "Avtalen har status 'OVERF' og skal ikke videre til api-databasen.")
         }
 
         val mapping = entities.getMapping(event.arenaTable, event.arenaId).bind()

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessor.kt
@@ -63,7 +63,7 @@ class AvtaleInfoEventProcessor(
             return@either ProcessingResult(Ignored, "Avtale har en til-dato som er før 2023")
         }
 
-        if(data.AVTALESTATUSKODE === Avtalestatuskode.Overfort) {
+        if (data.AVTALESTATUSKODE === Avtalestatuskode.Overfort) {
             return@either ProcessingResult(Ignored, "Avtalen har status 'OVERF' og skal ikke videre til api-databasen.")
         }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaAvtaleInfo.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/arena/ArenaAvtaleInfo.kt
@@ -55,4 +55,7 @@ enum class Avtalestatuskode {
 
     @SerialName("AVBRU")
     Avbrutt,
+
+    @SerialName("OVERF")
+    Overfort,
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/ArenaEntityMapping.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/ArenaEntityMapping.kt
@@ -14,5 +14,6 @@ data class ArenaEntityMapping(
         Handled,
         Ignored,
         Unhandled,
+        Overfort,
     }
 }

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Avtale.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/models/db/Avtale.kt
@@ -24,6 +24,7 @@ data class Avtale(
         Aktiv,
         Avsluttet,
         Avbrutt,
+        Overfort,
         ;
 
         companion object {
@@ -32,6 +33,7 @@ data class Avtale(
                 Avtalestatuskode.Gjennomforer -> Aktiv
                 Avtalestatuskode.Avsluttet -> Avsluttet
                 Avtalestatuskode.Avbrutt -> Avbrutt
+                Avtalestatuskode.Overfort -> Overfort
             }
         }
     }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessorTest.kt
@@ -3,6 +3,7 @@ package no.nav.mulighetsrommet.arena.adapter.events.processors
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -140,17 +141,6 @@ class AvtaleInfoEventProcessorTest : FunSpec({
                 database.assertThat("avtale").isEmpty
             }
 
-            test("ignore avtaler med status OVERF") {
-                val processor = createProcessor()
-
-                val event = createArenaAvtaleInfoEvent(Insert) {
-                    it.copy(AVTALESTATUSKODE = Avtalestatuskode.Overfort)
-                }
-
-                processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
-                database.assertThat("avtale").isEmpty
-            }
-
             test("should treat all operations as upserts") {
                 val (e1, mapping) = prepareEvent(createArenaAvtaleInfoEvent(Insert))
 
@@ -277,6 +267,33 @@ class AvtaleInfoEventProcessorTest : FunSpec({
 
                     url.getLastPathParameterAsUUID() shouldBe mapping.entityId
                 }
+            }
+
+            test("should not call api with handle event when status is OVERF from Arena") {
+                val (event, mapping) = prepareEvent(
+                    createArenaAvtaleInfoEvent(Insert) {
+                        it.copy(
+                            AVTALESTATUSKODE = Avtalestatuskode.Overfort,
+                        )
+                    },
+                )
+
+                val engine = createMockEngine(
+                    "/ords/arbeidsgiver" to {
+                        respondJson(ArenaOrdsArrangor("123456", "1000000"))
+                    },
+                    "/api/v1/internal/arena/avtale" to { respondOk() },
+                    "/api/v1/internal/arena/avtale/${mapping.entityId}" to { respondOk() },
+                )
+                val processor = createProcessor(engine)
+
+                processor.handleEvent(event).shouldBeRight()
+
+                database.assertThat("avtale").row()
+                    .value("id").isEqualTo(mapping.entityId)
+                    .value("status").isEqualTo(Avtale.Status.Overfort.name)
+
+                engine.requestHistory.shouldBeEmpty()
             }
         }
     }

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessorTest.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/AvtaleInfoEventProcessorTest.kt
@@ -140,6 +140,17 @@ class AvtaleInfoEventProcessorTest : FunSpec({
                 database.assertThat("avtale").isEmpty
             }
 
+            test("ignore avtaler med status OVERF") {
+                val processor = createProcessor()
+
+                val event = createArenaAvtaleInfoEvent(Insert) {
+                    it.copy(AVTALESTATUSKODE = Avtalestatuskode.Overfort)
+                }
+
+                processor.handleEvent(event).shouldBeRight().should { it.status shouldBe Ignored }
+                database.assertThat("avtale").isEmpty
+            }
+
             test("should treat all operations as upserts") {
                 val (e1, mapping) = prepareEvent(createArenaAvtaleInfoEvent(Insert))
 


### PR DESCRIPTION
Arena vil kunne sende avtaler via Kafka med status `OVERF`. 
Denne PRen legger til støtte for statusen i arena-adapter. Vi ignorerer avtaler med status overført. Dvs, vi sender dem ikke videre til api-db.

