### PR TITLE
Ikke kast feil ved 404 fra Norg på geografisk område

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2Client.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/norg2/Norg2Client.kt
@@ -66,7 +66,6 @@ class Norg2Client(
             }
             HttpStatusCode.OK -> {
                 val enhet = response.body<Norg2EnhetDto>()
-                log.debug("Fant nav enhet: ${enhet.navn} $ for geografisk område: $geografiskOmraade")
                 enhet.right()
             }
             else -> {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/BrukerService.kt
@@ -173,11 +173,7 @@ class BrukerService(
             .map { navEnhetService.hentEnhet(it.enhetNr) }
             .getOrElse {
                 when (it) {
-                    NorgError.NotFound -> throw StatusException(
-                        HttpStatusCode.InternalServerError,
-                        "Fant ikke nav enhet til geografisk tilknytning.",
-                    )
-
+                    NorgError.NotFound -> null
                     NorgError.Error -> throw StatusException(
                         HttpStatusCode.InternalServerError,
                         "Fant ikke nav enhet til geografisk tilknytning.",


### PR DESCRIPTION
Dette kan skjer litt i dev f. eks. Og siden det ellers går greit når vi ikke finner brukers enhet (f. eks ved utenlandske brukere) tenker jeg vi kan gjøre det her også.