### PR TITLE
sørg for at mutations blir satt riktig

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/SanityMutateDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/SanityMutateDto.kt
@@ -10,23 +10,33 @@ data class Mutations<T>(
 )
 
 @Serializable
-data class Mutation<T>(
+class Mutation<T> private constructor(
     val createIfNotExists: T? = null,
     val createOrReplace: T? = null,
     val patch: T? = null,
     val delete: Delete? = null,
-)
+) {
+    companion object {
+        fun <T> createIfNotExists(data: T) = Mutation(createIfNotExists = data)
 
-@Serializable
-data class Delete(
-    val id: String,
-)
+        fun <T> createOrReplace(data: T) = Mutation(createOrReplace = data)
 
-@Serializable
-data class Patch<T>(
-    val id: String,
-    val set: T,
-)
+        fun <T> patch(id: String, set: T) = Mutation(patch = Patch(id = id, set = set))
+
+        fun delete(id: String) = Mutation<Unit>(delete = Delete(id))
+    }
+
+    @Serializable
+    data class Delete(
+        val id: String,
+    )
+
+    @Serializable
+    data class Patch<T>(
+        val id: String,
+        val set: T,
+    )
+}
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
@@ -10,7 +10,6 @@ import no.nav.mulighetsrommet.api.clients.AccessType
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
-import no.nav.mulighetsrommet.api.domain.dto.Delete
 import no.nav.mulighetsrommet.api.domain.dto.Mutation
 import no.nav.mulighetsrommet.api.domain.dto.NavAnsattDto
 import no.nav.mulighetsrommet.api.domain.dto.SanityResponse
@@ -122,7 +121,7 @@ class NavAnsattService(
             return
         }
 
-        val result = sanityClient.mutate(mutations = ider.map { Mutation(Delete(it)) })
+        val result = sanityClient.mutate(mutations = ider.map { Mutation.delete(it) })
         if (result.status != HttpStatusCode.OK) {
             throw Exception("Klarte ikke slette Sanity-dokument: ${result.bodyAsText()}")
         }
@@ -187,7 +186,7 @@ class NavAnsattService(
             navn = "${ansatt.fornavn} ${ansatt.etternavn}",
         )
 
-        return Mutation(createOrReplace = sanityPatch)
+        return Mutation.createOrReplace(sanityPatch)
     }
 
     private fun upsertRedaktor(ansatt: NavAnsattDto, id: String): Mutation<SanityRedaktor> {
@@ -199,7 +198,7 @@ class NavAnsattService(
             navIdent = Slug(current = ansatt.navIdent.value),
             epost = Slug(current = ansatt.epost),
         )
-        return Mutation(createOrReplace = sanityPatch)
+        return Mutation.createOrReplace(sanityPatch)
     }
 
     private suspend fun upsertMutations(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavEnheterSyncService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavEnheterSyncService.kt
@@ -1,7 +1,10 @@
 package no.nav.mulighetsrommet.api.services
 
 import io.ktor.http.*
-import no.nav.mulighetsrommet.api.clients.norg2.*
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Client
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2EnhetDto
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Response
+import no.nav.mulighetsrommet.api.clients.norg2.Norg2Type
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetDbo
 import no.nav.mulighetsrommet.api.domain.dbo.NavEnhetStatus
@@ -102,7 +105,7 @@ class NavEnheterSyncService(
 
     private suspend fun lagreEnheterTilSanity(sanityEnheter: List<SanityEnhet>) {
         logger.info("Oppdaterer Sanity-enheter - Antall: ${sanityEnheter.size}")
-        val mutations = sanityEnheter.map { Mutation(createOrReplace = it) }
+        val mutations = sanityEnheter.map { Mutation.createOrReplace(it) }
 
         val response = sanityClient.mutate(mutations)
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityTiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SanityTiltaksgjennomforingService.kt
@@ -22,8 +22,8 @@ class SanityTiltaksgjennomforingService(
         val response = sanityClient.mutate(
             listOf(
                 // Deletes both drafts and published dokuments
-                Mutation<Unit>(delete = Delete(id = "drafts.$sanityId")),
-                Mutation(delete = Delete(id = "$sanityId")),
+                Mutation.delete(id = "drafts.$sanityId"),
+                Mutation.delete(id = "$sanityId"),
             ),
         )
 
@@ -71,7 +71,7 @@ class SanityTiltaksgjennomforingService(
         )
 
         val response = sanityClient.mutate(
-            listOf(Mutation(createOrReplace = sanityTiltaksgjennomforing)),
+            listOf(Mutation.createOrReplace(sanityTiltaksgjennomforing)),
         )
 
         if (response.status != HttpStatusCode.OK) {
@@ -95,7 +95,7 @@ class SanityTiltaksgjennomforingService(
         }
 
         val response = sanityClient.mutate(
-            listOf(Mutation(patch = Patch(id = id, set = sanityTiltaksgjennomforingFields))),
+            listOf(Mutation.patch(id = id, set = sanityTiltaksgjennomforingFields)),
         )
 
         if (response.status != HttpStatusCode.OK) {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
@@ -70,8 +70,6 @@ class NavAnsattServiceTest : FunSpec({
         engine = MockEngine { request ->
             if (request.method === HttpMethod.Post) {
                 return@MockEngine respondOk()
-            } else if (request.method === HttpMethod.Delete) {
-                return@MockEngine respondOk()
             }
 
             val query = request.url.parameters.getOrFail<String>("query")


### PR DESCRIPTION
Ved å gjøre constructor privat så kan vi sørge for at 'Delete' mutation ikke blir satt i feltet for 'createIfNotExists' ved en feiltakelse.