### PR TITLE
:sparkles: Dupliser avtale

### DIFF
--- a/frontend/mr-admin-flate/src/api/tiltakstyper/useMigrerteTiltakstyper.ts
+++ b/frontend/mr-admin-flate/src/api/tiltakstyper/useMigrerteTiltakstyper.ts
@@ -8,3 +8,9 @@ export function useMigrerteTiltakstyper() {
     queryFn: () => mulighetsrommetClient.tiltakstyper.getMigrerteTiltakstyper(),
   });
 }
+
+export function useMigrerteTiltakstyperForAvtaler() {
+  const { data = [], ...rest } = useMigrerteTiltakstyper();
+
+  return { data: data?.concat("VASV", "ARBFORB"), ...rest };
+}

--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
@@ -15,8 +15,10 @@ import { useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { MultiValue } from "react-select";
 import { useAvtaleAdministratorer } from "../../api/ansatt/useAvtaleAdministratorer";
+import { useMigrerteTiltakstyperForAvtaler } from "../../api/tiltakstyper/useMigrerteTiltakstyper";
 import { useSokVirksomheter } from "../../api/virksomhet/useSokVirksomhet";
 import { useVirksomhet } from "../../api/virksomhet/useVirksomhet";
+import { useVirksomhetKontaktpersoner } from "../../api/virksomhet/useVirksomhetKontaktpersoner";
 import { erAnskaffetTiltak } from "../../utils/tiltakskoder";
 import { addYear } from "../../utils/Utils";
 import { Separator } from "../detaljside/Metadata";
@@ -28,8 +30,6 @@ import skjemastyles from "../skjema/Skjema.module.scss";
 import { VirksomhetKontaktpersonerModal } from "../virksomhet/VirksomhetKontaktpersonerModal";
 import { InferredAvtaleSchema } from "./AvtaleSchema";
 import { getLokaleUnderenheterAsSelectOptions, underenheterOptions } from "./AvtaleSkjemaConst";
-import { useVirksomhetKontaktpersoner } from "../../api/virksomhet/useVirksomhetKontaktpersoner";
-import { useMigrerteTiltakstyper } from "../../api/tiltakstyper/useMigrerteTiltakstyper";
 
 const minStartdato = new Date(2000, 0, 1);
 
@@ -43,12 +43,8 @@ interface Props {
 export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: Props) {
   const [sokLeverandor, setSokLeverandor] = useState("");
   const { data: leverandorVirksomheter = [] } = useSokVirksomheter(sokLeverandor);
-  const { data: migrerteTiltakstyper } = useMigrerteTiltakstyper();
+  const { data: migrerteTiltakstyper } = useMigrerteTiltakstyperForAvtaler();
 
-  const migrerteTiltakstyperOgTiltakstyperUtenAvtaleIArena = migrerteTiltakstyper?.concat(
-    "VASV",
-    "ARBFORB",
-  );
   const { data: administratorer } = useAvtaleAdministratorer();
   const virksomhetKontaktpersonerModalRef = useRef<HTMLDialogElement>(null);
 
@@ -71,7 +67,7 @@ export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: 
 
   const arenaOpphavOgIngenEierskap =
     avtale?.opphav === Opphav.ARENA &&
-    !migrerteTiltakstyperOgTiltakstyperUtenAvtaleIArena?.includes(watchedTiltakstype.arenaKode);
+    !migrerteTiltakstyper?.includes(watchedTiltakstype.arenaKode);
 
   const navRegionerOptions = enheter
     .filter((enhet) => enhet.type === NavEnhetType.FYLKE)
@@ -137,14 +133,10 @@ export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: 
                     navn: tiltakstype.navn,
                     id: tiltakstype.id,
                   },
-                  label: !migrerteTiltakstyperOgTiltakstyperUtenAvtaleIArena?.includes(
-                    tiltakstype.arenaKode,
-                  )
+                  label: !migrerteTiltakstyper?.includes(tiltakstype.arenaKode)
                     ? `${tiltakstype.navn} må opprettes i Arena`
                     : tiltakstype.navn,
-                  isDisabled: !migrerteTiltakstyperOgTiltakstyperUtenAvtaleIArena?.includes(
-                    tiltakstype.arenaKode,
-                  ),
+                  isDisabled: !migrerteTiltakstyper?.includes(tiltakstype.arenaKode),
                 }))}
               />
               <ControlledSokeSelect

--- a/frontend/mr-admin-flate/src/components/avtaler/DupliserAvtale.module.scss
+++ b/frontend/mr-admin-flate/src/components/avtaler/DupliserAvtale.module.scss
@@ -1,0 +1,8 @@
+.button {
+  background-color: var(--a-surface-action);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  max-height: 2rem;
+  max-width: 2rem;
+}

--- a/frontend/mr-admin-flate/src/components/avtaler/DupliserAvtale.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/DupliserAvtale.tsx
@@ -1,0 +1,46 @@
+import { LayersPlusIcon } from "@navikt/aksel-icons";
+import { Button } from "@navikt/ds-react";
+import { Avtale, Opphav } from "mulighetsrommet-api-client";
+import { useNavigate } from "react-router-dom";
+import styles from "./DupliserAvtale.module.scss";
+import { useMigrerteTiltakstyperForAvtaler } from "../../api/tiltakstyper/useMigrerteTiltakstyper";
+
+interface Props {
+  avtale: Avtale;
+}
+
+export function DupliserAvtale({ avtale }: Props) {
+  const navigate = useNavigate();
+  const { data: migrerteTiltakstyper } = useMigrerteTiltakstyperForAvtaler();
+
+  if (!migrerteTiltakstyper.includes(avtale.tiltakstype.arenaKode)) return null;
+
+  function apneRedigeringForDupliseringAvAvtale() {
+    navigate(`/avtaler/${avtale.id}/skjema`, {
+      state: {
+        avtale: {
+          ...avtale,
+          id: window.crypto.randomUUID(),
+          startDato: undefined,
+          sluttDato: undefined,
+          opphav: Opphav.MR_ADMIN_FLATE,
+        },
+      },
+    });
+  }
+
+  return (
+    <Button
+      title="Dupliser avtale"
+      className={styles.button}
+      onClick={apneRedigeringForDupliseringAvAvtale}
+    >
+      <LayersPlusIcon
+        style={{ margin: "0 auto", display: "block" }}
+        color="white"
+        fontSize="1.5rem"
+        aria-label="Ikon for duplisering av dokument"
+      />
+    </Button>
+  );
+}

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/DupliserTiltak.tsx
@@ -1,9 +1,9 @@
 import { LayersPlusIcon } from "@navikt/aksel-icons";
-import styles from "./DupliserTiltak.module.scss";
 import { Button } from "@navikt/ds-react";
-import { Opphav, Tiltaksgjennomforing, Toggles } from "mulighetsrommet-api-client";
+import { Opphav, Tiltaksgjennomforing } from "mulighetsrommet-api-client";
 import { useNavigate } from "react-router-dom";
-import { useFeatureToggle } from "../../api/features/feature-toggles";
+import { useMigrerteTiltakstyper } from "../../api/tiltakstyper/useMigrerteTiltakstyper";
+import styles from "./DupliserTiltak.module.scss";
 
 interface Props {
   tiltaksgjennomforing: Tiltaksgjennomforing;
@@ -11,11 +11,9 @@ interface Props {
 
 export function DupliserTiltak({ tiltaksgjennomforing }: Props) {
   const navigate = useNavigate();
-  const { data: kanDuplisereTiltak } = useFeatureToggle(
-    Toggles.MR_ADMIN_FLATE_KAN_DUPLISERE_TILTAK,
-  );
+  const { data: migrerteTiltakstyper } = useMigrerteTiltakstyper();
 
-  if (!kanDuplisereTiltak) return null;
+  if (!migrerteTiltakstyper?.includes(tiltaksgjennomforing.tiltakstype.arenaKode)) return null;
 
   function apneRedigeringForDupliseringAvTiltak() {
     navigate(`/tiltaksgjennomforinger/${tiltaksgjennomforing.id}/skjema`, {

--- a/frontend/mr-admin-flate/src/mocks/api/features.ts
+++ b/frontend/mr-admin-flate/src/mocks/api/features.ts
@@ -6,5 +6,4 @@ export const mockFeatures: Features = {
   "mulighetsrommet-veilederflate-arena-oppskrifter": true,
   "mulighetsrommet.admin-flate.show-notater": false,
   "mulighetsrommet.admin-flate.midlertidig-stengt": false,
-  "mr-admin-flate.kan-duplisere-tiltak": true,
 };

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
@@ -13,6 +13,7 @@ import { useNavigateAndReplaceUrl } from "../../hooks/useNavigateWithoutReplacin
 import { ContainerLayout } from "../../layouts/ContainerLayout";
 import commonStyles from "../Page.module.scss";
 import styles from "./DetaljerAvtalePage.module.scss";
+import { DupliserAvtale } from "../../components/avtaler/DupliserAvtale";
 
 export function AvtalePage() {
   const avtaleId = useGetAvtaleIdFromUrlOrThrow();
@@ -59,6 +60,7 @@ export function AvtalePage() {
             {avtale.navn ?? "..."}
           </Heading>
           <AvtalestatusTag avtale={avtale} />
+          <DupliserAvtale avtale={avtale} />
         </div>
       </Header>
       <Tabs value={currentTab()}>

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleSkjemaPage.tsx
@@ -1,5 +1,5 @@
 import { Tiltakstypestatus } from "mulighetsrommet-api-client";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useHentAnsatt } from "../../api/ansatt/useHentAnsatt";
 import { useNavEnheter } from "../../api/enhet/useNavEnheter";
 import { useTiltakstyper } from "../../api/tiltakstyper/useTiltakstyper";
@@ -23,6 +23,7 @@ const AvtaleSkjemaPage = () => {
   );
   const { data: ansatt, isLoading: isLoadingAnsatt } = useHentAnsatt();
   const { data: enheter, isLoading: isLoadingEnheter } = useNavEnheter();
+  const location = useLocation();
 
   const redigeringsModus = avtale && inneholderUrl(avtale?.id);
 
@@ -56,7 +57,7 @@ const AvtaleSkjemaPage = () => {
                 tiltakstyper={tiltakstyper.data}
                 ansatt={ansatt}
                 enheter={enheter}
-                avtale={avtale}
+                avtale={location.state?.avtale ? location.state.avtale : avtale}
                 redigeringsModus={redigeringsModus!}
               />
             )}

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
@@ -6,5 +6,4 @@ export const mockFeatures: Features = {
   "mulighetsrommet-veilederflate-arena-oppskrifter": true,
   "mulighetsrommet.admin-flate.show-notater": true,
   "mulighetsrommet.admin-flate.midlertidig-stengt": false,
-  "mr-admin-flate.kan-duplisere-tiltak": true,
 };

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -21,7 +21,6 @@ app:
     - AVKLARAG
     - DIGIOPPARB
     - GRUFAGYRKE
-    - GRUPPEAMO
     - INDJOBSTOT
     - INDOPPFAG
     - IPSUNG

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -3450,7 +3450,6 @@ components:
         - mulighetsrommet-veilederflate-arena-oppskrifter
         - mulighetsrommet.admin-flate.show-notater
         - mulighetsrommet.admin-flate.midlertidig-stengt
-        - mr-admin-flate.kan-duplisere-tiltak
 
     PublisertRequest:
       type: object


### PR DESCRIPTION
Kan nå duplisere avtaler for tiltakstyper vi har tatt eierskap til (pluss AFT og VTA)