### PR TITLE
Kan lagre ned kobling mellom avtale, programområde og utdanning i egen tabell

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
@@ -1,10 +1,10 @@
-import { avtaleDetaljerTabAtom } from "@/api/atoms";
-import { useUpsertAvtale } from "@/api/avtaler/useUpsertAvtale";
-import { useHandleApiUpsertResponse } from "@/api/effects";
-import { erAnskaffetTiltak } from "@/utils/tiltakskoder";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { Tabs } from "@navikt/ds-react";
-import { useAtom } from "jotai";
+import {avtaleDetaljerTabAtom} from "@/api/atoms";
+import {useUpsertAvtale} from "@/api/avtaler/useUpsertAvtale";
+import {useHandleApiUpsertResponse} from "@/api/effects";
+import {erAnskaffetTiltak} from "@/utils/tiltakskoder";
+import {zodResolver} from "@hookform/resolvers/zod";
+import {Tabs} from "@navikt/ds-react";
+import {useAtom} from "jotai";
 import {
   AvtaleDto,
   AvtaleRequest,
@@ -14,19 +14,19 @@ import {
   TiltakstypeDto,
 } from "@mr/api-client";
 import React from "react";
-import { DeepPartial, FormProvider, SubmitHandler, useForm } from "react-hook-form";
-import { v4 as uuidv4 } from "uuid";
-import { Separator } from "../detaljside/Metadata";
-import { AvtaleSchema, InferredAvtaleSchema } from "@/components/redaksjoneltInnhold/AvtaleSchema";
-import { AvtaleRedaksjoneltInnholdForm } from "./AvtaleRedaksjoneltInnholdForm";
-import { AvtaleSkjemaDetaljer } from "./AvtaleSkjemaDetaljer";
-import { AvtaleSkjemaKnapperad } from "./AvtaleSkjemaKnapperad";
-import { AvtalePersonvernForm } from "./AvtalePersonvernForm";
-import { Laster } from "../laster/Laster";
-import { InlineErrorBoundary } from "@mr/frontend-common";
-import { RedaksjoneltInnholdBunnKnapperad } from "@/components/redaksjoneltInnhold/RedaksjoneltInnholdBunnKnapperad";
+import {DeepPartial, FormProvider, SubmitHandler, useForm} from "react-hook-form";
+import {v4 as uuidv4} from "uuid";
+import {Separator} from "../detaljside/Metadata";
+import {AvtaleSchema, InferredAvtaleSchema} from "@/components/redaksjoneltInnhold/AvtaleSchema";
+import {AvtaleRedaksjoneltInnholdForm} from "./AvtaleRedaksjoneltInnholdForm";
+import {AvtaleSkjemaDetaljer} from "./AvtaleSkjemaDetaljer";
+import {AvtaleSkjemaKnapperad} from "./AvtaleSkjemaKnapperad";
+import {AvtalePersonvernForm} from "./AvtalePersonvernForm";
+import {Laster} from "../laster/Laster";
+import {InlineErrorBoundary} from "@mr/frontend-common";
+import {RedaksjoneltInnholdBunnKnapperad} from "@/components/redaksjoneltInnhold/RedaksjoneltInnholdBunnKnapperad";
 import styles from "./AvtaleSkjemaContainer.module.scss";
-import { TabWithErrorBorder } from "../skjema/TabWithErrorBorder";
+import {TabWithErrorBorder} from "../skjema/TabWithErrorBorder";
 
 interface Props {
   onClose: () => void;
@@ -40,14 +40,14 @@ interface Props {
 }
 
 export function AvtaleSkjemaContainer({
-  onClose,
-  onSuccess,
-  ansatt,
-  avtale,
-  redigeringsModus,
-  defaultValues,
-  ...props
-}: Props) {
+                                        onClose,
+                                        onSuccess,
+                                        ansatt,
+                                        avtale,
+                                        redigeringsModus,
+                                        defaultValues,
+                                        ...props
+                                      }: Props) {
   const [activeTab, setActiveTab] = useAtom(avtaleDetaljerTabAtom);
 
   const mutation = useUpsertAvtale();
@@ -59,7 +59,7 @@ export function AvtaleSkjemaContainer({
 
   const {
     handleSubmit,
-    formState: { errors },
+    formState: {errors},
     watch,
   } = form;
 
@@ -93,6 +93,12 @@ export function AvtaleSkjemaContainer({
         opsjonsmodell: data?.opsjonsmodellData?.opsjonsmodell || null,
         customOpsjonsmodellNavn: data?.opsjonsmodellData?.customOpsjonsmodellNavn || null,
       },
+      programomradeMedUtdanningerRequest: data.programomradeOgUtdanninger
+        ? {
+          programomradeId: data.programomradeOgUtdanninger?.programomradeId,
+          utdanningsIder: data.programomradeOgUtdanninger?.utdanningsIder || [],
+        }
+        : null,
     };
 
     mutation.mutate(requestBody);
@@ -104,7 +110,7 @@ export function AvtaleSkjemaContainer({
     (validation) => {
       validation.errors.forEach((error) => {
         const name = mapErrorToSchemaPropertyName(error.name);
-        form.setError(name, { type: "custom", message: error.message });
+        form.setError(name, {type: "custom", message: error.message});
       });
 
       function mapErrorToSchemaPropertyName(name: string) {
@@ -115,6 +121,8 @@ export function AvtaleSkjemaContainer({
           opsjonMaksVarighet: "opsjonsmodellData.opsjonMaksVarighet",
           customOpsjonsmodellNavn: "opsjonsmodellData.customOpsjonsmodellNavn",
           tiltakstypeId: "tiltakstype",
+          programomrade: "programomradeOgUtdanninger.programomradeId",
+          utdanninger: "programomradeOgUtdanninger.utdanningsIder",
         };
         return (mapping[name] ?? name) as keyof InferredAvtaleSchema;
       }
@@ -152,7 +160,7 @@ export function AvtaleSkjemaContainer({
                 hasError={hasRedaksjoneltInnholdErrors}
               />
             </div>
-            <AvtaleSkjemaKnapperad redigeringsModus={redigeringsModus} onClose={onClose} />
+            <AvtaleSkjemaKnapperad redigeringsModus={redigeringsModus} onClose={onClose}/>
           </Tabs.List>
           <Tabs.Panel value="detaljer">
             <AvtaleSkjemaDetaljer
@@ -164,18 +172,18 @@ export function AvtaleSkjemaContainer({
           </Tabs.Panel>
           <Tabs.Panel value="personvern">
             <InlineErrorBoundary>
-              <React.Suspense fallback={<Laster tekst="Laster innhold" />}>
-                <AvtalePersonvernForm tiltakstypeId={watchedTiltakstype?.id} />
+              <React.Suspense fallback={<Laster tekst="Laster innhold"/>}>
+                <AvtalePersonvernForm tiltakstypeId={watchedTiltakstype?.id}/>
               </React.Suspense>
             </InlineErrorBoundary>
           </Tabs.Panel>
           <Tabs.Panel value="redaksjonelt-innhold">
-            <AvtaleRedaksjoneltInnholdForm tiltakstype={watchedTiltakstype} />
+            <AvtaleRedaksjoneltInnholdForm tiltakstype={watchedTiltakstype}/>
           </Tabs.Panel>
         </Tabs>
-        <Separator />
+        <Separator/>
         <RedaksjoneltInnholdBunnKnapperad>
-          <AvtaleSkjemaKnapperad redigeringsModus={redigeringsModus} onClose={onClose} />
+          <AvtaleSkjemaKnapperad redigeringsModus={redigeringsModus} onClose={onClose}/>
         </RedaksjoneltInnholdBunnKnapperad>
       </form>
     </FormProvider>

--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaContainer.tsx
@@ -1,10 +1,10 @@
-import {avtaleDetaljerTabAtom} from "@/api/atoms";
-import {useUpsertAvtale} from "@/api/avtaler/useUpsertAvtale";
-import {useHandleApiUpsertResponse} from "@/api/effects";
-import {erAnskaffetTiltak} from "@/utils/tiltakskoder";
-import {zodResolver} from "@hookform/resolvers/zod";
-import {Tabs} from "@navikt/ds-react";
-import {useAtom} from "jotai";
+import { avtaleDetaljerTabAtom } from "@/api/atoms";
+import { useUpsertAvtale } from "@/api/avtaler/useUpsertAvtale";
+import { useHandleApiUpsertResponse } from "@/api/effects";
+import { erAnskaffetTiltak } from "@/utils/tiltakskoder";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Tabs } from "@navikt/ds-react";
+import { useAtom } from "jotai";
 import {
   AvtaleDto,
   AvtaleRequest,
@@ -14,19 +14,19 @@ import {
   TiltakstypeDto,
 } from "@mr/api-client";
 import React from "react";
-import {DeepPartial, FormProvider, SubmitHandler, useForm} from "react-hook-form";
-import {v4 as uuidv4} from "uuid";
-import {Separator} from "../detaljside/Metadata";
-import {AvtaleSchema, InferredAvtaleSchema} from "@/components/redaksjoneltInnhold/AvtaleSchema";
-import {AvtaleRedaksjoneltInnholdForm} from "./AvtaleRedaksjoneltInnholdForm";
-import {AvtaleSkjemaDetaljer} from "./AvtaleSkjemaDetaljer";
-import {AvtaleSkjemaKnapperad} from "./AvtaleSkjemaKnapperad";
-import {AvtalePersonvernForm} from "./AvtalePersonvernForm";
-import {Laster} from "../laster/Laster";
-import {InlineErrorBoundary} from "@mr/frontend-common";
-import {RedaksjoneltInnholdBunnKnapperad} from "@/components/redaksjoneltInnhold/RedaksjoneltInnholdBunnKnapperad";
+import { DeepPartial, FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import { v4 as uuidv4 } from "uuid";
+import { Separator } from "../detaljside/Metadata";
+import { AvtaleSchema, InferredAvtaleSchema } from "@/components/redaksjoneltInnhold/AvtaleSchema";
+import { AvtaleRedaksjoneltInnholdForm } from "./AvtaleRedaksjoneltInnholdForm";
+import { AvtaleSkjemaDetaljer } from "./AvtaleSkjemaDetaljer";
+import { AvtaleSkjemaKnapperad } from "./AvtaleSkjemaKnapperad";
+import { AvtalePersonvernForm } from "./AvtalePersonvernForm";
+import { Laster } from "../laster/Laster";
+import { InlineErrorBoundary } from "@mr/frontend-common";
+import { RedaksjoneltInnholdBunnKnapperad } from "@/components/redaksjoneltInnhold/RedaksjoneltInnholdBunnKnapperad";
 import styles from "./AvtaleSkjemaContainer.module.scss";
-import {TabWithErrorBorder} from "../skjema/TabWithErrorBorder";
+import { TabWithErrorBorder } from "../skjema/TabWithErrorBorder";
 
 interface Props {
   onClose: () => void;
@@ -40,14 +40,14 @@ interface Props {
 }
 
 export function AvtaleSkjemaContainer({
-                                        onClose,
-                                        onSuccess,
-                                        ansatt,
-                                        avtale,
-                                        redigeringsModus,
-                                        defaultValues,
-                                        ...props
-                                      }: Props) {
+  onClose,
+  onSuccess,
+  ansatt,
+  avtale,
+  redigeringsModus,
+  defaultValues,
+  ...props
+}: Props) {
   const [activeTab, setActiveTab] = useAtom(avtaleDetaljerTabAtom);
 
   const mutation = useUpsertAvtale();
@@ -59,7 +59,7 @@ export function AvtaleSkjemaContainer({
 
   const {
     handleSubmit,
-    formState: {errors},
+    formState: { errors },
     watch,
   } = form;
 
@@ -95,9 +95,9 @@ export function AvtaleSkjemaContainer({
       },
       programomradeMedUtdanningerRequest: data.programomradeOgUtdanninger
         ? {
-          programomradeId: data.programomradeOgUtdanninger?.programomradeId,
-          utdanningsIder: data.programomradeOgUtdanninger?.utdanningsIder || [],
-        }
+            programomradeId: data.programomradeOgUtdanninger?.programomradeId,
+            utdanningsIder: data.programomradeOgUtdanninger?.utdanningsIder || [],
+          }
         : null,
     };
 
@@ -110,7 +110,7 @@ export function AvtaleSkjemaContainer({
     (validation) => {
       validation.errors.forEach((error) => {
         const name = mapErrorToSchemaPropertyName(error.name);
-        form.setError(name, {type: "custom", message: error.message});
+        form.setError(name, { type: "custom", message: error.message });
       });
 
       function mapErrorToSchemaPropertyName(name: string) {
@@ -160,7 +160,7 @@ export function AvtaleSkjemaContainer({
                 hasError={hasRedaksjoneltInnholdErrors}
               />
             </div>
-            <AvtaleSkjemaKnapperad redigeringsModus={redigeringsModus} onClose={onClose}/>
+            <AvtaleSkjemaKnapperad redigeringsModus={redigeringsModus} onClose={onClose} />
           </Tabs.List>
           <Tabs.Panel value="detaljer">
             <AvtaleSkjemaDetaljer
@@ -172,18 +172,18 @@ export function AvtaleSkjemaContainer({
           </Tabs.Panel>
           <Tabs.Panel value="personvern">
             <InlineErrorBoundary>
-              <React.Suspense fallback={<Laster tekst="Laster innhold"/>}>
-                <AvtalePersonvernForm tiltakstypeId={watchedTiltakstype?.id}/>
+              <React.Suspense fallback={<Laster tekst="Laster innhold" />}>
+                <AvtalePersonvernForm tiltakstypeId={watchedTiltakstype?.id} />
               </React.Suspense>
             </InlineErrorBoundary>
           </Tabs.Panel>
           <Tabs.Panel value="redaksjonelt-innhold">
-            <AvtaleRedaksjoneltInnholdForm tiltakstype={watchedTiltakstype}/>
+            <AvtaleRedaksjoneltInnholdForm tiltakstype={watchedTiltakstype} />
           </Tabs.Panel>
         </Tabs>
-        <Separator/>
+        <Separator />
         <RedaksjoneltInnholdBunnKnapperad>
-          <AvtaleSkjemaKnapperad redigeringsModus={redigeringsModus} onClose={onClose}/>
+          <AvtaleSkjemaKnapperad redigeringsModus={redigeringsModus} onClose={onClose} />
         </RedaksjoneltInnholdBunnKnapperad>
       </form>
     </FormProvider>

--- a/frontend/mr-admin-flate/src/components/redaksjoneltInnhold/AvtaleSchema.ts
+++ b/frontend/mr-admin-flate/src/components/redaksjoneltInnhold/AvtaleSchema.ts
@@ -1,7 +1,13 @@
-import { Avtaletype, OpsjonsmodellKey, Personopplysning, Tiltakskode } from "@mr/api-client";
+import {
+  Avtaletype,
+  OpsjonsmodellKey,
+  Personopplysning,
+  ProgramomradeMedUtdanningerRequest,
+  Tiltakskode,
+} from "@mr/api-client";
 import z from "zod";
-import { FaneinnholdSchema } from "./FaneinnholdSchema";
 import { AmoKategoriseringSchema } from "./AmoKategoriseringSchema";
+import { FaneinnholdSchema } from "./FaneinnholdSchema";
 
 export const AvtaleSchema = z
   .object({
@@ -65,6 +71,7 @@ export const AvtaleSchema = z
     personvernBekreftet: z.boolean({ required_error: "Du må ta stilling til personvern" }),
     personopplysninger: z.nativeEnum(Personopplysning).array(),
     amoKategorisering: AmoKategoriseringSchema.nullish(),
+    programomradeOgUtdanninger: z.custom<ProgramomradeMedUtdanningerRequest>().nullable(),
   })
   .superRefine((data, ctx) => {
     if (

--- a/frontend/mr-admin-flate/src/components/utdanning/AvtaleUtdanningSkjema.tsx
+++ b/frontend/mr-admin-flate/src/components/utdanning/AvtaleUtdanningSkjema.tsx
@@ -1,15 +1,21 @@
 import { Toggles } from "@mr/api-client";
+import { Alert, Select } from "@navikt/ds-react";
+import { useFormContext } from "react-hook-form";
 import { useFeatureToggle } from "../../api/features/useFeatureToggle";
 import { useHentUtdanninger } from "../../api/utdanning/useHentUtdanninger";
-import { Alert, Select } from "@navikt/ds-react";
-import { useState } from "react";
+import { InferredAvtaleSchema } from "../redaksjoneltInnhold/AvtaleSchema";
+import { ControlledMultiSelect } from "../skjema/ControlledMultiSelect";
 
 export function AvtaleUtdanningSkjema() {
   const { data: enableUtdanningskjema } = useFeatureToggle(
     Toggles.MULIGHETSROMMET_ADMIN_FLATE_ENABLE_UTDANNINGSKATEGORIER,
   );
   const { data: utdanninger, isPending } = useHentUtdanninger();
-  const [programomrade, setProgramomrade] = useState<string | null>(null);
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext<InferredAvtaleSchema>();
 
   if (!enableUtdanningskjema) {
     return null;
@@ -27,34 +33,41 @@ export function AvtaleUtdanningSkjema() {
     return <Alert variant="warning">Klarte ikke hente programområder og utdanninger</Alert>;
   }
 
+  const watchedProgramomrade = watch("programomradeOgUtdanninger.programomradeId");
   const programomrader = utdanninger.map((utdanning) => utdanning.programomrade);
   const utdanningerForProgramomrade = utdanninger
-    .filter((utdanning) => utdanning.programomrade.id === programomrade)
+    .filter((utdanning) => utdanning.programomrade.id === watchedProgramomrade)
     .map((utdanning) => utdanning.utdanninger)
     .flat();
 
   return (
     <>
+      <pre>{JSON.stringify(watch("programomradeOgUtdanninger"), null, 2)}</pre>
       <Select
         size="small"
         label="Velg programområde"
-        onChange={(e) => setProgramomrade(e.currentTarget.value)}
+        {...register("programomradeOgUtdanninger.programomradeId")}
+        error={errors.programomradeOgUtdanninger?.programomradeId?.message}
       >
-        <option value={undefined}>Velg programområde</option>
         {programomrader.map((programomrade) => (
           <option value={programomrade.id} key={programomrade.id}>
             {programomrade.navn}
           </option>
         ))}
       </Select>
-      {programomrade && (
-        <Select label="Velg sluttkompetanse" size="small">
-          {utdanningerForProgramomrade.map((utdanning) => (
-            <option value={utdanning.id} key={utdanning.navn}>
-              {utdanning.navn}
-            </option>
-          ))}
-        </Select>
+      {watchedProgramomrade && (
+        <ControlledMultiSelect
+          size="small"
+          placeholder="Velg sluttkompetanser"
+          label="Velg sluttkompetanser"
+          {...register("programomradeOgUtdanninger.utdanningsIder")}
+          options={utdanningerForProgramomrade.map((utdanning) => {
+            return {
+              value: utdanning.id,
+              label: utdanning.navn,
+            };
+          })}
+        />
       )}
     </>
   );

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_programomrader_og_utdanninger.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_programomrader_og_utdanninger.ts
@@ -1,5 +1,5 @@
-import { ProgramomradeMedUtdanning } from "@mr/api-client";
-export const mockProgramomraderOgUtdanninger: ProgramomradeMedUtdanning[] = [
+import { ProgramomradeMedUtdanninger } from "@mr/api-client";
+export const mockProgramomraderOgUtdanninger: ProgramomradeMedUtdanninger[] = [
   {
     programomrade: {
       id: "8303c8a1-4c0f-45a2-beb4-021e9f5d30d3",

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidator.kt
@@ -146,12 +146,19 @@ class AvtaleValidator(
             }
 
             if (unleashService.isEnabled("mulighetsrommet.admin-flate.enable-utdanningskategorier")) {
-                if (avtale.programomradeOgUtdanningerRequest == null) {
-                    add(ValidationError.ofCustomLocation("programomrade", "Du må velge et programområde og én eller flere sluttkompetanser"))
-                }
+                if (tiltakstype.tiltakskode == Tiltakskode.GRUPPE_FAG_OG_YRKESOPPLAERING) {
+                    if (avtale.programomradeOgUtdanningerRequest == null) {
+                        add(
+                            ValidationError.ofCustomLocation(
+                                "programomrade",
+                                "Du må velge et programområde og én eller flere sluttkompetanser",
+                            ),
+                        )
+                    }
 
-                if (avtale.programomradeOgUtdanningerRequest != null && avtale.programomradeOgUtdanningerRequest.utdanningsIder.isEmpty()) {
-                    add(ValidationError.ofCustomLocation("utdanninger", "Du må velge minst én sluttkompetanse"))
+                    if (avtale.programomradeOgUtdanningerRequest != null && avtale.programomradeOgUtdanningerRequest.utdanningsIder.isEmpty()) {
+                        add(ValidationError.ofCustomLocation("utdanninger", "Du må velge minst én sluttkompetanse"))
+                    }
                 }
             }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/AvtaleDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dbo/AvtaleDbo.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.domain.dbo
 
 import no.nav.mulighetsrommet.api.routes.v1.Opsjonsmodell
+import no.nav.mulighetsrommet.api.routes.v1.ProgramomradeMedUtdanningerRequest
 import no.nav.mulighetsrommet.domain.dto.*
 import java.time.LocalDate
 import java.util.*
@@ -29,4 +30,5 @@ data class AvtaleDbo(
     val amoKategorisering: AmoKategorisering?,
     val opsjonsmodell: Opsjonsmodell?,
     val customOpsjonsmodellNavn: String?,
+    val programomradeOgUtdanningerRequest: ProgramomradeMedUtdanningerRequest?,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/AvtaleDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/domain/dto/AvtaleDto.kt
@@ -3,6 +3,7 @@ package no.nav.mulighetsrommet.api.domain.dto
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.domain.dbo.ArenaNavEnhet
 import no.nav.mulighetsrommet.api.domain.dbo.AvtaleDbo
+import no.nav.mulighetsrommet.api.repositories.ProgramomradeMedUtdanninger
 import no.nav.mulighetsrommet.api.routes.v1.OpsjonLoggRequest
 import no.nav.mulighetsrommet.api.routes.v1.OpsjonsmodellData
 import no.nav.mulighetsrommet.domain.Tiltakskode
@@ -47,6 +48,7 @@ data class AvtaleDto(
     val amoKategorisering: AmoKategorisering?,
     val opsjonsmodellData: OpsjonsmodellData? = null,
     val opsjonerRegistrert: List<OpsjonLoggRegistrert>?,
+    val programomradeMedUtdanninger: ProgramomradeMedUtdanninger? = null,
 ) {
     @Serializable
     data class Tiltakstype(
@@ -123,6 +125,7 @@ data class AvtaleDto(
             opsjonMaksVarighet = opsjonsmodellData?.opsjonMaksVarighet,
             opsjonsmodell = opsjonsmodellData?.opsjonsmodell,
             customOpsjonsmodellNavn = opsjonsmodellData?.customOpsjonsmodellNavn,
+            programomradeOgUtdanningerRequest = programomradeMedUtdanninger?.toRequest(),
         )
 
     fun toArenaAvtaleDbo() =

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/okonomi/refusjon/RefusjonRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/okonomi/refusjon/RefusjonRoutes.kt
@@ -9,6 +9,8 @@ import no.nav.mulighetsrommet.api.okonomi.prismodell.Prismodell
 import no.nav.mulighetsrommet.domain.dto.Organisasjonsnummer
 import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
+import no.nav.pdfgen.core.Environment
+import no.nav.pdfgen.core.PDFGenCore
 import no.nav.pdfgen.core.pdf.createHtmlFromTemplateData
 import no.nav.pdfgen.core.pdf.createPDFA
 import org.koin.ktor.ext.inject
@@ -18,10 +20,9 @@ import java.util.*
 
 fun Route.refusjonRoutes() {
     VeraGreenfieldFoundryProvider.initialise()
-    // TODO Enable PDFGenCore
-/*    PDFGenCore.init(
+    PDFGenCore.init(
         Environment(),
-    )*/
+    )
     val service: RefusjonService by inject()
 
     route("/api/v1/intern/refusjon") {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/okonomi/refusjon/RefusjonRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/okonomi/refusjon/RefusjonRoutes.kt
@@ -9,8 +9,6 @@ import no.nav.mulighetsrommet.api.okonomi.prismodell.Prismodell
 import no.nav.mulighetsrommet.domain.dto.Organisasjonsnummer
 import no.nav.mulighetsrommet.domain.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
-import no.nav.pdfgen.core.Environment
-import no.nav.pdfgen.core.PDFGenCore
 import no.nav.pdfgen.core.pdf.createHtmlFromTemplateData
 import no.nav.pdfgen.core.pdf.createPDFA
 import org.koin.ktor.ext.inject
@@ -20,9 +18,10 @@ import java.util.*
 
 fun Route.refusjonRoutes() {
     VeraGreenfieldFoundryProvider.initialise()
-    PDFGenCore.init(
+    // TODO Enable PDFGenCore
+/*    PDFGenCore.init(
         Environment(),
-    )
+    )*/
     val service: RefusjonService by inject()
 
     route("/api/v1/intern/refusjon") {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/UtdanningRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/UtdanningRepository.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.repositories
 
 import kotlinx.serialization.Serializable
 import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.routes.v1.ProgramomradeMedUtdanningerRequest
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.domain.serializers.UUIDSerializer
 import org.intellij.lang.annotations.Language
@@ -9,7 +10,7 @@ import java.util.*
 
 class UtdanningRepository(private val db: Database) {
 
-    fun getUtdanningerMedProgramomrader(): List<UtdanningerMedProgramomrade> {
+    fun getUtdanningerMedProgramomrader(): List<ProgramomradeMedUtdanninger> {
         @Language("PostgreSQL")
         val programomraderQuery = """
             SELECT * FROM utdanning_programomrade where utdanningsprogram = 'YRKESFAGLIG' and array_length(nus_koder, 1) > 0
@@ -54,7 +55,7 @@ class UtdanningRepository(private val db: Database) {
         }.asList.let { db.run(it) }
 
         val utdanningerMedProgramomrade = programomrader.map { programomrade ->
-            UtdanningerMedProgramomrade(
+            ProgramomradeMedUtdanninger(
                 programomrade = programomrade,
                 utdanninger = utdanninger.filter { it.programlopStart == programomrade.id },
             )
@@ -65,10 +66,17 @@ class UtdanningRepository(private val db: Database) {
 }
 
 @Serializable
-data class UtdanningerMedProgramomrade(
+data class ProgramomradeMedUtdanninger(
     val programomrade: Programomrade,
     val utdanninger: List<UtdanningDbo>,
-)
+) {
+    fun toRequest(): ProgramomradeMedUtdanningerRequest {
+        return ProgramomradeMedUtdanningerRequest(
+            programomradeId = programomrade.id,
+            utdanningsIder = utdanninger.map { it.id },
+        )
+    }
+}
 
 @Serializable
 data class Programomrade(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/v1/AvtaleRoutes.kt
@@ -55,6 +55,7 @@ data class AvtaleRequest(
     val personvernBekreftet: Boolean,
     val amoKategorisering: AmoKategorisering?,
     val opsjonsmodellData: OpsjonsmodellData?,
+    val programomradeMedUtdanningerRequest: ProgramomradeMedUtdanningerRequest?,
 )
 
 @Serializable
@@ -98,6 +99,16 @@ data class SlettOpsjonLoggRequest(
     val id: UUID,
     @Serializable(with = UUIDSerializer::class)
     val avtaleId: UUID,
+)
+
+@Serializable
+data class ProgramomradeMedUtdanningerRequest(
+    @Serializable(with = UUIDSerializer::class)
+    val programomradeId: UUID,
+    val utdanningsIder: List<
+        @Serializable(with = UUIDSerializer::class)
+        UUID,
+        >,
 )
 
 fun Route.avtaleRoutes() {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/services/AvtaleService.kt
@@ -20,7 +20,10 @@ import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.database.utils.Pagination
 import no.nav.mulighetsrommet.domain.Tiltakskode
 import no.nav.mulighetsrommet.domain.constants.ArenaMigrering.Opphav
-import no.nav.mulighetsrommet.domain.dto.*
+import no.nav.mulighetsrommet.domain.dto.AvbruttAarsak
+import no.nav.mulighetsrommet.domain.dto.AvtaleStatus
+import no.nav.mulighetsrommet.domain.dto.NavIdent
+import no.nav.mulighetsrommet.domain.dto.TiltaksgjennomforingStatus
 import no.nav.mulighetsrommet.notifications.NotificationRepository
 import no.nav.mulighetsrommet.notifications.NotificationType
 import no.nav.mulighetsrommet.notifications.ScheduledNotification
@@ -71,6 +74,7 @@ class AvtaleService(
                         amoKategorisering = amoKategorisering,
                         opsjonsmodell = opsjonsmodellData?.opsjonsmodell,
                         customOpsjonsmodellNavn = opsjonsmodellData?.customOpsjonsmodellNavn,
+                        programomradeOgUtdanningerRequest = programomradeMedUtdanningerRequest,
                     )
                 }
                 validator.validate(dbo, previous)

--- a/mulighetsrommet-api/src/main/resources/db/migration/V183__table-for-avtale-and-utdanning.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V183__table-for-avtale-and-utdanning.sql
@@ -1,0 +1,6 @@
+create table utdanning_programomrade_avtale
+(
+    avtale_id uuid references avtale(id),
+    programomrade_id uuid references utdanning_programomrade(id),
+    utdanning_id uuid references utdanning(id)
+)

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1862,7 +1862,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ProgramomradeMedUtdanning"
+                  $ref: "#/components/schemas/ProgramomradeMedUtdanninger"
 
 components:
   securitySchemes:
@@ -2317,6 +2317,9 @@ components:
         opsjonsmodellData:
           $ref: "#/components/schemas/OpsjonsmodellData"
           nullable: true
+        programomradeMedUtdanningerRequest:
+          $ref: "#/components/schemas/ProgramomradeMedUtdanningerRequest"
+          nullable: true
       required:
         - id
         - navn
@@ -2337,6 +2340,7 @@ components:
         - personvernBekreftet
         - amoKategorisering
         - opsjonsmodellData
+        - programomradeMedUtdanningerRequest
 
     EmbeddedTiltakstype:
       type: object
@@ -4979,7 +4983,22 @@ components:
         - sats
         - belop
 
-    ProgramomradeMedUtdanning:
+    ProgramomradeMedUtdanningerRequest:
+      type: object
+      properties:
+        programomradeId:
+          type: string
+          format: uuid
+        utdanningsIder:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
+        - programomradeId
+        - utdanningsIder
+
+    ProgramomradeMedUtdanninger:
       type: object
       properties:
         programomrade:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/avtaler/AvtaleValidatorTest.kt
@@ -736,7 +736,7 @@ class AvtaleValidatorTest : FunSpec({
             )
         }
 
-        test("Skal validere at minst én utdanning er valgt når programområde er satt ogtiltakstypen er Gruppe Fag- og yrkesopplæring") {
+        test("Skal validere at minst én utdanning er valgt når programområde er satt og tiltakstypen er Gruppe Fag- og yrkesopplæring") {
             val programomradeId = UUID.randomUUID()
 
             @Language("PostgreSQL")

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -36,6 +36,7 @@ object AvtaleFixtures {
         opsjonMaksVarighet = LocalDate.now().plusYears(3),
         opsjonsmodell = Opsjonsmodell.TO_PLUSS_EN,
         customOpsjonsmodellNavn = null,
+        programomradeOgUtdanningerRequest = null,
     )
 
     val oppfolgingMedAvtale = AvtaleDbo(
@@ -62,6 +63,7 @@ object AvtaleFixtures {
         opsjonMaksVarighet = LocalDate.now().plusYears(3),
         opsjonsmodell = Opsjonsmodell.TO_PLUSS_EN,
         customOpsjonsmodellNavn = null,
+        programomradeOgUtdanningerRequest = null,
     )
 
     val gruppeAmo = AvtaleDbo(
@@ -88,6 +90,7 @@ object AvtaleFixtures {
         opsjonMaksVarighet = LocalDate.now().plusYears(3),
         opsjonsmodell = Opsjonsmodell.TO_PLUSS_EN,
         customOpsjonsmodellNavn = null,
+        programomradeOgUtdanningerRequest = null,
     )
 
     val IPS = AvtaleDbo(
@@ -114,6 +117,7 @@ object AvtaleFixtures {
         opsjonMaksVarighet = LocalDate.now().plusYears(3),
         opsjonsmodell = Opsjonsmodell.TO_PLUSS_EN,
         customOpsjonsmodellNavn = null,
+        programomradeOgUtdanningerRequest = null,
     )
 
     val VTA = AvtaleDbo(
@@ -140,6 +144,7 @@ object AvtaleFixtures {
         opsjonMaksVarighet = null,
         opsjonsmodell = null,
         customOpsjonsmodellNavn = null,
+        programomradeOgUtdanningerRequest = null,
     )
 
     val AFT = AvtaleDbo(
@@ -166,6 +171,7 @@ object AvtaleFixtures {
         opsjonMaksVarighet = null,
         opsjonsmodell = null,
         customOpsjonsmodellNavn = null,
+        programomradeOgUtdanningerRequest = null,
     )
 
     val EnkelAmo = AvtaleDbo(
@@ -192,6 +198,7 @@ object AvtaleFixtures {
         opsjonMaksVarighet = LocalDate.now().plusYears(3),
         opsjonsmodell = Opsjonsmodell.TO_PLUSS_EN,
         customOpsjonsmodellNavn = null,
+        programomradeOgUtdanningerRequest = null,
     )
 
     val jobbklubb = AvtaleDbo(
@@ -218,6 +225,7 @@ object AvtaleFixtures {
         opsjonMaksVarighet = LocalDate.now().plusYears(3),
         opsjonsmodell = Opsjonsmodell.TO_PLUSS_EN,
         customOpsjonsmodellNavn = null,
+        programomradeOgUtdanningerRequest = null,
     )
 
     val avtaleRequest = AvtaleRequest(
@@ -245,5 +253,6 @@ object AvtaleFixtures {
             opsjonsmodell = Opsjonsmodell.TO_PLUSS_EN,
             customOpsjonsmodellNavn = null,
         ),
+        programomradeMedUtdanningerRequest = null,
     )
 }


### PR DESCRIPTION
Oppretter egen tabell for å koble avtale, programområde og utdanning.
Det gjenstår å hente ut koblingene og vise de som en del av lagret av avtale.
Det kommer kanskje i denne pr'en, eller i egen pr senere.
