### PR TITLE
1.0 - Henter deltakelser/avtaler basert på cut-off dato for team Tiltak

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/TiltakshistorikkDto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/TiltakshistorikkDto.kt
@@ -96,6 +96,7 @@ sealed class Tiltakshistorikk {
             MENTOR,
             INKLUDERINGSTILSKUDD,
             SOMMERJOBB,
+            VARIG_TILRETTELAGT_ARBEID_ORDINAR,
         }
     }
 }

--- a/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/ktor/plugins/StatusPages.kt
+++ b/common/ktor/src/main/kotlin/no/nav/mulighetsrommet/ktor/plugins/StatusPages.kt
@@ -16,7 +16,6 @@ import no.nav.mulighetsrommet.securelog.SecureLog
 import org.slf4j.MDC
 
 fun Application.configureStatusPages() {
-
     fun logException(statusCode: HttpStatusCode, cause: Throwable, call: ApplicationCall) {
         val message = "${statusCode.description} (${statusCode.value}) on method: ${call.request.httpMethod.value} ${call.request.path()}: ${cause.message}"
         SecureLog.logger.error(message, cause)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/TiltakshistorikkService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/TiltakshistorikkService.kt
@@ -146,6 +146,7 @@ class TiltakshistorikkService(
             Tiltakshistorikk.ArbeidsgiverAvtale.Tiltakstype.MENTOR -> "MENTOR"
             Tiltakshistorikk.ArbeidsgiverAvtale.Tiltakstype.INKLUDERINGSTILSKUDD -> "INKLUTILS"
             Tiltakshistorikk.ArbeidsgiverAvtale.Tiltakstype.SOMMERJOBB -> "TILSJOBB"
+            Tiltakshistorikk.ArbeidsgiverAvtale.Tiltakstype.VARIG_TILRETTELAGT_ARBEID_ORDINAR -> "VATIAROR"
         }
         val tiltakstype = tiltakstypeService.getByArenaTiltakskode(arenaKode)
         val arrangorNavn = getArrangorNavn(deltakelse.arbeidsgiver.organisasjonsnummer)

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/Application.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/Application.kt
@@ -55,7 +55,7 @@ fun Application.configure(config: AppConfig) {
         tokenProvider = cachedTokenProvider.withScope(config.clients.tiltakDatadeling.scope),
     )
 
-    val tiltakshistorikkService = TiltakshistorikkService(deltakerRepository, tiltakDatadelingClient)
+    val tiltakshistorikkService = TiltakshistorikkService(deltakerRepository, tiltakDatadelingClient, config.arbeidsgiverTiltakCutOffDatoMapping)
 
     val kafka = configureKafka(config.kafka, db, deltakerRepository, gruppetiltakRepository)
 

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/Config.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/Config.kt
@@ -6,6 +6,8 @@ import no.nav.mulighetsrommet.database.DatabaseConfig
 import no.nav.mulighetsrommet.database.FlywayMigrationManager
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.ktor.ServerConfig
+import no.nav.tiltak.historikk.clients.Avtale
+import java.time.LocalDate
 
 data class Config(
     val server: ServerConfig,
@@ -19,6 +21,7 @@ data class AppConfig(
     val auth: AuthConfig,
     val kafka: KafkaConfig,
     val clients: ClientConfig,
+    val arbeidsgiverTiltakCutOffDatoMapping: Map<Avtale.Tiltakstype, LocalDate> = emptyMap(),
 )
 
 data class ClientConfig(

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/clients/TiltakDatadelingClient.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/clients/TiltakDatadelingClient.kt
@@ -195,6 +195,7 @@ data class Avtale(
         MENTOR,
         INKLUDERINGSTILSKUDD,
         SOMMERJOBB,
+        VTAO,
     }
 
     enum class Status {

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/repositories/DeltakerRepository.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/repositories/DeltakerRepository.kt
@@ -6,7 +6,6 @@ import no.nav.amt.model.AmtDeltakerV1Dto
 import no.nav.mulighetsrommet.arena.ArenaDeltakerDbo
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.model.*
-import no.nav.mulighetsrommet.model.Tiltakskode
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -52,7 +51,10 @@ class DeltakerRepository(private val db: Database) {
         queryOf(query, deltaker.toSqlParameters()).asExecute.runWithSession(session)
     }
 
-    fun getArenaHistorikk(identer: List<NorskIdent>, maxAgeYears: Int?) = db.session { session ->
+    fun getArenaHistorikk(
+        identer: List<NorskIdent>,
+        maxAgeYears: Int?,
+    ) = db.session { session ->
         @Language("PostgreSQL")
         val query = """
                 select

--- a/mulighetsrommet-tiltakshistorikk/src/main/resources/application-dev.yaml
+++ b/mulighetsrommet-tiltakshistorikk/src/main/resources/application-dev.yaml
@@ -28,3 +28,8 @@ app:
     tiltakDatadeling:
       url: http://tiltak-datadeling.team-tiltak
       scope: api://dev-gcp.team-tiltak.tiltak-datadeling/.default
+
+  arbeidsgiverTiltakCutOffDatoMapping:
+    MIDLERTIDIG_LONNSTILSKUDD: 2023-2-1
+    VARIG_LONNSTILSKUDD: 2023-2-1
+    ARBEIDSTRENING: 2025-1-24

--- a/mulighetsrommet-tiltakshistorikk/src/main/resources/application-local.yaml
+++ b/mulighetsrommet-tiltakshistorikk/src/main/resources/application-local.yaml
@@ -29,3 +29,8 @@ app:
     tiltakDatadeling:
       url: http://localhost:8090/tiltak-datadeling
       scope: default
+
+  arbeidsgiverTiltakCutOffDatoMapping:
+    MIDLERTIDIG_LONNSTILSKUDD: 2023-2-1
+    VARIG_LONNSTILSKUDD: 2023-2-1
+    ARBEIDSTRENING: 2025-1-24

--- a/mulighetsrommet-tiltakshistorikk/src/main/resources/application-prod.yaml
+++ b/mulighetsrommet-tiltakshistorikk/src/main/resources/application-prod.yaml
@@ -28,3 +28,8 @@ app:
     tiltakDatadeling:
       url: http://tiltak-datadeling.team-tiltak
       scope: api://prod-gcp.team-tiltak.tiltak-datadeling/.default
+
+  arbeidsgiverTiltakCutOffDatoMapping:
+    MIDLERTIDIG_LONNSTILSKUDD: 2023-2-1
+    VARIG_LONNSTILSKUDD: 2023-2-1
+    ARBEIDSTRENING: 2025-1-24


### PR DESCRIPTION
Legger til rette for å hente avtaler fra team Tiltak når de har overtatt basert på en cutoff-dato som er konfigurert opp i application.yaml. Hvis cutoff-datoen ikke er satt så henter vi deltakelser fra Arena-dataene.