### PR TITLE
Bug: Flyttet knapper fra venstre til høyre side i skjemaer

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
@@ -186,6 +186,7 @@ export function AvtaleSkjemaContainer({
                 variant="danger"
                 type="button"
                 onClick={() => avbrytModalRef.current?.showModal()}
+                className={skjemastyles.avbryt_knapp}
               >
                 Avbryt avtale
               </Button>

--- a/frontend/mr-admin-flate/src/components/filter/AvtaleFilterButtons.module.scss
+++ b/frontend/mr-admin-flate/src/components/filter/AvtaleFilterButtons.module.scss
@@ -1,0 +1,17 @@
+.filterbuttons_container {
+  display: grid;
+  grid-template-columns: auto auto;
+  height: 100%;
+  align-items: center;
+  .nullstill_filter {
+    grid-column: 1;
+    width: fit-content;
+  }
+
+  .opprett_avtale_knapp {
+    grid-column: 2;
+    width: fit-content;
+    display: flex;
+    justify-self: flex-end;
+  }
+}

--- a/frontend/mr-admin-flate/src/components/filter/AvtaleFilterButtons.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/AvtaleFilterButtons.tsx
@@ -3,6 +3,7 @@ import { useAtom, WritableAtom } from "jotai";
 import { AvtaleFilter, defaultAvtaleFilter } from "../../api/atoms";
 import { Lenkeknapp } from "../lenkeknapp/Lenkeknapp";
 import { HarSkrivetilgang } from "../authActions/HarSkrivetilgang";
+import style from "./AvtaleFilterButtons.module.scss";
 
 interface Props {
   filterAtom: WritableAtom<AvtaleFilter, [newValue: AvtaleFilter], void>;
@@ -13,15 +14,7 @@ export function AvtaleFilterButtons({ filterAtom, tiltakstypeId }: Props) {
   const [filter, setFilter] = useAtom(filterAtom);
 
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "row",
-        justifyContent: "space-between",
-        height: "100%",
-        alignItems: "center",
-      }}
-    >
+    <div className={style.filterbuttons_container}>
       {filter.sok.length > 0 ||
       filter.navRegioner.length > 0 ||
       (!tiltakstypeId && filter.tiltakstyper.length > 0) ||
@@ -30,7 +23,7 @@ export function AvtaleFilterButtons({ filterAtom, tiltakstypeId }: Props) {
         <Button
           type="button"
           size="small"
-          style={{ maxWidth: "130px" }}
+          className={style.nullstill_filter}
           variant="tertiary"
           onClick={() => {
             setFilter({
@@ -41,15 +34,14 @@ export function AvtaleFilterButtons({ filterAtom, tiltakstypeId }: Props) {
         >
           Nullstill filter
         </Button>
-      ) : (
-        <div></div>
-      )}
-      {/*
-        Empty div over for å dytte de andre knappene til høyre uavhengig
-        av om nullstill knappen er der
-      */}
+      ) : null}
       <HarSkrivetilgang ressurs="Avtale">
-        <Lenkeknapp to="/avtaler/skjema" size="small" variant="primary">
+        <Lenkeknapp
+          to="/avtaler/skjema"
+          size="small"
+          variant="primary"
+          className={style.opprett_avtale_knapp}
+        >
           Opprett ny avtale
         </Lenkeknapp>
       </HarSkrivetilgang>

--- a/frontend/mr-admin-flate/src/components/skjema/Skjema.module.scss
+++ b/frontend/mr-admin-flate/src/components/skjema/Skjema.module.scss
@@ -156,9 +156,18 @@
 }
 
 .flex_container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 50% 50%;
+
+  .knapperad {
+    grid-column: 2;
+  }
+
+  .avbryt_knapp {
+    grid-column: 1;
+    width: fit-content;
+    height: fit-content;
+  }
 }
 
 .red_tab_title {

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaContainer.tsx
@@ -190,6 +190,7 @@ export const TiltaksgjennomforingSkjemaContainer = ({
                 variant="danger"
                 type="button"
                 onClick={() => avbrytModalRef.current?.showModal()}
+                className={skjemastyles.avbryt_knapp}
               >
                 Avbryt gjennomføring
               </Button>


### PR DESCRIPTION
Alle primær-knapper står nå til høyre under skjemaene.

![image](https://github.com/navikt/mulighetsrommet/assets/21334782/5ab33ab2-dd0c-4d32-baa8-17dbdfedc2c1)
![image](https://github.com/navikt/mulighetsrommet/assets/21334782/d6730ed8-af63-4b3f-ad4d-22886a6c95d1)
