### PR TITLE
Viser Åpent for innsøk for noen tiltakstyper

### DIFF
--- a/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaDetaljer.tsx
@@ -4,6 +4,7 @@ import {
   Avtale,
   Tiltaksgjennomforing,
   TiltaksgjennomforingKontaktperson,
+  Tiltakskode,
 } from "mulighetsrommet-api-client";
 import { ControlledSokeSelect } from "mulighetsrommet-frontend-common";
 import { useEffect, useRef } from "react";
@@ -32,6 +33,15 @@ import {
 interface Props {
   tiltaksgjennomforing?: Tiltaksgjennomforing;
   avtale: Avtale;
+}
+
+function visApentForInnsok(arenaKode: Tiltakskode) {
+  return [
+    Tiltakskode.JOBBK,
+    Tiltakskode.DIGIOPPARB,
+    Tiltakskode.GRUPPEAMO,
+    Tiltakskode.GRUFAGYRKE,
+  ].includes(arenaKode);
 }
 
 export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtale }: Props) => {
@@ -164,13 +174,15 @@ export const TiltaksgjennomforingSkjemaDetaljer = ({ tiltaksgjennomforing, avtal
                 format: "iso-string",
               }}
             />
-            <Switch
-              size="small"
-              readOnly={erArenaOpphavOgIngenEierskap(tiltaksgjennomforing, migrerteTiltakstyper)}
-              {...register("apentForInnsok")}
-            >
-              Åpen for innsøk
-            </Switch>
+            {visApentForInnsok(avtale.tiltakstype.arenaKode) ? (
+              <Switch
+                size="small"
+                readOnly={erArenaOpphavOgIngenEierskap(tiltaksgjennomforing, migrerteTiltakstyper)}
+                {...register("apentForInnsok")}
+              >
+                Åpen for innsøk
+              </Switch>
+            ) : null}
 
             <HStack justify="space-between">
               <TextField

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
@@ -43,7 +43,13 @@ const TiltaksgjennomforingSkjemaPage = () => {
         onClose={() => {
           navigerTilbake();
         }}
-        onSuccess={(id) => navigate(`/tiltaksgjennomforinger/${id}`)}
+        onSuccess={(id) =>
+          navigate(
+            avtaleId
+              ? `/avtaler/${avtaleId}/tiltaksgjennomforinger/${id}`
+              : `/tiltaksgjennomforinger/${id}`,
+          )
+        }
         avtale={avtale}
         ansatt={ansatt}
         tiltaksgjennomforing={


### PR DESCRIPTION
Viser Åpent for innsøk for tiltakstypene jobbklubb, digital jobbklubb, gruppe-AMO og gruppe fag- og yrkesutdanning.
De andre tiltakstypene har ikke skjemavalg for å sette åpent for innsøk.

Viser fortsatt at tiltaket er åpent for innsøk i detaljvisningen.

(tar også med en routing-fiks som gjør at man blir routet til gjennomføringer man oppretter i kontekst av avtalen).
