### PR TITLE
test med parameter for jdbc url

### DIFF
--- a/common/database/src/main/kotlin/no/nav/mulighetsrommet/database/Database.kt
+++ b/common/database/src/main/kotlin/no/nav/mulighetsrommet/database/Database.kt
@@ -25,8 +25,6 @@ class Database(val config: DatabaseConfig) {
                 schema = config.schema
             }
             driverClassName = "org.postgresql.Driver"
-            username = config.user
-            password = config.password.value
             maximumPoolSize = config.maximumPoolSize
             healthCheckRegistry = HealthCheckRegistry()
 

--- a/common/database/src/main/kotlin/no/nav/mulighetsrommet/database/DatabaseConfig.kt
+++ b/common/database/src/main/kotlin/no/nav/mulighetsrommet/database/DatabaseConfig.kt
@@ -1,17 +1,15 @@
 package no.nav.mulighetsrommet.database
 
 data class DatabaseConfig(
-    val host: String,
-    val port: Int,
-    val name: String,
+    val jdbcUrl: String,
     val schema: String?,
-    val user: String,
-    val password: Password,
     val maximumPoolSize: Int,
     val googleCloudSqlInstance: String? = null,
 ) {
-    val jdbcUrl
-        get() = "jdbc:postgresql://$host:$port/$name"
+    init {
+        val postgresPrefix = "jdbc:postgresql://"
+        require(jdbcUrl.startsWith(postgresPrefix)) { "jdbcUrl must start with '$postgresPrefix'" }
+    }
 }
 
 @JvmInline

--- a/common/database/src/testFixtures/kotlin/no/nav/mulighetsrommet/database/kotest/extensions/DatabaseTestConfig.kt
+++ b/common/database/src/testFixtures/kotlin/no/nav/mulighetsrommet/database/kotest/extensions/DatabaseTestConfig.kt
@@ -16,13 +16,8 @@ fun createDatabaseTestSchema(
     val currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
     val schema = "$currentTime-${UUID.randomUUID()}"
     return DatabaseConfig(
-        host,
-        port,
-        name,
-        schema,
-        user,
-        password,
-        2,
-        null,
+        jdbcUrl = "jdbc:postgresql://$host:$port/$name?user=$user&password=${password.value}",
+        schema = schema,
+        maximumPoolSize = 2,
     )
 }

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: ${DB_HOST}
-    port: ${DB_PORT}
-    name: ${DB_DATABASE}
-    user: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    jdbcUrl: ${DB_JDBC_URL}
     maximumPoolSize: 10
   flyway:
     strategy: Migrate

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: localhost
-    port: 5442
-    name: mr-api
-    user: valp
-    password: valp
+    jdbcUrl: jdbc:postgresql://localhost:5442/mr-api?user=valp&password=valp
     maximumPoolSize: 10
   flyway:
     # Kjører repeatable migrasjoner hver gang applikasjon startes

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: ${DB_HOST}
-    port: ${DB_PORT}
-    name: ${DB_DATABASE}
-    user: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    jdbcUrl: ${DB_JDBC_URL}
     maximumPoolSize: 10
   flyway:
     strategy: Migrate

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-dev.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: ${DB_HOST}
-    port: ${DB_PORT}
-    name: ${DB_DATABASE}
-    user: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    jdbcUrl: ${DB_JDBC_URL}
     maximumPoolSize: 10
 
   services:

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-local.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: localhost
-    port: 5442
-    name: mr-arena-adapter
-    user: valp
-    password: valp
+    jdbcUrl: jdbc:postgresql://localhost:5442/mr-arena-adapter?user=valp&password=valp
     maximumPoolSize: 10
 
   services:

--- a/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-arena-adapter/src/main/resources/application-prod.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: ${DB_HOST}
-    port: ${DB_PORT}
-    name: ${DB_DATABASE}
-    user: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    jdbcUrl: ${DB_JDBC_URL}
     maximumPoolSize: 20
 
   services:

--- a/mulighetsrommet-tiltakshistorikk/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-tiltakshistorikk/src/main/resources/application-dev.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: ${DB_HOST}
-    port: ${DB_PORT}
-    name: ${DB_DATABASE}
-    user: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    jdbcUrl: ${DB_JDBC_URL}
     maximumPoolSize: 10
 
   auth:

--- a/mulighetsrommet-tiltakshistorikk/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-tiltakshistorikk/src/main/resources/application-local.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: localhost
-    port: 5442
-    name: mr-tiltakshistorikk
-    user: valp
-    password: valp
+    jdbcUrl: jdbc:postgresql://localhost:5442/mr-tiltakshistorikk?user=valp&password=valp
     maximumPoolSize: 10
 
   auth:

--- a/mulighetsrommet-tiltakshistorikk/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-tiltakshistorikk/src/main/resources/application-prod.yaml
@@ -4,11 +4,7 @@ server:
 
 app:
   database:
-    host: ${DB_HOST}
-    port: ${DB_PORT}
-    name: ${DB_DATABASE}
-    user: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    jdbcUrl: ${DB_JDBC_URL}
     maximumPoolSize: 20
 
   auth:


### PR DESCRIPTION
Nye sql-databaser har privat ip-adresse og krever noe ekstra certs. Den nye env-variabelenf for jdbc-url inkluderer dette by default. Denne pr'en legger like greit opp til å benytte denne miljøvariabelen over hele linja.

(Skal teste med en manuell deploy til dev før denne merges)