### PR TITLE
Fjern maksVarighetAar fra annen opsjon

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/opsjoner/opsjonsmodeller.ts
+++ b/frontend/mr-admin-flate/src/components/avtaler/opsjoner/opsjonsmodeller.ts
@@ -33,7 +33,7 @@ export const opsjonsmodeller: Opsjonsmodell[] = [
   {
     value: OpsjonsmodellKey.ANNET,
     label: "Annen opsjonsmodell",
-    maksVarighetAar: 5,
+    maksVarighetAar: null,
     initialSluttdatoEkstraAar: undefined,
     kreverMaksVarighet: true,
   },


### PR DESCRIPTION
Siden den kan være over 5 år nå uansett, så ble det enklere og bare fjerne denne da den ble satt som default verdi og overskrev hvis man hadde satt noe annet. Også litt misvisende og ha en maks grense som man kan overstyre.