### PR TITLE
NUS-data til databasetabell

### DIFF
--- a/frontend/arena-adapter-manager/src/core/api.tsx
+++ b/frontend/arena-adapter-manager/src/core/api.tsx
@@ -110,7 +110,8 @@ export type MrApiTask =
   | "generate-validation-report"
   | "initial-load-tiltakstyper"
   | "initial-load-tiltaksgjennomforinger"
-  | "sync-navansatte";
+  | "sync-navansatte"
+  | "sync-nusdata";
 
 export const runTask = (base: ApiBase, task: MrApiTask, input?: object) =>
   fetch(`${base}/tasks/${task}`, {

--- a/frontend/arena-adapter-manager/src/pages/MrApiManagement.tsx
+++ b/frontend/arena-adapter-manager/src/pages/MrApiManagement.tsx
@@ -69,6 +69,22 @@ export function MrApiManagement() {
         <RunTask base={ApiBase.MR_API} task={"sync-navansatte"}>
           Synkroniserer NAV-ansatte fra relevante AD-grupper.
         </RunTask>
+        <RunTask
+          base={ApiBase.MR_API}
+          task={"sync-nusdata"}
+          input={{
+            type: "object",
+            description: "Synkroniserer NUS-data basert på valgt versjon",
+            properties: {
+              version: {
+                title: "Versjon",
+                type: "string",
+                enum: ["2437"],
+              },
+            },
+            required: ["version"],
+          }}
+        />
       </VStack>
     </Box>
   );

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -42,8 +42,8 @@ fun Application.configure(config: AppConfig) {
     FlywayMigrationManager(config.flyway).migrate(db)
 
     routing {
+        maamRoutes()
         authenticate(AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
-            maamRoutes()
         }
 
         authenticate(AuthProvider.AZURE_AD_NAV_IDENT.name, AuthProvider.AZURE_AD_TILTAKSADMINISTRASJON_GENERELL.name) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -42,8 +42,8 @@ fun Application.configure(config: AppConfig) {
     FlywayMigrationManager(config.flyway).migrate(db)
 
     routing {
-        maamRoutes()
         authenticate(AuthProvider.AZURE_AD_TEAM_MULIGHETSROMMET.name) {
+            maamRoutes()
         }
 
         authenticate(AuthProvider.AZURE_AD_NAV_IDENT.name, AuthProvider.AZURE_AD_TILTAKSADMINISTRASJON_GENERELL.name) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Config.kt
@@ -4,6 +4,7 @@ import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import no.nav.mulighetsrommet.api.clients.brreg.BrregClient
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
+import no.nav.mulighetsrommet.api.clients.ssb.SsbNusClient
 import no.nav.mulighetsrommet.api.domain.dbo.NavAnsattRolle
 import no.nav.mulighetsrommet.api.tasks.*
 import no.nav.mulighetsrommet.database.DatabaseConfig
@@ -45,6 +46,7 @@ data class AppConfig(
     val axsys: ServiceClientConfig,
     val pdl: ServiceClientConfig,
     val engine: HttpClientEngine = CIO.create(),
+    val ssbNusConfig: SsbNusClient.Config,
 )
 
 data class AuthConfig(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/ssb/SsbNusClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/ssb/SsbNusClient.kt
@@ -1,0 +1,72 @@
+package no.nav.mulighetsrommet.api.clients.ssb
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import no.nav.mulighetsrommet.ktor.clients.ClientResponseMetricPlugin
+import org.slf4j.LoggerFactory
+
+class SsbNusClient(engine: HttpClientEngine = CIO.create(), val config: Config) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Serializable
+    data class Input(
+        val version: String,
+    )
+
+    data class Config(
+        val baseUrl: String,
+    )
+
+    private val client: HttpClient = HttpClient(engine) {
+        expectSuccess = false
+        install(Logging) {
+            logger = Logger.DEFAULT
+            level = LogLevel.INFO
+        }
+
+        install(ClientResponseMetricPlugin)
+        install(HttpRequestRetry) {
+            retryOnException(maxRetries = 3, retryOnTimeout = true)
+            exponentialDelay()
+            modifyRequest {
+                response?.let {
+                    logger.warn("Request failed with response status=${it.status}")
+                }
+                logger.info("Retrying request method=${request.method.value}, url=${request.url.buildString()}")
+            }
+        }
+
+        install(HttpTimeout) {
+            requestTimeoutMillis = 5000
+        }
+
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                },
+            )
+        }
+
+        defaultRequest {
+            contentType(ContentType.Application.Json)
+        }
+    }
+
+    internal suspend fun fetchNusData(version: String): SsbNusData {
+        val response = client.get {
+            url("${config.baseUrl}/klass/v1/versions/$version")
+        }
+        return response.body()
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/ssb/SsbNusData.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/ssb/SsbNusData.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 data class SsbNusData(
     val validFrom: String,
     val classificationItems: List<ClassificationItem>,
-    val _links: Link,
 )
 
 @Serializable
@@ -17,13 +16,3 @@ data class ClassificationItem(
     val name: String,
     val shortName: String? = null,
 )
-
-@Serializable
-data class Link(
-    val self: Self,
-) {
-    @Serializable
-    class Self(
-        val href: String,
-    )
-}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/ssb/SsbNusData.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/ssb/SsbNusData.kt
@@ -1,0 +1,29 @@
+package no.nav.mulighetsrommet.api.clients.ssb
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SsbNusData(
+    val validFrom: String,
+    val classificationItems: List<ClassificationItem>,
+    val _links: Link,
+)
+
+@Serializable
+data class ClassificationItem(
+    val code: String,
+    val parentCode: String,
+    val level: String,
+    val name: String,
+    val shortName: String? = null,
+)
+
+@Serializable
+data class Link(
+    val self: Self,
+) {
+    @Serializable
+    class Self(
+        val href: String,
+    )
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NusKodeverkDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/NusKodeverkDbo.kt
@@ -1,0 +1,10 @@
+package no.nav.mulighetsrommet.api.domain.dbo
+
+data class NusKodeverkDbo(
+    val id: String,
+    val name: String,
+    val parent: String,
+    val level: String,
+    val version: String,
+    val selfLink: String,
+)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -173,6 +173,7 @@ private fun repositories() = module {
     single { ArrangorRepository(get()) }
     single { KafkaConsumerRepositoryImpl(get()) }
     single { VeilederJoyrideRepository(get()) }
+    single { SsbNusRepository(get()) }
 }
 
 private fun services(appConfig: AppConfig) = module {
@@ -341,6 +342,7 @@ private fun services(appConfig: AppConfig) = module {
     single { AvtaleValidator(get(), get(), get(), get()) }
     single { TiltaksgjennomforingValidator(get(), get(), get()) }
     single { SsbNusClient(engine = appConfig.engine, config = appConfig.ssbNusConfig) }
+    single { SsbNusService(get(), get()) }
 }
 
 private fun tasks(config: TaskConfig) = module {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -26,6 +26,7 @@ import no.nav.mulighetsrommet.api.clients.norg2.Norg2Client
 import no.nav.mulighetsrommet.api.clients.oppfolging.VeilarboppfolgingClient
 import no.nav.mulighetsrommet.api.clients.pdl.PdlClient
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
+import no.nav.mulighetsrommet.api.clients.ssb.SsbNusClient
 import no.nav.mulighetsrommet.api.clients.vedtak.VeilarbvedtaksstotteClient
 import no.nav.mulighetsrommet.api.repositories.*
 import no.nav.mulighetsrommet.api.services.*
@@ -339,6 +340,7 @@ private fun services(appConfig: AppConfig) = module {
     }
     single { AvtaleValidator(get(), get(), get(), get()) }
     single { TiltaksgjennomforingValidator(get(), get(), get()) }
+    single { SsbNusClient(engine = appConfig.engine, config = appConfig.ssbNusConfig) }
 }
 
 private fun tasks(config: TaskConfig) = module {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepository.kt
@@ -1,0 +1,42 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.clients.ssb.ClassificationItem
+import no.nav.mulighetsrommet.api.clients.ssb.SsbNusData
+import no.nav.mulighetsrommet.database.Database
+import org.intellij.lang.annotations.Language
+
+class SsbNusRepository(private val db: Database) {
+    fun saveData(data: SsbNusData, version: String) {
+        @Language("PostgreSQL")
+        val query = """
+        insert into nus_kodeverk(id, name, parent, level, version, self_link)
+        values(:id, :name, :parent, :level, :version, :selfLink)
+        on conflict (id, version) do update set
+            name = excluded.name,
+            parent = excluded.parent,
+            level = excluded.level,
+            self_link = excluded.self_link
+        """.trimIndent()
+
+        db.transaction { tx ->
+            data.classificationItems.forEach { classificationItem ->
+                tx.run(
+                    queryOf(
+                        query,
+                        classificationItem.toSqlParams() + mapOf("version" to version, "selfLink" to data._links.self.href),
+                    ).asExecute,
+                )
+            }
+        }
+    }
+}
+
+private fun ClassificationItem.toSqlParams(): Map<String, String> {
+    return mapOf(
+        "id" to code,
+        "name" to name,
+        "parent" to parentCode,
+        "level" to level,
+    )
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepository.kt
@@ -10,13 +10,12 @@ class SsbNusRepository(private val db: Database) {
     fun upsert(data: SsbNusData, version: String) {
         @Language("PostgreSQL")
         val query = """
-        insert into nus_kodeverk(id, name, parent, level, version, self_link)
-        values(:id, :name, :parent, :level, :version, :selfLink)
-        on conflict (id, version) do update set
+        insert into nus_kodeverk(code, name, parent, level, version)
+        values(:code, :name, :parent, :level, :version)
+        on conflict (code, version) do update set
             name = excluded.name,
             parent = excluded.parent,
-            level = excluded.level,
-            self_link = excluded.self_link
+            level = excluded.level
         """.trimIndent()
 
         db.transaction { tx ->
@@ -24,7 +23,7 @@ class SsbNusRepository(private val db: Database) {
                 tx.run(
                     queryOf(
                         query,
-                        classificationItem.toSqlParams() + mapOf("version" to version, "selfLink" to data._links.self.href),
+                        classificationItem.toSqlParams() + mapOf("version" to version),
                     ).asExecute,
                 )
             }
@@ -34,7 +33,7 @@ class SsbNusRepository(private val db: Database) {
 
 private fun ClassificationItem.toSqlParams(): Map<String, String> {
     return mapOf(
-        "id" to code,
+        "code" to code,
         "name" to name,
         "parent" to parentCode,
         "level" to level,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepository.kt
@@ -7,7 +7,7 @@ import no.nav.mulighetsrommet.database.Database
 import org.intellij.lang.annotations.Language
 
 class SsbNusRepository(private val db: Database) {
-    fun saveData(data: SsbNusData, version: String) {
+    fun upsert(data: SsbNusData, version: String) {
         @Language("PostgreSQL")
         val query = """
         insert into nus_kodeverk(id, name, parent, level, version, self_link)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/MaamRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/MaamRoutes.kt
@@ -7,6 +7,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.clients.ssb.SsbNusClient
+import no.nav.mulighetsrommet.api.services.SsbNusService
 import no.nav.mulighetsrommet.api.tasks.GenerateValidationReport
 import no.nav.mulighetsrommet.api.tasks.InitialLoadTiltaksgjennomforinger
 import no.nav.mulighetsrommet.api.tasks.InitialLoadTiltakstyper
@@ -24,7 +25,7 @@ fun Route.maamRoutes() {
             val initialLoadTiltaksgjennomforinger: InitialLoadTiltaksgjennomforinger by inject()
             val initialLoadTiltakstyper: InitialLoadTiltakstyper by inject()
             val synchronizeNavAnsatte: SynchronizeNavAnsatte by inject()
-            val ssbNusClient: SsbNusClient by inject()
+            val ssbNusService: SsbNusService by inject()
 
             post("generate-validation-report") {
                 val taskId = generateValidationReport.schedule()
@@ -52,8 +53,7 @@ fun Route.maamRoutes() {
 
             post("sync-nusdata") {
                 val input = call.receive<SsbNusClient.Input>()
-                val nusData = ssbNusClient.fetchNusData(input.version)
-                // Upsert to db table
+                ssbNusService.syncData(version = input.version)
                 call.respond(HttpStatusCode.Accepted, GeneralTaskResponse(id = "NUS data synced for version ${input.version}"))
             }
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/MaamRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/MaamRoutes.kt
@@ -6,6 +6,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.api.clients.ssb.SsbNusClient
 import no.nav.mulighetsrommet.api.tasks.GenerateValidationReport
 import no.nav.mulighetsrommet.api.tasks.InitialLoadTiltaksgjennomforinger
 import no.nav.mulighetsrommet.api.tasks.InitialLoadTiltakstyper
@@ -23,6 +24,7 @@ fun Route.maamRoutes() {
             val initialLoadTiltaksgjennomforinger: InitialLoadTiltaksgjennomforinger by inject()
             val initialLoadTiltakstyper: InitialLoadTiltakstyper by inject()
             val synchronizeNavAnsatte: SynchronizeNavAnsatte by inject()
+            val ssbNusClient: SsbNusClient by inject()
 
             post("generate-validation-report") {
                 val taskId = generateValidationReport.schedule()
@@ -47,6 +49,13 @@ fun Route.maamRoutes() {
                 val taskId = synchronizeNavAnsatte.schedule()
                 call.respond(HttpStatusCode.Accepted, ScheduleTaskResponse(id = taskId))
             }
+
+            post("sync-nusdata") {
+                val input = call.receive<SsbNusClient.Input>()
+                val nusData = ssbNusClient.fetchNusData(input.version)
+                // Upsert to db table
+                call.respond(HttpStatusCode.Accepted, GeneralTaskResponse(id = "NUS data synced for version ${input.version}"))
+            }
         }
 
         route("/topics") {
@@ -70,4 +79,9 @@ fun Route.maamRoutes() {
 data class ScheduleTaskResponse(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
+)
+
+@Serializable
+data class GeneralTaskResponse(
+    val id: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SsbNusService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SsbNusService.kt
@@ -6,6 +6,6 @@ import no.nav.mulighetsrommet.api.repositories.SsbNusRepository
 class SsbNusService(val client: SsbNusClient, private val ssbNusRepository: SsbNusRepository) {
     suspend fun syncData(version: String) {
         val data = client.fetchNusData(version)
-        ssbNusRepository.saveData(data, version)
+        ssbNusRepository.upsert(data, version)
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SsbNusService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/SsbNusService.kt
@@ -1,0 +1,11 @@
+package no.nav.mulighetsrommet.api.services
+
+import no.nav.mulighetsrommet.api.clients.ssb.SsbNusClient
+import no.nav.mulighetsrommet.api.repositories.SsbNusRepository
+
+class SsbNusService(val client: SsbNusClient, private val ssbNusRepository: SsbNusRepository) {
+    suspend fun syncData(version: String) {
+        val data = client.fetchNusData(version)
+        ssbNusRepository.saveData(data, version)
+    }
+}

--- a/mulighetsrommet-api/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-dev.yaml
@@ -155,3 +155,6 @@ app:
     token: ${UNLEASH_SERVER_API_TOKEN}
     instanceId: ${NAIS_CLIENT_ID}
     environment: development
+
+  ssbNusConfig:
+    baseUrl: "https://data.ssb.no/api"

--- a/mulighetsrommet-api/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-local.yaml
@@ -156,3 +156,6 @@ app:
     token: ${UNLEASH_SERVER_API_TOKEN:-}
     instanceId: mulighetsrommet-api
     environment: development
+
+  ssbNusConfig:
+    baseUrl: "https://data.ssb.no/api"

--- a/mulighetsrommet-api/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-api/src/main/resources/application-prod.yaml
@@ -147,3 +147,6 @@ app:
     token: ${UNLEASH_SERVER_API_TOKEN}
     instanceId: ${NAIS_CLIENT_ID}
     environment: production
+
+  ssbNusConfig:
+    baseUrl: "https://data.ssb.no/api"

--- a/mulighetsrommet-api/src/main/resources/db/migration/V148__create_table_nus_kodeverk.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V148__create_table_nus_kodeverk.sql
@@ -1,0 +1,10 @@
+create table nus_kodeverk(
+    id text not null,
+    name text not null,
+    parent text not null,
+    level text not null,
+    version text not null,
+    self_link text not null,
+    primary key (id, version)
+);
+

--- a/mulighetsrommet-api/src/main/resources/db/migration/V148__create_table_nus_kodeverk.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V148__create_table_nus_kodeverk.sql
@@ -1,10 +1,9 @@
 create table nus_kodeverk(
-    id text not null,
+    code text not null,
     name text not null,
     parent text not null,
     level text not null,
     version text not null,
-    self_link text not null,
-    primary key (id, version)
+    primary key (code, version)
 );
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -4,6 +4,7 @@ import io.ktor.server.application.*
 import io.ktor.server.testing.*
 import no.nav.mulighetsrommet.api.clients.brreg.BrregClient
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
+import no.nav.mulighetsrommet.api.clients.ssb.SsbNusClient
 import no.nav.mulighetsrommet.api.tasks.*
 import no.nav.mulighetsrommet.database.DatabaseConfig
 import no.nav.mulighetsrommet.database.FlywayMigrationManager
@@ -93,6 +94,10 @@ fun createTestApplicationConfig() = AppConfig(
     axsys = ServiceClientConfig(url = "", scope = ""),
     pdl = ServiceClientConfig(url = "", scope = ""),
     migrerteTiltak = emptyList(),
+    ssbNusConfig = SsbNusClient.Config(
+        baseUrl = "",
+
+    ),
 )
 
 fun createKafkaConfig(): KafkaConfig {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestConfig.kt
@@ -96,7 +96,6 @@ fun createTestApplicationConfig() = AppConfig(
     migrerteTiltak = emptyList(),
     ssbNusConfig = SsbNusClient.Config(
         baseUrl = "",
-
     ),
 )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepositoryTest.kt
@@ -1,0 +1,27 @@
+package no.nav.mulighetsrommet.api.repositories
+
+import io.kotest.core.spec.style.FunSpec
+import no.nav.mulighetsrommet.api.clients.ssb.ClassificationItem
+import no.nav.mulighetsrommet.api.clients.ssb.Link
+import no.nav.mulighetsrommet.api.clients.ssb.SsbNusData
+import no.nav.mulighetsrommet.api.createDatabaseTestConfig
+import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
+
+class SsbNusRepositoryTest : FunSpec({
+    val database = extension(FlywayDatabaseTestListener(createDatabaseTestConfig()))
+
+    test("CRUD") {
+        val ssbNusRepository = SsbNusRepository(database.db)
+        val ssbData = SsbNusData(
+            classificationItems = listOf(
+                ClassificationItem("1", "1", "1", "Høyere utdanning"),
+                ClassificationItem("2", "2", "2", "Barnehage"),
+                ClassificationItem("3", "3", "3", "Grunnskole"),
+            ),
+            _links = Link(Link.Self("selfLink")),
+            validFrom = "20240425",
+        )
+
+        ssbNusRepository.upsert(ssbData, "1")
+    }
+})

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/SsbNusRepositoryTest.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.api.repositories
 
 import io.kotest.core.spec.style.FunSpec
 import no.nav.mulighetsrommet.api.clients.ssb.ClassificationItem
-import no.nav.mulighetsrommet.api.clients.ssb.Link
 import no.nav.mulighetsrommet.api.clients.ssb.SsbNusData
 import no.nav.mulighetsrommet.api.createDatabaseTestConfig
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
@@ -18,7 +17,6 @@ class SsbNusRepositoryTest : FunSpec({
                 ClassificationItem("2", "2", "2", "Barnehage"),
                 ClassificationItem("3", "3", "3", "Grunnskole"),
             ),
-            _links = Link(Link.Self("selfLink")),
             validFrom = "20240425",
         )
 


### PR DESCRIPTION
Jeg har opprettet en ny task i MAAM der man spesifiserer NUS-versjon og så synkroniserer vi NUS-data fra SSB til ny tabell i databasen.

![image](https://github.com/navikt/mulighetsrommet/assets/9053627/ad08b2bf-0d93-4f9a-86ed-f802963ac936)

Tanken på sikt er så å koble tiltakstype til nus_kodeverk-tabellen slik at vi kan hente ut valgte nus_koder til frontend og la bruker velge på avtale og gjennomføringsnivå hvilke kategorier som skal med. Alt det kommer i senere PRs.