### PR TITLE
Brødsmulenavigering i admin-flate

### DIFF
--- a/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.module.scss
+++ b/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.module.scss
@@ -1,0 +1,24 @@
+.navContainer {
+  background-color: white;
+  padding-left: 0.5rem;
+}
+
+.container {
+  display: flex;
+  list-style: none;
+  padding: 0.5rem;
+  margin: 0;
+  gap: 0.5rem;
+  flex-direction: row;
+}
+
+.link:hover {
+  cursor: pointer;
+}
+
+.item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
+++ b/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
@@ -42,9 +42,10 @@ export function Brodsmuler({ brodsmuler }: Props) {
     <nav aria-label="Brødsmulesti" className={styles.navContainer}>
       <ol className={styles.container}>
         {filtrerteBrodsmuler.filter(erBrodsmule).map((item, index) => {
+          const erSisteBrodsmule = index > 0 && index === filtrerteBrodsmuler.length - 1;
           return (
             <li key={index}>
-              {index > 0 && index === filtrerteBrodsmuler.length - 1 ? (
+              {erSisteBrodsmule ? (
                 <span aria-current="page">{item.tittel}</span>
               ) : (
                 <div className={styles.item}>

--- a/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
+++ b/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
@@ -1,0 +1,43 @@
+import { ArrowRightIcon } from "@navikt/aksel-icons";
+import { Link } from "react-router-dom";
+import styles from "./Brodsmuler.module.scss";
+
+export interface Brodsmule {
+  tittel: string;
+  lenke: string;
+}
+
+interface Props {
+  brodsmuler: Array<Brodsmule | undefined>;
+}
+
+function erBrodsmule(brodsmule: Brodsmule | undefined): brodsmule is Brodsmule {
+  return brodsmule !== undefined;
+}
+
+export function Brodsmuler({ brodsmuler }: Props) {
+  const filtrerteBrodsmuler = brodsmuler.filter(erBrodsmule);
+
+  return (
+    <nav aria-label="Brødsmulesti" className={styles.navContainer}>
+      <ol className={styles.container}>
+        {filtrerteBrodsmuler.filter(erBrodsmule).map((item, index) => {
+          return (
+            <li key={index}>
+              {index > 0 && index === filtrerteBrodsmuler.length - 1 ? (
+                <span>{item.tittel}</span>
+              ) : (
+                <div className={styles.item}>
+                  <Link className={styles.link} to={item.lenke}>
+                    {item.tittel}
+                  </Link>
+                  <ArrowRightIcon />
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
+++ b/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
@@ -31,7 +31,7 @@ export function Brodsmuler({ brodsmuler }: Props) {
                   <Link className={styles.link} to={item.lenke}>
                     {item.tittel}
                   </Link>
-                  <ArrowRightIcon />
+                  <ArrowRightIcon aria-label="Ikon for pil til høyre" />
                 </div>
               )}
             </li>

--- a/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
+++ b/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
@@ -3,7 +3,18 @@ import { Link } from "react-router-dom";
 import styles from "./Brodsmuler.module.scss";
 
 export interface Brodsmule {
-  tittel: string;
+  tittel:
+    | "Forside"
+    | "Avtaler"
+    | "Rediger avtale"
+    | "Ny avtale"
+    | "Avtaledetaljer"
+    | "Tiltaksgjennomføringer"
+    | "Tiltaksgjennomføringdetaljer"
+    | "Rediger tiltaksgjennomføring"
+    | "Ny tiltaksgjennomføring"
+    | "Tiltakstyper"
+    | "Tiltakstypedetaljer";
   lenke: string;
 }
 
@@ -25,13 +36,13 @@ export function Brodsmuler({ brodsmuler }: Props) {
           return (
             <li key={index}>
               {index > 0 && index === filtrerteBrodsmuler.length - 1 ? (
-                <span>{item.tittel}</span>
+                <span aria-current="page">{item.tittel}</span>
               ) : (
                 <div className={styles.item}>
                   <Link className={styles.link} to={item.lenke}>
                     {item.tittel}
                   </Link>
-                  <ArrowRightIcon aria-label="Ikon for pil til høyre" />
+                  <ArrowRightIcon aria-hidden="true" aria-label="Ikon for pil til høyre" />
                 </div>
               )}
             </li>

--- a/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
+++ b/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
@@ -2,6 +2,8 @@ import { ArrowRightIcon } from "@navikt/aksel-icons";
 import { Link } from "react-router-dom";
 import styles from "./Brodsmuler.module.scss";
 
+type Id = string;
+
 export interface Brodsmule {
   tittel:
     | "Forside"
@@ -15,7 +17,14 @@ export interface Brodsmule {
     | "Ny tiltaksgjennomføring"
     | "Tiltakstyper"
     | "Tiltakstypedetaljer";
-  lenke: string;
+  lenke:
+    | "/"
+    | "/tiltakstyper"
+    | `/tiltakstyper/${Id}`
+    | "/avtaler"
+    | `/avtaler/${Id}`
+    | "/tiltaksgjennomforinger"
+    | `/tiltaksgjennomforinger/${Id}`;
 }
 
 interface Props {

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
@@ -14,6 +14,7 @@ import { ContainerLayout } from "../../layouts/ContainerLayout";
 import commonStyles from "../Page.module.scss";
 import styles from "./DetaljerAvtalePage.module.scss";
 import { DupliserAvtale } from "../../components/avtaler/DupliserAvtale";
+import { Brodsmuler } from "../../components/navigering/Brodsmuler";
 
 export function AvtalePage() {
   const avtaleId = useGetAvtaleIdFromUrlOrThrow();
@@ -54,6 +55,13 @@ export function AvtalePage() {
 
   return (
     <main className={styles.avtaleinfo}>
+      <Brodsmuler
+        brodsmuler={[
+          { tittel: "Forside", lenke: "/" },
+          { tittel: "Avtaler", lenke: "/avtaler" },
+          { tittel: "Avtaledetaljer", lenke: `/avtaler/${avtale.id}` },
+        ]}
+      />
       <Header>
         <div className={headerStyles.tiltaksnavn_status}>
           <Heading size="large" level="2">

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleSkjemaPage.tsx
@@ -12,6 +12,7 @@ import { AvtaleSkjemaContainer } from "../../components/avtaler/AvtaleSkjemaCont
 import { useAvtale } from "../../api/avtaler/useAvtale";
 import { AvtalestatusTag } from "../../components/statuselementer/AvtalestatusTag";
 import { Heading } from "@navikt/ds-react";
+import { Brodsmule, Brodsmuler } from "../../components/navigering/Brodsmuler";
 
 const AvtaleSkjemaPage = () => {
   const navigate = useNavigate();
@@ -35,8 +36,24 @@ const AvtaleSkjemaPage = () => {
     return <Laster size="xlarge" tekst={"Laster avtale..."} />;
   }
 
+  const brodsmuler: Array<Brodsmule | undefined> = [
+    { tittel: "Forside", lenke: "/" },
+    { tittel: "Avtaler", lenke: "/avtaler" },
+    redigeringsModus
+      ? {
+          tittel: "Avtaledetaljer",
+          lenke: `/avtaler/${avtale?.id}`,
+        }
+      : undefined,
+    {
+      tittel: redigeringsModus ? "Rediger avtale" : "Ny avtale",
+      lenke: redigeringsModus ? `/avtaler/${avtale?.id}/skjema` : "/avtaler/skjema",
+    },
+  ];
+
   return (
     <main>
+      <Brodsmuler brodsmuler={brodsmuler} />
       <Header>
         <Heading size="large" level="2">
           {redigeringsModus ? "Rediger avtale" : "Opprett ny avtale"}

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
@@ -10,12 +10,19 @@ import { FilterAndTableLayout } from "../../components/filter/FilterAndTableLayo
 import { AvtaleFilterButtons } from "../../components/filter/AvtaleFilterButtons";
 import { AvtaleFilterTags } from "../../components/filter/AvtaleFilterTags";
 import { TilToppenKnapp } from "../../../../frontend-common/components/tilToppenKnapp/TilToppenKnapp";
+import { Brodsmuler } from "../../components/navigering/Brodsmuler";
 
 export function AvtalerPage() {
   useTitle("Avtaler");
 
   return (
     <>
+      <Brodsmuler
+        brodsmuler={[
+          { tittel: "Forside", lenke: "/" },
+          { tittel: "Avtaler", lenke: "/avtaler" },
+        ]}
+      />
       <HeaderBanner heading="Oversikt over avtaler" harUndermeny />
       <ReloadAppErrorBoundary>
         <MainContainer>

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
@@ -1,7 +1,7 @@
 import { Alert, Heading, Tabs } from "@navikt/ds-react";
 import classNames from "classnames";
 import { Toggles } from "mulighetsrommet-api-client";
-import { Link, Outlet, useLocation } from "react-router-dom";
+import { Link, Outlet, useLocation, useParams } from "react-router-dom";
 import { useFeatureToggle } from "../../api/features/feature-toggles";
 import { useTiltaksgjennomforingById } from "../../api/tiltaksgjennomforing/useTiltaksgjennomforingById";
 import { Header } from "../../components/detaljside/Header";
@@ -14,9 +14,11 @@ import { ContainerLayout } from "../../layouts/ContainerLayout";
 import commonStyles from "../Page.module.scss";
 import { DupliserTiltak } from "../../components/tiltaksgjennomforinger/DupliserTiltak";
 import { PREVIEW_ARBEIDSMARKEDSTILTAK_URL } from "../../constants";
+import { Brodsmuler } from "../../components/navigering/Brodsmuler";
 
 export function TiltaksgjennomforingPage() {
   const { pathname } = useLocation();
+  const { avtaleId } = useParams();
   const { navigateAndReplaceUrl } = useNavigateAndReplaceUrl();
   const { data: tiltaksgjennomforing, isLoading } = useTiltaksgjennomforingById();
   const { data: showNotater } = useFeatureToggle(Toggles.MULIGHETSROMMET_ADMIN_FLATE_SHOW_NOTATER);
@@ -28,7 +30,7 @@ export function TiltaksgjennomforingPage() {
   if (!tiltaksgjennomforing) {
     return (
       <Alert variant="warning">
-        Klarte ikke finne tiltaksgjennømforing
+        Klarte ikke finne tiltaksgjennomføring
         <div>
           <Link to="/">Til forside</Link>
         </div>
@@ -48,6 +50,19 @@ export function TiltaksgjennomforingPage() {
 
   return (
     <main>
+      <Brodsmuler
+        brodsmuler={[
+          { tittel: "Forside", lenke: "/" },
+          avtaleId
+            ? { tittel: "Avtaler", lenke: "/avtaler" }
+            : { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+          avtaleId ? { tittel: "Avtaledetaljer", lenke: `/avtaler/${avtaleId}` } : undefined,
+          {
+            tittel: "Tiltaksgjennomføringdetaljer",
+            lenke: `/tiltaksgjennomforinger/${tiltaksgjennomforing.id}`,
+          },
+        ]}
+      />
       <Header harForhandsvisningsknapp>
         <div
           className={classNames(

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
@@ -1,5 +1,5 @@
 import { Alert, Heading } from "@navikt/ds-react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useAvtale } from "../../api/avtaler/useAvtale";
 import { useTiltaksgjennomforingById } from "../../api/tiltaksgjennomforing/useTiltaksgjennomforingById";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
@@ -11,14 +11,16 @@ import { TiltaksgjennomforingSkjemaContainer } from "../../components/tiltaksgje
 import { ErrorMeldinger } from "../../components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaErrors";
 import { TiltaksgjennomforingstatusTag } from "../../components/statuselementer/TiltaksgjennomforingstatusTag";
 import { useHentAnsatt } from "../../api/ansatt/useHentAnsatt";
+import { Brodsmule, Brodsmuler } from "../../components/navigering/Brodsmuler";
 
 const TiltaksgjennomforingSkjemaPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { avtaleId } = useParams();
   const { data: tiltaksgjennomforing, isLoading: tiltaksgjennomforingLoading } =
     useTiltaksgjennomforingById();
   const { data: avtale, isLoading: avtaleIsLoading } = useAvtale(tiltaksgjennomforing?.avtaleId);
   const { data: ansatt, isPending: isPendingAnsatt } = useHentAnsatt();
-  const location = useLocation();
 
   const redigeringsModus = tiltaksgjennomforing && inneholderUrl(tiltaksgjennomforing?.id);
 
@@ -53,8 +55,36 @@ const TiltaksgjennomforingSkjemaPage = () => {
     );
   }
 
+  const brodsmuler: Array<Brodsmule | undefined> = [
+    { tittel: "Forside", lenke: "/" },
+    avtaleId
+      ? { tittel: "Avtaler", lenke: "/avtaler" }
+      : { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+    avtaleId
+      ? {
+          tittel: "Avtaledetaljer",
+          lenke: `/avtaler/${avtaleId}`,
+        }
+      : undefined,
+    redigeringsModus
+      ? {
+          tittel: "Tiltaksgjennomføringdetaljer",
+          lenke: avtaleId
+            ? `/avtaler/${avtaleId}/tiltaksgjennomforinger/${tiltaksgjennomforing?.id}`
+            : `/tiltaksgjennomforinger/${tiltaksgjennomforing?.id}`,
+        }
+      : undefined,
+    {
+      tittel: redigeringsModus ? "Rediger tiltaksgjennomføring" : "Ny tiltaksgjennomføring",
+      lenke: redigeringsModus
+        ? `/tiltaksgjennomforinger/${tiltaksgjennomforing?.id}/skjema`
+        : "/tiltaksgjennomforinger/skjema",
+    },
+  ];
+
   return (
     <main>
+      <Brodsmuler brodsmuler={brodsmuler} />
       <Header>
         <Heading size="large" level="2">
           {redigeringsModus ? "Rediger tiltaksgjennomføring" : "Opprett ny tiltaksgjennomføring"}

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
@@ -10,12 +10,19 @@ import { TiltaksgjennomforingFilterTags } from "../../components/filter/Tiltaksg
 import { TiltaksgjennomforingFilter } from "../../components/filter/Tiltaksgjennomforingfilter";
 import { ReloadAppErrorBoundary } from "../../ErrorBoundary";
 import { TilToppenKnapp } from "../../../../frontend-common/components/tilToppenKnapp/TilToppenKnapp";
+import { Brodsmuler } from "../../components/navigering/Brodsmuler";
 
 export function TiltaksgjennomforingerPage() {
   useTitle("Tiltaksgjennomføringer");
 
   return (
     <>
+      <Brodsmuler
+        brodsmuler={[
+          { tittel: "Forside", lenke: "/" },
+          { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+        ]}
+      />
       <HeaderBanner heading="Oversikt over tiltaksgjennomføringer" />
       <MainContainer>
         <ContainerLayout>

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
@@ -8,6 +8,7 @@ import { TiltakstypestatusTag } from "../../components/statuselementer/Tiltaksty
 import { useNavigateAndReplaceUrl } from "../../hooks/useNavigateWithoutReplacingUrl";
 import { ContainerLayout } from "../../layouts/ContainerLayout";
 import commonStyles from "../Page.module.scss";
+import { Brodsmuler } from "../../components/navigering/Brodsmuler";
 
 export function DetaljerTiltakstypePage() {
   const { pathname } = useLocation();
@@ -32,6 +33,13 @@ export function DetaljerTiltakstypePage() {
 
   return (
     <main>
+      <Brodsmuler
+        brodsmuler={[
+          { tittel: "Forside", lenke: "/" },
+          { tittel: "Tiltakstyper", lenke: "/tiltakstyper" },
+          { tittel: "Tiltakstypedetaljer", lenke: `/tiltakstyper/${tiltakstype.id}` },
+        ]}
+      />
       <Header>
         <Heading size="large" level="2">
           {tiltakstype?.navn ?? "..."}

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/TiltakstyperPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/TiltakstyperPage.tsx
@@ -5,11 +5,18 @@ import { HeaderBanner } from "../../layouts/HeaderBanner";
 import { useTitle } from "mulighetsrommet-frontend-common";
 import { ReloadAppErrorBoundary } from "../../ErrorBoundary";
 import { TilToppenKnapp } from "../../../../frontend-common/components/tilToppenKnapp/TilToppenKnapp";
+import { Brodsmuler } from "../../components/navigering/Brodsmuler";
 
 export function TiltakstyperPage() {
   useTitle("Tiltakstyper");
   return (
     <>
+      <Brodsmuler
+        brodsmuler={[
+          { tittel: "Forside", lenke: "/" },
+          { tittel: "Tiltakstyper", lenke: "/tiltakstyper" },
+        ]}
+      />
       <HeaderBanner heading="Oversikt over tiltakstyper" />
       <MainContainer>
         <ContainerLayout>


### PR DESCRIPTION
Se video i Avklaringer på Slack. Filen er for stor for å laste opp på Github.

<img width="519" alt="image" src="https://github.com/navikt/mulighetsrommet/assets/9053627/ea60e682-773d-42d7-99bd-a822f90bb6f7">
<img width="966" alt="image" src="https://github.com/navikt/mulighetsrommet/assets/9053627/a132441e-9e27-460d-ab3d-924d822ad852">
<img width="577" alt="image" src="https://github.com/navikt/mulighetsrommet/assets/9053627/142bb655-aeb1-49ac-b8d0-7d92f295aa2d">
<img width="538" alt="image" src="https://github.com/navikt/mulighetsrommet/assets/9053627/b2630a2f-c0ac-46e0-ae7e-44251d4b2a18">
