### PR TITLE
Flytt validering av avtale lengde til backend

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaDetaljer.tsx
@@ -81,7 +81,7 @@ export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: 
 
   const { startDato } = watch("startOgSluttDato") ?? {};
   const sluttDatoFraDato = startDato ? new Date(startDato) : minStartdato;
-  const sluttDatoTilDato = addYear(startDato ? new Date(startDato) : new Date(), 5);
+  const sluttDatoTilDato = addYear(startDato ? new Date(startDato) : new Date(), 20);
 
   return (
     <div className={skjemastyles.container}>
@@ -204,9 +204,7 @@ export function AvtaleSkjemaDetaljer({ tiltakstyper, ansatt, enheter, avtale }: 
                 toDate={sluttDatoTilDato}
                 {...register("startOgSluttDato.sluttDato")}
                 format={"iso-string"}
-                invalidDatoEtterPeriode={
-                  "Avtaleperioden kan ikke vare lenger enn 5 år for anskaffede tiltak"
-                }
+                invalidDatoEtterPeriode={"Avtaleperioden kan ikke vare lenger enn 20 år"}
               />
             </HGrid>
           </FormGroup>

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
@@ -52,8 +52,15 @@ class AvtaleValidator(
                 add(ValidationError.of(AvtaleDbo::administratorer, "Du må velge minst én administrator"))
             }
 
-            if (avtale.sluttDato != null && avtale.sluttDato.isBefore(avtale.startDato)) {
-                add(ValidationError.of(AvtaleDbo::startDato, "Startdato må være før sluttdato"))
+            if (avtale.sluttDato != null) {
+                if (avtale.sluttDato.isBefore(avtale.startDato)) {
+                    add(ValidationError.of(AvtaleDbo::startDato, "Startdato må være før sluttdato"))
+                }
+                if (!listOf(Tiltakskode.ARBEIDSFORBEREDENDE_TRENING, Tiltakskode.VARIG_TILRETTELAGT_ARBEID_SKJERMET).contains(Tiltakskode.fromArenaKode(tiltakstype.arenaKode)) &&
+                    avtale.startDato.plusYears(5).isBefore(avtale.sluttDato)
+                ) {
+                    add(ValidationError.of(AvtaleDbo::sluttDato, "Avtaleperioden kan ikke vare lenger enn 5 år for anskaffede tiltak"))
+                }
             }
 
             if (currentAvtale?.tiltakstype?.arenaKode == Tiltakskode.toArenaKode(Tiltakskode.GRUPPE_FAG_OG_YRKESOPPLAERING) && currentAvtale.nusData == null) {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
@@ -188,6 +188,21 @@ class AvtaleValidatorTest : FunSpec({
         )
     }
 
+    test("Avtalens lengde er maks 5 år for ikke AFT/VTA") {
+        val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService, arrangorer)
+
+        val dagensDato = LocalDate.now()
+        val dbo = avtaleDbo.copy(startDato = dagensDato, sluttDato = dagensDato.plusYears(5))
+
+        validator.validate(dbo, null).shouldBeRight()
+
+        val dbo2 = avtaleDbo.copy(startDato = dagensDato, sluttDato = dagensDato.plusYears(6))
+
+        validator.validate(dbo2, null).shouldBeLeft().shouldContainExactlyInAnyOrder(
+            listOf(ValidationError("sluttDato", "Avtaleperioden kan ikke vare lenger enn 5 år for anskaffede tiltak")),
+        )
+    }
+
     test("Avtalens sluttdato være lik eller etter startdato") {
         val validator = AvtaleValidator(tiltakstyper, gjennomforinger, navEnheterService, arrangorer)
 


### PR DESCRIPTION
Sånn at det går an å lage AFT/VTA avtaler lengre enn 5 år