### PR TITLE
Opprett egne lenker i Sanity

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Faneinnhold.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Faneinnhold.kt
@@ -13,5 +13,6 @@ data class Faneinnhold(
     val pameldingOgVarighetInfoboks: String? = null,
     val kontaktinfo: List<JsonObject>? = null,
     val kontaktinfoInfoboks: String? = null,
+    val lenker: List<JsonObject>? = null,
     val delMedBruker: String? = null,
 )

--- a/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
+++ b/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
@@ -137,7 +137,7 @@ export const faneinnhold = defineType({
       description: "KOMMER SNART - Legg til lenker som blir synlig for NAV-ansatte",
       type: "array",
       of: [{ type: "lenke" }],
-      readOnly: false,
+      readOnly: true,
     }),
   ],
 });

--- a/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
+++ b/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
@@ -137,7 +137,7 @@ export const faneinnhold = defineType({
       description: "KOMMER SNART - Legg til lenker som blir synlig for NAV-ansatte",
       type: "array",
       of: [{ type: "lenke" }],
-      readOnly: true,
+      readOnly: false,
     }),
   ],
 });

--- a/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
+++ b/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
@@ -134,9 +134,10 @@ export const faneinnhold = defineType({
     defineField({
       name: "lenker",
       title: "Lenker",
-      description: "Legg til lenker som blir synlig for NAV-ansatte",
+      description: "KOMMER SNART - Legg til lenker som blir synlig for NAV-ansatte",
       type: "array",
       of: [{ type: "lenke" }],
+      readOnly: true,
     }),
   ],
 });

--- a/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
+++ b/frontend/mulighetsrommet-cms/schemas/faneinnhold.ts
@@ -29,6 +29,10 @@ export const faneinnhold = defineType({
       name: "kontaktinfo",
       title: "Kontaktinfo",
     },
+    {
+      name: "lenker",
+      title: "Lenker",
+    },
   ],
   fields: [
     defineField({
@@ -51,8 +55,8 @@ export const faneinnhold = defineType({
           blockContentValidation(
             doc,
             MAKS_LENGDE_INNHOLD,
-            "Innholdet er for langt. Kan innholdet være kortere og mer konsist?"
-          )
+            "Innholdet er for langt. Kan innholdet være kortere og mer konsist?",
+          ),
         ),
     }),
     defineField({
@@ -75,8 +79,8 @@ export const faneinnhold = defineType({
           blockContentValidation(
             doc,
             MAKS_LENGDE_INNHOLD,
-            "Innholdet er for langt. Kan innholdet være kortere og mer konsist?"
-          )
+            "Innholdet er for langt. Kan innholdet være kortere og mer konsist?",
+          ),
         ),
     }),
     defineField({
@@ -99,8 +103,8 @@ export const faneinnhold = defineType({
           blockContentValidation(
             doc,
             MAKS_LENGDE_INNHOLD,
-            "Innholdet er for langt. Kan innholdet være kortere og mer konsist?"
-          )
+            "Innholdet er for langt. Kan innholdet være kortere og mer konsist?",
+          ),
         ),
     }),
     defineField({
@@ -123,9 +127,16 @@ export const faneinnhold = defineType({
           blockContentValidation(
             doc,
             MAKS_LENGDE_INNHOLD,
-            "Innholdet er for langt. Kan innholdet være kortere og mer konsist?"
-          )
+            "Innholdet er for langt. Kan innholdet være kortere og mer konsist?",
+          ),
         ),
+    }),
+    defineField({
+      name: "lenker",
+      title: "Lenker",
+      description: "Legg til lenker som blir synlig for NAV-ansatte",
+      type: "array",
+      of: [{ type: "lenke" }],
     }),
   ],
 });

--- a/frontend/mulighetsrommet-cms/schemas/lenke.ts
+++ b/frontend/mulighetsrommet-cms/schemas/lenke.ts
@@ -28,7 +28,15 @@ export const lenke = {
     }),
     defineField({
       title: "Åpne i ny fane?",
+      description: "Skru på hvis du vil at lenken skal åpnes i ny fane",
       name: "apneINyFane",
+      type: "boolean",
+      initialValue: false,
+    }),
+    defineField({
+      title: "Kun tilgjengelig for veileder i Modia?",
+      description: "Skru på hvis du vil at lenken bare skal vises for veiledere i Modia",
+      name: "visKunForVeileder",
       type: "boolean",
       initialValue: false,
     }),

--- a/frontend/mulighetsrommet-cms/schemas/lenke.ts
+++ b/frontend/mulighetsrommet-cms/schemas/lenke.ts
@@ -17,12 +17,20 @@ export const lenke = {
     defineField({
       title: "Lenke",
       name: "lenke",
-      type: "string",
+      type: "url",
+      validation: (Rule) => Rule.required().error("Du må lime inn en gyldig url"),
     }),
     defineField({
       title: "Lenkenavn",
       name: "lenkenavn",
       type: "string",
+      validation: (Rule) => Rule.required().error("Du må skrive inn et navn for lenken"),
+    }),
+    defineField({
+      title: "Åpne i ny fane?",
+      name: "apneINyFane",
+      type: "boolean",
+      initialValue: false,
     }),
   ],
   preview: {

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -271,7 +271,8 @@ export const tiltaksgjennomforing = defineType({
     defineField({
       name: "delingMedBruker",
       title: "Informasjon som kan deles med bruker",
-      description: "Informasjon om tiltaket som veileder kan dele med bruker. Standard tekst fra tiltakstype brukes hvis ikke utfyllt.",
+      description:
+        "Informasjon om tiltaket som veileder kan dele med bruker. Standard tekst fra tiltakstype brukes hvis ikke utfyllt.",
       type: "text",
     }),
   ],

--- a/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
+++ b/frontend/mulighetsrommet-cms/schemas/tiltaksgjennomforing.ts
@@ -272,7 +272,7 @@ export const tiltaksgjennomforing = defineType({
       name: "delingMedBruker",
       title: "Informasjon som kan deles med bruker",
       description:
-        "Informasjon om tiltaket som veileder kan dele med bruker. Standard tekst fra tiltakstype brukes hvis ikke utfyllt.",
+        "Informasjon om tiltaket som veileder kan dele med bruker. Standard tekst fra tiltakstype brukes hvis ikke utfylt.",
       type: "text",
     }),
   ],

--- a/frontend/mulighetsrommet-veileder-flate/src/apps/modia/views/ModiaArbeidsmarkedstiltakDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/apps/modia/views/ModiaArbeidsmarkedstiltakDetaljer.tsx
@@ -30,6 +30,7 @@ import {
 import { useTitle } from "mulighetsrommet-frontend-common";
 import { Link } from "react-router-dom";
 import styles from "./ModiaArbeidsmarkedstiltakDetaljer.module.scss";
+import { LenkeListe } from "../../../components/sidemeny/Lenker";
 
 export function ModiaArbeidsmarkedstiltakDetaljer() {
   const { fnr } = useModiaContext();
@@ -173,6 +174,7 @@ export function ModiaArbeidsmarkedstiltakDetaljer() {
                 </Button>
               </div>
             )}
+            <LenkeListe lenker={tiltaksgjennomforing.faneinnhold?.lenker} />
           </>
         }
       />

--- a/frontend/mulighetsrommet-veileder-flate/src/apps/nav/views/NavArbeidsmarkedstiltakDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/apps/nav/views/NavArbeidsmarkedstiltakDetaljer.tsx
@@ -3,6 +3,7 @@ import { ViewTiltaksgjennomforingDetaljer } from "@/layouts/ViewTiltaksgjennomfo
 import { Tilbakeknapp } from "@/components/tilbakeknapp/Tilbakeknapp";
 import { TiltakLoader } from "@/components/TiltakLoader";
 import { useNavTiltaksgjennomforingById } from "@/core/api/queries/useTiltaksgjennomforingById";
+import { LenkeListe } from "../../../components/sidemeny/Lenker";
 
 export function NavArbeidsmarkedstiltakDetaljer() {
   const { data, isLoading, isError } = useNavTiltaksgjennomforingById();
@@ -21,7 +22,11 @@ export function NavArbeidsmarkedstiltakDetaljer() {
     <ViewTiltaksgjennomforingDetaljer
       tiltaksgjennomforing={data}
       knapperad={<Tilbakeknapp tilbakelenke=".." tekst="Tilbake til tiltaksoversikten" />}
-      brukerActions={null}
+      brukerActions={
+        <LenkeListe
+          lenker={data?.faneinnhold?.lenker?.filter((lenke) => !lenke.visKunForVeileder)}
+        />
+      }
     />
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/apps/nav/views/PreviewArbeidsmarkedstiltakDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/apps/nav/views/PreviewArbeidsmarkedstiltakDetaljer.tsx
@@ -5,6 +5,7 @@ import { Tilbakeknapp } from "@/components/tilbakeknapp/Tilbakeknapp";
 import { DelMedBruker } from "@/apps/modia/delMedBruker/DelMedBruker";
 import { TiltakLoader } from "@/components/TiltakLoader";
 import { usePreviewTiltaksgjennomforingById } from "@/core/api/queries/useTiltaksgjennomforingById";
+import { LenkeListe } from "../../../components/sidemeny/Lenker";
 
 export function PreviewArbeidsmarkedstiltakDetaljer() {
   const { data, isPending, isError } = usePreviewTiltaksgjennomforingById();
@@ -28,33 +29,36 @@ export function PreviewArbeidsmarkedstiltakDetaljer() {
         brukersInnsatsgruppe={brukersInnsatsgruppe}
         knapperad={<Tilbakeknapp tilbakelenke=".." tekst="Tilbake til tiltaksoversikten" />}
         brukerActions={
-          <DelMedBruker
-            tiltaksgjennomforing={data}
-            veiledernavn="{Veiledernavn}"
-            brukerdata={{
-              innsatsgruppe: Innsatsgruppe.VARIG_TILPASSET_INNSATS,
-              fnr: "12345678910",
-              fornavn: "{NAVN}",
-              manuellStatus: {
-                erUnderManuellOppfolging: false,
-                krrStatus: { kanVarsles: true, erReservert: false },
-              },
-              varsler: [],
-              enheter: [
-                {
-                  navn: "{GEOGRAFISK_ENHET}",
-                  enhetsnummer: "0",
-                  overordnetEnhet: "0100",
-                  type: NavEnhetType.LOKAL,
-                  status: NavEnhetStatus.AKTIV,
+          <>
+            <DelMedBruker
+              tiltaksgjennomforing={data}
+              veiledernavn="{Veiledernavn}"
+              brukerdata={{
+                innsatsgruppe: Innsatsgruppe.VARIG_TILPASSET_INNSATS,
+                fnr: "12345678910",
+                fornavn: "{NAVN}",
+                manuellStatus: {
+                  erUnderManuellOppfolging: false,
+                  krrStatus: { kanVarsles: true, erReservert: false },
                 },
-              ],
-            }}
-            lagreVeilederHarDeltTiltakMedBruker={async (dialogId, gjennomforing) => {
-              // eslint-disable-next-line no-console
-              console.log("Del med bruker", dialogId, gjennomforing);
-            }}
-          />
+                varsler: [],
+                enheter: [
+                  {
+                    navn: "{GEOGRAFISK_ENHET}",
+                    enhetsnummer: "0",
+                    overordnetEnhet: "0100",
+                    type: NavEnhetType.LOKAL,
+                    status: NavEnhetStatus.AKTIV,
+                  },
+                ],
+              }}
+              lagreVeilederHarDeltTiltakMedBruker={async (dialogId, gjennomforing) => {
+                // eslint-disable-next-line no-console
+                console.log("Del med bruker", dialogId, gjennomforing);
+              }}
+            />
+            <LenkeListe lenker={data?.faneinnhold?.lenker} />
+          </>
         }
       />
     </>

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/Lenker.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/Lenker.tsx
@@ -1,11 +1,6 @@
 import { ExternalLinkIcon } from "@navikt/aksel-icons";
 import { Box, Heading, Link, List } from "@navikt/ds-react";
-
-interface Lenke {
-  lenkenavn: string;
-  lenke: string;
-  apneINyFane?: boolean;
-}
+import { Lenke } from "mulighetsrommet-api-client";
 
 interface Props {
   lenker?: Lenke[];

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/Lenker.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/Lenker.tsx
@@ -1,0 +1,37 @@
+import { ExternalLinkIcon } from "@navikt/aksel-icons";
+import { Box, Heading, Link, List } from "@navikt/ds-react";
+
+interface Lenke {
+  lenkenavn: string;
+  lenke: string;
+  apneINyFane?: boolean;
+}
+
+interface Props {
+  lenker?: Lenke[];
+}
+
+export function LenkeListe({ lenker }: Props) {
+  if (!lenker || lenker.length === 0) return null;
+
+  return (
+    <Box background="bg-subtle" padding="5">
+      <Heading level="4" size="small">
+        Lenker
+      </Heading>
+      <List as="ul">
+        {lenker.map(({ lenke, apneINyFane, lenkenavn }, index) => (
+          <List.Item key={index}>
+            <Link
+              href={lenke}
+              target={apneINyFane ? "_blank" : undefined}
+              rel={apneINyFane ? "noopener noreferrer" : undefined}
+            >
+              {lenkenavn} {apneINyFane ? <ExternalLinkIcon /> : null}
+            </Link>
+          </List.Item>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/sidemeny/SidemenyDetaljer.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Panel } from "@navikt/ds-react";
+import { BodyShort, Box } from "@navikt/ds-react";
 import {
   TiltaksgjennomforingOppstartstype,
   Tiltakskode,
@@ -62,7 +62,7 @@ const SidemenyDetaljer = ({ tiltaksgjennomforing }: Props) => {
   return (
     <>
       <EstimertVentetid tiltaksgjennomforing={tiltaksgjennomforing} />
-      <Panel className={styles.panel} id="sidemeny">
+      <Box padding="5" background="bg-subtle" className={styles.panel} id="sidemeny">
         {tiltaksnummer && (
           <div className={styles.rad}>
             <BodyShort size="small" className={styles.tittel}>
@@ -120,7 +120,7 @@ const SidemenyDetaljer = ({ tiltaksgjennomforing }: Props) => {
             <Regelverksinfo regelverkLenker={tiltakstype.regelverkLenker} />
           </div>
         )}
-      </Panel>
+      </Box>
     </>
   );
 };

--- a/frontend/mulighetsrommet-veileder-flate/src/layouts/ViewTiltaksgjennomforingDetaljer.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/layouts/ViewTiltaksgjennomforingDetaljer.tsx
@@ -1,13 +1,13 @@
+import { Oppskrift } from "@/components/oppskrift/Oppskrift";
+import { useGetTiltaksgjennomforingIdFraUrl } from "@/core/api/queries/useGetTiltaksgjennomforingIdFraUrl";
 import { PadlockLockedFillIcon } from "@navikt/aksel-icons";
 import { Alert } from "@navikt/ds-react";
 import { Innsatsgruppe, VeilederflateTiltaksgjennomforing } from "mulighetsrommet-api-client";
+import { ReactNode, useState } from "react";
 import SidemenyDetaljer from "../components/sidemeny/SidemenyDetaljer";
 import TiltaksdetaljerFane from "../components/tabs/TiltaksdetaljerFane";
-import { useGetTiltaksgjennomforingIdFraUrl } from "@/core/api/queries/useGetTiltaksgjennomforingIdFraUrl";
 import TiltaksgjennomforingsHeader from "./TiltaksgjennomforingsHeader";
 import styles from "./ViewTiltaksgjennomforingDetaljer.module.scss";
-import { Oppskrift } from "@/components/oppskrift/Oppskrift";
-import { ReactNode, useState } from "react";
 
 interface Props {
   tiltaksgjennomforing: VeilederflateTiltaksgjennomforing;

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
@@ -54,6 +54,18 @@ export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
       varsler: [],
     },
     faneinnhold: {
+      lenker: [
+        {
+          lenke: "https://www.google.com",
+          lenkenavn: "Søk via Google",
+          apneINyFane: true,
+        },
+        {
+          lenke: "https://www.vg.no",
+          lenkenavn: "Sjekk nyhetene på VG",
+          apneINyFane: false,
+        },
+      ],
       forHvem: [
         {
           style: "normal",

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/fixtures/mockTiltaksgjennomforinger.ts
@@ -59,11 +59,13 @@ export const mockTiltaksgjennomforinger: VeilederflateTiltaksgjennomforing[] = [
           lenke: "https://www.google.com",
           lenkenavn: "Søk via Google",
           apneINyFane: true,
+          visKunForVeileder: false,
         },
         {
           lenke: "https://www.vg.no",
           lenkenavn: "Sjekk nyhetene på VG",
           apneINyFane: false,
+          visKunForVeileder: true,
         },
       ],
       forHvem: [

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/VeilederflateService.kt
@@ -258,6 +258,7 @@ class VeilederflateService(
                 pameldingOgVarighet,
                 kontaktinfoInfoboks,
                 kontaktinfo,
+                lenker
               },
               delingMedBruker,
             }[0]

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -3537,8 +3537,11 @@ components:
           format: uri
         apneINyFane:
           type: boolean
+        visKunForVeileder:
+          type: boolean
       required:
         - lenkenavn
         - lenke
         - apneINyFane
+        - visKunForVeileder
 

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2956,6 +2956,10 @@ components:
           type: object
         kontaktinfoInfoboks:
           type: string
+        lenker:
+          type: array
+          items:
+            $ref: "#/components/schemas/Lenke"
         delMedBruker:
           type: string
 
@@ -3522,3 +3526,19 @@ components:
       required:
         - verdi
         - enhet
+
+    Lenke:
+      type: object
+      properties:
+        lenkenavn:
+          type: string
+        lenke:
+          type: string
+          format: uri
+        apneINyFane:
+          type: boolean
+      required:
+        - lenkenavn
+        - lenke
+        - apneINyFane
+


### PR DESCRIPTION
Legger til støtte i Sanity for egne lenker knyttet direkte til tiltaksgjennomføring.

Følgende gjenstår:
- Finere design (Bernard lager skisser)
- Støtte lenker på faneinnhold for avtaler og gjennomføringer i admin-flate (Planlagt som egen PR)
- Skru på lenker i Sanity (er read-only for øyeblikket fordi jeg ikke vil lage egen feature toggle for dette)

- **:construction: Støtter lenker fra Sanity til veilederflaten (kun i Modia)**
- **Readonly for lenker i Sanity foreløpig**
