### PR TITLE
Fjern warn på 404 fra brreg

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/brreg/BrregClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/brreg/BrregClient.kt
@@ -144,7 +144,6 @@ class BrregClient(
             }
 
             HttpStatusCode.NotFound -> {
-                log.warn("NotFound: orgnr=$orgnr")
                 BrregError.NotFound.left()
             }
 


### PR DESCRIPTION
Siden det er meningen den skal skje ofte

da vi sjekker på hovedenhet først før vi vet om det er en underenhet