### PR TITLE
Skrur på støtte for å schedulere publisering i Sanity

### DIFF
--- a/frontend/mulighetsrommet-cms/sanity.config.ts
+++ b/frontend/mulighetsrommet-cms/sanity.config.ts
@@ -13,6 +13,9 @@ const createCommonConfig = (dataset: "production" | "test", basePath: string) =>
   projectId: PROJECT_ID,
   dataset,
   basePath,
+  scheduledPublishing: {
+    enabled: true,
+  },
   document: {
     unstable_comments: {
       // Comments enabled https://www.sanity.io/blog/introducing-comments


### PR DESCRIPTION
Dette gjør at for tiltak i Sanity kan redaktør velge når tiltaket skal publiseres i fremtiden.
