### PR TITLE
Persister sortering fra tabell i atom

### DIFF
--- a/frontend/mr-admin-flate/src/api/arrangor/useArrangorer.ts
+++ b/frontend/mr-admin-flate/src/api/arrangor/useArrangorer.ts
@@ -16,7 +16,7 @@ export function useArrangorer(til?: ArrangorTil, filter?: Partial<ArrangorerFilt
         sok: debouncedSok || undefined,
         page: filter?.page,
         size: filter?.pageSize,
-        sortering: filter?.sortering,
+        sortering: filter?.sortering?.sortString,
       });
     },
   });

--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -145,7 +145,7 @@ export type TiltakstypeFilter = z.infer<typeof tiltakstypeFilterSchema>;
 
 export const defaultTiltakstypeFilter: TiltakstypeFilter = {
   sort: {
-    sortString: "navn-ascending",
+    sortString: SorteringTiltakstyper.NAVN_ASCENDING,
     tableSort: {
       orderBy: "navn",
       direction: "ascending",
@@ -182,7 +182,7 @@ export const defaultTiltaksgjennomforingfilter: TiltaksgjennomforingFilter = {
   tiltakstyper: [],
   statuser: [],
   sortering: {
-    sortString: "navn-ascending",
+    sortString: SorteringTiltaksgjennomforinger.NAVN_ASCENDING,
     tableSort: {
       orderBy: "navn",
       direction: "ascending",
@@ -274,7 +274,7 @@ export type ArrangorerFilter = z.infer<typeof arrangorerFilterSchema>;
 export const defaultArrangorerFilter: ArrangorerFilter = {
   sok: "",
   sortering: {
-    sortString: "navn-ascending",
+    sortString: SorteringArrangorer.NAVN_ASCENDING,
     tableSort: {
       orderBy: "navn",
       direction: "ascending",

--- a/frontend/mr-admin-flate/src/api/atoms.ts
+++ b/frontend/mr-admin-flate/src/api/atoms.ts
@@ -1,4 +1,5 @@
 import { ARRANGORER_PAGE_SIZE, AVTALE_PAGE_SIZE, PAGE_SIZE } from "@/constants";
+import { SortState } from "@navikt/ds-react";
 import { atom, WritableAtom } from "jotai";
 import { atomFamily } from "jotai/utils";
 import { RESET } from "jotai/vanilla/utils";
@@ -130,13 +131,26 @@ function atomWithHashAndStorage<Value>(
   );
 }
 
+function createSorteringProps(sortItems: z.ZodType) {
+  return z.object({
+    tableSort: z.custom<SortState>(),
+    sortString: sortItems,
+  });
+}
+
 const tiltakstypeFilterSchema = z.object({
-  sort: z.custom<SorteringTiltakstyper>().optional(),
+  sort: createSorteringProps(z.custom<SorteringTiltakstyper>()).optional(),
 });
 export type TiltakstypeFilter = z.infer<typeof tiltakstypeFilterSchema>;
 
 export const defaultTiltakstypeFilter: TiltakstypeFilter = {
-  sort: SorteringTiltakstyper.NAVN_ASCENDING,
+  sort: {
+    sortString: "navn-ascending",
+    tableSort: {
+      orderBy: "navn",
+      direction: "ascending",
+    },
+  },
 };
 
 export const tiltakstypeFilterAtom = atomWithHashAndStorage<TiltakstypeFilter>(
@@ -151,7 +165,7 @@ const tiltaksgjennomforingFilterSchema = z.object({
   navEnheter: z.custom<NavEnhet>().array(),
   tiltakstyper: z.string().array(),
   statuser: z.custom<TiltaksgjennomforingStatus>().array(),
-  sortering: z.custom<SorteringTiltaksgjennomforinger>(),
+  sortering: createSorteringProps(z.custom<SorteringTiltaksgjennomforinger>()),
   avtale: z.string(),
   arrangorer: z.string().array(),
   visMineGjennomforinger: z.boolean(),
@@ -167,7 +181,13 @@ export const defaultTiltaksgjennomforingfilter: TiltaksgjennomforingFilter = {
   navEnheter: [],
   tiltakstyper: [],
   statuser: [],
-  sortering: SorteringTiltaksgjennomforinger.NAVN_ASCENDING,
+  sortering: {
+    sortString: "navn-ascending",
+    tableSort: {
+      orderBy: "navn",
+      direction: "ascending",
+    },
+  },
   avtale: "",
   arrangorer: [],
   publisert: [],
@@ -205,7 +225,7 @@ const avtaleFilterSchema = z.object({
   avtaletyper: z.custom<Avtaletype>().array(),
   navRegioner: z.string().array(),
   tiltakstyper: z.string().array(),
-  sortering: z.custom<SorteringAvtaler>(),
+  sortering: createSorteringProps(z.custom<SorteringAvtaler>()),
   arrangorer: z.string().array(),
   visMineAvtaler: z.boolean(),
   personvernBekreftet: z.boolean().array(),
@@ -221,7 +241,13 @@ export const defaultAvtaleFilter: AvtaleFilter = {
   avtaletyper: [],
   navRegioner: [],
   tiltakstyper: [],
-  sortering: SorteringAvtaler.NAVN_ASCENDING,
+  sortering: {
+    sortString: SorteringAvtaler.NAVN_ASCENDING,
+    tableSort: {
+      orderBy: "navn",
+      direction: "ascending",
+    },
+  },
   arrangorer: [],
   visMineAvtaler: false,
   personvernBekreftet: [],
@@ -241,13 +267,19 @@ const arrangorerFilterSchema = z.object({
   sok: z.string(),
   page: z.number(),
   pageSize: z.number(),
-  sortering: z.custom<SorteringArrangorer>(),
+  sortering: createSorteringProps(z.custom<SorteringArrangorer>()),
 });
 
 export type ArrangorerFilter = z.infer<typeof arrangorerFilterSchema>;
 export const defaultArrangorerFilter: ArrangorerFilter = {
   sok: "",
-  sortering: SorteringArrangorer.NAVN_ASCENDING,
+  sortering: {
+    sortString: "navn-ascending",
+    tableSort: {
+      orderBy: "navn",
+      direction: "ascending",
+    },
+  },
   page: 1,
   pageSize: ARRANGORER_PAGE_SIZE,
 };

--- a/frontend/mr-admin-flate/src/api/avtaler/useAvtaler.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useAvtaler.ts
@@ -13,7 +13,7 @@ export function useAvtaler(filter: Partial<AvtaleFilter>) {
     statuser: filter.statuser,
     avtaletyper: filter.avtaletyper,
     navRegioner: filter.navRegioner,
-    sort: filter.sortering,
+    sort: filter.sortering?.sortString,
     page: filter.page ?? 1,
     size: filter.pageSize,
     arrangorer: filter.arrangorer,

--- a/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger.ts
+++ b/frontend/mr-admin-flate/src/api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger.ts
@@ -22,7 +22,7 @@ export function useAdminTiltaksgjennomforinger(filter: Partial<Tiltaksgjennomfor
     navEnheter: filter.navEnheter?.map((e) => e.enhetsnummer) ?? [],
     tiltakstyper: filter.tiltakstyper,
     statuser: filter.statuser,
-    sort: filter.sortering ? filter.sortering : undefined,
+    sort: filter.sortering ? filter.sortering.sortString : undefined,
     page: filter.page ?? 1,
     size: filter.pageSize,
     avtaleId: filter.avtale ? filter.avtale : undefined,

--- a/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstyper.ts
+++ b/frontend/mr-admin-flate/src/api/tiltakstyper/useTiltakstyper.ts
@@ -6,7 +6,7 @@ import { TiltakstyperService } from "mulighetsrommet-api-client";
 
 export function useTiltakstyper(filter: TiltakstypeFilter = {}, page: number = 1) {
   const queryFilter = {
-    sort: filter.sort,
+    sort: filter.sort?.sortString,
     page,
     size: PAGE_SIZE,
   };

--- a/frontend/mr-admin-flate/src/components/tabell/ArrangorerTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/ArrangorerTabell.tsx
@@ -1,15 +1,14 @@
+import { Alert, Pagination, Table } from "@navikt/ds-react";
 import { WritableAtom, useAtom } from "jotai";
-import { ArrangorerFilter } from "../../api/atoms";
-import { useArrangorer } from "../../api/arrangor/useArrangorer";
-import { useSort } from "../../hooks/useSort";
+import { ArrangorTil, SorteringArrangorer } from "mulighetsrommet-api-client";
 import { ToolbarContainer } from "mulighetsrommet-frontend-common/components/toolbar/toolbarContainer/ToolbarContainer";
+import { Link } from "react-router-dom";
+import { useArrangorer } from "../../api/arrangor/useArrangorer";
+import { ArrangorerFilter } from "../../api/atoms";
+import { Laster } from "../laster/Laster";
+import { PagineringContainer } from "../paginering/PagineringContainer";
 import { PagineringsOversikt } from "../paginering/PagineringOversikt";
 import { TabellWrapper } from "./TabellWrapper";
-import { Laster } from "../laster/Laster";
-import { Alert, Pagination, Table } from "@navikt/ds-react";
-import { ArrangorTil, SorteringArrangorer } from "mulighetsrommet-api-client";
-import { Link } from "react-router-dom";
-import { PagineringContainer } from "../paginering/PagineringContainer";
 
 interface Props {
   filterAtom: WritableAtom<ArrangorerFilter, [newValue: ArrangorerFilter], void>;
@@ -18,9 +17,8 @@ interface Props {
 }
 
 export function ArrangorerTabell({ filterAtom, tagsHeight, filterOpen }: Props) {
-  const [sort, setSort] = useSort("navn");
   const [filter, setFilter] = useAtom(filterAtom);
-
+  const sort = filter.sortering.tableSort;
   const { data, isLoading } = useArrangorer(ArrangorTil.AVTALE, filter);
 
   function updateFilter(newFilter: Partial<ArrangorerFilter>) {
@@ -36,13 +34,11 @@ export function ArrangorerTabell({ filterAtom, tagsHeight, filterOpen }: Props) 
           : "descending"
         : "ascending";
 
-    setSort({
-      orderBy: sortKey,
-      direction,
-    });
-
     updateFilter({
-      sortering: `${sortKey}-${direction}` as SorteringArrangorer,
+      sortering: {
+        sortString: `${sortKey}-${direction}` as SorteringArrangorer,
+        tableSort: { orderBy: sortKey, direction },
+      },
       page: sort.orderBy !== sortKey || sort.direction !== direction ? 1 : filter.page,
     });
   };

--- a/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/AvtaleTabell.tsx
@@ -1,28 +1,27 @@
-import { Alert, Button, Pagination, Table, VStack } from "@navikt/ds-react";
-import { useAtom, WritableAtom } from "jotai";
-import { OpenAPI, SorteringAvtaler } from "mulighetsrommet-api-client";
-import { Lenke } from "mulighetsrommet-frontend-common/components/lenke/Lenke";
-import { createRef, useEffect, useState } from "react";
 import { AvtaleFilter } from "@/api/atoms";
 import { useAvtaler } from "@/api/avtaler/useAvtaler";
+import { TabellWrapper } from "@/components/tabell/TabellWrapper";
 import { APPLICATION_NAME } from "@/constants";
-import { useSort } from "@/hooks/useSort";
 import {
   capitalizeEveryWord,
   createQueryParamsForExcelDownload,
   formaterDato,
   formaterNavEnheter,
 } from "@/utils/Utils";
+import { FileExcelIcon } from "@navikt/aksel-icons";
+import { Alert, Button, Pagination, Table, VStack } from "@navikt/ds-react";
+import { useAtom, WritableAtom } from "jotai";
+import { OpenAPI, SorteringAvtaler } from "mulighetsrommet-api-client";
+import { Lenke } from "mulighetsrommet-frontend-common/components/lenke/Lenke";
+import { ToolbarContainer } from "mulighetsrommet-frontend-common/components/toolbar/toolbarContainer/ToolbarContainer";
+import { ToolbarMeny } from "mulighetsrommet-frontend-common/components/toolbar/toolbarMeny/ToolbarMeny";
+import { createRef, useEffect, useState } from "react";
 import { ShowOpphavValue } from "../debug/ShowOpphavValue";
 import { Laster } from "../laster/Laster";
 import { PagineringContainer } from "../paginering/PagineringContainer";
 import { PagineringsOversikt } from "../paginering/PagineringOversikt";
 import { AvtalestatusTag } from "../statuselementer/AvtalestatusTag";
 import styles from "./Tabell.module.scss";
-import { FileExcelIcon } from "@navikt/aksel-icons";
-import { ToolbarContainer } from "mulighetsrommet-frontend-common/components/toolbar/toolbarContainer/ToolbarContainer";
-import { TabellWrapper } from "@/components/tabell/TabellWrapper";
-import { ToolbarMeny } from "mulighetsrommet-frontend-common/components/toolbar/toolbarMeny/ToolbarMeny";
 
 async function lastNedFil(filter: AvtaleFilter) {
   const headers = new Headers();
@@ -50,11 +49,10 @@ interface Props {
 }
 
 export function AvtaleTabell({ filterAtom, tagsHeight, filterOpen }: Props) {
-  const [sort, setSort] = useSort("navn");
   const [filter, setFilter] = useAtom(filterAtom);
   const [lasterExcel, setLasterExcel] = useState(false);
   const [excelUrl, setExcelUrl] = useState("");
-
+  const sort = filter.sortering.tableSort;
   const { data, isLoading } = useAvtaler(filter);
 
   const link = createRef<HTMLAnchorElement>();
@@ -95,13 +93,11 @@ export function AvtaleTabell({ filterAtom, tagsHeight, filterOpen }: Props) {
           : "descending"
         : "ascending";
 
-    setSort({
-      orderBy: sortKey,
-      direction,
-    });
-
     updateFilter({
-      sortering: `${sortKey}-${direction}` as SorteringAvtaler,
+      sortering: {
+        sortString: `${sortKey}-${direction}` as SorteringAvtaler,
+        tableSort: { orderBy: sortKey, direction },
+      },
       page: sort.orderBy !== sortKey || sort.direction !== direction ? 1 : filter.page,
     });
   };

--- a/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/TiltaksgjennomforingsTabell.tsx
@@ -1,21 +1,20 @@
+import { TiltaksgjennomforingFilter } from "@/api/atoms";
+import { useAdminTiltaksgjennomforinger } from "@/api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger";
+import { TabellWrapper } from "@/components/tabell/TabellWrapper";
+import { formaterDato, formaterNavEnheter } from "@/utils/Utils";
 import { Alert, Pagination, Table, Tag, VStack } from "@navikt/ds-react";
 import { useAtom, WritableAtom } from "jotai";
 import { SorteringTiltaksgjennomforinger } from "mulighetsrommet-api-client";
+import { TiltaksgjennomforingStatusTag } from "mulighetsrommet-frontend-common";
 import { Lenke } from "mulighetsrommet-frontend-common/components/lenke/Lenke";
+import { ToolbarContainer } from "mulighetsrommet-frontend-common/components/toolbar/toolbarContainer/ToolbarContainer";
 import React from "react";
-import { TiltaksgjennomforingFilter } from "@/api/atoms";
-import { useAdminTiltaksgjennomforinger } from "@/api/tiltaksgjennomforing/useAdminTiltaksgjennomforinger";
-import { useSort } from "@/hooks/useSort";
 import pageStyles from "../../pages/Page.module.scss";
-import { formaterDato, formaterNavEnheter } from "@/utils/Utils";
 import { ShowOpphavValue } from "../debug/ShowOpphavValue";
 import { Laster } from "../laster/Laster";
 import { PagineringContainer } from "../paginering/PagineringContainer";
 import { PagineringsOversikt } from "../paginering/PagineringOversikt";
 import styles from "./Tabell.module.scss";
-import { ToolbarContainer } from "mulighetsrommet-frontend-common/components/toolbar/toolbarContainer/ToolbarContainer";
-import { TabellWrapper } from "@/components/tabell/TabellWrapper";
-import { TiltaksgjennomforingStatusTag } from "mulighetsrommet-frontend-common";
 
 const SkjulKolonne = ({ children, skjul }: { children: React.ReactNode; skjul: boolean }) => {
   return skjul ? null : <>{children}</>;
@@ -34,9 +33,8 @@ export function TiltaksgjennomforingsTabell({
   tagsHeight,
   filterOpen,
 }: Props) {
-  const [sort, setSort] = useSort("navn");
   const [filter, setFilter] = useAtom(filterAtom);
-
+  const sort = filter.sortering.tableSort;
   const { data, isLoading } = useAdminTiltaksgjennomforinger(filter);
 
   function updateFilter(newFilter: Partial<TiltaksgjennomforingFilter>) {
@@ -52,13 +50,11 @@ export function TiltaksgjennomforingsTabell({
           : "descending"
         : "ascending";
 
-    setSort({
-      orderBy: sortKey,
-      direction,
-    });
-
     updateFilter({
-      sortering: `${sortKey}-${direction}` as SorteringTiltaksgjennomforinger,
+      sortering: {
+        sortString: `${sortKey}-${direction}` as SorteringTiltaksgjennomforinger,
+        tableSort: { orderBy: sortKey, direction },
+      },
       page: sort.orderBy !== sortKey || sort.direction !== direction ? 1 : filter.page,
     });
   };

--- a/frontend/mr-admin-flate/src/components/tabell/TiltakstypeTabell.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/TiltakstypeTabell.tsx
@@ -1,20 +1,19 @@
+import { tiltakstypeFilterAtom } from "@/api/atoms";
+import { useTiltakstyper } from "@/api/tiltakstyper/useTiltakstyper";
+import { TabellWrapper } from "@/components/tabell/TabellWrapper";
+import { formaterDato } from "@/utils/Utils";
 import { Alert, Table } from "@navikt/ds-react";
 import { useAtom } from "jotai";
 import { SorteringTiltakstyper } from "mulighetsrommet-api-client";
 import { Lenke } from "mulighetsrommet-frontend-common/components/lenke/Lenke";
-import { tiltakstypeFilterAtom } from "@/api/atoms";
-import { useTiltakstyper } from "@/api/tiltakstyper/useTiltakstyper";
-import { useSort } from "@/hooks/useSort";
-import { formaterDato } from "@/utils/Utils";
 import { Laster } from "../laster/Laster";
 import { TiltakstypestatusTag } from "../statuselementer/TiltakstypestatusTag";
 import styles from "./Tabell.module.scss";
-import { TabellWrapper } from "@/components/tabell/TabellWrapper";
 
 export function TiltakstypeTabell() {
   const [filter, setFilter] = useAtom(tiltakstypeFilterAtom);
   const { data, isLoading } = useTiltakstyper(filter);
-  const [sort, setSort] = useSort("navn");
+  const sort = filter.sort?.tableSort;
   const tiltakstyper = data?.data ?? [];
 
   if ((!tiltakstyper || tiltakstyper.length === 0) && isLoading) {
@@ -26,16 +25,17 @@ export function TiltakstypeTabell() {
   }
 
   const handleSort = (sortKey: string) => {
-    const direction = sort.direction === "ascending" ? "descending" : "ascending";
-
-    setSort({
-      orderBy: sortKey,
-      direction,
-    });
+    const direction = sort?.direction === "ascending" ? "descending" : "ascending";
 
     setFilter({
       ...filter,
-      sort: `${sortKey}-${direction}` as SorteringTiltakstyper,
+      sort: {
+        sortString: `${sortKey}-${direction}` as SorteringTiltakstyper,
+        tableSort: {
+          orderBy: sortKey,
+          direction,
+        },
+      },
     });
   };
   return (

--- a/frontend/mr-admin-flate/src/components/tabell/Types.tsx
+++ b/frontend/mr-admin-flate/src/components/tabell/Types.tsx
@@ -1,4 +1,0 @@
-export interface Sortering {
-  orderBy: string;
-  direction: "ascending" | "descending";
-}

--- a/frontend/mr-admin-flate/src/hooks/useSort.ts
+++ b/frontend/mr-admin-flate/src/hooks/useSort.ts
@@ -1,9 +1,0 @@
-import { useState } from "react";
-import { Sortering } from "../components/tabell/Types";
-
-export const useSort = (sortKey: string, direction: "ascending" | "descending" = "ascending") => {
-  return useState<Sortering>({
-    orderBy: sortKey,
-    direction,
-  });
-};

--- a/frontend/mr-admin-flate/src/utils/Utils.test.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.test.ts
@@ -1,11 +1,11 @@
+import { AvtaleFilter } from "@/api/atoms";
+import { Avtalestatus, Avtaletype } from "mulighetsrommet-api-client";
 import { describe, expect, test } from "vitest";
 import {
   capitalizeEveryWord,
   createQueryParamsForExcelDownload,
   kalkulerStatusBasertPaaFraOgTilDato,
 } from "./Utils";
-import { Avtalestatus, Avtaletype, SorteringAvtaler } from "mulighetsrommet-api-client";
-import { AvtaleFilter } from "@/api/atoms";
 
 describe("Utils - kalkulerStatusBasertPaaFraOgTilDato", () => {
   test("Skal returnere status 'Aktiv' når nå er større eller lik fra-dato og nå er mindre eller lik til-dato", () => {
@@ -85,7 +85,13 @@ describe("Avtaletabell", () => {
       avtaletyper: [Avtaletype.AVTALE],
       navRegioner: ["0600"],
       tiltakstyper: ["123"],
-      sortering: SorteringAvtaler.NAVN_ASCENDING,
+      sortering: {
+        sortString: "navn-ascending",
+        tableSort: {
+          orderBy: "navn",
+          direction: "ascending",
+        },
+      },
       arrangorer: ["123456789"],
       visMineAvtaler: true,
       personvernBekreftet: [true],

--- a/frontend/mr-admin-flate/src/utils/Utils.test.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.test.ts
@@ -1,5 +1,5 @@
 import { AvtaleFilter } from "@/api/atoms";
-import { Avtalestatus, Avtaletype } from "mulighetsrommet-api-client";
+import { Avtalestatus, Avtaletype, SorteringAvtaler } from "mulighetsrommet-api-client";
 import { describe, expect, test } from "vitest";
 import {
   capitalizeEveryWord,
@@ -86,7 +86,7 @@ describe("Avtaletabell", () => {
       navRegioner: ["0600"],
       tiltakstyper: ["123"],
       sortering: {
-        sortString: "navn-ascending",
+        sortString: SorteringAvtaler.NAVN_ASCENDING,
         tableSort: {
           orderBy: "navn",
           direction: "ascending",


### PR DESCRIPTION
Persisterer i atom hvilket sortering som er gjort fra tabell slik at tabell-headere har korrekt state mellom navigering.