### PR TITLE
Oppdaterer postgres til 16 i docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
         }
 
   mulighetsrommet-db:
-    image: "postgres:15.6-alpine"
+    image: "postgres:16.3-alpine"
     restart: "always"
     volumes:
       - "mulighetsrommet-db:/var/lib/postgresql/data"


### PR DESCRIPTION
Hvis du bruker Colima, gjør dette først:
1. Oppdater til ny Postgres-versjon i docker-compose.yaml // Dette gjøres i denne PRen
2. Kjør `colima delete`
3. Kjør `colima start --memory 8 --cpu 4` 
4. Kjør `restart_dc` 

Hvis du ikke bruker Colima kan du gjøre følgende:
1. `docker compose down mulighetsrommet-db --volumes` // Dette fjerner data fra db lokalt
2. docker compose up mulighetsrommet-db`
3. Kjør `dump_dev_db`
4. Hvis det ikke fungerer så se stegene under for å oppdatere lokal Postgres-versjon for å få dump_dev_db-scriptet til å fungere

Installer ny postgres-versjon med brew
1. `brew uninstall postgresql@14`
2. `brew install postgresql@<versjon>`
3. `brew link postgresql@<versjon> --force`
4. `brew services start postgresql@<versjon>`
5. Kjør `dump_dev_db`