### PR TITLE
Ikke lov å endre oppstartstype for kurs-tiltak

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/SelectOppstartstype.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/SelectOppstartstype.tsx
@@ -8,9 +8,10 @@ import { useGetTiltaksgjennomforingIdFromUrl } from "../../hooks/useGetTiltaksgj
 
 interface SelectOppstartstypeProps {
   name: string;
+  readonly: boolean;
 }
 
-export function SelectOppstartstype({ name }: SelectOppstartstypeProps) {
+export function SelectOppstartstype({ name, readonly = false }: SelectOppstartstypeProps) {
   const id = useGetTiltaksgjennomforingIdFromUrl();
 
   const { field, fieldState } = useController({ name });
@@ -25,6 +26,7 @@ export function SelectOppstartstype({ name }: SelectOppstartstypeProps) {
         placeholder="Velg oppstart"
         name={name}
         onChange={field.onChange}
+        readOnly={readonly}
         options={[
           {
             label: "Felles oppstartsdato",

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -153,7 +153,10 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
           </FormGroup>
           <Separator />
           <FormGroup>
-            <SelectOppstartstype name="oppstart" />
+            <SelectOppstartstype
+              name="oppstart"
+              readonly={isTiltakMedFellesOppstart(avtale.tiltakstype.arenaKode)}
+            />
             <FraTilDatoVelger
               size="small"
               fra={{

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -155,7 +155,7 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
           <FormGroup>
             <SelectOppstartstype
               name="oppstart"
-              readonly={isTiltakMedFellesOppstart(avtale.tiltakstype.arenaKode)}
+              readonly={!isTiltakMedFellesOppstart(avtale.tiltakstype.arenaKode)}
             />
             <FraTilDatoVelger
               size="small"

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
@@ -72,7 +72,6 @@ class TiltaksgjennomforingValidator(
                 }
             }
 
-
             if (!Tiltakskoder.isTiltakMedAvtalerFraMulighetsrommet(avtale.tiltakstype.arenaKode)) {
                 if (dbo.startDato.isBefore(avtale.startDato)) {
                     add(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
@@ -63,6 +63,17 @@ class TiltaksgjennomforingValidator(
                 validateKursTiltak(dbo)
             }
 
+            if (!Tiltakskoder.isKursTiltak(avtale.tiltakstype.arenaKode)) {
+                if (dbo.oppstart == TiltaksgjennomforingOppstartstype.LOPENDE) {
+                    add(
+                        ValidationError.of(
+                            TiltaksgjennomforingDbo::oppstart,
+                            "Tiltaket må ha felles oppstartstype",
+                        ),
+                    )
+                }
+            }
+
             if (!Tiltakskoder.isTiltakMedAvtalerFraMulighetsrommet(avtale.tiltakstype.arenaKode)) {
                 if (dbo.startDato.isBefore(avtale.startDato)) {
                     add(
@@ -203,15 +214,6 @@ class TiltaksgjennomforingValidator(
                 ValidationError.of(
                     TiltaksgjennomforingDbo::deltidsprosent,
                     "Deltidsprosent kan ikke være større enn 100",
-                ),
-            )
-        }
-
-        if (dbo.oppstart != TiltaksgjennomforingOppstartstype.FELLES) {
-            add(
-                ValidationError.of(
-                    TiltaksgjennomforingDbo::oppstart,
-                    "Oppstartstypen kan bare ha felles oppstartsdato for valgt tiltakstype fra avtalen",
                 ),
             )
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
@@ -61,18 +61,17 @@ class TiltaksgjennomforingValidator(
 
             if (Tiltakskoder.isKursTiltak(avtale.tiltakstype.arenaKode)) {
                 validateKursTiltak(dbo)
-            }
-
-            if (!Tiltakskoder.isKursTiltak(avtale.tiltakstype.arenaKode)) {
-                if (dbo.oppstart == TiltaksgjennomforingOppstartstype.LOPENDE) {
+            } else {
+                if (dbo.oppstart == TiltaksgjennomforingOppstartstype.FELLES) {
                     add(
                         ValidationError.of(
                             TiltaksgjennomforingDbo::oppstart,
-                            "Tiltaket må ha felles oppstartstype",
+                            "Tiltaket må ha løpende oppstartstype",
                         ),
                     )
                 }
             }
+
 
             if (!Tiltakskoder.isTiltakMedAvtalerFraMulighetsrommet(avtale.tiltakstype.arenaKode)) {
                 if (dbo.startDato.isBefore(avtale.startDato)) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidator.kt
@@ -11,6 +11,7 @@ import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.routes.v1.responses.ValidationError
 import no.nav.mulighetsrommet.domain.Tiltakskoder
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
+import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype
 import no.nav.mulighetsrommet.domain.dto.Tiltaksgjennomforingsstatus.GJENNOMFORES
 
 class TiltaksgjennomforingValidator(
@@ -202,6 +203,15 @@ class TiltaksgjennomforingValidator(
                 ValidationError.of(
                     TiltaksgjennomforingDbo::deltidsprosent,
                     "Deltidsprosent kan ikke være større enn 100",
+                ),
+            )
+        }
+
+        if (dbo.oppstart != TiltaksgjennomforingOppstartstype.FELLES) {
+            add(
+                ValidationError.of(
+                    TiltaksgjennomforingDbo::oppstart,
+                    "Oppstartstypen kan bare ha felles oppstartsdato for valgt tiltakstype fra avtalen",
                 ),
             )
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -29,27 +29,6 @@ object AvtaleFixtures {
         faneinnhold = null,
     )
 
-    val jobbklubb = AvtaleDbo(
-        id = UUID.randomUUID(),
-        navn = "Avtalenavn",
-        avtalenummer = "2023#1",
-        tiltakstypeId = TiltakstypeFixtures.Jobbklubb.id,
-        leverandorOrganisasjonsnummer = "123456789",
-        leverandorUnderenheter = emptyList(),
-        startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2023, 2, 28),
-        avtaletype = Avtaletype.Rammeavtale,
-        prisbetingelser = null,
-        opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-        administratorer = emptyList(),
-        navEnheter = listOf("2990"),
-        leverandorKontaktpersonId = null,
-        antallPlasser = null,
-        url = null,
-        beskrivelse = null,
-        faneinnhold = null,
-    )
-
     val avtaleForVta = AvtaleDbo(
         id = UUID.randomUUID(),
         navn = "Avtalenavn for VTA",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -29,6 +29,27 @@ object AvtaleFixtures {
         faneinnhold = null,
     )
 
+    val jobbklubb = AvtaleDbo(
+        id = UUID.randomUUID(),
+        navn = "Avtalenavn",
+        avtalenummer = "2023#1",
+        tiltakstypeId = TiltakstypeFixtures.Jobbklubb.id,
+        leverandorOrganisasjonsnummer = "123456789",
+        leverandorUnderenheter = emptyList(),
+        startDato = LocalDate.of(2023, 1, 1),
+        sluttDato = LocalDate.of(2023, 2, 28),
+        avtaletype = Avtaletype.Rammeavtale,
+        prisbetingelser = null,
+        opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
+        administratorer = emptyList(),
+        navEnheter = listOf("2990"),
+        leverandorKontaktpersonId = null,
+        antallPlasser = null,
+        url = null,
+        beskrivelse = null,
+        faneinnhold = null,
+    )
+
     val avtaleForVta = AvtaleDbo(
         id = UUID.randomUUID(),
         navn = "Avtalenavn for VTA",

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -57,34 +57,6 @@ object TiltaksgjennomforingFixtures {
         estimertVentetidEnhet = "dag",
     )
 
-    val Jobbklubb1 = TiltaksgjennomforingDbo(
-        id = UUID.randomUUID(),
-        navn = "Oppfølging 1",
-        tiltakstypeId = TiltakstypeFixtures.Jobbklubb.id,
-        tiltaksnummer = "2024#1",
-        arrangorOrganisasjonsnummer = "976663934",
-        startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2023, 2, 1),
-        apentForInnsok = true,
-        antallPlasser = 12,
-        administratorer = listOf(),
-        navRegion = "2990",
-        navEnheter = listOf("2990"),
-        oppstart = TiltaksgjennomforingOppstartstype.FELLES,
-        opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
-        kontaktpersoner = emptyList(),
-        arrangorKontaktpersoner = emptyList(),
-        stengtFra = null,
-        stengtTil = null,
-        stedForGjennomforing = "Oslo",
-        avtaleId = AvtaleFixtures.jobbklubb.id,
-        faneinnhold = null,
-        beskrivelse = null,
-        deltidsprosent = 100.0,
-        estimertVentetidVerdi = 3,
-        estimertVentetidEnhet = "dag",
-    )
-
     val Oppfolging1Request = TiltaksgjennomforingRequest(
         id = Oppfolging1.id,
         navn = Oppfolging1.navn,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -42,7 +42,7 @@ object TiltaksgjennomforingFixtures {
         administratorer = listOf(),
         navRegion = "2990",
         navEnheter = listOf("2990"),
-        oppstart = TiltaksgjennomforingOppstartstype.FELLES,
+        oppstart = TiltaksgjennomforingOppstartstype.LOPENDE,
         opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
         kontaktpersoner = emptyList(),
         arrangorKontaktpersoner = emptyList(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -57,6 +57,34 @@ object TiltaksgjennomforingFixtures {
         estimertVentetidEnhet = "dag",
     )
 
+    val Jobbklubb1 = TiltaksgjennomforingDbo(
+        id = UUID.randomUUID(),
+        navn = "Oppfølging 1",
+        tiltakstypeId = TiltakstypeFixtures.Jobbklubb.id,
+        tiltaksnummer = "2024#1",
+        arrangorOrganisasjonsnummer = "976663934",
+        startDato = LocalDate.of(2023, 1, 1),
+        sluttDato = LocalDate.of(2023, 2, 1),
+        apentForInnsok = true,
+        antallPlasser = 12,
+        administratorer = listOf(),
+        navRegion = "2990",
+        navEnheter = listOf("2990"),
+        oppstart = TiltaksgjennomforingOppstartstype.FELLES,
+        opphav = ArenaMigrering.Opphav.MR_ADMIN_FLATE,
+        kontaktpersoner = emptyList(),
+        arrangorKontaktpersoner = emptyList(),
+        stengtFra = null,
+        stengtTil = null,
+        stedForGjennomforing = "Oslo",
+        avtaleId = AvtaleFixtures.jobbklubb.id,
+        faneinnhold = null,
+        beskrivelse = null,
+        deltidsprosent = 100.0,
+        estimertVentetidVerdi = 3,
+        estimertVentetidEnhet = "dag",
+    )
+
     val Oppfolging1Request = TiltaksgjennomforingRequest(
         id = Oppfolging1.id,
         navn = Oppfolging1.navn,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -97,7 +97,7 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
                     ),
                 )
                 it.sanityId shouldBe null
-                it.oppstart shouldBe TiltaksgjennomforingOppstartstype.FELLES
+                it.oppstart shouldBe TiltaksgjennomforingOppstartstype.LOPENDE
                 it.opphav shouldBe ArenaMigrering.Opphav.MR_ADMIN_FLATE
                 it.stengtFra shouldBe null
                 it.kontaktpersoner shouldBe listOf()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidatorTest.kt
@@ -117,8 +117,8 @@ class TiltaksgjennomforingValidatorTest : FunSpec({
     test("should fail when tiltakstype does not support change of oppstartstype") {
         val validator = TiltaksgjennomforingValidator(avtaler)
 
-        validator.validate(gjennomforing.copy(oppstart = TiltaksgjennomforingOppstartstype.LOPENDE), null).shouldBeLeft().shouldContainExactlyInAnyOrder(
-            ValidationError("oppstart", "Tiltaket må ha felles oppstartstype"),
+        validator.validate(gjennomforing.copy(oppstart = TiltaksgjennomforingOppstartstype.FELLES), null).shouldBeLeft().shouldContainExactlyInAnyOrder(
+            ValidationError("oppstart", "Tiltaket må ha løpende oppstartstype"),
         )
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidatorTest.kt
@@ -37,24 +37,8 @@ class TiltaksgjennomforingValidatorTest : FunSpec({
         leverandorUnderenheter = listOf("000000001", "000000002"),
         navEnheter = listOf("0400", "0502"),
     )
-    val jobbklubbAvtale = AvtaleFixtures.jobbklubb.copy(
-        startDato = avtaleStartDato,
-        sluttDato = avtaleSluttDato,
-        leverandorOrganisasjonsnummer = "000000000",
-        leverandorUnderenheter = listOf("000000001", "000000002"),
-        navEnheter = listOf("0400", "0502"),
-    )
 
     val gjennomforing = TiltaksgjennomforingFixtures.Oppfolging1.copy(
-        startDato = avtaleStartDato,
-        sluttDato = avtaleSluttDato,
-        navRegion = "0400",
-        navEnheter = listOf("0502"),
-        arrangorOrganisasjonsnummer = "000000001",
-        administratorer = listOf("B123456"),
-    )
-
-    val gjennomforingForJobbklubb = TiltaksgjennomforingFixtures.Jobbklubb1.copy(
         startDato = avtaleStartDato,
         sluttDato = avtaleSluttDato,
         navRegion = "0400",
@@ -104,7 +88,6 @@ class TiltaksgjennomforingValidatorTest : FunSpec({
 
         avtaler = AvtaleRepository(database.db)
         avtaler.upsert(avtale)
-        avtaler.upsert(jobbklubbAvtale)
 
         tiltaksgjennomforinger = TiltaksgjennomforingRepository(database.db)
     }
@@ -134,8 +117,8 @@ class TiltaksgjennomforingValidatorTest : FunSpec({
     test("should fail when tiltakstype does not support change of oppstartstype") {
         val validator = TiltaksgjennomforingValidator(avtaler)
 
-        validator.validate(gjennomforingForJobbklubb.copy(oppstart = TiltaksgjennomforingOppstartstype.LOPENDE), null).shouldBeLeft().shouldContainExactlyInAnyOrder(
-            ValidationError("oppstart", "Oppstartstypen kan bare ha felles oppstartsdato for valgt tiltakstype fra avtalen"),
+        validator.validate(gjennomforing.copy(oppstart = TiltaksgjennomforingOppstartstype.LOPENDE), null).shouldBeLeft().shouldContainExactlyInAnyOrder(
+            ValidationError("oppstart", "Tiltaket må ha felles oppstartstype"),
         )
     }
 


### PR DESCRIPTION
Det skal ikke være lov å endre oppstartstype for jobbklubb, gruppe amo eller gruppe fag og yrkesopplæring

