### PR TITLE
Stopp upsert av avtaler hvis vi ikke eier tiltakstypen

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -22,6 +22,7 @@ data class Config(
 
 data class AppConfig(
     val database: FlywayDatabaseAdapter.Config,
+    val migrerteTiltak: List<String>,
     val kafka: KafkaConfig,
     val auth: AuthConfig,
     val sanity: SanityClient.Config,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -262,7 +262,20 @@ private fun services(appConfig: AppConfig) = module {
             get(),
         )
     }
-    single { AvtaleService(get(), get(), get(), get(), get(), get(), get(), get()) }
+    single {
+        AvtaleService(
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            appConfig.kafka.producers.arenaMigreringTiltaksgjennomforinger.tiltakstyper,
+        )
+    }
     single { TiltakshistorikkService(get(), get()) }
     single { VeilederflateService(get(), get(), get(), get()) }
     single { BrukerService(get(), get(), get(), get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -11,7 +11,6 @@ import no.nav.common.token_client.builder.AzureAdTokenClientBuilder
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.mulighetsrommet.api.AppConfig
-import no.nav.mulighetsrommet.api.KafkaConfig
 import no.nav.mulighetsrommet.api.SlackConfig
 import no.nav.mulighetsrommet.api.TaskConfig
 import no.nav.mulighetsrommet.api.avtaler.AvtaleValidator
@@ -66,7 +65,7 @@ fun Application.configureDependencyInjection(appConfig: AppConfig) {
 
         modules(
             db(appConfig.database),
-            kafka(appConfig.kafka),
+            kafka(appConfig),
             repositories(),
             services(appConfig),
             tasks(appConfig.tasks),
@@ -91,7 +90,8 @@ private fun db(config: FlywayDatabaseAdapter.Config): Module {
     }
 }
 
-private fun kafka(config: KafkaConfig) = module {
+private fun kafka(appConfig: AppConfig) = module {
+    val config = appConfig.kafka
     val producerProperties = when (NaisEnv.current()) {
         NaisEnv.Local -> KafkaPropertiesBuilder.producerBuilder()
             .withBaseProperties()
@@ -111,7 +111,7 @@ private fun kafka(config: KafkaConfig) = module {
     single {
         ArenaMigreringTiltaksgjennomforingKafkaProducer(
             producerClient,
-            config.producers.arenaMigreringTiltaksgjennomforinger,
+            config.producers.arenaMigreringTiltaksgjennomforinger.copy(tiltakstyper = appConfig.migrerteTiltak),
         )
     }
     single { TiltaksgjennomforingKafkaProducer(producerClient, config.producers.tiltaksgjennomforinger) }
@@ -273,7 +273,7 @@ private fun services(appConfig: AppConfig) = module {
             get(),
             get(),
             get(),
-            appConfig.kafka.producers.arenaMigreringTiltaksgjennomforinger.tiltakstyper,
+            appConfig.migrerteTiltak,
         )
     }
     single { TiltakshistorikkService(get(), get()) }
@@ -297,7 +297,7 @@ private fun services(appConfig: AppConfig) = module {
             get(),
             get(),
             get(),
-            appConfig.kafka.producers.arenaMigreringTiltaksgjennomforinger.tiltakstyper,
+            appConfig.migrerteTiltak,
         )
     }
     single { SanityTiltaksgjennomforingService(get(), get(), get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -47,7 +47,7 @@ class TiltaksgjennomforingService(
     ): Either<List<ValidationError>, TiltaksgjennomforingAdminDto> {
         virksomhetService.getOrSyncVirksomhet(request.arrangorOrganisasjonsnummer)
 
-        // TODO Fjern tiltakstypesjekk når vi har blitt master for alle tiltakstyper
+        // TODO Fjern tiltakstypesjekk for tiltak når vi har blitt master for alle tiltakstyper
         val tiltakstype = tiltakstyper.get(request.tiltakstypeId)
             ?: throw BadRequestException("Fant ikke tiltakstype med id: ${request.tiltakstypeId}")
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/kafka/producers/ArenaMigreringTiltaksgjennomforingKafkaProducer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/kafka/producers/ArenaMigreringTiltaksgjennomforingKafkaProducer.kt
@@ -17,7 +17,7 @@ class ArenaMigreringTiltaksgjennomforingKafkaProducer(
 
     data class Config(
         val topic: String,
-        val tiltakstyper: List<String>,
+        val tiltakstyper: List<String> = emptyList(),
     )
 
     fun publish(value: ArenaMigreringTiltaksgjennomforingDto) {

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -13,14 +13,15 @@ app:
     migrationConfig:
       strategy: Migrate
 
+  migrerteTiltak:
+    - VASV
+
   kafka:
     producerId: mulighetsrommet-api-kafka-producer.v1
     consumerGroupId: mulighetsrommet-api-kafka-consumer.v1
     producers:
       arenaMigreringTiltaksgjennomforinger:
         topic: team-mulighetsrommet.arena-migrering-tiltaksgjennomforinger-v1
-        tiltakstyper:
-          - VASV
       tiltaksgjennomforinger:
         topic: team-mulighetsrommet.siste-tiltaksgjennomforinger-v1
       tiltakstyper:

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -15,6 +15,19 @@ app:
       # Kan kjøres når du må kjøre flyway repair
       # strategy: RepairAndMigrate
 
+  migrerteTiltak:
+    - ARBFORB
+    - ARBRRHDAG
+    - AVKLARAG
+    - DIGIOPPARB
+    - GRUFAGYRKE
+    - GRUPPEAMO
+    - INDJOBSTOT
+    - INDOPPFAG
+    - IPSUNG
+    - JOBBK
+    - UTVAOONAV
+    - VASV
 
   kafka:
     brokerUrl: localhost:29092
@@ -23,19 +36,6 @@ app:
     producers:
       arenaMigreringTiltaksgjennomforinger:
         topic: arena-migrering-tiltaksgjennomforinger-v1
-        tiltakstyper:
-          - ARBFORB
-          - ARBRRHDAG
-          - AVKLARAG
-          - DIGIOPPARB
-          - GRUFAGYRKE
-          - GRUPPEAMO
-          - INDJOBSTOT
-          - INDOPPFAG
-          - IPSUNG
-          - JOBBK
-          - UTVAOONAV
-          - VASV
       tiltaksgjennomforinger:
         topic: siste-tiltaksgjennomforinger-v1
       tiltakstyper:

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -13,13 +13,14 @@ app:
     migrationConfig:
       strategy: Migrate
 
+  migrerteTiltak: []
+
   kafka:
     producerId: mulighetsrommet-api-kafka-producer.v1
     consumerGroupId: mulighetsrommet-api-kafka-consumer.v1
     producers:
       arenaMigreringTiltaksgjennomforinger:
         topic: team-mulighetsrommet.arena-migrering-tiltaksgjennomforinger-v1
-        tiltakstyper: []
       tiltaksgjennomforinger:
         topic: team-mulighetsrommet.siste-tiltaksgjennomforinger-v1
       tiltakstyper:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -93,6 +93,7 @@ fun createTestApplicationConfig() = AppConfig(
         environment = "",
     ),
     axsys = ServiceClientConfig(url = "", scope = ""),
+    migrerteTiltak = emptyList(),
 )
 
 fun createKafkaConfig(): KafkaConfig {
@@ -104,7 +105,6 @@ fun createKafkaConfig(): KafkaConfig {
             tiltakstyper = TiltakstypeKafkaProducer.Config(topic = "siste-tiltakstyper-v1"),
             arenaMigreringTiltaksgjennomforinger = ArenaMigreringTiltaksgjennomforingKafkaProducer.Config(
                 topic = "arena-migrering-tiltaksgjennomforinger-v1",
-                tiltakstyper = listOf("INDOPPFAG"),
             ),
         ),
         consumerGroupId = "mulighetsrommet-api-consumer",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/MulighetsrommetTestDomain.kt
@@ -16,6 +16,8 @@ data class MulighetsrommetTestDomain(
         TiltakstypeFixtures.Oppfolging,
         TiltakstypeFixtures.Arbeidstrening,
         TiltakstypeFixtures.VTA,
+        TiltakstypeFixtures.Jobbklubb,
+        TiltakstypeFixtures.AFT,
     ),
     val avtaler: List<AvtaleDbo> = listOf(AvtaleFixtures.oppfolging, AvtaleFixtures.avtaleForVta),
     val gjennomforinger: List<TiltaksgjennomforingDbo> = listOf(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltakstypeFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltakstypeFixtures.kt
@@ -39,6 +39,17 @@ object TiltakstypeFixtures {
         sistEndretDatoIArena = LocalDateTime.of(2023, 1, 11, 0, 0, 0),
     )
 
+    val Jobbklubb = TiltakstypeDbo(
+        id = UUID.fromString("801340cd-f0ae-4da9-a01c-caad692933a2"),
+        navn = "Jobbklubb",
+        tiltakskode = "JOBBK",
+        rettPaaTiltakspenger = true,
+        fraDato = LocalDate.of(2023, 1, 1),
+        tilDato = LocalDate.of(2025, 12, 31),
+        registrertDatoIArena = LocalDateTime.of(2023, 1, 11, 0, 0, 0),
+        sistEndretDatoIArena = LocalDateTime.of(2023, 1, 11, 0, 0, 0),
+    )
+
     val Arbeidstrening = TiltakstypeDbo(
         id = UUID.fromString("87cbc5c0-962e-4f34-93df-d78a887872a6"),
         navn = "Arbeidstrening",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/routes/AvtaleRoutesTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/routes/AvtaleRoutesTest.kt
@@ -105,7 +105,7 @@ class AvtaleRoutesTest : FunSpec({
             auth = createAuthConfig(oauth, roles = listOf(avtaleSkrivRolle, tiltaksadministrasjonGenerellRolle)),
             engine = engine,
             database = databaseConfig,
-            // TODO Få inn enable tiltakstype som config her
+            migrerteTiltak = listOf("INDOPPFAG"),
         )
         withTestApplication(config) {
             val client = createClient {
@@ -133,13 +133,12 @@ class AvtaleRoutesTest : FunSpec({
                         AvtaleFixtures.avtaleRequest.copy(
                             id = UUID.randomUUID(),
                             navEnheter = listOf(NavEnhetFixtures.Oslo.enhetsnummer),
-                            tiltakstypeId = tiltakstype.id
-                        )
+                            tiltakstypeId = tiltakstype.id,
+                        ),
                     )
                 }
                 response.status shouldBe status
             }
-
         }
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/routes/TiltaksgjennomforingRoutesTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/routes/TiltaksgjennomforingRoutesTest.kt
@@ -123,6 +123,7 @@ class TiltaksgjennomforingRoutesTest : FunSpec({
             auth = createAuthConfig(oauth, roles = listOf(tiltaksgjennomforingSkrivRolle, tiltaksadministrasjonGenerellRolle)),
             engine = engine,
             database = databaseConfig,
+            migrerteTiltak = listOf("INDOPPFAG"),
         )
         withTestApplication(config) {
             val client = createClient {
@@ -140,7 +141,7 @@ class TiltaksgjennomforingRoutesTest : FunSpec({
                         "NAVident" to "ABC123",
                         "groups" to listOf(
                             tiltaksgjennomforingSkrivRolle.adGruppeId,
-                            tiltaksadministrasjonGenerellRolle.adGruppeId
+                            tiltaksadministrasjonGenerellRolle.adGruppeId,
                         ),
                     )
                     bearerAuth(
@@ -152,7 +153,7 @@ class TiltaksgjennomforingRoutesTest : FunSpec({
                             avtaleId = AvtaleFixtures.oppfolging.id,
                             navRegion = NavEnhetFixtures.Oslo.enhetsnummer,
                             navEnheter = listOf(NavEnhetFixtures.Sagene.enhetsnummer),
-                            tiltakstypeId = tiltakstype.id
+                            tiltakstypeId = tiltakstype.id,
                         ),
                     )
                 }


### PR DESCRIPTION
Legger inn sperre for upserting av avtaler som opprettes hos oss, så lenge vi ikke har tatt eierskap til tiltakstypen.
Redigering vil fortsatt fungere som før.

Fiks av readonly-felter når opphav er Arena, men vi er master kommer i separat PR senere.
