### PR TITLE
Initial oppsett for arrangørsider (Gule Sider)

### DIFF
--- a/frontend/mr-admin-flate/public/mockServiceWorker.js
+++ b/frontend/mr-admin-flate/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.2.11'
+const PACKAGE_VERSION = '2.2.13'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/frontend/mr-admin-flate/src/App.tsx
+++ b/frontend/mr-admin-flate/src/App.tsx
@@ -26,6 +26,7 @@ import { AvtaleInfo } from "./pages/avtaler/AvtaleInfo";
 import TiltaksgjennomforingSkjemaPage from "./pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage";
 import { TiltaksgjennomforingerForAvtalePage } from "./pages/tiltaksgjennomforinger/TiltaksgjennomforingerForAvtalePage";
 import { initializeAmplitude } from "./logging/amplitude";
+import { ArrangorerPage } from "./pages/arrangor/ArrangorerPage";
 
 if (import.meta.env.PROD) {
   initializeFaro({
@@ -156,6 +157,7 @@ export function App() {
         element={<TiltaksgjennomforingSkjemaPage />}
         errorElement={<ErrorPage />}
       />
+      <Route path="arrangorer" element={<ArrangorerPage />} errorElement={<ErrorPage />} />
       <Route path="notifikasjoner" element={<NotifikasjonerPage />} errorElement={<ErrorPage />}>
         <Route index element={<Notifikasjonsliste lest={false} />} errorElement={<ErrorPage />} />
         <Route

--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -228,6 +228,22 @@ export const avtaleFilterAtom = atomWithHashAndStorage<AvtaleFilter>(
   avtaleFilterSchema,
 );
 
+const arrangorerFilterSchema = z.object({
+  sok: z.string(),
+});
+
+export type ArrangorerFilter = z.infer<typeof arrangorerFilterSchema>;
+export const defaultArrangorerFilter: ArrangorerFilter = {
+  sok: "",
+};
+
+export const arrangorerFilterAtom = atomWithHashAndStorage<ArrangorerFilter>(
+  "arrangorer-filter",
+  defaultArrangorerFilter,
+  sessionStorage,
+  arrangorerFilterSchema,
+);
+
 export const getAvtalerForTiltakstypeFilterAtom = atomFamily<
   string,
   WritableAtom<AvtaleFilter, [newValue: AvtaleFilter], void>

--- a/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.tsx
+++ b/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.tsx
@@ -19,12 +19,16 @@ export function AdministratorHeader() {
   const { data: debugIsEnabled } = useFeatureToggle(
     Toggles.MULIGHETSROMMET_ADMIN_FLATE_ENABLE_DEBUGGER,
   );
+  const { data: arrangorsiderIsEnabled } = useFeatureToggle(
+    Toggles.MULIGHETSROMMET_ADMIN_FLATE_ENABLE_ARRANGOR_SIDER,
+  );
 
   const ansattNavn = data ? [data.fornavn, data.etternavn].join(" ") : "Team Valp";
 
   const tiltakstyperLinkRef = useRef<HTMLAnchorElement>(null);
   const avtalerLinkRef = useRef<HTMLAnchorElement>(null);
   const gjennomforingerLinkRef = useRef<HTMLAnchorElement>(null);
+  const arrangorerLinkRef = useRef<HTMLAnchorElement>(null);
   const individuelleGjennomforingerLinkRef = useRef<HTMLAnchorElement>(null);
   const veilederflateLinkRef = useRef<HTMLAnchorElement>(null);
   const notifikasjonerLinkRef = useRef<HTMLAnchorElement>(null);
@@ -73,6 +77,17 @@ export function AdministratorHeader() {
                 Tiltaksgjennomføringer
               </Link>
             </Dropdown.Menu.GroupedList.Item>
+            {arrangorsiderIsEnabled ? (
+              <Dropdown.Menu.GroupedList.Item
+                onClick={() => arrangorerLinkRef.current?.click()}
+                as="span"
+              >
+                <Link ref={arrangorerLinkRef} to="/arrangorer">
+                  Arrangører
+                </Link>
+              </Dropdown.Menu.GroupedList.Item>
+            ) : null}
+            <Dropdown.Menu.Divider />
             <Dropdown.Menu.GroupedList.Item
               onClick={() => notifikasjonerLinkRef.current?.click()}
               as="span"
@@ -81,6 +96,7 @@ export function AdministratorHeader() {
                 Notifikasjoner
               </Link>
             </Dropdown.Menu.GroupedList.Item>
+            <Dropdown.Menu.Divider />
             <Dropdown.Menu.GroupedList.Item
               onClick={() => individuelleGjennomforingerLinkRef.current?.click()}
               as="span"
@@ -101,6 +117,7 @@ export function AdministratorHeader() {
                 Veilederflate forhåndsvisning <ExternalLinkIcon />
               </Link>
             </Dropdown.Menu.GroupedList.Item>
+            <Dropdown.Menu.Divider />
             <Dropdown.Menu.GroupedList.Item
               onClick={() => endringsmeldingerLinkRef.current?.click()}
               as="span"

--- a/frontend/mr-admin-flate/src/components/filter/ArrangorerFilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/ArrangorerFilter.tsx
@@ -1,0 +1,36 @@
+import { WritableAtom, useAtom } from "jotai";
+import { ArrangorerFilter as ArrangorerFilterProps } from "../../api/atoms";
+import { Search, Skeleton, VStack } from "@navikt/ds-react";
+
+interface Props {
+  filterAtom: WritableAtom<ArrangorerFilterProps, [newValue: ArrangorerFilterProps], void>;
+}
+
+export function ArrangorerFilter({ filterAtom }: Props) {
+  const [filter, setFilter] = useAtom(filterAtom);
+
+  if (filter.sok.length > 0) {
+    return (
+      <VStack gap="2">
+        <Skeleton height={50} variant="rounded" />
+      </VStack>
+    );
+  }
+
+  return (
+    <div>
+      <Search
+        label="Søk etter arrangør"
+        hideLabel
+        size="small"
+        variant="simple"
+        placeholder="Navn, organisasjonsnummer"
+        onChange={(search: string) => {
+          setFilter({ ...filter, sok: search });
+        }}
+        value={filter.sok}
+        aria-label="Søk etter arrangør"
+      />
+    </div>
+  );
+}

--- a/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
+++ b/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
@@ -18,7 +18,8 @@ export interface Brodsmule {
     | "Ny tiltaksgjennomføring"
     | "Tiltakstyper"
     | "Tiltakstypedetaljer"
-    | "Tiltaktypens avtaler";
+    | "Tiltaktypens avtaler"
+    | "Arrangører";
   lenke:
     | "/"
     | "/tiltakstyper"
@@ -26,7 +27,8 @@ export interface Brodsmule {
     | "/avtaler"
     | `/avtaler/${Id}`
     | "/tiltaksgjennomforinger"
-    | `/tiltaksgjennomforinger/${Id}`;
+    | `/tiltaksgjennomforinger/${Id}`
+    | "/arrangorer";
 }
 
 interface Props {

--- a/frontend/mr-admin-flate/src/mocks/api/features.ts
+++ b/frontend/mr-admin-flate/src/mocks/api/features.ts
@@ -6,4 +6,5 @@ export const mockFeatures: Features = {
   "mulighetsrommet-veilederflate-arena-oppskrifter": true,
   "mulighetsrommet.admin-flate.show-notater": true,
   "mulighetsrommet.admin-flate.enableDebugger": true,
+  "mulighetsrommet.admin-flate.enableArrangorSider": true,
 };

--- a/frontend/mr-admin-flate/src/pages/arrangor/ArrangorerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/arrangor/ArrangorerPage.tsx
@@ -1,0 +1,44 @@
+import { useTitle } from "mulighetsrommet-frontend-common";
+import { FilterAndTableLayout } from "mulighetsrommet-frontend-common/components/filterAndTableLayout/FilterAndTableLayout";
+import { useState } from "react";
+import { ReloadAppErrorBoundary } from "../../ErrorBoundary";
+import { arrangorerFilterAtom } from "../../api/atoms";
+import { ArrangorerFilter } from "../../components/filter/ArrangorerFilter";
+import { Brodsmuler } from "../../components/navigering/Brodsmuler";
+import { ContainerLayout } from "../../layouts/ContainerLayout";
+import { HeaderBanner } from "../../layouts/HeaderBanner";
+import { MainContainer } from "../../layouts/MainContainer";
+import { NullstillKnappForArrangorer } from "./NullstillKnappForArrangorer";
+
+export function ArrangorerPage() {
+  useTitle("Arrangører");
+  const [filterOpen, setFilterOpen] = useState<boolean>(true);
+  return (
+    <>
+      <Brodsmuler
+        brodsmuler={[
+          { tittel: "Forside", lenke: "/" },
+          { tittel: "Arrangører", lenke: "/arrangorer" },
+        ]}
+      />
+      <HeaderBanner heading="Arrangører" />
+      <ReloadAppErrorBoundary>
+        <MainContainer>
+          <ContainerLayout>
+            <FilterAndTableLayout
+              nullstillFilterButton={
+                <NullstillKnappForArrangorer filterAtom={arrangorerFilterAtom} />
+              }
+              filter={<ArrangorerFilter filterAtom={arrangorerFilterAtom} />}
+              tags={null}
+              buttons={null}
+              table={null}
+              setFilterOpen={setFilterOpen}
+              filterOpen={filterOpen}
+            />
+          </ContainerLayout>
+        </MainContainer>
+      </ReloadAppErrorBoundary>
+    </>
+  );
+}

--- a/frontend/mr-admin-flate/src/pages/arrangor/NullstillKnappForArrangorer.tsx
+++ b/frontend/mr-admin-flate/src/pages/arrangor/NullstillKnappForArrangorer.tsx
@@ -1,0 +1,19 @@
+import { WritableAtom, useAtom } from "jotai";
+import { NullstillFilterKnapp } from "mulighetsrommet-frontend-common/components/nullstillFilterKnapp/NullstillFilterKnapp";
+import { ArrangorerFilter, defaultArrangorerFilter } from "../../api/atoms";
+
+interface Props {
+  filterAtom: WritableAtom<ArrangorerFilter, [newValue: ArrangorerFilter], void>;
+}
+
+export function NullstillKnappForArrangorer({ filterAtom }: Props) {
+  const [filter, setFilter] = useAtom(filterAtom);
+
+  return (
+    <div>
+      {filter.sok.length > 0 ? (
+        <NullstillFilterKnapp onClick={() => setFilter({ ...defaultArrangorerFilter })} />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
@@ -6,4 +6,5 @@ export const mockFeatures: Features = {
   "mulighetsrommet-veilederflate-arena-oppskrifter": true,
   "mulighetsrommet.admin-flate.show-notater": true,
   "mulighetsrommet.admin-flate.enableDebugger": false,
+  "mulighetsrommet.admin-flate.enableArrangorSider": false,
 };

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -3363,6 +3363,7 @@ components:
         - mulighetsrommet-veilederflate-arena-oppskrifter
         - mulighetsrommet.admin-flate.show-notater
         - mulighetsrommet.admin-flate.enableDebugger
+        - mulighetsrommet.admin-flate.enableArrangorSider
 
     PublisertRequest:
       type: object


### PR DESCRIPTION
Mye som gjenstår, men prøver å ikke lage PRene alt for store. 

Følgens skal også inn i egen PR på sikt:

- [ ] Vise arrangører i tabell
- [ ] Implementere søk på navn eller orgnr
- [ ] Kunne trykke på arrangør for å gå til detaljvisning
- [ ] ++++

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/8635176a-3e3a-47a4-b4d7-59105527c554)
![image](https://github.com/navikt/mulighetsrommet/assets/9053627/156bb173-742c-448c-b1b7-84a9a1a81f60)
