### PR TITLE
Setter opp wiremock for pdl og hent-oppfølgingsperiode

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/components/oversikt/Tiltaksgjennomforingsoversikt.tsx
@@ -135,36 +135,38 @@ export const Tiltaksgjennomforingsoversikt = ({
       >
         {tags}
         {varsler}
-        <div className={styles.visnings_og_sorteringsmeny}>
-          <div className={styles.visningsmeny}>
-            <ViserAntallTiltakTekst />
+        {gjennomforingerForSide.length > 0 ? (
+          <div className={styles.visnings_og_sorteringsmeny}>
+            <div className={styles.visningsmeny}>
+              <ViserAntallTiltakTekst />
 
-            <Select
-              size="small"
-              label="Velg antall"
-              hideLabel
-              name="size"
-              value={pageData.pageSize}
-              onChange={(e) => {
-                setPages({ page: 1, pageSize: parseInt(e.currentTarget.value) });
-                logEvent({
-                  name: "arbeidsmarkedstiltak.vis-antall-tiltak",
-                  data: {
-                    valgt_antall: parseInt(e.currentTarget.value),
-                    antall_tiltak: tiltaksgjennomforinger.length,
-                  },
-                });
-              }}
-            >
-              {antallSize.map((ant) => (
-                <option key={ant} value={ant}>
-                  {ant}
-                </option>
-              ))}
-            </Select>
+              <Select
+                size="small"
+                label="Velg antall"
+                hideLabel
+                name="size"
+                value={pageData.pageSize}
+                onChange={(e) => {
+                  setPages({ page: 1, pageSize: parseInt(e.currentTarget.value) });
+                  logEvent({
+                    name: "arbeidsmarkedstiltak.vis-antall-tiltak",
+                    data: {
+                      valgt_antall: parseInt(e.currentTarget.value),
+                      antall_tiltak: tiltaksgjennomforinger.length,
+                    },
+                  });
+                }}
+              >
+                {antallSize.map((ant) => (
+                  <option key={ant} value={ant}>
+                    {ant}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <Sorteringsmeny sortValue={sortValue} setSortValue={setSortValue} />
           </div>
-          <Sorteringsmeny sortValue={sortValue} setSortValue={setSortValue} />
-        </div>
+        ) : null}
       </div>
       {feilmelding}
       <ul
@@ -191,22 +193,25 @@ export const Tiltaksgjennomforingsoversikt = ({
           );
         })}
       </ul>
-      {/*)}*/}
-      <div
-        className={classnames(
-          styles.under_oversikt,
-          filterOpen && styles.under_oversikt_filter_open,
-        )}
-      >
-        <ViserAntallTiltakTekst />
-        <Pagination
-          size="small"
-          page={pageData.page}
-          onPageChange={(page) => setPages({ ...pageData, page })}
-          count={pagination(tiltaksgjennomforinger) === 0 ? 1 : pagination(tiltaksgjennomforinger)}
-          data-version="v1"
-        />
-      </div>
+      {gjennomforingerForSide.length > 0 ? (
+        <div
+          className={classnames(
+            styles.under_oversikt,
+            filterOpen && styles.under_oversikt_filter_open,
+          )}
+        >
+          <ViserAntallTiltakTekst />
+          <Pagination
+            size="small"
+            page={pageData.page}
+            onPageChange={(page) => setPages({ ...pageData, page })}
+            count={
+              pagination(tiltaksgjennomforinger) === 0 ? 1 : pagination(tiltaksgjennomforinger)
+            }
+            data-version="v1"
+          />
+        </div>
+      ) : null}
     </>
   );
 };

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/oppfolging/VeilarboppfolgingClient.kt
@@ -108,7 +108,7 @@ class VeilarboppfolgingClient(
             }
     }
 
-    suspend fun hentGjeldendePeriode(fnr: String, accessToken: String?): Either<OppfolgingError, OppfolgingPeriodeMinimalDTO> {
+    private suspend fun hentGjeldendePeriode(fnr: String, accessToken: String?): Either<OppfolgingError, OppfolgingPeriodeMinimalDTO> {
         gjeldendePeriodeCache.getIfPresent(fnr)?.let { return@hentGjeldendePeriode it.right() }
 
         val response = client.post("$baseUrl/v3/oppfolging/hent-gjeldende-periode") {

--- a/mulighetsrommet-api/wiremock/mappings/mr-gjeldende-periode.json
+++ b/mulighetsrommet-api/wiremock/mappings/mr-gjeldende-periode.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/veilarboppfolging/api/v3/oppfolging/hent-gjeldende-periode"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "uuid": "875b10ab-ae9a-425e-ab6b-153ecc90d9fe",
+      "startDato": "2024-01-01T00:00:00+01:00[Europe/Oslo]"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/mulighetsrommet-api/wiremock/mappings/mr-pdl.json
+++ b/mulighetsrommet-api/wiremock/mappings/mr-pdl.json
@@ -1,13 +1,23 @@
 {
   "request": {
     "method": "POST",
-    "urlPattern": "/veilarboppfolging/api/v3/oppfolging/hent-gjeldende-periode"
+    "urlPattern": "/pdl/graphql"
   },
   "response": {
     "status": 200,
     "jsonBody": {
-      "uuid": "875b10ab-ae9a-425e-ab6b-153ecc90d9fe",
-      "startDato": "2024-01-01T00:00:00+01:00[Europe/Oslo]"
+      "data": {
+        "hentIdenter": {
+          "identer": [
+            {
+              "ident": "12118323058",
+              "gruppe": "AKTORID",
+              "historisk": false
+            }
+          ]
+        }
+      },
+      "errors": []
     },
     "headers": {
       "Content-Type": "application/json"

--- a/mulighetsrommet-api/wiremock/mappings/mr-pdl.json
+++ b/mulighetsrommet-api/wiremock/mappings/mr-pdl.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/veilarboppfolging/api/v3/oppfolging/hent-gjeldende-periode"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "uuid": "875b10ab-ae9a-425e-ab6b-153ecc90d9fe",
+      "startDato": "2024-01-01T00:00:00+01:00[Europe/Oslo]"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
Setter opp Wiremock for pdl og hent-oppfølgingsperiode som manglet.
Fjerner paginering når ingen data eksisterer. Se skjermbilder for før og etter.

**Før**
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/134bc8a4-52a8-497b-9bf6-717d81d218da)

**Etter**
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/752780ad-0688-4756-aaec-a9d6a865f8de)
