### PR TITLE
Legg til gjennomforingsnavn i oppgave-description

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/db/TilsagnQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/db/TilsagnQueries.kt
@@ -349,7 +349,7 @@ class TilsagnQueries(private val session: Session) {
             gjennomforing = TilsagnDto.Gjennomforing(
                 id = uuid("gjennomforing_id"),
                 tiltakskode = Tiltakskode.valueOf(string("tiltakskode")),
-                navn = string("gjennomforing_navn")
+                navn = string("gjennomforing_navn"),
             ),
             periodeSlutt = localDate("periode_slutt"),
             periodeStart = localDate("periode_start"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/db/TilsagnQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/db/TilsagnQueries.kt
@@ -349,6 +349,7 @@ class TilsagnQueries(private val session: Session) {
             gjennomforing = TilsagnDto.Gjennomforing(
                 id = uuid("gjennomforing_id"),
                 tiltakskode = Tiltakskode.valueOf(string("tiltakskode")),
+                navn = string("gjennomforing_navn")
             ),
             periodeSlutt = localDate("periode_slutt"),
             periodeStart = localDate("periode_start"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnDto.kt
@@ -44,7 +44,7 @@ data class TilsagnDto(
         @Serializable(with = UUIDSerializer::class)
         val id: UUID,
         val tiltakskode: Tiltakskode,
-        val navn: String
+        val navn: String,
     )
 
     @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnDto.kt
@@ -44,6 +44,7 @@ data class TilsagnDto(
         @Serializable(with = UUIDSerializer::class)
         val id: UUID,
         val tiltakskode: Tiltakskode,
+        val navn: String
     )
 
     @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/DelutbetalingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/DelutbetalingQueries.kt
@@ -184,6 +184,7 @@ class DelutbetalingQueries(private val session: Session) {
         val delutbetaling: DelutbetalingDto,
         val gjennomforingId: UUID,
         val tiltakskode: Tiltakskode,
+        val gjennomforingsnavn: String
     )
 
     fun getOppgaveData(
@@ -207,6 +208,7 @@ class DelutbetalingQueries(private val session: Session) {
                 delutbetaling.aarsaker,
                 delutbetaling.forklaring,
                 tilsagn.gjennomforing_id,
+                gjennomforing.navn,
                 tiltakstype.tiltakskode
             from delutbetaling
                 inner join tilsagn on tilsagn.id = delutbetaling.tilsagn_id
@@ -227,6 +229,7 @@ class DelutbetalingQueries(private val session: Session) {
             DelutbetalingOppgaveData(
                 delutbetaling = it.toDelutbetalingDto(),
                 gjennomforingId = it.uuid("gjennomforing_id"),
+                gjennomforingsnavn = it.string("navn"),
                 tiltakskode = Tiltakskode.valueOf(it.string("tiltakskode")),
             )
         }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/DelutbetalingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/DelutbetalingQueries.kt
@@ -184,7 +184,7 @@ class DelutbetalingQueries(private val session: Session) {
         val delutbetaling: DelutbetalingDto,
         val gjennomforingId: UUID,
         val tiltakskode: Tiltakskode,
-        val gjennomforingsnavn: String
+        val gjennomforingsnavn: String,
     )
 
     fun getOppgaveData(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverService.kt
@@ -85,7 +85,7 @@ class OppgaverService(val db: ApiDatabase) {
                     tiltakskoder = tiltakskoder.ifEmpty { null },
                 )
                 .mapNotNull { data ->
-                    data.delutbetaling.toOppgave(data.tiltakskode, data.gjennomforingId)
+                    data.delutbetaling.toOppgave(data.tiltakskode, data.gjennomforingId, data.gjennomforingsnavn)
                 }
                 .filter { oppgavetyper.isEmpty() || it.type in oppgavetyper }
                 .filter { it.type.rolle in roller }
@@ -129,7 +129,7 @@ class OppgaverService(val db: ApiDatabase) {
         is TilGodkjenning -> Oppgave(
             type = OppgaveType.TILSAGN_TIL_GODKJENNING,
             title = "Tilsagn til godkjenning",
-            description = "Tilsagnet er til godkjenning og må behandles",
+            description = "Tilsagnet for ${gjennomforing.navn} er sendt til godkjenning",
             tiltakstype = gjennomforing.tiltakskode,
             link = OppgaveLink(
                 linkText = "Se tilsagn",
@@ -141,7 +141,7 @@ class OppgaverService(val db: ApiDatabase) {
         is Returnert -> Oppgave(
             type = OppgaveType.TILSAGN_RETURNERT,
             title = "Tilsagn returnert",
-            description = "Tilsagnet ble returnert av beslutter",
+            description = "Tilsagnet for ${gjennomforing.navn} ble returnert av beslutter",
             tiltakstype = gjennomforing.tiltakskode,
             link = OppgaveLink(
                 linkText = "Se tilsagn",
@@ -153,7 +153,7 @@ class OppgaverService(val db: ApiDatabase) {
         is TilAnnullering -> Oppgave(
             type = OppgaveType.TILSAGN_TIL_ANNULLERING,
             title = "Tilsagn til annullering",
-            description = "Tilsagnet er til annullering og må behandles",
+            description = "Tilsagnet for ${gjennomforing.navn} er sendt til annullering",
             tiltakstype = gjennomforing.tiltakskode,
             link = OppgaveLink(
                 linkText = "Se tilsagn",
@@ -168,11 +168,12 @@ class OppgaverService(val db: ApiDatabase) {
     private fun DelutbetalingDto.toOppgave(
         tiltakskode: Tiltakskode,
         gjennomforingId: UUID,
+        gjennomforingsnavn: String,
     ): Oppgave? = when (this) {
         is DelutbetalingDto.DelutbetalingTilGodkjenning -> Oppgave(
             type = OppgaveType.UTBETALING_TIL_GODKJENNING,
             title = "Utbetaling til godkjenning",
-            description = "Utbetalingen er til godkjenning og må behandles",
+            description = "Utbetalingen for $gjennomforingsnavn er sendt til godkjenning",
             tiltakstype = tiltakskode,
             link = OppgaveLink(
                 linkText = "Se utbetaling",
@@ -184,7 +185,7 @@ class OppgaverService(val db: ApiDatabase) {
         is DelutbetalingDto.DelutbetalingAvvist -> Oppgave(
             type = OppgaveType.UTBETALING_RETURNERT,
             title = "Utbetaling returnert",
-            description = "Utbetaling ble returnert av beslutter",
+            description = "Utbetaling for $gjennomforingsnavn ble returnert av beslutter",
             tiltakstype = tiltakskode,
             link = OppgaveLink(
                 linkText = "Se utbetaling",
@@ -202,7 +203,7 @@ class OppgaverService(val db: ApiDatabase) {
         UtbetalingStatus.INNSENDT_AV_ARRANGOR -> Oppgave(
             type = OppgaveType.UTBETALING_TIL_BEHANDLING,
             title = "Utbetaling klar til behandling",
-            description = "Innsendt utbetaling er klar til behandling",
+            description = "Innsendt utbetaling for ${gjennomforing.navn} er klar til behandling",
             tiltakstype = tiltakstype.tiltakskode,
             link = OppgaveLink(
                 linkText = "Se utbetaling",

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__tilsagn_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__tilsagn_admin_view.sql
@@ -27,6 +27,7 @@ select tilsagn.id,
        arrangor.navn                                                             as arrangor_navn,
        arrangor.slettet_dato is not null                                         as arrangor_slettet,
        gjennomforing.tiltaksnummer                                               as tiltaksnummer,
+       gjennomforing.navn                                                        as gjennomforing_navn,
        tiltakstype.tiltakskode                                                   as tiltakskode
 from tilsagn
          inner join nav_enhet on nav_enhet.enhetsnummer = tilsagn.kostnadssted

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnQueriesTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnQueriesTest.kt
@@ -61,6 +61,7 @@ class TilsagnQueriesTest : FunSpec({
                     gjennomforing = TilsagnDto.Gjennomforing(
                         id = AFT1.id,
                         tiltakskode = TiltakstypeFixtures.AFT.tiltakskode!!,
+                        navn = AFT1.navn,
                     ),
                     periodeStart = LocalDate.of(2023, 1, 1),
                     periodeSlutt = LocalDate.of(2023, 1, 31),


### PR DESCRIPTION
Henter inn gjennomføringsnavn i tilsagnDTO og DelutbetalingOppgaveData, og bruker disse i tekstene i oppgave-description. Tar også bort " og må behandles" i tekstene.

**Visuelt blir det seende sånn ut etter endringene:**

![Screenshot 2025-02-21 at 09 52 52](https://github.com/user-attachments/assets/136e598b-0fec-4f97-861e-48e33d949fa8)

