### PR TITLE
Kjører schedulert jobb hvert 15m man-fre

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/NotifyFailedKafkaEvents.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/NotifyFailedKafkaEvents.kt
@@ -3,8 +3,8 @@ package no.nav.mulighetsrommet.api.tasks
 import com.github.kagkarlsson.scheduler.task.helper.RecurringTask
 import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import com.github.kagkarlsson.scheduler.task.schedule.DisabledSchedule
-import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay
 import com.github.kagkarlsson.scheduler.task.schedule.Schedule
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules
 import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.kafka.KafkaConsumerRepositoryImpl
@@ -20,14 +20,14 @@ class NotifyFailedKafkaEvents(
 
     data class Config(
         val disabled: Boolean = false,
-        val delayOfMinutes: Int,
+        val cronPattern: String,
         val maxRetries: Int,
     ) {
         fun toSchedule(): Schedule {
             return if (disabled) {
                 DisabledSchedule()
             } else {
-                FixedDelay.ofMinutes(delayOfMinutes)
+                Schedules.cron(cronPattern)
             }
         }
     }

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -135,7 +135,7 @@ app:
       cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     notifyFailedKafkaEvents:
       maxRetries: 5
-      delayOfMinutes: 15
+      cronPattern: "0 */15 * ? * MON-FRI"
     generateValidationReport:
       bucketName: mulighetsrommet-api-uploads-dev
     updateApentForInnsok:

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -137,7 +137,7 @@ app:
     notifyFailedKafkaEvents:
       disabled: true
       maxRetries: 5
-      delayOfMinutes: 15
+      cronPattern: "0 */15 * ? * MON-FRI"
     updateApentForInnsok:
       disabled: true
       cronPattern: "0 */1 * * * *" # Hvert 1 minutt

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -127,7 +127,7 @@ app:
       cronPattern: "0 0 6 * * *" # Hver morgen kl. 06:00
     notifyFailedKafkaEvents:
       maxRetries: 5
-      delayOfMinutes: 15
+      cronPattern: "0 */15 * ? * MON-FRI"
     generateValidationReport:
       bucketName: mulighetsrommet-api-uploads-prod
     updateApentForInnsok:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -69,7 +69,7 @@ fun createTestApplicationConfig() = AppConfig(
         notifySluttdatoForAvtalerNarmerSeg = NotifySluttdatoForAvtalerNarmerSeg.Config(disabled = true),
         notifyFailedKafkaEvents = NotifyFailedKafkaEvents.Config(
             disabled = true,
-            delayOfMinutes = 15,
+            cronPattern = "",
             maxRetries = 5,
         ),
         updateApentForInnsok = UpdateApentForInnsok.Config(


### PR DESCRIPTION
Endrer jobben som sjekker feilede Kafka-events til å kjøre hvert 15. minutt (som før), men bare mandag til fredag, og ikke i helg.
