### PR TITLE
øk linkerd outbound connect timeout til 2s

### DIFF
--- a/mulighetsrommet-api/.nais/nais-prod.yaml
+++ b/mulighetsrommet-api/.nais/nais-prod.yaml
@@ -131,3 +131,5 @@ spec:
   env:
     - name: OTEL_JAVAAGENT_EXCLUDE_CLASSES
       value: "no.nav.mulighetsrommet.api.clients.dialog.*,no.nav.mulighetsrommet.api.services.BrukerService"
+  annotations:
+   config.linkerd.io/proxy-outbound-connect-timeout: "2s"


### PR DESCRIPTION
Fordi vi ser noen timouts der mot Sanity spesifikt. Det skjer når man ikke klarer opprette TCP connection innen denne timouten (som default var 1 sekund)