### PR TITLE
bugfix/adressebeskyttelse

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/okonomi/refusjon/ArrangorflateRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/okonomi/refusjon/ArrangorflateRoutes.kt
@@ -260,8 +260,9 @@ private suspend fun getPersoner(
         }
 }
 
-private fun toRefusjonskravPerson(person: HentPersonBolkResponse.Person) =
-    when (person.adressebeskyttelse.first().gradering) {
+private fun toRefusjonskravPerson(person: HentPersonBolkResponse.Person): RefusjonKravDeltakelse.Person {
+    val gradering = person.adressebeskyttelse.firstOrNull()?.gradering ?: PdlGradering.UGRADERT
+    return when (gradering) {
         PdlGradering.UGRADERT -> {
             val navn = person.navn.first().let { navn ->
                 val fornavnOgMellomnavn = listOfNotNull(navn.fornavn, navn.mellomnavn).joinToString(" ")
@@ -281,6 +282,7 @@ private fun toRefusjonskravPerson(person: HentPersonBolkResponse.Person) =
             fodselsdato = null,
         )
     }
+}
 
 @Serializable
 data class RefusjonKravKompakt(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/okonomi/refusjon/HentAdressebeskyttetPersonBolkPdlQuery.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/okonomi/refusjon/HentAdressebeskyttetPersonBolkPdlQuery.kt
@@ -76,8 +76,7 @@ data class HentPersonBolkResponse(
     data class Person(
         @Serializable(with = NonEmptyListSerializer::class)
         val navn: NonEmptyList<PdlNavn>,
-        @Serializable(with = NonEmptyListSerializer::class)
-        val adressebeskyttelse: NonEmptyList<Adressebeskyttelse>,
+        val adressebeskyttelse: List<Adressebeskyttelse>,
         @Serializable(with = NonEmptyListSerializer::class)
         val foedselsdato: NonEmptyList<Foedselsdato>,
     )

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/pdl/HentAdressebeskyttetPersonBolkPdlQueryTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/pdl/HentAdressebeskyttetPersonBolkPdlQueryTest.kt
@@ -79,7 +79,7 @@ class HentAdressebeskyttetPersonBolkPdlQueryTest : FunSpec({
                 navn = nonEmptyListOf(
                     PdlNavn(fornavn = "Ola", etternavn = "Normann"),
                 ),
-                adressebeskyttelse = nonEmptyListOf(
+                adressebeskyttelse = listOf(
                     HentPersonBolkResponse.Adressebeskyttelse(gradering = PdlGradering.STRENGT_FORTROLIG),
                 ),
                 foedselsdato = nonEmptyListOf(
@@ -146,7 +146,7 @@ class HentAdressebeskyttetPersonBolkPdlQueryTest : FunSpec({
                 navn = nonEmptyListOf(
                     PdlNavn(fornavn = "Ola", etternavn = "Normann"),
                 ),
-                adressebeskyttelse = nonEmptyListOf(
+                adressebeskyttelse = listOf(
                     HentPersonBolkResponse.Adressebeskyttelse(gradering = PdlGradering.UGRADERT),
                 ),
                 foedselsdato = nonEmptyListOf(


### PR DESCRIPTION
- **hent adressebeskyttelse i bolk-spørring**
- **skjul personinfo om adressebeskyttede personer i refusjonsløsning**
- **organize imports**
- **implementer en kompakt visning av refusjonskrav**
- **ta høyde for at adressebeskyttelse også er en liste**
- **forenkle utleding av navn**
- **ta høyde for at adressebeskyttelse kan være tom**
