### PR TITLE
test publisering av gjennomføringer til migreringstopic

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -111,7 +111,7 @@ private fun kafka(appConfig: AppConfig) = module {
     single {
         ArenaMigreringTiltaksgjennomforingKafkaProducer(
             producerClient,
-            config.producers.arenaMigreringTiltaksgjennomforinger.copy(tiltakstyper = appConfig.migrerteTiltak),
+            config.producers.arenaMigreringTiltaksgjennomforinger,
         )
     }
     single { TiltaksgjennomforingKafkaProducer(producerClient, config.producers.tiltaksgjennomforinger) }
@@ -132,6 +132,7 @@ private fun kafka(appConfig: AppConfig) = module {
         val consumers = listOf(
             TiltaksgjennomforingTopicConsumer(
                 config = config.consumers.tiltaksgjennomforingerV1,
+                migrerteTiltak = appConfig.migrerteTiltak,
                 arenaAdapterClient = get(),
                 arenaMigreringTiltaksgjennomforingKafkaProducer = get(),
                 tiltaksgjennomforingRepository = get(),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/kafka/producers/ArenaMigreringTiltaksgjennomforingKafkaProducer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/kafka/producers/ArenaMigreringTiltaksgjennomforingKafkaProducer.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import no.nav.common.kafka.producer.KafkaProducerClient
 import no.nav.mulighetsrommet.api.domain.dto.ArenaMigreringTiltaksgjennomforingDto
-import no.nav.mulighetsrommet.env.NaisEnv
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -17,23 +16,17 @@ class ArenaMigreringTiltaksgjennomforingKafkaProducer(
 
     data class Config(
         val topic: String,
-        val tiltakstyper: List<String> = emptyList(),
     )
 
     fun publish(value: ArenaMigreringTiltaksgjennomforingDto) {
-        if (!config.tiltakstyper.contains(value.tiltakskode)) {
-            return
-        }
         val record: ProducerRecord<String, String?> = ProducerRecord(
             config.topic,
             value.id.toString(),
             Json.encodeToString(value),
         )
 
-        if (NaisEnv.current().isDevGCP()) {
-            logger.info("publish på ${config.topic} id: ${value.id}")
-            kafkaProducerClient.sendSync(record)
-        }
+        logger.info("publish på ${config.topic} id: ${value.id}")
+        kafkaProducerClient.sendSync(record)
     }
 
     fun retract(id: UUID) {
@@ -43,9 +36,7 @@ class ArenaMigreringTiltaksgjennomforingKafkaProducer(
             null,
         )
 
-        if (NaisEnv.current().isDevGCP()) {
-            logger.info("retract på ${config.topic} id: $id")
-            kafkaProducerClient.sendSync(record)
-        }
+        logger.info("retract på ${config.topic} id: $id")
+        kafkaProducerClient.sendSync(record)
     }
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/kafka/consumers/TiltaksgjennomforingTopicConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/kafka/consumers/TiltaksgjennomforingTopicConsumerTest.kt
@@ -1,0 +1,127 @@
+package no.nav.mulighetsrommet.kafka.consumers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.mockk.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import no.nav.common.kafka.producer.KafkaProducerClient
+import no.nav.mulighetsrommet.api.clients.arenaadapter.ArenaAdapterClient
+import no.nav.mulighetsrommet.api.createDatabaseTestConfig
+import no.nav.mulighetsrommet.api.domain.dto.ArenaMigreringTiltaksgjennomforingDto
+import no.nav.mulighetsrommet.api.domain.dto.TiltaksgjennomforingDto
+import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
+import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
+import no.nav.mulighetsrommet.api.fixtures.TiltaksgjennomforingFixtures
+import no.nav.mulighetsrommet.api.fixtures.TiltakstypeFixtures
+import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
+import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+import no.nav.mulighetsrommet.domain.dto.ArenaTiltaksgjennomforingDto
+import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
+import no.nav.mulighetsrommet.kafka.producers.ArenaMigreringTiltaksgjennomforingKafkaProducer
+
+class TiltaksgjennomforingTopicConsumerTest : FunSpec({
+    val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
+
+    context("migrerte gjennomføringer") {
+        val producerClient = mockk<KafkaProducerClient<String, String?>>(relaxed = true)
+        val producer = spyk(
+            ArenaMigreringTiltaksgjennomforingKafkaProducer(
+                producerClient,
+                config = ArenaMigreringTiltaksgjennomforingKafkaProducer.Config(topic = "topic"),
+            ),
+        )
+
+        val gjennomforinger = TiltaksgjennomforingRepository(database.db)
+
+        MulighetsrommetTestDomain(
+            tiltakstyper = listOf(TiltakstypeFixtures.Oppfolging),
+            avtaler = listOf(AvtaleFixtures.oppfolging),
+            gjennomforinger = listOf(TiltaksgjennomforingFixtures.Oppfolging1),
+        ).initialize(database.db)
+
+        val gjennomforing = gjennomforinger.get(TiltaksgjennomforingFixtures.Oppfolging1.id)
+        gjennomforing.shouldNotBeNull()
+
+        val endretTidspunkt = gjennomforinger.getUpdatedAt(gjennomforing.id)
+        endretTidspunkt.shouldNotBeNull()
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        test("skal ikke publisere gjennomføringer til migreringstopic før tiltakstype er migrert") {
+            val arenaAdapterClient = mockk<ArenaAdapterClient>()
+            coEvery { arenaAdapterClient.hentArenadata(gjennomforing.id) } returns null
+
+            val migrerteTiltak = listOf<String>()
+
+            val consumer = TiltaksgjennomforingTopicConsumer(
+                KafkaTopicConsumer.Config(id = "id", topic = "topic"),
+                migrerteTiltak,
+                gjennomforinger,
+                producer,
+                arenaAdapterClient,
+            )
+
+            consumer.consume(
+                gjennomforing.id.toString(),
+                Json.encodeToJsonElement(TiltaksgjennomforingDto.from(gjennomforing)),
+            )
+
+            verify(exactly = 0) { producer.publish(any()) }
+            verify(exactly = 0) { producerClient.sendSync(any()) }
+        }
+
+        test("skal publisere gjennomføringer til tiltaksgjennomføringer når tiltakstype er migrert") {
+            val arenaAdapterClient = mockk<ArenaAdapterClient>()
+            coEvery { arenaAdapterClient.hentArenadata(gjennomforing.id) } returns null
+
+            val migrerteTiltak = listOf(TiltakstypeFixtures.Oppfolging.tiltakskode)
+
+            val consumer = TiltaksgjennomforingTopicConsumer(
+                KafkaTopicConsumer.Config(id = "id", topic = "topic"),
+                migrerteTiltak,
+                gjennomforinger,
+                producer,
+                arenaAdapterClient,
+            )
+
+            consumer.consume(
+                gjennomforing.id.toString(),
+                Json.encodeToJsonElement(TiltaksgjennomforingDto.from(gjennomforing)),
+            )
+
+            val expectedMessage = ArenaMigreringTiltaksgjennomforingDto.from(gjennomforing, null, endretTidspunkt)
+            verify(exactly = 1) { producer.publish(expectedMessage) }
+            verify(exactly = 1) { producerClient.sendSync(any()) }
+        }
+
+        test("skal inkludere eksisterende arenaId når gjennomføring allerede eksisterer i Arena") {
+            val arenaAdapterClient = mockk<ArenaAdapterClient>()
+            coEvery { arenaAdapterClient.hentArenadata(gjennomforing.id) } returns ArenaTiltaksgjennomforingDto(
+                arenaId = 123,
+                status = "AVSLU",
+            )
+
+            val migrerteTiltak = listOf(TiltakstypeFixtures.Oppfolging.tiltakskode)
+
+            val consumer = TiltaksgjennomforingTopicConsumer(
+                KafkaTopicConsumer.Config(id = "id", topic = "topic"),
+                migrerteTiltak,
+                gjennomforinger,
+                producer,
+                arenaAdapterClient,
+            )
+
+            consumer.consume(
+                gjennomforing.id.toString(),
+                Json.encodeToJsonElement(TiltaksgjennomforingDto.from(gjennomforing)),
+            )
+
+            val expectedMessage = ArenaMigreringTiltaksgjennomforingDto.from(gjennomforing, 123, endretTidspunkt)
+            verify(exactly = 1) { producer.publish(expectedMessage) }
+            verify(exactly = 1) { producerClient.sendSync(any()) }
+        }
+    }
+})


### PR DESCRIPTION
- Flytter sjekk av tiltakstype til consumer i stedet for producer. Dette løser opp i tilfeller der exceptions kastes vi forsøker å konvertere gjennomføringer til TiltaksgjennomforingMigreringDto fordi de mangler NAV-enhet, uten at det er behov for det fordi vi uansett ikke har konfigurert appen med at tiltakstype er migrert
- Støtter også publish til topic i prod (gitt at sjekken nevnt over går gjennom)