### PR TITLE
Ikke be om sorterte data fra Brreg

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
@@ -80,10 +80,12 @@ export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: 
   const sluttDatoTilDato = addYear(startDato ? new Date(startDato) : new Date(), 5);
 
   const leverandorOptions = () => {
-    const options = leverandorVirksomheter.map((enhet) => ({
-      value: enhet.organisasjonsnummer,
-      label: `${enhet.navn} - ${enhet.organisasjonsnummer}`,
-    }));
+    const options = leverandorVirksomheter
+      .sort((a, b) => a.navn.localeCompare(b.navn))
+      .map((enhet) => ({
+        value: enhet.organisasjonsnummer,
+        label: `${enhet.navn} - ${enhet.organisasjonsnummer}`,
+      }));
 
     if (leverandorData) {
       options.push({

--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaConst.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaConst.tsx
@@ -32,12 +32,14 @@ export const erArenaOpphavOgIngenEierskap = (
 };
 
 export const arrangorUnderenheterOptions = (avtale: Avtale) => {
-  return (avtale?.leverandorUnderenheter ?? []).map((arrangor) => {
-    return {
-      label: `${arrangor.navn} - ${arrangor.organisasjonsnummer}`,
-      value: arrangor.organisasjonsnummer,
-    };
-  });
+  return (avtale?.leverandorUnderenheter ?? [])
+    .sort((a, b) => a.navn.localeCompare(b.navn))
+    .map((arrangor) => {
+      return {
+        label: `${arrangor.navn} - ${arrangor.organisasjonsnummer}`,
+        value: arrangor.organisasjonsnummer,
+      };
+    });
 };
 
 function defaultNavRegion(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/brreg/BrregClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/brreg/BrregClient.kt
@@ -46,7 +46,6 @@ class BrregClient(
 
         val response = client.get("$baseUrl/enheter") {
             parameter("size", 20)
-            parameter("sort", "navn,ASC")
             parameter(sokEllerOppslag, orgnr)
         }
 
@@ -66,7 +65,6 @@ class BrregClient(
     suspend fun hentUnderenheterForOverordnetEnhet(orgnr: String): Either<BrregError, List<VirksomhetDto>> {
         val underenheterResponse = client.get("$baseUrl/underenheter") {
             parameter("size", 1000)
-            parameter("sort", "navn,ASC")
             parameter("overordnetEnhet", orgnr)
         }
 

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2753,7 +2753,6 @@ components:
       type: object
       properties:
         navn:
-          nullable: true
           type: string
         organisasjonsnummer:
           type: string


### PR DESCRIPTION
 Fjerner sortering av enheter fra Brreg, men sorterer alfabetisk på navn når vi viser options i dropdown
