### PR TITLE
Hent ut programområde og utdanninger til avtalen

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaConst.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleSkjemaConst.tsx
@@ -64,5 +64,13 @@ export function defaultAvtaleData(
       opsjonsmodell: avtale?.opsjonsmodellData?.opsjonsmodell ?? undefined,
       customOpsjonsmodellNavn: avtale?.opsjonsmodellData?.customOpsjonsmodellNavn ?? undefined,
     },
+    programomradeOgUtdanninger: avtale?.programomradeMedUtdanninger
+      ? {
+          programomradeId: avtale.programomradeMedUtdanninger.programomrade.id,
+          utdanningsIder: avtale.programomradeMedUtdanninger.utdanninger.map(
+            (utdanning) => utdanning.id,
+          ),
+        }
+      : undefined,
   };
 }

--- a/frontend/mr-admin-flate/src/components/ledetekster/avtaleLedetekster.ts
+++ b/frontend/mr-admin-flate/src/components/ledetekster/avtaleLedetekster.ts
@@ -24,4 +24,9 @@ export const avtaletekster = {
   tiltaksarrangorUnderenheterLabel: "Tiltaksarrangør underenheter",
   kontaktpersonerHosTiltaksarrangorLabel: "Kontaktpersoner hos tiltaksarrangør",
   avtaltForlengelseLabel: "Avtalt mulighet for forlengelse",
+  programomradeOgUtdanninger: {
+    laster: "Laster...",
+    velgProgramomrade: "Velg programområde",
+    velgSluttkompetanser: "Velg sluttkompetanser",
+  },
 } as const;

--- a/frontend/mr-admin-flate/src/components/ledetekster/avtaleLedetekster.ts
+++ b/frontend/mr-admin-flate/src/components/ledetekster/avtaleLedetekster.ts
@@ -28,5 +28,7 @@ export const avtaletekster = {
     laster: "Laster...",
     velgProgramomrade: "Velg programområde",
     velgSluttkompetanser: "Velg sluttkompetanser",
+    programomradeLabel: "Programområde",
+    sluttkompetanserLabel: "Sluttkompetanser",
   },
 } as const;

--- a/frontend/mr-admin-flate/src/components/utdanning/AvtaleUtdanningSkjema.tsx
+++ b/frontend/mr-admin-flate/src/components/utdanning/AvtaleUtdanningSkjema.tsx
@@ -5,6 +5,7 @@ import { useFeatureToggle } from "../../api/features/useFeatureToggle";
 import { useHentUtdanninger } from "../../api/utdanning/useHentUtdanninger";
 import { InferredAvtaleSchema } from "../redaksjoneltInnhold/AvtaleSchema";
 import { ControlledMultiSelect } from "../skjema/ControlledMultiSelect";
+import { avtaletekster } from "../ledetekster/avtaleLedetekster";
 
 export function AvtaleUtdanningSkjema() {
   const { data: enableUtdanningskjema } = useFeatureToggle(
@@ -24,7 +25,7 @@ export function AvtaleUtdanningSkjema() {
   if (isPending) {
     return (
       <Select disabled label="Velg programområde">
-        <option>Laster...</option>
+        <option>{avtaletekster.programomradeOgUtdanninger.laster}</option>
       </Select>
     );
   }
@@ -42,10 +43,9 @@ export function AvtaleUtdanningSkjema() {
 
   return (
     <>
-      <pre>{JSON.stringify(watch("programomradeOgUtdanninger"), null, 2)}</pre>
       <Select
         size="small"
-        label="Velg programområde"
+        label={avtaletekster.programomradeOgUtdanninger.velgProgramomrade}
         {...register("programomradeOgUtdanninger.programomradeId")}
         error={errors.programomradeOgUtdanninger?.programomradeId?.message}
       >
@@ -58,8 +58,8 @@ export function AvtaleUtdanningSkjema() {
       {watchedProgramomrade && (
         <ControlledMultiSelect
           size="small"
-          placeholder="Velg sluttkompetanser"
-          label="Velg sluttkompetanser"
+          placeholder={avtaletekster.programomradeOgUtdanninger.velgSluttkompetanser}
+          label={avtaletekster.programomradeOgUtdanninger.velgSluttkompetanser}
           {...register("programomradeOgUtdanninger.utdanningsIder")}
           options={utdanningerForProgramomrade.map((utdanning) => {
             return {

--- a/frontend/mr-admin-flate/src/components/utdanning/ProgramomradeOgUtdanningerDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/utdanning/ProgramomradeOgUtdanningerDetaljer.tsx
@@ -2,6 +2,7 @@ import { ProgramomradeMedUtdanninger } from "@mr/api-client";
 import { Bolk } from "../detaljside/Bolk";
 import { Metadata, Separator } from "../detaljside/Metadata";
 import { List } from "@navikt/ds-react";
+import { avtaletekster } from "../ledetekster/avtaleLedetekster";
 
 interface Props {
   programomradeMedUtdanninger: ProgramomradeMedUtdanninger;
@@ -11,16 +12,21 @@ export function ProgramomradeOgUtdanningerDetaljer({ programomradeMedUtdanninger
   return (
     <>
       <Bolk>
-        <Metadata header="Programområde" verdi={programomradeMedUtdanninger.programomrade.navn} />
+        <Metadata
+          header={avtaletekster.programomradeOgUtdanninger.programomradeLabel}
+          verdi={programomradeMedUtdanninger.programomrade.navn}
+        />
       </Bolk>
       <Bolk>
         <Metadata
-          header="Utdanninger"
+          header={avtaletekster.programomradeOgUtdanninger.sluttkompetanserLabel}
           verdi={
             <List>
-              {programomradeMedUtdanninger.utdanninger.map((utdanning) => (
-                <List.Item key={utdanning.id}>{utdanning.navn}</List.Item>
-              ))}
+              {programomradeMedUtdanninger.utdanninger
+                .sort((a, b) => a.navn.localeCompare(b.navn))
+                .map((utdanning) => (
+                  <List.Item key={utdanning.id}>{utdanning.navn}</List.Item>
+                ))}
             </List>
           }
         />

--- a/frontend/mr-admin-flate/src/components/utdanning/ProgramomradeOgUtdanningerDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/utdanning/ProgramomradeOgUtdanningerDetaljer.tsx
@@ -1,0 +1,31 @@
+import { ProgramomradeMedUtdanninger } from "@mr/api-client";
+import { Bolk } from "../detaljside/Bolk";
+import { Metadata, Separator } from "../detaljside/Metadata";
+import { List } from "@navikt/ds-react";
+
+interface Props {
+  programomradeMedUtdanninger: ProgramomradeMedUtdanninger;
+}
+
+export function ProgramomradeOgUtdanningerDetaljer({ programomradeMedUtdanninger }: Props) {
+  return (
+    <>
+      <Bolk>
+        <Metadata header="Programområde" verdi={programomradeMedUtdanninger.programomrade.navn} />
+      </Bolk>
+      <Bolk>
+        <Metadata
+          header="Utdanninger"
+          verdi={
+            <List>
+              {programomradeMedUtdanninger.utdanninger.map((utdanning) => (
+                <List.Item key={utdanning.id}>{utdanning.navn}</List.Item>
+              ))}
+            </List>
+          }
+        />
+      </Bolk>
+      <Separator />
+    </>
+  );
+}

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
@@ -20,6 +20,7 @@ import { Fragment } from "react";
 import { Link } from "react-router-dom";
 import { opsjonsmodellTilTekst } from "../../components/avtaler/opsjoner/opsjonsmodeller";
 import styles from "./AvtaleDetaljer.module.scss";
+import { ProgramomradeOgUtdanningerDetaljer } from "../../components/utdanning/ProgramomradeOgUtdanningerDetaljer";
 
 export function AvtaleDetaljer() {
   const { data: avtale, isPending, error } = useAvtale();
@@ -49,6 +50,7 @@ export function AvtaleDetaljer() {
     arenaAnsvarligEnhet,
     arrangor,
     amoKategorisering,
+    programomradeMedUtdanninger,
   } = avtale;
 
   return (
@@ -83,6 +85,12 @@ export function AvtaleDetaljer() {
             <Separator />
           </>
         )}
+
+        {programomradeMedUtdanninger ? (
+          <ProgramomradeOgUtdanningerDetaljer
+            programomradeMedUtdanninger={programomradeMedUtdanninger}
+          />
+        ) : null}
 
         <Heading size="small" as="h3">
           Avtalens varighet

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/repositories/AvtaleRepository.kt
@@ -597,6 +597,9 @@ class AvtaleRepository(private val db: Database) {
         val amoKategorisering = stringOrNull("amo_kategorisering_json")
             ?.let { JsonIgnoreUnknownKeys.decodeFromString<AmoKategorisering>(it) }
 
+        val programomradeMedUtdanninger = stringOrNull("programomrade_og_utdanninger_json")
+            ?.let { JsonIgnoreUnknownKeys.decodeFromString<ProgramomradeMedUtdanninger>(it) }
+
         return AvtaleDto(
             id = uuid("id"),
             navn = string("navn"),
@@ -637,6 +640,7 @@ class AvtaleRepository(private val db: Database) {
             opsjonsmodellData = opsjonsmodellData,
             opsjonerRegistrert = opsjonerRegistrert.sortedBy { it.aktivertDato },
             amoKategorisering = amoKategorisering,
+            programomradeMedUtdanninger = programomradeMedUtdanninger,
         )
     }
 

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2214,6 +2214,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/OpsjonLoggRegistrert"
+        programomradeMedUtdanninger:
+            $ref: "#/components/schemas/ProgramomradeMedUtdanninger"
       required:
         - id
         - tiltakstype


### PR DESCRIPTION
Legger til støtte for å hente ut lagret programområde og tilhørende sluttkompetanser/utdanninger. Viser de også i detaljvisning for avtale.

![image](https://github.com/user-attachments/assets/1ffc043d-8435-4c99-9cf8-a3d808fe5b47)

![image](https://github.com/user-attachments/assets/60831017-7a0d-4461-8e12-85450a3f9e63)

