### PR TITLE
Feature/aar lopenr

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Lopenummer.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dto/Lopenummer.kt
@@ -1,0 +1,26 @@
+package no.nav.mulighetsrommet.domain.dto
+
+import kotlinx.serialization.Serializable
+
+private val LOPENUMMER_REGEX = "^(\\d{4})/(\\d+)$".toRegex()
+
+@Serializable
+@JvmInline
+value class Lopenummer(val value: String) {
+    init {
+        require(LOPENUMMER_REGEX.matches(value)) {
+            "The format of 'Lopenummer' is invalid. Expected '{year}/{id}'."
+        }
+    }
+
+    fun getParts(): Pair<Int, Int> {
+        val groupValues = LOPENUMMER_REGEX.matchEntire(value)?.groupValues ?: emptyList()
+        val first = requireNotNull(groupValues.getOrNull(1)?.toInt()) {
+            "'year' is missing from Lopenummer."
+        }
+        val second = requireNotNull(groupValues.getOrNull(2)?.toInt()) {
+            "'id' is missing from Lopenummer."
+        }
+        return Pair(first, second)
+    }
+}

--- a/frontend/mr-admin-flate/src/components/ledetekster/avtaleLedetekster.ts
+++ b/frontend/mr-admin-flate/src/components/ledetekster/avtaleLedetekster.ts
@@ -1,6 +1,7 @@
 export const avtaletekster = {
   avtalenavnLabel: "Avtalenavn",
-  avtalenummerLabel: "Avtalenummer",
+  lopenummerLabel: "Løpenummer",
+  arenaAvtalenummerLabel: "Avtalenummer i Arena",
   tiltakstypeLabel: "Tiltakstype",
   avtaletypeLabel: "Avtaletype",
   startdatoLabel: "Startdato",

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
@@ -3,18 +3,18 @@ import { Alert, Heading, HelpText, VStack } from "@navikt/ds-react";
 import { NOM_ANSATT_SIDE } from "mulighetsrommet-frontend-common/constants";
 import { Fragment } from "react";
 import { useAvtale } from "@/api/avtaler/useAvtale";
-import { Bolk } from "../../components/detaljside/Bolk";
-import { Metadata, Separator } from "../../components/detaljside/Metadata";
-import { Laster } from "../../components/laster/Laster";
-import { avtaletypeTilTekst, formaterDato } from "../../utils/Utils";
-import { erAnskaffetTiltak } from "../../utils/tiltakskoder";
+import { Bolk } from "@/components/detaljside/Bolk";
+import { Metadata, Separator } from "@/components/detaljside/Metadata";
+import { Laster } from "@/components/laster/Laster";
+import { avtaletypeTilTekst, formaterDato } from "@/utils/Utils";
+import { erAnskaffetTiltak } from "@/utils/tiltakskoder";
 import styles from "../DetaljerInfo.module.scss";
 import { Link } from "react-router-dom";
-import { NavEnhet, Toggles } from "mulighetsrommet-api-client";
-import { avtaletekster } from "../../components/ledetekster/avtaleLedetekster";
+import { NavEnhet, Opphav, Toggles } from "mulighetsrommet-api-client";
+import { avtaletekster } from "@/components/ledetekster/avtaleLedetekster";
 import { getDisplayName } from "@/api/enhet/helpers";
-import { ArrangorKontaktpersonDetaljer } from "../arrangor/ArrangorKontaktpersonDetaljer";
-import { useFeatureToggle } from "../../api/features/feature-toggles";
+import { ArrangorKontaktpersonDetaljer } from "@/pages/arrangor/ArrangorKontaktpersonDetaljer";
+import { useFeatureToggle } from "@/api/features/feature-toggles";
 
 export function AvtaleDetaljer() {
   const { data: avtale, isPending, error } = useAvtale();
@@ -52,6 +52,7 @@ export function AvtaleDetaljer() {
   const {
     navn,
     avtalenummer,
+    lopenummer,
     tiltakstype,
     avtaletype,
     startDato,
@@ -61,6 +62,7 @@ export function AvtaleDetaljer() {
     kontorstruktur,
     arenaAnsvarligEnhet,
     arrangor,
+    opphav,
   } = avtale;
 
   return (
@@ -68,7 +70,11 @@ export function AvtaleDetaljer() {
       <div className={styles.detaljer}>
         <Bolk aria-label="Avtalenavn og avtalenummer">
           <Metadata header={avtaletekster.avtalenavnLabel} verdi={navn} />
-          <Metadata header={avtaletekster.avtalenummerLabel} verdi={avtalenummer} />
+          {opphav === Opphav.MR_ADMIN_FLATE ? (
+            <Metadata header={avtaletekster.lopenummerLabel} verdi={lopenummer} />
+          ) : (
+            <Metadata header={avtaletekster.arenaAvtalenummerLabel} verdi={avtalenummer} />
+          )}
         </Bolk>
 
         <Bolk aria-label={avtaletekster.tiltakstypeLabel}>

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/AvtaleAdminDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/AvtaleAdminDto.kt
@@ -6,10 +6,7 @@ import no.nav.mulighetsrommet.api.domain.dbo.AvtaleDbo
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering
 import no.nav.mulighetsrommet.domain.dbo.ArenaAvtaleDbo
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
-import no.nav.mulighetsrommet.domain.dto.Avtalestatus
-import no.nav.mulighetsrommet.domain.dto.Avtaletype
-import no.nav.mulighetsrommet.domain.dto.Faneinnhold
-import no.nav.mulighetsrommet.domain.dto.NavIdent
+import no.nav.mulighetsrommet.domain.dto.*
 import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import java.time.LocalDate
@@ -22,6 +19,7 @@ data class AvtaleAdminDto(
     val tiltakstype: Tiltakstype,
     val navn: String,
     val avtalenummer: String?,
+    val lopenummer: Lopenummer?,
     val arrangor: ArrangorHovedenhet,
     @Serializable(with = LocalDateSerializer::class)
     val startDato: LocalDate,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -24,6 +24,7 @@ import no.nav.mulighetsrommet.domain.dbo.ArenaAvtaleDbo
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
 import no.nav.mulighetsrommet.domain.dto.Avtalestatus
 import no.nav.mulighetsrommet.domain.dto.Avtaletype
+import no.nav.mulighetsrommet.domain.dto.Lopenummer
 import no.nav.mulighetsrommet.domain.dto.NavIdent
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
@@ -480,6 +481,7 @@ class AvtaleRepository(private val db: Database) {
             id = uuid("id"),
             navn = string("navn"),
             avtalenummer = stringOrNull("avtalenummer"),
+            lopenummer = stringOrNull("lopenummer")?.let { Lopenummer(it) },
             startDato = startDato,
             sluttDato = sluttDato,
             opphav = ArenaMigrering.Opphav.valueOf(string("opphav")),

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__avtale_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__avtale_admin_view.sql
@@ -1,10 +1,10 @@
---2024-04-09 migrering drop'et view uten å endre det. Da forsvant det i prod
 drop view if exists avtale_admin_dto_view;
 
 create view avtale_admin_dto_view as
 select avtale.id,
        avtale.navn,
        avtale.avtalenummer,
+       avtale.lopenummer,
        avtale.start_dato,
        avtale.slutt_dato,
        avtale.opphav,

--- a/mulighetsrommet-api/src/main/resources/db/migration/V137__generate_lopenummer.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V137__generate_lopenummer.sql
@@ -1,0 +1,33 @@
+alter table avtale
+    add lopenummer text unique;
+
+alter table tiltaksgjennomforing
+    add lopenummer text unique;
+
+create or replace function generate_lopenummer() returns trigger as
+$$
+declare
+    year text;
+begin
+    if new.lopenummer is null then
+        year := date_part('year', new.created_at);
+
+        execute ('create sequence if not exists lopenummer_' || year || '_seq as integer minvalue 10000');
+
+        new.lopenummer = year || '/' || nextval('lopenummer_' || year || '_seq');
+    end if;
+    return new;
+end;
+$$ language plpgsql;
+
+create or replace trigger avtale_generate_lopenummer
+    before insert
+    on avtale
+    for each row
+execute procedure generate_lopenummer();
+
+create or replace trigger tiltaksgjennomforing_generate_lopenummer
+    before insert
+    on tiltaksgjennomforing
+    for each row
+execute procedure generate_lopenummer();

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1968,6 +1968,8 @@ components:
           type: string
         avtalenummer:
           type: string
+        lopenummer:
+          type: string
         arrangor:
           $ref: "#/components/schemas/ArrangorHovedenhet"
         startDato:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
@@ -7,6 +7,8 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -96,6 +98,25 @@ class AvtaleRepositoryTest : FunSpec({
                 it.opphav shouldBe ArenaMigrering.Opphav.ARENA
                 it.prisbetingelser shouldBe "Alt er dyrt"
             }
+        }
+
+        test("upsert genererer nye løpenummer") {
+            val avtaler = AvtaleRepository(database.db)
+
+            val avtale1Id = AvtaleFixtures.oppfolging.id
+            val avtale2Id = UUID.randomUUID()
+
+            avtaler.upsert(AvtaleFixtures.oppfolging)
+            avtaler.upsert(AvtaleFixtures.oppfolging.copy(id = avtale2Id))
+
+            val get = avtaler.get(avtale1Id)
+            val avtale1Lopenummer = get.shouldNotBeNull().lopenummer.shouldNotBeNull()
+            val avtale2Lopenummer = avtaler.get(avtale2Id).shouldNotBeNull().lopenummer.shouldNotBeNull()
+
+            avtale1Lopenummer.getParts().first shouldBe LocalDate.now().year
+            avtale2Lopenummer.getParts().first shouldBe LocalDate.now().year
+            avtale1Lopenummer.getParts().second shouldBeGreaterThanOrEqual 10_000
+            avtale1Lopenummer.getParts().second shouldBeLessThan avtale2Lopenummer.getParts().second
         }
 
         test("upsert setter opphav til MR_ADMIN_FLATE") {


### PR DESCRIPTION
Nytt løpenummer blir generert basert på en trigger som utleder året basert på `created_at` til rad som insertes. 
Denne triggeren blir installert på både avtaler og gjennomføringer, som vil si at vi fra nå av begynner å generere løpenummere på greier vi mottar fra arena, samt de vi oppretter i ny løsning. Siden det er samme rutine som utleder løpenummeret sikrer vi også at dette er unikt på tvers av både avtaler og gjennomføringer.
Løpenummeret fra Tiltaksadministrasjon blir foreløpig kun vist i frontend når opphav er admin-flate, og nytt løpenummer blir ikke vist for gjennomføringer siden Arena uansett vil fortsette å generere dette.