### PR TITLE
BUGFIX: Advarsel om datoendring fungerer uten useEffect

### DIFF
--- a/frontend/frontend-common/components/varsel/VarselModal.tsx
+++ b/frontend/frontend-common/components/varsel/VarselModal.tsx
@@ -62,6 +62,7 @@ export function VarselModal({
       <Modal.Footer className={footerClassName ? footerClassName : styles.footer}>
         {secondaryButton && (
           <Button
+            type="button"
             variant="secondary"
             onClick={() => {
               handleClose();

--- a/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingFormDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingFormDetaljer.tsx
@@ -87,17 +87,6 @@ export function GjennomforingFormDetaljer({ gjennomforing, avtale }: Props) {
   const antallDeltakere = deltakerSummary?.antallDeltakere;
 
   useEffect(() => {
-    if (
-      gjennomforing &&
-      antallDeltakere &&
-      antallDeltakere > 0 &&
-      gjennomforing.startDato !== watchStartDato
-    ) {
-      endreStartDatoModalRef.current?.showModal();
-    }
-  }, [watchStartDato, antallDeltakere, gjennomforing]);
-
-  useEffect(() => {
     if (watchStartDato && new Date(watchStartDato) < new Date()) {
       setValue("tilgjengeligForArrangorFraOgMedDato", null);
     }
@@ -105,16 +94,29 @@ export function GjennomforingFormDetaljer({ gjennomforing, avtale }: Props) {
 
   const watchSluttDato = watch("startOgSluttDato.sluttDato");
 
-  useEffect(() => {
+  function visAdvarselForStartDato() {
     if (
       gjennomforing &&
       antallDeltakere &&
       antallDeltakere > 0 &&
+      watchStartDato &&
+      gjennomforing.startDato !== watchStartDato
+    ) {
+      endreStartDatoModalRef.current?.showModal();
+    }
+  }
+
+  function visAdvarselForSluttDato() {
+    if (
+      gjennomforing &&
+      antallDeltakere &&
+      antallDeltakere > 0 &&
+      watchSluttDato &&
       gjennomforing.sluttDato !== watchSluttDato
     ) {
       endreSluttDatoModalRef.current?.showModal();
     }
-  }, [watchSluttDato, antallDeltakere, gjennomforing]);
+  }
 
   const regionerOptions = avtale.kontorstruktur
     .map((struk) => struk.region)
@@ -202,7 +204,9 @@ export function GjennomforingFormDetaljer({ gjennomforing, avtale }: Props) {
                 label={gjennomforingTekster.startdatoLabel}
                 fromDate={minStartdato}
                 toDate={maxSluttdato}
-                {...register("startOgSluttDato.startDato")}
+                {...register("startOgSluttDato.startDato", {
+                  onChange: visAdvarselForStartDato,
+                })}
                 format={"iso-string"}
               />
               <ControlledDateInput
@@ -210,7 +214,9 @@ export function GjennomforingFormDetaljer({ gjennomforing, avtale }: Props) {
                 label={gjennomforingTekster.sluttdatoLabel}
                 fromDate={minStartdato}
                 toDate={maxSluttdato}
-                {...register("startOgSluttDato.sluttDato")}
+                {...register("startOgSluttDato.sluttDato", {
+                  onChange: visAdvarselForSluttDato,
+                })}
                 format={"iso-string"}
               />
             </HGrid>


### PR DESCRIPTION
Fjerner bruk av useEffect for å sjekke om vi skal vise advarsel om datoendring-modal. Nå sjekker vi hver gang det skjer en onChange på start- eller sluttdato for gjennomføringen istedenfor.
