### PR TITLE
Støtte filtrering på publisert/ikke publisert

### DIFF
--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -155,6 +155,7 @@ const tiltaksgjennomforingFilterSchema = z.object({
   avtale: z.string(),
   arrangorer: z.string().array(),
   visMineGjennomforinger: z.boolean(),
+  publisert: z.string().array(),
   page: z.number(),
   pageSize: z.number(),
 });
@@ -168,6 +169,7 @@ export const defaultTiltaksgjennomforingfilter: TiltaksgjennomforingFilter = {
   sortering: SorteringTiltaksgjennomforinger.NAVN_ASCENDING,
   avtale: "",
   arrangorer: [],
+  publisert: [],
   visMineGjennomforinger: false,
   page: 1,
   pageSize: PAGE_SIZE,

--- a/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger.ts
+++ b/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger.ts
@@ -4,6 +4,16 @@ import { QueryKeys } from "@/api/QueryKeys";
 import { TiltaksgjennomforingFilter } from "../atoms";
 import { mulighetsrommetClient } from "@/api/client";
 
+function getPublisertStatus(statuser: string[] = []): boolean | null {
+  if (statuser.length === 0) return null;
+
+  if (statuser.every((status) => status === "publisert")) return true;
+
+  if (statuser.every((status) => status === "ikke-publisert")) return false;
+
+  return null;
+}
+
 export function useAdminTiltaksgjennomforinger(filter: Partial<TiltaksgjennomforingFilter>) {
   const debouncedSok = useDebounce(filter.search?.trim(), 300);
 
@@ -16,6 +26,7 @@ export function useAdminTiltaksgjennomforinger(filter: Partial<Tiltaksgjennomfor
     page: filter.page ?? 1,
     size: filter.pageSize,
     avtaleId: filter.avtale ? filter.avtale : undefined,
+    publisert: getPublisertStatus(filter.publisert),
     arrangorer: filter.arrangorer,
   };
 

--- a/frontend/mr-admin-flate/src/components/filter/TiltaksgjennomforingFilter.tsx
+++ b/frontend/mr-admin-flate/src/components/filter/TiltaksgjennomforingFilter.tsx
@@ -205,6 +205,34 @@ export function TiltaksgjennomforingFilter({ filterAtom, skjulFilter }: Props) {
             />
           </Accordion.Content>
         </Accordion.Item>
+        <Accordion.Item open={accordionsOpen.includes("publiserteStatuser")}>
+          <Accordion.Header
+            onClick={() => {
+              setAccordionsOpen([...addOrRemove(accordionsOpen, "publiserteStatuser")]);
+            }}
+          >
+            <FilterAccordionHeader
+              tittel="Publisert"
+              antallValgteFilter={filter.publisert.length}
+            />
+          </Accordion.Header>
+          <Accordion.Content>
+            <CheckboxList
+              items={[
+                { value: "publisert", label: "Publisert" },
+                { value: "ikke-publisert", label: "Ikke publisert" },
+              ]}
+              isChecked={(id) => filter.publisert.includes(id)}
+              onChange={(id) => {
+                setFilter({
+                  ...filter,
+                  page: 1,
+                  publisert: addOrRemove(filter.publisert, id),
+                });
+              }}
+            />
+          </Accordion.Content>
+        </Accordion.Item>
       </Accordion>
     </>
   );

--- a/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -218,7 +218,7 @@ export function TiltaksgjennomforingsTabell({
                       </SkjulKolonne>
                       <Table.DataCell>
                         <VStack align={"center"}>
-                          {tiltaksgjennomforing.publisertForAlle ? (
+                          {tiltaksgjennomforing.publisert ? (
                             <Tag
                               aria-label="Tiltaket er publisert for alle"
                               title="Tiltaket er publisert for alle"

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_tiltaksgjennomforinger.ts
@@ -48,7 +48,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     stedForGjennomforing: "Brummundal",
     kontaktpersoner: [petrusKontaktperson, nikolineKontaktperson],
     publisert: true,
-    publisertForAlle: true,
+
     beskrivelse: "bla bla bla beskrivelse",
     faneinnhold: {
       forHvem: [
@@ -115,7 +115,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     apentForInnsok: true,
     kontaktpersoner: [],
     publisert: false,
-    publisertForAlle: false,
+
     tilgjengeligForArrangorFraOgMedDato: null,
     nusData: null,
   },
@@ -147,7 +147,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     apentForInnsok: true,
     kontaktpersoner: [],
     publisert: false,
-    publisertForAlle: true,
+
     tilgjengeligForArrangorFraOgMedDato: null,
     nusData: null,
   },
@@ -174,7 +174,7 @@ export const mockTiltaksgjennomforinger: Tiltaksgjennomforing[] = [
     apentForInnsok: true,
     kontaktpersoner: [],
     publisert: false,
-    publisertForAlle: true,
+
     tilgjengeligForArrangorFraOgMedDato: null,
     nusData: null,
   },
@@ -216,7 +216,7 @@ for (let i = 0; i < x; i++) {
     apentForInnsok: true,
     kontaktpersoner: [],
     publisert: false,
-    publisertForAlle: true,
+
     tilgjengeligForArrangorFraOgMedDato: null,
     nusData: null,
   });

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltaksgjennomforingAdminDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/TiltaksgjennomforingAdminDto.kt
@@ -54,7 +54,6 @@ data class TiltaksgjennomforingAdminDto(
     @Serializable(with = LocalDateTimeSerializer::class)
     val createdAt: LocalDateTime,
     val publisert: Boolean,
-    val publisertForAlle: Boolean,
     val deltidsprosent: Double,
     val estimertVentetid: EstimertVentetid?,
     val personvernBekreftet: Boolean,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/TiltaksgjennomforingRoutes.kt
@@ -163,6 +163,7 @@ data class AdminTiltaksgjennomforingFilter(
     val avtaleId: UUID? = null,
     val arrangorIds: List<UUID> = emptyList(),
     val administratorNavIdent: NavIdent? = null,
+    val publisert: Boolean? = null,
 )
 
 fun <T : Any> PipelineContext<T, ApplicationCall>.getAdminTiltaksgjennomforingsFilter(): AdminTiltaksgjennomforingFilter {
@@ -175,6 +176,7 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getAdminTiltaksgjennomforingsF
     val sortering = call.request.queryParameters["sort"]
     val avtaleId = call.request.queryParameters["avtaleId"]?.let { if (it.isEmpty()) null else UUID.fromString(it) }
     val arrangorIds = call.parameters.getAll("arrangorer")?.map { UUID.fromString(it) } ?: emptyList()
+    val publisert = call.request.queryParameters["publisert"]?.let { it.toBoolean() }
 
     return AdminTiltaksgjennomforingFilter(
         search = search,
@@ -185,6 +187,7 @@ fun <T : Any> PipelineContext<T, ApplicationCall>.getAdminTiltaksgjennomforingsF
         avtaleId = avtaleId,
         arrangorIds = arrangorIds,
         administratorNavIdent = null,
+        publisert = publisert,
     )
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/TiltaksgjennomforingService.kt
@@ -90,6 +90,7 @@ class TiltaksgjennomforingService(
         avtaleId = filter.avtaleId,
         arrangorIds = filter.arrangorIds,
         administratorNavIdent = filter.administratorNavIdent,
+        publisert = filter.publisert,
         /**
          * Hardkodet filter så man kun viser relevante gjennomføringer i Tiltaksadmin
          */

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/UpdateTiltaksgjennomforingStatus.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/UpdateTiltaksgjennomforingStatus.kt
@@ -51,6 +51,7 @@ class UpdateTiltaksgjennomforingStatus(
             tiltaksgjennomforinger.forEach { id ->
                 val gjennomforing = requireNotNull(tiltaksgjennomforingRepository.get(id))
                 tiltaksgjennomforingKafkaProducer.publish(TiltaksgjennomforingDto.from(gjennomforing))
+                tiltaksgjennomforingRepository.setPublisert(gjennomforing.id, false)
             }
 
             tiltaksgjennomforinger

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tiltaksgjennomforing_admin_view.sql
@@ -21,8 +21,6 @@ select gjennomforing.id,
        gjennomforing.estimert_ventetid_enhet,
        gjennomforing.sted_for_gjennomforing,
        gjennomforing.publisert,
-       gjennomforing.publisert and gjennomforing.avbrutt_tidspunkt is null
-                                           as publisert_for_alle,
        gjennomforing.nav_region            as nav_region_enhetsnummer,
        nav_region.navn                     as nav_region_navn,
        nav_region.type                     as nav_region_type,

--- a/mulighetsrommet-api/src/main/resources/db/migration/V154__update_publisert_for_tiltaksgjennomforinger.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V154__update_publisert_for_tiltaksgjennomforinger.sql
@@ -1,0 +1,4 @@
+update tiltaksgjennomforing
+set publisert = false
+where avbrutt_tidspunkt is not null
+   or (slutt_dato is not null and slutt_dato < now());

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -406,6 +406,11 @@ paths:
               type: string
               format: uuid
         - in: query
+          name: publisert
+          schema:
+            type: boolean
+            nullable: true
+        - in: query
           name: size
           schema:
             type: number
@@ -2171,8 +2176,6 @@ components:
           type: string
         publisert:
           type: boolean
-        publisertForAlle:
-          type: boolean
         deltidsprosent:
           type: number
         estimertVentetid:
@@ -2214,7 +2217,6 @@ components:
         - opphav
         - kontaktpersoner
         - publisert
-        - publisertForAlle
         - deltidsprosent
         - tilgjengeligForArrangorFraOgMedDato
         - nusData

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/repositories/TiltaksgjennomforingRepositoryTest.kt
@@ -495,15 +495,15 @@ class TiltaksgjennomforingRepositoryTest : FunSpec({
             val gjennomforing = Oppfolging1.copy(id = UUID.randomUUID())
             tiltaksgjennomforinger.upsert(gjennomforing)
             tiltaksgjennomforinger.setPublisert(gjennomforing.id, true)
-            tiltaksgjennomforinger.get(gjennomforing.id)?.publisertForAlle shouldBe true
+            tiltaksgjennomforinger.get(gjennomforing.id)?.publisert shouldBe true
 
             tiltaksgjennomforinger.setPublisert(gjennomforing.id, false)
-            tiltaksgjennomforinger.get(gjennomforing.id)?.publisertForAlle shouldBe false
+            tiltaksgjennomforinger.get(gjennomforing.id)?.publisert shouldBe false
 
             tiltaksgjennomforinger.setPublisert(gjennomforing.id, true)
             tiltaksgjennomforinger.avbryt(gjennomforing.id, LocalDateTime.now(), AvbruttAarsak.Feilregistrering)
 
-            tiltaksgjennomforinger.get(gjennomforing.id)?.publisertForAlle shouldBe false
+            tiltaksgjennomforinger.get(gjennomforing.id)?.publisert shouldBe false
         }
 
         test("faneinnhold") {


### PR DESCRIPTION
Legger til støtte for filtrering av publiserte/ikke publiserte gjennomføringer.
Fjerner også publisert_for_alle-feltet og oppdaterer heller publisert-kolonnen når vi avslutter og avbryter tiltak.
