### PR TITLE
Fjern kontaktperson/redaktør fra Sanity hvis ansatt skal slettes

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -301,7 +301,7 @@ private fun services(appConfig: AppConfig) = module {
     single { TiltakshistorikkService(get(), get(), get(), get(), get(), get()) }
     single { VeilederflateService(get(), get(), get(), get()) }
     single { BrukerService(get(), get(), get(), get(), get()) }
-    single { NavAnsattService(appConfig.auth.roles, get(), get(), get(), get(), get(), get(), get()) }
+    single { NavAnsattService(appConfig.auth.roles, get(), get(), get(), get(), get(), get(), get(), get()) }
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get(), get()) }
     single { MicrosoftGraphService(get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -301,7 +301,7 @@ private fun services(appConfig: AppConfig) = module {
     single { TiltakshistorikkService(get(), get(), get(), get(), get(), get()) }
     single { VeilederflateService(get(), get(), get(), get()) }
     single { BrukerService(get(), get(), get(), get(), get()) }
-    single { NavAnsattService(appConfig.auth.roles, get(), get(), get(), get(), get(), get(), get(), get()) }
+    single { NavAnsattService(appConfig.auth.roles, get(), get(), get(), get(), get(), get(), get()) }
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get(), get()) }
     single { MicrosoftGraphService(get()) }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
@@ -148,7 +148,7 @@ class NavAnsattService(
         val queryResponse = sanityClient.query(
             """
             *[_type == "tiltaksgjennomforing" && (${'$'}navIdent in kontaktpersoner[].navKontaktperson->navIdent.current || ${'$'}navIdent in redaktor[]->navIdent.current)]
-            {kontaktpersoner[]{navKontaktperson->, enheter}, _id, tiltaksgjennomforingNavn, redaktor[]->}
+            {kontaktpersoner[]{navKontaktperson->, enheter, _key}, _id, tiltaksgjennomforingNavn, redaktor[]->}
 
             """.trimIndent(),
             params = listOf(SanityParam.of("navIdent", ansatt.navIdent.value)),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
@@ -191,6 +191,7 @@ class NavAnsattService(
                         _ref = it.navKontaktperson._id,
                     ),
                     enheter = it.enheter,
+                    _key = UUID.randomUUID().toString(),
                 )
             },
             redaktor = redaktorer.map {
@@ -438,6 +439,7 @@ data class GjennomforingAndKontaktpersoner(
     data class NavKontaktperson<T>(
         val navKontaktperson: T,
         val enheter: List<SanityReference>,
+        val _key: String,
     )
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
@@ -19,9 +19,11 @@ import no.nav.mulighetsrommet.api.domain.dto.NavAnsattDto
 import no.nav.mulighetsrommet.api.domain.dto.SanityResponse
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
+import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.utils.EnhetFilter
 import no.nav.mulighetsrommet.api.utils.NavAnsattFilter
 import no.nav.mulighetsrommet.database.Database
+import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import no.nav.mulighetsrommet.notifications.NotificationMetadata
 import no.nav.mulighetsrommet.notifications.NotificationService
 import no.nav.mulighetsrommet.notifications.NotificationType
@@ -38,6 +40,7 @@ class NavAnsattService(
     private val navAnsattRepository: NavAnsattRepository,
     private val sanityClient: SanityClient,
     private val avtaleRepository: AvtaleRepository,
+    private val tiltaksgjennomforingRepository: TiltaksgjennomforingRepository,
     private val navEnhetService: NavEnhetService,
     private val notificationService: NotificationService,
 ) {
@@ -118,11 +121,21 @@ class NavAnsattService(
 
     private suspend fun deleteNavAnsatt(ansatt: NavAnsattDto) {
         val avtaleIds = avtaleRepository.getAvtaleIdsByAdministrator(ansatt.navIdent)
+        val gjennomforinger = getGjennomforingerFraSanityForAnsatt(ansatt)
 
         db.transactionSuspend { tx ->
             navAnsattRepository.deleteByAzureId(ansatt.azureId, tx)
+            removeSanityAnsattFraTiltaksgjennomforing(ansatt)
             deleteSanityAnsatt(ansatt)
         }
+
+        gjennomforinger
+            .forEach { gjennomforing ->
+                notifyRelevantAdministratorsForSanityGjennomforing(
+                    gjennomforing,
+                    ansatt.hovedenhet,
+                )
+            }
 
         avtaleIds
             .forEach {
@@ -132,6 +145,62 @@ class NavAnsattService(
                 }
             }
     }
+
+    private suspend fun getGjennomforingerFraSanityForAnsatt(ansatt: NavAnsattDto): List<GjennomforingAndKontaktpersoner> {
+        val queryResponse = sanityClient.query(
+            """
+                *[_type == "tiltaksgjennomforing" && (${'$'}navIdent in kontaktpersoner[].navKontaktperson->navIdent.current || ${'$'}navIdent in redaktor[]->navIdent.current)]
+            {kontaktpersoner[]{navKontaktperson->}, "gjennomforingsId": _id, tiltaksgjennomforingNavn, redaktor[]->}
+
+            """.trimIndent(),
+            params = listOf(SanityParam.of("navIdent", ansatt.navIdent.value)),
+        )
+
+        return when (queryResponse) {
+            is SanityResponse.Result -> queryResponse.decode<List<GjennomforingAndKontaktpersoner>>()
+            is SanityResponse.Error -> throw Exception("Klarte ikke hente ut id'er til sletting fra Sanity: ${queryResponse.error}")
+        }
+    }
+
+    private suspend fun removeSanityAnsattFraTiltaksgjennomforing(ansatt: NavAnsattDto) {
+        val gjennomforinger = getGjennomforingerFraSanityForAnsatt(ansatt)
+
+        if (gjennomforinger.isEmpty()) {
+            return
+        }
+
+        val mutations = gjennomforinger.map { gjennomforing ->
+            val kontaktpersoner = gjennomforing.kontaktpersoner.filter { it.navIdent.current != ansatt.navIdent.value }
+            val redaktorer = gjennomforing.redaktor.filter { it.navIdent.current != ansatt.navIdent.value }
+            createPatchGjennomforingsKontaktpersonMutation(gjennomforing, kontaktpersoner, redaktorer)
+        }
+        val response = sanityClient.mutate(mutations)
+        checkResponse(response)
+    }
+
+    private fun createPatchGjennomforingsKontaktpersonMutation(
+        gjennomforing: GjennomforingAndKontaktpersoner,
+        kontaktpersoner: List<SanityNavKontaktperson>,
+        redaktorer: List<SanityRedaktor>,
+    ): Mutation<Mutation.Patch<GjennomforingAndKontaktpersoner>> {
+        val patch = GjennomforingAndKontaktpersoner(
+            kontaktpersoner = kontaktpersoner,
+            redaktor = redaktorer,
+            _id = gjennomforing._id,
+            tiltaksgjennomforingNavn = gjennomforing.tiltaksgjennomforingNavn,
+        )
+
+        return Mutation.patch(gjennomforing._id.toString(), patch)
+    }
+
+    @Serializable
+    data class GjennomforingAndKontaktpersoner(
+        val kontaktpersoner: List<SanityNavKontaktperson>,
+        val redaktor: List<SanityRedaktor>,
+        val tiltaksgjennomforingNavn: String,
+        @Serializable(with = UUIDSerializer::class)
+        val _id: UUID,
+    )
 
     private fun notifyRelevantAdministrators(
         avtale: AvtaleAdminDto,
@@ -164,6 +233,44 @@ class NavAnsattService(
             metadata = NotificationMetadata(
                 linkText = "Gå til avtalen",
                 link = "/avtaler/${avtale.id}",
+            ),
+            targets = administrators,
+            createdAt = Instant.now(),
+        )
+        notificationService.scheduleNotification(notification)
+    }
+
+    private fun notifyRelevantAdministratorsForSanityGjennomforing(
+        gjennomforing: GjennomforingAndKontaktpersoner,
+        hovedenhet: NavAnsattDto.Hovedenhet,
+    ) {
+        val region = navEnhetService.hentOverordnetFylkesenhet(hovedenhet.enhetsnummer)
+            ?: return
+
+        val potentialAdministratorHovedenheter = navEnhetService.hentAlleEnheter(
+            EnhetFilter(
+                statuser = listOf(NavEnhetStatus.AKTIV),
+                overordnetEnhet = region.enhetsnummer,
+            ),
+        )
+            .map { it.enhetsnummer }
+            .plus(region.enhetsnummer)
+
+        val administrators = navAnsattRepository
+            .getAll(
+                roller = listOf(NavAnsattRolle.TILTAKSGJENNOMFORINGER_SKRIV),
+                hovedenhetIn = potentialAdministratorHovedenheter,
+            )
+            .map { it.navIdent }
+            .toNonEmptyListOrNull() ?: return
+
+        val notification = ScheduledNotification(
+            type = NotificationType.TASK,
+            title = """Kontaktperson eller redaktør for tiltak: "${gjennomforing.tiltaksgjennomforingNavn}" ble fjernet i Sanity""",
+            description = "Du har blitt varslet fordi din NAV-hovedenhet er i samme fylke som forrige kontaktperson/redaktørs NAV-hovedenhet. Gå til tiltaksgjennomføringen i Sanity og sjekk at kontaktpersonene og redaktørene for tiltaket er korrekt og oppdatert.",
+            metadata = NotificationMetadata(
+                linkText = "Gå til gjennomføringen i Sanity",
+                link = "https://mulighetsrommet-sanity-studio.intern.nav.no/prod/structure/tiltaksgjennomforinger;alleTiltaksgjennomforinger;${gjennomforing._id}",
             ),
             targets = administrators,
             createdAt = Instant.now(),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattService.kt
@@ -19,7 +19,6 @@ import no.nav.mulighetsrommet.api.domain.dto.NavAnsattDto
 import no.nav.mulighetsrommet.api.domain.dto.SanityResponse
 import no.nav.mulighetsrommet.api.repositories.AvtaleRepository
 import no.nav.mulighetsrommet.api.repositories.NavAnsattRepository
-import no.nav.mulighetsrommet.api.repositories.TiltaksgjennomforingRepository
 import no.nav.mulighetsrommet.api.utils.EnhetFilter
 import no.nav.mulighetsrommet.api.utils.NavAnsattFilter
 import no.nav.mulighetsrommet.database.Database
@@ -40,7 +39,6 @@ class NavAnsattService(
     private val navAnsattRepository: NavAnsattRepository,
     private val sanityClient: SanityClient,
     private val avtaleRepository: AvtaleRepository,
-    private val tiltaksgjennomforingRepository: TiltaksgjennomforingRepository,
     private val navEnhetService: NavEnhetService,
     private val notificationService: NotificationService,
 ) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tasks/SynchronizeNavAnsatte.kt
@@ -76,7 +76,7 @@ class SynchronizeNavAnsatte(
             throw BadRequestException("Synkronisering av ansatte kjører allerede.")
         }
 
-        client.reschedule(task.instance(existingTaskId), startTime.plusSeconds(30))
+        client.reschedule(task.instance(existingTaskId), startTime.plusSeconds(5))
         return UUID.randomUUID()
     }
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
@@ -99,25 +99,29 @@ class NavAnsattServiceTest :
                     respondJson(
                         content = sanityContentResult(
                             listOf(
-                                NavAnsattService.GjennomforingAndKontaktpersoner(
+                                GjennomforingAndKontaktpersoner(
                                     kontaktpersoner = listOf(
-                                        SanityNavKontaktperson(
-                                            _id = "123",
-                                            _type = "navKontaktperson",
-                                            enhet = ansatt1.hovedenhetKode,
-                                            telefonnummer = ansatt1.mobilnummer,
-                                            epost = ansatt1.epost,
-                                            navn = ansatt1.fornavn + " " + ansatt1.etternavn,
-                                            navIdent = Slug(current = ansatt1.navIdent.value),
+                                        GjennomforingAndKontaktpersoner.NavKontaktperson(
+                                            SanityNavKontaktperson(
+                                                _id = "123",
+                                                _type = "navKontaktperson",
+                                                enhet = ansatt1.hovedenhetKode,
+                                                telefonnummer = ansatt1.mobilnummer,
+                                                epost = ansatt1.epost,
+                                                navn = ansatt1.fornavn + " " + ansatt1.etternavn,
+                                                navIdent = Slug(current = ansatt1.navIdent.value),
+                                            ),
                                         ),
-                                        SanityNavKontaktperson(
-                                            _id = "456",
-                                            _type = "navKontaktperson",
-                                            enhet = ansatt2.hovedenhetKode,
-                                            telefonnummer = ansatt2.mobilnummer,
-                                            epost = ansatt2.epost,
-                                            navn = ansatt2.fornavn + " " + ansatt2.etternavn,
-                                            navIdent = Slug(current = ansatt2.navIdent.value),
+                                        GjennomforingAndKontaktpersoner.NavKontaktperson(
+                                            SanityNavKontaktperson(
+                                                _id = "456",
+                                                _type = "navKontaktperson",
+                                                enhet = ansatt2.hovedenhetKode,
+                                                telefonnummer = ansatt2.mobilnummer,
+                                                epost = ansatt2.epost,
+                                                navn = ansatt2.fornavn + " " + ansatt2.etternavn,
+                                                navIdent = Slug(current = ansatt2.navIdent.value),
+                                            ),
                                         ),
                                     ),
                                     redaktor = listOf(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
@@ -102,7 +102,7 @@ class NavAnsattServiceTest :
                                 GjennomforingAndKontaktpersoner(
                                     kontaktpersoner = listOf(
                                         GjennomforingAndKontaktpersoner.NavKontaktperson(
-                                            SanityNavKontaktperson(
+                                            navKontaktperson = SanityNavKontaktperson(
                                                 _id = "123",
                                                 _type = "navKontaktperson",
                                                 enhet = ansatt1.hovedenhetKode,
@@ -111,9 +111,10 @@ class NavAnsattServiceTest :
                                                 navn = ansatt1.fornavn + " " + ansatt1.etternavn,
                                                 navIdent = Slug(current = ansatt1.navIdent.value),
                                             ),
+                                            enheter = emptyList(),
                                         ),
                                         GjennomforingAndKontaktpersoner.NavKontaktperson(
-                                            SanityNavKontaktperson(
+                                            navKontaktperson = SanityNavKontaktperson(
                                                 _id = "456",
                                                 _type = "navKontaktperson",
                                                 enhet = ansatt2.hovedenhetKode,
@@ -122,6 +123,7 @@ class NavAnsattServiceTest :
                                                 navn = ansatt2.fornavn + " " + ansatt2.etternavn,
                                                 navIdent = Slug(current = ansatt2.navIdent.value),
                                             ),
+                                            enheter = emptyList(),
                                         ),
                                     ),
                                     redaktor = listOf(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/services/NavAnsattServiceTest.kt
@@ -112,6 +112,7 @@ class NavAnsattServiceTest :
                                                 navIdent = Slug(current = ansatt1.navIdent.value),
                                             ),
                                             enheter = emptyList(),
+                                            _key = UUID.randomUUID().toString(),
                                         ),
                                         GjennomforingAndKontaktpersoner.NavKontaktperson(
                                             navKontaktperson = SanityNavKontaktperson(
@@ -124,6 +125,7 @@ class NavAnsattServiceTest :
                                                 navIdent = Slug(current = ansatt2.navIdent.value),
                                             ),
                                             enheter = emptyList(),
+                                            _key = UUID.randomUUID().toString(),
                                         ),
                                     ),
                                     redaktor = listOf(


### PR DESCRIPTION
Når vi synkroniserer ansatte så prøver vi nå også å patche gjennomføringer i Sanity der den ansatte enten har vært kontaktperson eller redaktør. Hvis vi sletter de så gir vi også beskjed til administratorene i fylket om at de må sjekke at dataen er korrekt.