### PR TITLE
Feedback queryparam

### DIFF
--- a/frontend/mulighetsrommet-veileder-flate/src/apps/modia/views/Landingsside.tsx
+++ b/frontend/mulighetsrommet-veileder-flate/src/apps/modia/views/Landingsside.tsx
@@ -1,9 +1,9 @@
 import { useHistorikkV2 } from "@/api/queries/useHistorikkV2";
 import { InformationSquareFillIcon, PlusIcon } from "@navikt/aksel-icons";
 import { Alert, BodyShort, Heading, Skeleton, VStack } from "@navikt/ds-react";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { DeltakelseKort } from "../historikk/DeltakelseKort";
 import styles from "./Landingsside.module.scss";
 
@@ -22,7 +22,7 @@ function Feilmelding({ message }: { message: string }) {
 export function Landingsside() {
   return (
     <main className="mulighetsrommet-veileder-flate">
-      <VStack gap="10" className={styles.container}>
+      <VStack gap="5" className={styles.container}>
         <ErrorBoundary
           FallbackComponent={() =>
             Feilmelding({
@@ -32,6 +32,7 @@ export function Landingsside() {
           }
         >
           <Suspense fallback={<SkeletonLoader />}>
+            <FeedbackFraUrl />
             <Utkast />
           </Suspense>
         </ErrorBoundary>
@@ -110,5 +111,40 @@ function Utkast() {
         );
       })}
     </VStack>
+  );
+}
+
+function FeedbackFraUrl() {
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const successFeedbackHeading = queryParams.get("success_feedback_heading");
+  const successFeedbackBody = queryParams.get("success_feedback_body");
+  const [show, setShow] = useState(true);
+
+  function onClose() {
+    const searchParams = new URLSearchParams(location.search);
+    searchParams.delete("success_feedback_heading");
+    searchParams.delete("success_feedback_body");
+    window.history.replaceState(null, "", `${location.pathname}?${searchParams}`);
+    setShow(false);
+  }
+
+  if (!successFeedbackBody) {
+    return null;
+  }
+
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <Alert size="small" closeButton variant="success" onClose={onClose}>
+      {successFeedbackHeading ? (
+        <Heading size="small" spacing>
+          {decodeURIComponent(successFeedbackHeading)}
+        </Heading>
+      ) : null}
+      {decodeURIComponent(successFeedbackBody)}
+    </Alert>
   );
 }

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
@@ -2,7 +2,7 @@ import { Features } from "@/api/feature-toggles";
 
 export const mockFeatures: Features = {
   "mulighetsrommet.veilederflate.visDeltakerRegistrering": true,
-  "mulighetsrommet-veilederflate-landingsside": true,
+  "mulighetsrommet-veilederflate-landingsside": false,
   "mulighetsrommet-veilederflate-arena-oppskrifter": true,
   "mulighetsrommet.admin-flate.enableDebugger": false,
   "mulighetsrommet.admin-flate.tilgjengeliggjore-tiltak-for-arrangor": false,

--- a/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
+++ b/frontend/mulighetsrommet-veileder-flate/src/mock/api/features.ts
@@ -2,7 +2,7 @@ import { Features } from "@/api/feature-toggles";
 
 export const mockFeatures: Features = {
   "mulighetsrommet.veilederflate.visDeltakerRegistrering": true,
-  "mulighetsrommet-veilederflate-landingsside": false,
+  "mulighetsrommet-veilederflate-landingsside": true,
   "mulighetsrommet-veilederflate-arena-oppskrifter": true,
   "mulighetsrommet.admin-flate.enableDebugger": false,
   "mulighetsrommet.admin-flate.tilgjengeliggjore-tiltak-for-arrangor": false,


### PR DESCRIPTION
Feedback på "landingsside" når Komet navigerer veileder tilbake til start
Jeg legger på støtte for å sende med to query-params i url når dere navigerer veileder tilbake til forsiden/landingssiden.

Query-paramene er:
- success_feedback_heading  - Denne er optional, men rendrer heading hvis den eksisterer
- success_feedback_body   - Denne må være med, ellers rendres ingen melding

Når veileder trykker på X for å lukke så forsvinner meldingen fra url og refresh av siden etter det vil ikke vise feedbacken. Url'en blir også fjernet fra navigasjonshistorikken slik at om veileder trykker tilbake i nettleseren så vil de ikke se feedbacken da heller.

Her er eksempel-url fra lokal kjøring: http://127.0.0.1:3000/arbeidsmarkedstiltak?success_feedback_heading=Hei%20jeg%20er%20en%20heading&success_feedback_body=Hei%20jeg%20er%20innhold
<img width="1593" alt="image" src="https://github.com/navikt/mulighetsrommet/assets/9053627/aa90825d-25b1-4871-8d17-59fff9f97e18">
