### PR TITLE
Update gradle-build-action@v2 to gradle/actions/setup-gradle@v3

### DIFF
--- a/.github/actions/setup-backend/action.yaml
+++ b/.github/actions/setup-backend/action.yaml
@@ -10,7 +10,7 @@ runs:
         distribution: temurin
         java-version: 17
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
     - name: Set up test environment
       run: docker-compose --profile ci up -d
       shell: bash


### PR DESCRIPTION
v2 av gradle-build-action@v2 bruker Node 16 som er deprecated. 
Bumper derfor til v3 av gradle-build-action, som nå heter setup-gradle@v3
