### PR TITLE
Prøv med OkHttp mot Sanity

### DIFF
--- a/common/ktor-clients/build.gradle.kts
+++ b/common/ktor-clients/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation(projects.common.metrics)
     api(libs.ktor.client.cio)
+    api(libs.ktor.client.okhttp)
     api(libs.ktor.client.core)
     api(libs.ktor.client.contentNegotiation)
     api(libs.ktor.client.logging)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ kotliquery = "com.github.seratch:kotliquery:1.9.0"
 
 ktlint = "com.pinterest.ktlint:ktlint-cli:1.3.1"
 
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/sanity/SanityClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/sanity/SanityClient.kt
@@ -3,7 +3,7 @@ package no.nav.mulighetsrommet.api.clients.sanity
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
-import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
@@ -20,7 +20,7 @@ import no.nav.mulighetsrommet.ktor.clients.ClientResponseMetricPlugin
 import org.slf4j.LoggerFactory
 import java.util.*
 
-class SanityClient(engine: HttpClientEngine = CIO.create(), val config: Config) {
+class SanityClient(engine: HttpClientEngine = OkHttp.create(), val config: Config) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 


### PR DESCRIPTION
Har en teori om at noen av sanity cdn ip'ene er blokket ut av nais cluster (av en eller annen grunn), og ref denne bug'en i cio https://youtrack.jetbrains.com/issue/KTOR-4462/CIO-Apache-HTTP-client-doesnt-try-to-connect-to-all-resolved-IP-addresses så prøver cio kun første ip, mens okhttp vil prøve neste ved feil