### PR TITLE
Refactor/oppstartstype

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/ArenaTiltaksgjennomforingDbo.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/domain/dbo/ArenaTiltaksgjennomforingDbo.kt
@@ -25,6 +25,5 @@ data class ArenaTiltaksgjennomforingDbo(
     val antallPlasser: Int?,
     @Serializable(with = UUIDSerializer::class)
     val avtaleId: UUID?,
-    val oppstart: TiltaksgjennomforingOppstartstype,
     val deltidsprosent: Double,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepository.kt
@@ -292,7 +292,12 @@ class TiltaksgjennomforingRepository(private val db: Database) {
                 :apent_for_innsok,
                 :antall_plasser,
                 :avtale_id,
-                :oppstart::tiltaksgjennomforing_oppstartstype,
+                (select case
+                     when arena_kode in ('GRUPPEAMO', 'JOBBK', 'GRUFAGYRKE') then 'FELLES'
+                     else 'LOPENDE'
+                     end::tiltaksgjennomforing_oppstartstype
+                 from tiltakstype
+                 where tiltakstype.id = :tiltakstype_id::uuid),
                 :opphav::opphav,
                 :deltidsprosent,
                 :avbrutt_tidspunkt,
@@ -715,7 +720,6 @@ class TiltaksgjennomforingRepository(private val db: Database) {
         "apent_for_innsok" to apentForInnsok,
         "antall_plasser" to antallPlasser,
         "avtale_id" to avtaleId,
-        "oppstart" to oppstart.name,
         "deltidsprosent" to deltidsprosent,
         "avbrutt_tidspunkt" to when (avslutningsstatus) {
             Avslutningsstatus.AVLYST -> startDato.atStartOfDay().minusDays(1)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterService.kt
@@ -220,7 +220,6 @@ class ArenaAdapterService(
                 sluttDato = current.sluttDato,
                 apentForInnsok = current.apentForInnsok,
                 antallPlasser = current.antallPlasser,
-                oppstart = current.oppstart,
                 deltidsprosent = current.deltidsprosent,
                 avslutningsstatus = current.status.toAvslutningsstatus(),
             )
@@ -256,9 +255,6 @@ class ArenaAdapterService(
             antallPlasser = current.antallPlasser,
             avtaleId = current.avtaleId,
             deltidsprosent = current.deltidsprosent,
-
-            // Oppstart kan endres utenfor Arena, dette feltet er derfor ikke med i duplikatsjekken
-            oppstart = arenaGjennomforing.oppstart,
         )
         return currentAsArenaGjennomforing == arenaGjennomforing
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
@@ -66,7 +66,7 @@ class AvtaleValidatorTest : FunSpec({
             TiltakstypeFixtures.VTA,
             TiltakstypeFixtures.Oppfolging,
             TiltakstypeFixtures.Jobbklubb,
-            TiltakstypeFixtures.GRUPPE_AMO,
+            TiltakstypeFixtures.GruppeAmo,
             TiltakstypeFixtures.Arbeidstrening,
             TiltakstypeFixtures.Avklaring,
         ),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -56,7 +56,7 @@ object AvtaleFixtures {
         id = UUID.randomUUID(),
         navn = "Gruppe Amo",
         avtalenummer = "2024#8",
-        tiltakstypeId = TiltakstypeFixtures.GRUPPE_AMO.id,
+        tiltakstypeId = TiltakstypeFixtures.GruppeAmo.id,
         arrangorId = ArrangorFixtures.hovedenhet.id,
         arrangorUnderenheter = listOf(ArrangorFixtures.underenhet1.id),
         arrangorKontaktpersoner = emptyList(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -19,7 +19,7 @@ object TiltaksgjennomforingFixtures {
         arrangorOrganisasjonsnummer = "976663934",
         startDato = LocalDate.of(2023, 1, 1),
         sluttDato = LocalDate.of(2023, 2, 1),
-        arenaAnsvarligEnhet = "2990",
+        arenaAnsvarligEnhet = NavEnhetFixtures.Innlandet.enhetsnummer,
         avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         apentForInnsok = true,
         antallPlasser = null,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltaksgjennomforingFixtures.kt
@@ -23,7 +23,6 @@ object TiltaksgjennomforingFixtures {
         avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
         apentForInnsok = true,
         antallPlasser = null,
-        oppstart = TiltaksgjennomforingOppstartstype.FELLES,
         avtaleId = AvtaleFixtures.oppfolging.id,
         deltidsprosent = 100.0,
     )
@@ -201,7 +200,7 @@ object TiltaksgjennomforingFixtures {
     val GruppeAmo1 = TiltaksgjennomforingDbo(
         id = UUID.randomUUID(),
         navn = "Gruppe Amo 1",
-        tiltakstypeId = TiltakstypeFixtures.GRUPPE_AMO.id,
+        tiltakstypeId = TiltakstypeFixtures.GruppeAmo.id,
         arrangorId = ArrangorFixtures.underenhet1.id,
         startDato = LocalDate.of(2023, 1, 1),
         sluttDato = LocalDate.of(2023, 2, 1),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltakstypeFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TiltakstypeFixtures.kt
@@ -11,7 +11,7 @@ object TiltakstypeFixtures {
         arenaKode = "ARBFORB",
         rettPaaTiltakspenger = true,
         startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2025, 12, 31),
+        sluttDato = null,
     )
 
     val VTA = TiltakstypeDbo(
@@ -20,16 +20,25 @@ object TiltakstypeFixtures {
         arenaKode = "VASV",
         rettPaaTiltakspenger = false,
         startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2025, 12, 31),
+        sluttDato = null,
     )
 
-    val GRUPPE_AMO = TiltakstypeDbo(
-        id = UUID.fromString("6fb945d6-0a87-4b8a-82a4-067477c1e113"),
+    val ArbeidsrettetRehabilitering = TiltakstypeDbo(
+        id = UUID.fromString("bc7128f9-3d5f-4190-a19a-ca392f17eb5c"),
+        navn = "Arbeidsrettet rehabilitering",
+        arenaKode = "ARBRRHDAG",
+        rettPaaTiltakspenger = false,
+        startDato = LocalDate.of(2023, 1, 1),
+        sluttDato = null,
+    )
+
+    val GruppeAmo = TiltakstypeDbo(
+        id = UUID.fromString("ca0cbc97-0306-4d7d-a368-10087e71c365"),
         navn = "Gruppe amo",
         arenaKode = "GRUPPEAMO",
         rettPaaTiltakspenger = false,
         startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2025, 12, 31),
+        sluttDato = null,
     )
 
     val Oppfolging = TiltakstypeDbo(
@@ -38,7 +47,7 @@ object TiltakstypeFixtures {
         arenaKode = "INDOPPFAG",
         rettPaaTiltakspenger = true,
         startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2025, 12, 31),
+        sluttDato = null,
     )
 
     val Jobbklubb = TiltakstypeDbo(
@@ -47,7 +56,16 @@ object TiltakstypeFixtures {
         arenaKode = "JOBBK",
         rettPaaTiltakspenger = true,
         startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2025, 12, 31),
+        sluttDato = null,
+    )
+
+    val DigitalOppfolging = TiltakstypeDbo(
+        id = UUID.fromString("54300eac-a537-418e-a28b-9fa984a8d36f"),
+        navn = "Digital oppfølging",
+        arenaKode = "DIGIOPPARB",
+        rettPaaTiltakspenger = true,
+        startDato = LocalDate.of(2023, 1, 1),
+        sluttDato = null,
     )
 
     val Avklaring = TiltakstypeDbo(
@@ -56,7 +74,16 @@ object TiltakstypeFixtures {
         arenaKode = "AVKLARAG",
         rettPaaTiltakspenger = true,
         startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2025, 12, 31),
+        sluttDato = null,
+    )
+
+    val GruppeFagOgYrkesopplaering = TiltakstypeDbo(
+        id = UUID.fromString("bcee8523-70e1-4253-9000-6a1430ef4326"),
+        navn = "Fag- og yrkesopplæring (Gruppe)",
+        arenaKode = "GRUFAGYRKE",
+        rettPaaTiltakspenger = true,
+        startDato = LocalDate.of(2023, 1, 11),
+        sluttDato = null,
     )
 
     val Arbeidstrening = TiltakstypeDbo(
@@ -65,7 +92,7 @@ object TiltakstypeFixtures {
         arenaKode = "ARBTREN",
         rettPaaTiltakspenger = true,
         startDato = LocalDate.of(2023, 1, 11),
-        sluttDato = LocalDate.of(2025, 12, 31),
+        sluttDato = null,
     )
 
     val EnkelAmo = TiltakstypeDbo(
@@ -74,6 +101,6 @@ object TiltakstypeFixtures {
         arenaKode = "ENKELAMO",
         rettPaaTiltakspenger = true,
         startDato = LocalDate.of(2023, 1, 11),
-        sluttDato = LocalDate.of(2025, 12, 31),
+        sluttDato = null,
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepositoryTest.kt
@@ -483,7 +483,7 @@ class AvtaleRepositoryTest : FunSpec({
         }
 
         test("Filtrer på avtaletyper returnerer riktige avtaler") {
-            TiltakstypeRepository(database.db).upsert(TiltakstypeFixtures.GRUPPE_AMO)
+            TiltakstypeRepository(database.db).upsert(TiltakstypeFixtures.GruppeAmo)
 
             val avtale1 = AvtaleFixtures.gruppeAmo.copy(
                 id = UUID.randomUUID(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/ArenaAdapterServiceTest.kt
@@ -207,7 +207,6 @@ class ArenaAdapterServiceTest : FunSpec({
             avslutningsstatus = Avslutningsstatus.IKKE_AVSLUTTET,
             apentForInnsok = true,
             antallPlasser = null,
-            oppstart = TiltaksgjennomforingOppstartstype.FELLES,
             avtaleId = null,
             deltidsprosent = 100.0,
         )
@@ -338,7 +337,6 @@ class ArenaAdapterServiceTest : FunSpec({
                     apentForInnsok = gjennomforing.apentForInnsok,
                     antallPlasser = gjennomforing.antallPlasser,
                     avtaleId = gjennomforing.avtaleId,
-                    oppstart = gjennomforing.oppstart,
                     deltidsprosent = gjennomforing.deltidsprosent,
                 ),
             )
@@ -414,7 +412,6 @@ class ArenaAdapterServiceTest : FunSpec({
                 avslutningsstatus = Avslutningsstatus.AVSLUTTET,
                 apentForInnsok = false,
                 antallPlasser = 100,
-                oppstart = TiltaksgjennomforingOppstartstype.FELLES,
                 avtaleId = null,
                 deltidsprosent = 1.0,
             )
@@ -480,7 +477,6 @@ class ArenaAdapterServiceTest : FunSpec({
                 avslutningsstatus = Avslutningsstatus.AVLYST,
                 apentForInnsok = false,
                 antallPlasser = 100,
-                oppstart = TiltaksgjennomforingOppstartstype.FELLES,
                 avtaleId = null,
                 deltidsprosent = 1.0,
             )
@@ -827,7 +823,7 @@ private fun toTiltaksgjennomforingDto(dbo: ArenaTiltaksgjennomforingDbo, tiltaks
         startDato = startDato,
         sluttDato = sluttDato,
         status = TiltaksgjennomforingStatus.GJENNOMFORES,
-        oppstart = oppstart,
+        oppstart = TiltaksgjennomforingOppstartstype.LOPENDE,
         virksomhetsnummer = arrangorOrganisasjonsnummer,
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tiltaksgjennomforinger/TiltaksgjennomforingValidatorTest.kt
@@ -91,7 +91,7 @@ class TiltaksgjennomforingValidatorTest : FunSpec({
             TiltakstypeFixtures.VTA,
             TiltakstypeFixtures.AFT,
             TiltakstypeFixtures.Jobbklubb,
-            TiltakstypeFixtures.GRUPPE_AMO,
+            TiltakstypeFixtures.GruppeAmo,
             TiltakstypeFixtures.Oppfolging,
         ),
         avtaler = listOf(

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessor.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/processors/TiltakgjennomforingEventProcessor.kt
@@ -23,11 +23,8 @@ import no.nav.mulighetsrommet.arena.adapter.services.ArenaEntityService
 import no.nav.mulighetsrommet.arena.adapter.utils.ArenaUtils
 import no.nav.mulighetsrommet.domain.Tiltakshistorikk
 import no.nav.mulighetsrommet.domain.Tiltakskoder.isGruppetiltak
-import no.nav.mulighetsrommet.domain.Tiltakskoder.isKursTiltak
 import no.nav.mulighetsrommet.domain.dbo.ArenaTiltaksgjennomforingDbo
 import no.nav.mulighetsrommet.domain.dbo.Avslutningsstatus
-import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype.FELLES
-import no.nav.mulighetsrommet.domain.dbo.TiltaksgjennomforingOppstartstype.LOPENDE
 import no.nav.mulighetsrommet.domain.dto.JaNeiStatus
 import java.util.*
 
@@ -204,7 +201,6 @@ class TiltakgjennomforingEventProcessor(
             apentForInnsok = apentForInnsok,
             antallPlasser = antallPlasser,
             avtaleId = avtaleId,
-            oppstart = if (isKursTiltak(tiltakskode)) FELLES else LOPENDE,
             deltidsprosent = deltidsprosent,
         )
 }


### PR DESCRIPTION
Flytter utledningen av oppstartstype fra arena-adapter til api slik at vi slipper å gjøre unntak i duplkatsjekken