### PR TITLE
tillat at gjennomføring har andre NAV-enheter enn avtalen

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
@@ -191,18 +191,6 @@ class AvtaleValidator(
                     )
                 }
 
-                gjennomforing.navEnheter.forEach { enhet: NavEnhetDbo ->
-                    val enhetsnummer = enhet.enhetsnummer
-                    if (enhetsnummer !in avtale.navEnheter) {
-                        add(
-                            ValidationError.of(
-                                AvtaleDbo::navEnheter,
-                                "NAV-enheten $enhetsnummer er i bruk på en av avtalens gjennomføringer, men mangler blant avtalens NAV-enheter",
-                            ),
-                        )
-                    }
-                }
-
                 if (gjennomforing.startDato.isBefore(avtale.startDato)) {
                     val gjennomforingsStartDato = gjennomforing.startDato.format(
                         DateTimeFormatter.ofLocalizedDate(
@@ -269,7 +257,6 @@ class AvtaleValidator(
         val actualNavEnheter = resolveNavEnheter(navEnheter)
 
         if (!actualNavEnheter.any { it.value.type == Norg2Type.FYLKE }) {
-            add(ValidationError.of(AvtaleDbo::navEnheter, "Du må velge minst én NAV-region"))
             add(ValidationError.of(AvtaleDbo::navEnheter, "Du må velge minst én NAV-region"))
         }
 


### PR DESCRIPTION
- NAV-enheter på avtalen kan nå endres uavhengig av hva som finnes av
  NAV-enheter på gjennomføringer
- Gjennomføring valideres fortsatt ihht. det som er satt på avtalen
- Dette gjør det enklere for administratorer å gjøre endringer på
  avtaler som først vil påvirke eksisterende gjennomføringer når de evt.
  blir redigert
