### PR TITLE
Utleder on the fly status Venter på endring for utbetalinger i arrangørflate

### DIFF
--- a/frontend/arrangor-flate/app/components/utbetaling/UtbetalingTable.tsx
+++ b/frontend/arrangor-flate/app/components/utbetaling/UtbetalingTable.tsx
@@ -20,7 +20,6 @@ export function UtbetalingTable({ utbetalinger }: Props) {
       </Alert>
     );
   }
-
   return (
     <Table aria-label="Utbetalinger">
       <Table.Header>

--- a/frontend/arrangor-flate/app/components/utbetaling/UtbetalingTable.tsx
+++ b/frontend/arrangor-flate/app/components/utbetaling/UtbetalingTable.tsx
@@ -15,7 +15,7 @@ export function UtbetalingTable({ utbetalinger }: Props) {
 
   if (utbetalinger.length === 0) {
     return (
-      <Alert className="my-10" variant="info">
+      <Alert className="my-10 mt-10" variant="info">
         Det finnes ingen utbetalinger her
       </Alert>
     );
@@ -64,7 +64,10 @@ export function UtbetalingTable({ utbetalinger }: Props) {
                     <LinkWithTabState
                       className="hover:underline font-bold no-underline"
                       to={
-                        status === ArrFlateUtbetalingStatus.KLAR_FOR_GODKJENNING
+                        [
+                          ArrFlateUtbetalingStatus.KLAR_FOR_GODKJENNING,
+                          ArrFlateUtbetalingStatus.VENTER_PA_ENDRING,
+                        ].includes(status)
                           ? internalNavigation(orgnr).beregning(id)
                           : internalNavigation(orgnr).kvittering(id)
                       }
@@ -90,5 +93,7 @@ function statusTilTag(status: ArrFlateUtbetalingStatus): ReactNode {
       return <Tag variant="neutral">Behandles av Nav</Tag>;
     case ArrFlateUtbetalingStatus.KLAR_FOR_GODKJENNING:
       return <Tag variant="alt1">Klar for innsending</Tag>;
+    case ArrFlateUtbetalingStatus.VENTER_PA_ENDRING:
+      return <Tag variant="warning">Venter på endring</Tag>;
   }
 }

--- a/frontend/arrangor-flate/app/mocks/arrangorflateMocks.ts
+++ b/frontend/arrangor-flate/app/mocks/arrangorflateMocks.ts
@@ -6,6 +6,7 @@ import {
   TilsagnStatus,
   TilsagnType,
   ArrFlateUtbetalingStatus,
+  ArrFlateUtbetalingKompakt,
 } from "@mr/api-client-v2";
 import { http, HttpResponse, PathParams } from "msw";
 import { v4 as uuid } from "uuid";
@@ -50,10 +51,101 @@ const mockDeltakelser = [
   },
 ];
 
+const mockUtbetalinger: ArrFlateUtbetalingKompakt[] = [
+  {
+    id: "da28997b-c2ba-4f5c-b733-94eb57e57d19",
+    status: ArrFlateUtbetalingStatus.KLAR_FOR_GODKJENNING,
+    fristForGodkjenning: "2024-08-01T00:00:00",
+    tiltakstype: {
+      navn: "Arbeidsforberedende trening",
+    },
+
+    gjennomforing: {
+      id: uuid(),
+      navn: "AFT tiltak Moss",
+    },
+    arrangor: {
+      id: uuid(),
+      organisasjonsnummer: "123456789",
+      navn: "Fretex",
+      slettet: false,
+    },
+    periodeStart: "2024-06-01",
+    periodeSlutt: "2024-06-30",
+    belop: 308530,
+  },
+  {
+    id: "80a49868-0d06-4243-bc39-7ac33fbada88",
+    status: ArrFlateUtbetalingStatus.KLAR_FOR_GODKJENNING,
+    fristForGodkjenning: "2024-08-01T00:00:00",
+    tiltakstype: {
+      navn: "Arbeidsforberedende trening",
+    },
+    gjennomforing: {
+      id: uuid(),
+      navn: "Amo tiltak Halden",
+    },
+    arrangor: {
+      id: uuid(),
+      organisasjonsnummer: "123456789",
+      navn: "Fretex",
+      slettet: false,
+    },
+    periodeStart: "2024-06-01",
+    periodeSlutt: "2024-06-30",
+    belop: 85000,
+  },
+  {
+    id: "91591ca9-ac32-484e-b95a-1a1258c5c32a",
+    status: ArrFlateUtbetalingStatus.BEHANDLES_AV_NAV,
+    fristForGodkjenning: "2024-08-01T00:00:00",
+    tiltakstype: {
+      navn: "Arbeidsforberedende trening",
+    },
+    gjennomforing: {
+      id: uuid(),
+      navn: "Amo tiltak Halden",
+    },
+
+    arrangor: {
+      id: uuid(),
+      organisasjonsnummer: "123456789",
+      navn: "Fretex",
+      slettet: false,
+    },
+    periodeStart: "2024-06-01",
+    periodeSlutt: "2024-06-30",
+    belop: 85000,
+  },
+  {
+    id: "87b4425b-8be0-4938-94bc-2ba1ae7beb0e",
+    status: ArrFlateUtbetalingStatus.UTBETALT,
+    fristForGodkjenning: "2024-08-01T00:00:00",
+    tiltakstype: {
+      navn: "Arbeidsforberedende trening",
+    },
+    gjennomforing: {
+      id: uuid(),
+      navn: "Amo tiltak Halden",
+    },
+
+    arrangor: {
+      id: uuid(),
+      organisasjonsnummer: "123456789",
+      navn: "Fretex",
+      slettet: false,
+    },
+    periodeStart: "2024-06-01",
+    periodeSlutt: "2024-06-30",
+
+    belop: 85000,
+  },
+];
+
 const mockKrav: ArrFlateUtbetaling[] = [
   {
     type: "AFT",
-    id: uuid(),
+    id: "da28997b-c2ba-4f5c-b733-94eb57e57d19",
     status: ArrFlateUtbetalingStatus.KLAR_FOR_GODKJENNING,
     fristForGodkjenning: "2024-08-01T00:00:00",
     tiltakstype: {
@@ -85,7 +177,7 @@ const mockKrav: ArrFlateUtbetaling[] = [
   },
   {
     type: "AFT",
-    id: uuid(),
+    id: "80a49868-0d06-4243-bc39-7ac33fbada88",
     status: ArrFlateUtbetalingStatus.KLAR_FOR_GODKJENNING,
     fristForGodkjenning: "2024-08-01T00:00:00",
     tiltakstype: {
@@ -117,7 +209,7 @@ const mockKrav: ArrFlateUtbetaling[] = [
   },
   {
     type: "AFT",
-    id: uuid(),
+    id: "91591ca9-ac32-484e-b95a-1a1258c5c32a",
     status: ArrFlateUtbetalingStatus.BEHANDLES_AV_NAV,
     fristForGodkjenning: "2024-08-01T00:00:00",
     tiltakstype: {
@@ -149,7 +241,7 @@ const mockKrav: ArrFlateUtbetaling[] = [
   },
   {
     type: "AFT",
-    id: uuid(),
+    id: "87b4425b-8be0-4938-94bc-2ba1ae7beb0e",
     status: ArrFlateUtbetalingStatus.UTBETALT,
     fristForGodkjenning: "2024-08-01T00:00:00",
     tiltakstype: {
@@ -240,7 +332,7 @@ const mockTilsagn: ArrangorflateTilsagn[] = [
     type: TilsagnType.TILSAGN,
   },
   {
-    id: uuid(),
+    id: "80a49868-0d06-4243-bc39-7ac33fbada88",
     tiltakstype: {
       navn: "Arbeidsforberedende trening",
     },
@@ -329,7 +421,7 @@ const mockRelevanteForslag: RelevanteForslag[] = [
 export const arrangorflateHandlers = [
   http.get<PathParams, ArrFlateUtbetaling[]>(
     "*/api/v1/intern/arrangorflate/arrangor/:orgnr/utbetaling",
-    () => HttpResponse.json(mockKrav),
+    () => HttpResponse.json(mockUtbetalinger),
   ),
   http.get<PathParams, ArrFlateUtbetaling[]>(
     "*/api/v1/intern/arrangorflate/utbetaling/:id",

--- a/frontend/arrangor-flate/app/routes/$orgnr.utbetaling.$id.beregning.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr.utbetaling.$id.beregning.tsx
@@ -159,7 +159,11 @@ function ForhandsgodkjentBeregning({
       <HGrid gap="5" columns={1}>
         <GuidePanel>
           Hvis noen av opplysningene om deltakerne ikke stemmer, må det sendes forslag til Nav om
-          endring via <Link to={deltakerlisteUrl}>Deltakeroversikten</Link>.
+          endring via{" "}
+          <Link className="underline" to={deltakerlisteUrl}>
+            Deltakeroversikten
+          </Link>
+          .
         </GuidePanel>
         {deltakereMedRelevanteForslag.length > 0 && (
           <Alert variant="warning">

--- a/frontend/arrangor-flate/app/tailwind.css
+++ b/frontend/arrangor-flate/app/tailwind.css
@@ -1,7 +1,3 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
-@import "@navikt/ds-css" layer(components);
-
-a {
-  text-decoration: underline;
-}
+@import "@navikt/ds-css" layer(utilities);

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Queries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Queries.kt
@@ -12,18 +12,17 @@ import no.nav.mulighetsrommet.api.navansatt.db.NavAnsattQueries
 import no.nav.mulighetsrommet.api.navenhet.db.NavEnhetQueries
 import no.nav.mulighetsrommet.api.tilsagn.db.TilsagnQueries
 import no.nav.mulighetsrommet.api.tiltakstype.db.TiltakstypeQueries
-import no.nav.mulighetsrommet.api.utbetaling.db.DeltakerForslagQueries
-import no.nav.mulighetsrommet.api.utbetaling.db.DeltakerQueries
-import no.nav.mulighetsrommet.api.utbetaling.db.DelutbetalingQueries
-import no.nav.mulighetsrommet.api.utbetaling.db.UtbetalingQueries
+import no.nav.mulighetsrommet.api.utbetaling.db.*
 import no.nav.mulighetsrommet.api.veilederflate.VeilederJoyrideQueries
 import no.nav.mulighetsrommet.api.veilederflate.VeilederflateTiltakQueries
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.notifications.NotificationQueries
 import no.nav.mulighetsrommet.utdanning.db.UtdanningQueries
+import java.util.*
 import javax.sql.DataSource
 
 class QueryContext(val session: Session) {
+
     val queries by lazy { Queries() }
 
     inner class Queries {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorFlateService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorFlateService.kt
@@ -1,0 +1,73 @@
+package no.nav.mulighetsrommet.api.arrangorflate
+
+import io.ktor.server.plugins.*
+import no.nav.mulighetsrommet.api.ApiDatabase
+import no.nav.mulighetsrommet.api.arrangor.ArrangorService
+import no.nav.mulighetsrommet.api.arrangorflate.model.ArrFlateUtbetalingKompakt
+import no.nav.mulighetsrommet.api.tilsagn.model.ArrangorflateTilsagn
+import no.nav.mulighetsrommet.api.utbetaling.HentAdressebeskyttetPersonBolkPdlQuery
+import no.nav.mulighetsrommet.api.utbetaling.db.DeltakerForslag
+import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingDto
+import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingStatus
+import no.nav.mulighetsrommet.model.Organisasjonsnummer
+import java.util.*
+
+class ArrangorFlateService(
+    val arrangorService: ArrangorService,
+    val pdl: HentAdressebeskyttetPersonBolkPdlQuery,
+    val db: ApiDatabase,
+) {
+
+    fun getUtbetalinger(orgnr: Organisasjonsnummer): List<ArrFlateUtbetalingKompakt> {
+        return db.session {
+            queries.utbetaling.getByArrangorIds(orgnr).map {
+                if (it.status == UtbetalingStatus.UTBETALT) {
+                    return@map ArrFlateUtbetalingKompakt.fromUtbetalingDto(it)
+                }
+                val forslag = getDeltakerforslagByGjennomforing(it.gjennomforing.id)
+                val antallRelevanteForslag = getAntallRelevanteForslag(forslag, it)
+                val utbetaling = it.copy(status = if (antallRelevanteForslag > 0) UtbetalingStatus.VENTER_PA_ENDRING else it.status)
+                ArrFlateUtbetalingKompakt.fromUtbetalingDto(utbetaling)
+            }
+        }
+    }
+
+    private fun getAntallRelevanteForslag(forslag: Map<UUID, List<DeltakerForslag>>, utbetaling: UtbetalingDto): Int {
+        val relevanteForslag = getRelevanteForslag(forslag, utbetaling)
+        return relevanteForslag.sumOf { it.antallRelevanteForslag }
+    }
+
+    fun getUtbetaling(id: UUID): UtbetalingDto {
+        return db.session {
+            queries.utbetaling.get(id) ?: throw NotFoundException("Fant ikke utbetaling med id=$id")
+        }
+    }
+
+    fun getDeltakerforslagByGjennomforing(gjennomforingId: UUID): Map<UUID, List<DeltakerForslag>> {
+        return db.session {
+            queries.deltakerForslag.getForslagByGjennomforing(gjennomforingId)
+        }
+    }
+
+    fun getTilsagn(id: UUID): ArrangorflateTilsagn {
+        return db.session {
+            queries.tilsagn.getArrangorflateTilsagn(id) ?: throw NotFoundException("Fant ikke tilsagn")
+        }
+    }
+
+    fun getAlleTilsagnForOrganisasjon(orgnr: Organisasjonsnummer): List<ArrangorflateTilsagn> {
+        return db.session {
+            queries.tilsagn.getAllArrangorflateTilsagn(orgnr)
+        }
+    }
+
+    fun getRelevanteForslag(forslagByDeltakerId: Map<UUID, List<DeltakerForslag>>, utbetaling: UtbetalingDto): List<RelevanteForslag> {
+        return forslagByDeltakerId
+            .map { (deltakerId, forslag) ->
+                RelevanteForslag(
+                    deltakerId = deltakerId,
+                    antallRelevanteForslag = forslag.count { it.relevantForDeltakelse(utbetaling) },
+                )
+            }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/model/ArrFlateUtbetaling.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/model/ArrFlateUtbetaling.kt
@@ -54,6 +54,7 @@ data class ArrFlateUtbetaling(
         KLAR_FOR_GODKJENNING,
         BEHANDLES_AV_NAV,
         UTBETALT,
+        VENTER_PA_ENDRING,
         ;
 
         companion object {
@@ -65,6 +66,7 @@ data class ArrFlateUtbetaling(
                 -> BEHANDLES_AV_NAV
 
                 UtbetalingStatus.UTBETALT -> UTBETALT
+                UtbetalingStatus.VENTER_PA_ENDRING -> VENTER_PA_ENDRING
             }
         }
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -19,6 +19,7 @@ import no.nav.mulighetsrommet.api.arenaadapter.ArenaAdapterClient
 import no.nav.mulighetsrommet.api.arenaadapter.ArenaAdapterService
 import no.nav.mulighetsrommet.api.arrangor.ArrangorService
 import no.nav.mulighetsrommet.api.arrangor.kafka.AmtVirksomheterV1KafkaConsumer
+import no.nav.mulighetsrommet.api.arrangorflate.ArrangorFlateService
 import no.nav.mulighetsrommet.api.avtale.AvtaleService
 import no.nav.mulighetsrommet.api.avtale.AvtaleValidator
 import no.nav.mulighetsrommet.api.avtale.OpsjonLoggService
@@ -384,6 +385,7 @@ private fun services(appConfig: AppConfig) = module {
     single { AltinnRettigheterService(get(), get()) }
     single { OppgaverService(get()) }
     single { OkonomiBestillingService(appConfig.kafka.clients.okonomiBestilling, get(), get()) }
+    single { ArrangorFlateService(get(), get(), get()) }
 }
 
 private fun tasks(config: TaskConfig) = module {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/UtbetalingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/UtbetalingQueries.kt
@@ -5,7 +5,6 @@ import kotliquery.Row
 import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.utbetaling.model.*
-import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregningAft
 import no.nav.mulighetsrommet.database.requireSingle
 import no.nav.mulighetsrommet.database.withTransaction
 import no.nav.mulighetsrommet.model.*
@@ -332,7 +331,6 @@ class UtbetalingQueries(private val session: Session) {
     fun Row.toUtbetalingDto(): UtbetalingDto {
         val beregningsmodell = Beregningsmodell.valueOf(string("beregningsmodell"))
         val beregning = getBeregning(uuid("id"), beregningsmodell)
-
         val id = uuid("id")
         val delutbetalinger = DelutbetalingQueries(session).getByUtbetalingId(id)
         val innsender = stringOrNull("innsender")?.let { UtbetalingDto.Innsender.fromString(it) }
@@ -381,6 +379,7 @@ fun utbetalingStatus(
     if (delutbetaling.isNotEmpty() && delutbetaling.all { it is DelutbetalingDto.DelutbetalingUtbetalt }) {
         return UtbetalingStatus.UTBETALT
     }
+
     return when (innsender) {
         is UtbetalingDto.Innsender.ArrangorAnsatt -> UtbetalingStatus.INNSENDT_AV_ARRANGOR
         is UtbetalingDto.Innsender.NavAnsatt -> UtbetalingStatus.INNSENDT_AV_NAV

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/UtbetalingStatus.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/UtbetalingStatus.kt
@@ -5,4 +5,5 @@ enum class UtbetalingStatus {
     INNSENDT_AV_ARRANGOR,
     INNSENDT_AV_NAV,
     UTBETALT,
+    VENTER_PA_ENDRING,
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverService.kt
@@ -218,6 +218,7 @@ class OppgaverService(val db: ApiDatabase) {
         UtbetalingStatus.INNSENDT_AV_NAV,
         UtbetalingStatus.KLAR_FOR_GODKJENNING,
         UtbetalingStatus.UTBETALT,
+        UtbetalingStatus.VENTER_PA_ENDRING,
         -> null
     }
 }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -5691,6 +5691,7 @@ components:
         - KLAR_FOR_GODKJENNING
         - BEHANDLES_AV_NAV
         - UTBETALT
+        - VENTER_PA_ENDRING
 
     UtbetalingStatus:
       type: string


### PR DESCRIPTION
Ved uthenting av utbetalinger til arrangør henter vi potensielle forslag for deltakere og returnerer det som status for utbetalingen og viser til arrangør per utbetalingsrad.
Koden tar per nå og gjør oppslag inne i en .map. Det er ikke det mest effektive, men jeg syns lesbarheten er bedre enn å gjøre all logikk i db-laget. Vi kan refaktorere senere ved behov.
