### PR TITLE
Rename brodsmuler

### DIFF
--- a/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.tsx
+++ b/frontend/mr-admin-flate/src/components/administrator/AdministratorHeader.tsx
@@ -67,7 +67,7 @@ export function AdministratorHeader() {
                 to="/tiltaksgjennomforinger"
                 className={styles.menylenke}
               >
-                Tiltaksgjennomføringer
+                Gjennomføringer
               </Link>
             </Dropdown.Menu.GroupedList.Item>
             <Dropdown.Menu.GroupedList.Item

--- a/frontend/mr-admin-flate/src/components/forsidekort/ForsidekortListe.tsx
+++ b/frontend/mr-admin-flate/src/components/forsidekort/ForsidekortListe.tsx
@@ -27,18 +27,18 @@ export function ForsidekortListe() {
         tekst="Her finner du informasjon om avtaler for gruppetiltak"
       />
       <Forsidekort
-        navn="Tiltaksgjennomføringer"
+        navn="Gjennomføringer"
         ikon={
           <TiltaksgjennomforingIkon
             inkluderBakgrunn
-            aria-label="Tiltaksgjennomføringer for gruppetiltak"
+            aria-label="Gjennomføringer for gruppetiltak"
           />
         }
         url="tiltaksgjennomforinger"
-        tekst="Her finner du informasjon om tiltaksgjennomføringer for gruppetiltak"
+        tekst="Her finner du informasjon om Gjennomføringer for gruppetiltak"
       />
       <Forsidekort
-        navn="Individuelle tiltaksgjennomføringer"
+        navn="Individuelle Gjennomføringer"
         ikon={
           <img
             style={{ height: "64px", width: "64px" }}
@@ -48,7 +48,7 @@ export function ForsidekortListe() {
         }
         url={SANITY_STUDIO_URL}
         apneINyTab
-        tekst="Her administrerer du individuelle tiltaksgjennomføringer"
+        tekst="Her administrerer du individuelle Gjennomføringer"
       />
       <Forsidekort
         navn="Veilederflate forhåndsvisning"

--- a/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
+++ b/frontend/mr-admin-flate/src/components/navigering/Brodsmuler.tsx
@@ -33,7 +33,7 @@ export function Brodsmuler({ brodsmuler }: Props) {
     <nav aria-label="Brødsmulesti" className={styles.navContainer}>
       <ol className={styles.container}>
         {filtrerteBrodsmuler.filter(erBrodsmule).map((item, index) => {
-          const erSisteBrodsmule = index > 0 && index === filtrerteBrodsmuler.length - 1;
+          const erSisteBrodsmule = index >= 0 && index === filtrerteBrodsmuler.length - 1;
           return (
             <li key={index}>
               {erSisteBrodsmule ? (

--- a/frontend/mr-admin-flate/src/pages/arrangor/ArrangorPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/arrangor/ArrangorPage.tsx
@@ -17,7 +17,6 @@ export function ArrangorPage({ arrangorId }: Props) {
   const [openHovedenhet, setOpenHovedenhet] = useState(true); // TODO Fiks default open for arrangører med underenheter
 
   const brodsmuler: Brodsmule[] = [
-    { tittel: "Forside", lenke: "/" },
     { tittel: "Arrangører", lenke: "/arrangorer" },
     { tittel: `${arrangor?.navn}`, lenke: `/arrangorer/${arrangorId}` },
   ];

--- a/frontend/mr-admin-flate/src/pages/arrangor/ArrangorerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/arrangor/ArrangorerPage.tsx
@@ -1,17 +1,16 @@
-import { useOpenFilterWhenThreshold, useTitle } from "@mr/frontend-common";
-import { FilterAndTableLayout } from "@mr/frontend-common/components/filterAndTableLayout/FilterAndTableLayout";
-import { useState } from "react";
 import { arrangorerFilterAtom } from "@/api/atoms";
 import { ArrangorerFilter } from "@/components/filter/ArrangorerFilter";
-import { Brodsmuler } from "@/components/navigering/Brodsmuler";
+import { ArrangorerFilterTags } from "@/components/filter/ArrangorerFilterTags";
+import { ArrangorIkon } from "@/components/ikoner/ArrangorIkon";
+import { ArrangorerTabell } from "@/components/tabell/ArrangorerTabell";
+import { ReloadAppErrorBoundary } from "@/ErrorBoundary";
 import { ContainerLayout } from "@/layouts/ContainerLayout";
 import { HeaderBanner } from "@/layouts/HeaderBanner";
 import { MainContainer } from "@/layouts/MainContainer";
+import { useOpenFilterWhenThreshold, useTitle } from "@mr/frontend-common";
+import { FilterAndTableLayout } from "@mr/frontend-common/components/filterAndTableLayout/FilterAndTableLayout";
+import { useState } from "react";
 import { NullstillKnappForArrangorer } from "./NullstillKnappForArrangorer";
-import { ArrangorerTabell } from "@/components/tabell/ArrangorerTabell";
-import { ArrangorerFilterTags } from "@/components/filter/ArrangorerFilterTags";
-import { ArrangorIkon } from "@/components/ikoner/ArrangorIkon";
-import { ReloadAppErrorBoundary } from "@/ErrorBoundary";
 
 export function ArrangorerPage() {
   useTitle("Arrangører");
@@ -20,12 +19,6 @@ export function ArrangorerPage() {
 
   return (
     <>
-      <Brodsmuler
-        brodsmuler={[
-          { tittel: "Forside", lenke: "/" },
-          { tittel: "Arrangører", lenke: "/arrangorer" },
-        ]}
-      />
       <HeaderBanner heading="Arrangører" ikon={<ArrangorIkon />} />
       <ReloadAppErrorBoundary>
         <MainContainer>

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
@@ -19,10 +19,10 @@ function useAvtaleBrodsmuler(avtaleId?: string): Array<Brodsmule | undefined> {
   return [
     { tittel: "Forside", lenke: "/" },
     { tittel: "Avtaler", lenke: "/avtaler" },
-    { tittel: "Avtaledetaljer", lenke: `/avtaler/${avtaleId}` },
+    { tittel: "Avtale", lenke: `/avtaler/${avtaleId}` },
     erPaaGjennomforingerForAvtale
       ? {
-          tittel: "Avtalens gjennomføringer",
+          tittel: "Gjennomføringer",
           lenke: `/avtaler/${avtaleId}/tiltaksgjennomforinger`,
         }
       : undefined,

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalePage.tsx
@@ -17,7 +17,6 @@ import { Laster } from "../../components/laster/Laster";
 function useAvtaleBrodsmuler(avtaleId?: string): Array<Brodsmule | undefined> {
   const erPaaGjennomforingerForAvtale = useMatch("/avtaler/:avtaleId/tiltaksgjennomforinger");
   return [
-    { tittel: "Forside", lenke: "/" },
     { tittel: "Avtaler", lenke: "/avtaler" },
     { tittel: "Avtale", lenke: `/avtaler/${avtaleId}` },
     erPaaGjennomforingerForAvtale

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleSkjemaPage.tsx
@@ -28,7 +28,7 @@ export function AvtaleSkjemaPage() {
     { tittel: "Avtaler", lenke: "/avtaler" },
     redigeringsModus
       ? {
-          tittel: "Avtaledetaljer",
+          tittel: "Avtale",
           lenke: `/avtaler/${avtale?.id}`,
         }
       : undefined,

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleSkjemaPage.tsx
@@ -24,7 +24,6 @@ export function AvtaleSkjemaPage() {
   const redigeringsModus = avtale ? inneholderUrl(avtale.id) : false;
 
   const brodsmuler: Array<Brodsmule | undefined> = [
-    { tittel: "Forside", lenke: "/" },
     { tittel: "Avtaler", lenke: "/avtaler" },
     redigeringsModus
       ? {

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalerPage.tsx
@@ -1,21 +1,20 @@
 import { avtaleFilterAtom, AvtaleFilterSchema } from "@/api/atoms";
 import { AvtaleFilter } from "@/components/filter/AvtaleFilter";
-import { AvtaleTabell } from "@/components/tabell/AvtaleTabell";
-import { HeaderBanner } from "@/layouts/HeaderBanner";
-import { ContainerLayout } from "@/layouts/ContainerLayout";
-import { MainContainer } from "@/layouts/MainContainer";
-import { LagredeFilterOversikt, useOpenFilterWhenThreshold, useTitle } from "@mr/frontend-common";
-import { AvtaleFiltertags } from "@/components/filter/AvtaleFiltertags";
-import { TilToppenKnapp } from "@mr/frontend-common/components/tilToppenKnapp/TilToppenKnapp";
-import { Brodsmuler } from "@/components/navigering/Brodsmuler";
-import { AvtaleIkon } from "@/components/ikoner/AvtaleIkon";
-import { useState } from "react";
-import { FilterAndTableLayout } from "@mr/frontend-common/components/filterAndTableLayout/FilterAndTableLayout";
 import { AvtaleFilterButtons } from "@/components/filter/AvtaleFilterButtons";
+import { AvtaleFiltertags } from "@/components/filter/AvtaleFiltertags";
+import { AvtaleIkon } from "@/components/ikoner/AvtaleIkon";
+import { AvtaleTabell } from "@/components/tabell/AvtaleTabell";
+import { ReloadAppErrorBoundary } from "@/ErrorBoundary";
+import { ContainerLayout } from "@/layouts/ContainerLayout";
+import { HeaderBanner } from "@/layouts/HeaderBanner";
+import { MainContainer } from "@/layouts/MainContainer";
 import { NullstillKnappForAvtaler } from "@/pages/avtaler/NullstillKnappForAvtaler";
 import { LagretDokumenttype } from "@mr/api-client";
+import { LagredeFilterOversikt, useOpenFilterWhenThreshold, useTitle } from "@mr/frontend-common";
+import { FilterAndTableLayout } from "@mr/frontend-common/components/filterAndTableLayout/FilterAndTableLayout";
+import { TilToppenKnapp } from "@mr/frontend-common/components/tilToppenKnapp/TilToppenKnapp";
 import { useAtom } from "jotai/index";
-import { ReloadAppErrorBoundary } from "@/ErrorBoundary";
+import { useState } from "react";
 
 export function AvtalerPage() {
   useTitle("Avtaler");
@@ -26,12 +25,6 @@ export function AvtalerPage() {
 
   return (
     <>
-      <Brodsmuler
-        brodsmuler={[
-          { tittel: "Forside", lenke: "/" },
-          { tittel: "Avtaler", lenke: "/avtaler" },
-        ]}
-      />
       <HeaderBanner heading="Oversikt over avtaler" harUndermeny ikon={<AvtaleIkon />} />
       <ReloadAppErrorBoundary>
         <MainContainer>

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
@@ -24,7 +24,6 @@ function createBrodsmuler(
   refusjonskrav?: boolean,
 ): Array<Brodsmule | undefined> {
   return [
-    { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
       : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingPage.tsx
@@ -27,16 +27,16 @@ function createBrodsmuler(
     { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
-      : { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
-    avtaleId ? { tittel: "Avtaledetaljer", lenke: `/avtaler/${avtaleId}` } : undefined,
+      : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },
+    avtaleId ? { tittel: "Avtale", lenke: `/avtaler/${avtaleId}` } : undefined,
     avtaleId
       ? {
-          tittel: "Avtalens gjennomføringer",
+          tittel: "Gjennomføringer",
           lenke: `/avtaler/${avtaleId}/tiltaksgjennomforinger`,
         }
       : undefined,
     {
-      tittel: "Tiltaksgjennomføringdetaljer",
+      tittel: "Gjennomføring",
       lenke: `/tiltaksgjennomforinger/${tiltaksgjennomforingId}`,
     },
     tilsagn

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
@@ -62,29 +62,29 @@ export function TiltaksgjennomforingSkjemaPage() {
     { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
-      : { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+      : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },
     avtaleId
       ? {
-          tittel: "Avtaledetaljer",
+          tittel: "Avtale",
           lenke: `/avtaler/${avtaleId}`,
         }
       : undefined,
     erPaaGjennomforingerForAvtale
       ? {
-          tittel: "Avtalens gjennomføringer",
+          tittel: "Gjennomføringer",
           lenke: `/avtaler/${avtaleId}/tiltaksgjennomforinger`,
         }
       : undefined,
     redigeringsModus
       ? {
-          tittel: "Tiltaksgjennomføringdetaljer",
+          tittel: "Gjennomføring",
           lenke: avtaleId
             ? `/avtaler/${avtaleId}/tiltaksgjennomforinger/${tiltaksgjennomforing?.id}`
             : `/tiltaksgjennomforinger/${tiltaksgjennomforing?.id}`,
         }
       : undefined,
     {
-      tittel: redigeringsModus ? "Rediger gjennomføring" : "Ny tiltaksgjennomføring",
+      tittel: redigeringsModus ? "Rediger gjennomføring" : "Ny gjennomføring",
       lenke: redigeringsModus
         ? `/tiltaksgjennomforinger/${tiltaksgjennomforing?.id}/skjema`
         : "/tiltaksgjennomforinger/skjema",
@@ -97,7 +97,7 @@ export function TiltaksgjennomforingSkjemaPage() {
       <Header>
         <TiltaksgjennomforingIkon />
         <Heading size="large" level="2">
-          {redigeringsModus ? "Rediger gjennomføring" : "Opprett ny tiltaksgjennomføring"}
+          {redigeringsModus ? "Rediger gjennomføring" : "Opprett ny gjennomføring"}
         </Heading>
         {tiltaksgjennomforing ? (
           <GjennomforingStatusMedAarsakTag status={tiltaksgjennomforing.status} />

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingSkjemaPage.tsx
@@ -59,7 +59,6 @@ export function TiltaksgjennomforingSkjemaPage() {
   }
 
   const brodsmuler: Array<Brodsmule | undefined> = [
-    { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
       : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
@@ -1,21 +1,20 @@
-import { LagredeFilterOversikt, useOpenFilterWhenThreshold, useTitle } from "@mr/frontend-common";
+import { tiltaksgjennomforingfilterAtom, TiltaksgjennomforingFilterSchema } from "@/api/atoms";
+import { TiltaksgjennomforingFilter } from "@/components/filter/TiltaksgjennomforingFilter";
+import { TiltaksgjennomforingFilterButtons } from "@/components/filter/TiltaksgjennomforingFilterButtons";
+import { TiltaksgjennomforingFiltertags } from "@/components/filter/TiltaksgjennomforingFiltertags";
+import { TiltaksgjennomforingIkon } from "@/components/ikoner/TiltaksgjennomforingIkon";
 import { TiltaksgjennomforingsTabell } from "@/components/tabell/TiltaksgjennomforingsTabell";
+import { ReloadAppErrorBoundary } from "@/ErrorBoundary";
 import { ContainerLayout } from "@/layouts/ContainerLayout";
 import { HeaderBanner } from "@/layouts/HeaderBanner";
 import { MainContainer } from "@/layouts/MainContainer";
-import { tiltaksgjennomforingfilterAtom, TiltaksgjennomforingFilterSchema } from "@/api/atoms";
-import { FilterAndTableLayout } from "@mr/frontend-common/components/filterAndTableLayout/FilterAndTableLayout";
-import { TiltaksgjennomforingFilterButtons } from "@/components/filter/TiltaksgjennomforingFilterButtons";
-import { TiltaksgjennomforingFiltertags } from "@/components/filter/TiltaksgjennomforingFiltertags";
-import { TiltaksgjennomforingFilter } from "@/components/filter/TiltaksgjennomforingFilter";
-import { TilToppenKnapp } from "@mr/frontend-common/components/tilToppenKnapp/TilToppenKnapp";
-import { Brodsmuler } from "@/components/navigering/Brodsmuler";
-import { TiltaksgjennomforingIkon } from "@/components/ikoner/TiltaksgjennomforingIkon";
-import { useState } from "react";
 import { NullstillKnappForTiltaksgjennomforinger } from "@/pages/tiltaksgjennomforinger/NullstillKnappForTiltaksgjennomforinger";
 import { LagretDokumenttype } from "@mr/api-client";
+import { LagredeFilterOversikt, useOpenFilterWhenThreshold, useTitle } from "@mr/frontend-common";
+import { FilterAndTableLayout } from "@mr/frontend-common/components/filterAndTableLayout/FilterAndTableLayout";
+import { TilToppenKnapp } from "@mr/frontend-common/components/tilToppenKnapp/TilToppenKnapp";
 import { useAtom } from "jotai/index";
-import { ReloadAppErrorBoundary } from "@/ErrorBoundary";
+import { useState } from "react";
 
 export function TiltaksgjennomforingerPage() {
   useTitle("Gjennomføringer");
@@ -25,12 +24,6 @@ export function TiltaksgjennomforingerPage() {
 
   return (
     <>
-      <Brodsmuler
-        brodsmuler={[
-          { tittel: "Forside", lenke: "/" },
-          { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },
-        ]}
-      />
       <HeaderBanner heading="Oversikt over gjennomføringer" ikon={<TiltaksgjennomforingIkon />} />
       <MainContainer>
         <ContainerLayout>

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/TiltaksgjennomforingerPage.tsx
@@ -18,7 +18,7 @@ import { useAtom } from "jotai/index";
 import { ReloadAppErrorBoundary } from "@/ErrorBoundary";
 
 export function TiltaksgjennomforingerPage() {
-  useTitle("Tiltaksgjennomføringer");
+  useTitle("Gjennomføringer");
   const [filterOpen, setFilterOpen] = useOpenFilterWhenThreshold(1450);
   const [tagsHeight, setTagsHeight] = useState(0);
   const [filter, setFilter] = useAtom(tiltaksgjennomforingfilterAtom);
@@ -28,13 +28,10 @@ export function TiltaksgjennomforingerPage() {
       <Brodsmuler
         brodsmuler={[
           { tittel: "Forside", lenke: "/" },
-          { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+          { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },
         ]}
       />
-      <HeaderBanner
-        heading="Oversikt over tiltaksgjennomføringer"
-        ikon={<TiltaksgjennomforingIkon />}
-      />
+      <HeaderBanner heading="Oversikt over gjennomføringer" ikon={<TiltaksgjennomforingIkon />} />
       <MainContainer>
         <ContainerLayout>
           <FilterAndTableLayout

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/refusjonskrav/detaljer/RefusjonskravDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/refusjonskrav/detaljer/RefusjonskravDetaljer.tsx
@@ -20,7 +20,7 @@ export function RefusjonskravDetaljer() {
   );
 
   const brodsmuler: Array<Brodsmule | undefined> = [
-    { tittel: "Forside", lenke: "/" },
+    { tittel: "", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
       : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/refusjonskrav/detaljer/RefusjonskravDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/refusjonskrav/detaljer/RefusjonskravDetaljer.tsx
@@ -23,21 +23,21 @@ export function RefusjonskravDetaljer() {
     { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
-      : { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+      : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },
     avtaleId
       ? {
-          tittel: "Avtaledetaljer",
+          tittel: "Avtale",
           lenke: `/avtaler/${avtaleId}`,
         }
       : undefined,
     erPaaGjennomforingerForAvtale
       ? {
-          tittel: "Avtalens gjennomføringer",
+          tittel: "Gjennomføringer",
           lenke: `/avtaler/${avtaleId}/tiltaksgjennomforinger`,
         }
       : undefined,
     {
-      tittel: "Tiltaksgjennomføringdetaljer",
+      tittel: "Gjennomføring",
       lenke: `/tiltaksgjennomforinger/${tiltaksgjennomforingId}`,
     },
     {

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/detaljer/TilsagnDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/detaljer/TilsagnDetaljer.tsx
@@ -53,21 +53,21 @@ export function TilsagnDetaljer() {
     { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
-      : { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+      : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },
     avtaleId
       ? {
-          tittel: "Avtaledetaljer",
+          tittel: "Avtale",
           lenke: `/avtaler/${avtaleId}`,
         }
       : undefined,
     erPaaGjennomforingerForAvtale
       ? {
-          tittel: "Avtalens gjennomføringer",
+          tittel: "Gjennomføringer",
           lenke: `/avtaler/${avtaleId}/tiltaksgjennomforinger`,
         }
       : undefined,
     {
-      tittel: "Tiltaksgjennomføringdetaljer",
+      tittel: "Gjennomføring",
       lenke: `/tiltaksgjennomforinger/${tiltaksgjennomforingId}`,
     },
     {

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/detaljer/TilsagnDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/detaljer/TilsagnDetaljer.tsx
@@ -50,7 +50,6 @@ export function TilsagnDetaljer() {
   );
 
   const brodsmuler: Array<Brodsmule | undefined> = [
-    { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
       : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/opprett/OpprettTilsagnSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/opprett/OpprettTilsagnSkjemaPage.tsx
@@ -25,16 +25,16 @@ export function OpprettTilsagnSkjemaPage() {
     { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
-      : { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+      : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },
     avtaleId
       ? {
-          tittel: "Avtaledetaljer",
+          tittel: "Avtale",
           lenke: `/avtaler/${avtaleId}`,
         }
       : undefined,
     erPaaGjennomforingerForAvtale
       ? {
-          tittel: "Avtalens gjennomføringer",
+          tittel: "Gjennomføringer",
           lenke: `/avtaler/${avtaleId}/tiltaksgjennomforinger`,
         }
       : undefined,

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/opprett/OpprettTilsagnSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/opprett/OpprettTilsagnSkjemaPage.tsx
@@ -22,7 +22,6 @@ export function OpprettTilsagnSkjemaPage() {
   );
 
   const brodsmuler: Array<Brodsmule | undefined> = [
-    { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
       : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/rediger/RedigerTilsagnSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/rediger/RedigerTilsagnSkjemaPage.tsx
@@ -26,21 +26,21 @@ export function RedigerTilsagnSkjemaPage() {
     { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
-      : { tittel: "Tiltaksgjennomføringer", lenke: "/tiltaksgjennomforinger" },
+      : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },
     avtaleId
       ? {
-          tittel: "Avtaledetaljer",
+          tittel: "Avtale",
           lenke: `/avtaler/${avtaleId}`,
         }
       : undefined,
     erPaaGjennomforingerForAvtale
       ? {
-          tittel: "Avtalens gjennomføringer",
+          tittel: "Gjennomføringer",
           lenke: `/avtaler/${avtaleId}/tiltaksgjennomforinger`,
         }
       : undefined,
     {
-      tittel: "Tiltaksgjennomføringdetaljer",
+      tittel: "Gjennomføring",
       lenke: avtaleId
         ? `/avtaler/${avtaleId}/tiltaksgjennomforinger/${gjennomforing.id}`
         : `/tiltaksgjennomforinger/${gjennomforing.id}`,

--- a/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/rediger/RedigerTilsagnSkjemaPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltaksgjennomforinger/tilsagn/rediger/RedigerTilsagnSkjemaPage.tsx
@@ -23,7 +23,6 @@ export function RedigerTilsagnSkjemaPage() {
   );
 
   const brodsmuler: Array<Brodsmule | undefined> = [
-    { tittel: "Forside", lenke: "/" },
     avtaleId
       ? { tittel: "Avtaler", lenke: "/avtaler" }
       : { tittel: "Gjennomføringer", lenke: "/tiltaksgjennomforinger" },

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
@@ -13,7 +13,6 @@ import { tiltakstypeLoader } from "./tiltakstyperLoaders";
 function useTiltakstypeBrodsmuler(tiltakstypeId?: string): Array<Brodsmule | undefined> {
   const match = useMatch("/tiltakstyper/:tiltakstypeId/avtaler");
   return [
-    { tittel: "Forside", lenke: "/" },
     { tittel: "Tiltakstyper", lenke: "/tiltakstyper" },
     { tittel: "Tiltakstype", lenke: `/tiltakstyper/${tiltakstypeId}` },
     match ? { tittel: "Avtaler", lenke: `/tiltakstyper/${tiltakstypeId}/avtaler` } : undefined,

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/DetaljerTiltakstypePage.tsx
@@ -15,10 +15,8 @@ function useTiltakstypeBrodsmuler(tiltakstypeId?: string): Array<Brodsmule | und
   return [
     { tittel: "Forside", lenke: "/" },
     { tittel: "Tiltakstyper", lenke: "/tiltakstyper" },
-    { tittel: "Tiltakstypedetaljer", lenke: `/tiltakstyper/${tiltakstypeId}` },
-    match
-      ? { tittel: "Tiltaktypens avtaler", lenke: `/tiltakstyper/${tiltakstypeId}/avtaler` }
-      : undefined,
+    { tittel: "Tiltakstype", lenke: `/tiltakstyper/${tiltakstypeId}` },
+    match ? { tittel: "Avtaler", lenke: `/tiltakstyper/${tiltakstypeId}/avtaler` } : undefined,
   ];
 }
 

--- a/frontend/mr-admin-flate/src/pages/tiltakstyper/TiltakstyperPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/tiltakstyper/TiltakstyperPage.tsx
@@ -1,25 +1,18 @@
-import { ContainerLayout } from "@/layouts/ContainerLayout";
-import { MainContainer } from "@/layouts/MainContainer";
-import { HeaderBanner } from "@/layouts/HeaderBanner";
-import { useTitle } from "@mr/frontend-common";
-import { TilToppenKnapp } from "@mr/frontend-common/components/tilToppenKnapp/TilToppenKnapp";
-import { Brodsmuler } from "@/components/navigering/Brodsmuler";
 import { TiltakstypeIkon } from "@/components/ikoner/TiltakstypeIkon";
-import { Skeleton } from "@navikt/ds-react";
-import { Suspense } from "react";
 import { TiltakstypeTabell } from "@/components/tabell/TiltakstypeTabell";
 import { ReloadAppErrorBoundary } from "@/ErrorBoundary";
+import { ContainerLayout } from "@/layouts/ContainerLayout";
+import { HeaderBanner } from "@/layouts/HeaderBanner";
+import { MainContainer } from "@/layouts/MainContainer";
+import { useTitle } from "@mr/frontend-common";
+import { TilToppenKnapp } from "@mr/frontend-common/components/tilToppenKnapp/TilToppenKnapp";
+import { Skeleton } from "@navikt/ds-react";
+import { Suspense } from "react";
 
 export function TiltakstyperPage() {
   useTitle("Tiltakstyper");
   return (
     <>
-      <Brodsmuler
-        brodsmuler={[
-          { tittel: "Forside", lenke: "/" },
-          { tittel: "Tiltakstyper", lenke: "/tiltakstyper" },
-        ]}
-      />
       <HeaderBanner heading="Oversikt over tiltakstyper" ikon={<TiltakstypeIkon />} />
       <MainContainer>
         <ContainerLayout>

--- a/frontend/mr-admin-flate/tests/adminflate.spec.ts
+++ b/frontend/mr-admin-flate/tests/adminflate.spec.ts
@@ -51,7 +51,7 @@ test.describe("Smoketest og UU", () => {
     await sjekkUU(page, "opprett-ny-tiltaksgjenomforing_knapp");
   });
 
-  test("Tiltaksgjennomføringer", async ({ page }) => {
+  test("Gjennomføringer", async ({ page }) => {
     await page.getByTestId("forsidekort-tiltaksgjennomforinger").click();
     await expect(page.getByTestId("header_oversikt-over-tiltaksgjennomforinger")).toBeVisible();
     await sjekkUU(page, "header_oversikt-over-tiltaksgjennomforinger");

--- a/frontend/mr-admin-flate/tests/adminflate.spec.ts
+++ b/frontend/mr-admin-flate/tests/adminflate.spec.ts
@@ -52,13 +52,13 @@ test.describe("Smoketest og UU", () => {
   });
 
   test("Gjennomføringer", async ({ page }) => {
-    await page.getByTestId("forsidekort-tiltaksgjennomforinger").click();
-    await expect(page.getByTestId("header_oversikt-over-tiltaksgjennomforinger")).toBeVisible();
-    await sjekkUU(page, "header_oversikt-over-tiltaksgjennomforinger");
+    await page.getByTestId("forsidekort-gjennomforinger").click();
+    await expect(page.getByTestId("header_oversikt-over-gjennomforinger")).toBeVisible();
+    await sjekkUU(page, "header_oversikt-over-gjennomforinger");
   });
 
   test("Tiltaksgjennomføring - Info", async ({ page }) => {
-    await page.getByTestId("forsidekort-tiltaksgjennomforinger").click();
+    await page.getByTestId("forsidekort-gjennomforinger").click();
     await page.getByTestId("filtertab").click();
     await page.getByTestId("tiltaksgjennomforing-tabell_tittel").first().click();
     await expect(page.getByText("Tiltaksnavn")).toBeVisible();


### PR DESCRIPTION
Fjerner brødsmuler der det bare blir en brødsmule (fra hovedsidene for tiltakstype, avtaler og gjennomføringer).
Renamer også brødsmuler til å ta litt mindre plass.

- **Rename brødsmuler**
- **Fjern forside fra brødsmuler**
