### PR TITLE
Utkast avtale

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/AvtaleStatus.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/AvtaleStatus.kt
@@ -11,6 +11,9 @@ sealed class AvtaleStatus {
     data object AVSLUTTET : AvtaleStatus() {
         override val enum = Enum.AVSLUTTET
     }
+    data object UTKAST : AvtaleStatus() {
+        override val enum = Enum.UTKAST
+    }
     data class AVBRUTT(val tidspunkt: LocalDateTime, val aarsak: AvbruttAarsak) : AvtaleStatus() {
         override val enum = Enum.AVBRUTT
     }
@@ -19,6 +22,7 @@ sealed class AvtaleStatus {
         fun fromString(name: String, tidspunkt: LocalDateTime?, aarsak: AvbruttAarsak?): AvtaleStatus = when (Enum.valueOf(name)) {
             Enum.AKTIV -> AKTIV
             Enum.AVSLUTTET -> AVSLUTTET
+            Enum.UTKAST -> UTKAST
             Enum.AVBRUTT -> {
                 requireNotNull(tidspunkt)
                 requireNotNull(aarsak)
@@ -31,5 +35,6 @@ sealed class AvtaleStatus {
         AKTIV,
         AVSLUTTET,
         AVBRUTT,
+        UTKAST,
     }
 }

--- a/frontend/mr-admin-flate/src/api/avtaler/useUpsertAvtale.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useUpsertAvtale.ts
@@ -11,7 +11,7 @@ export function useUpsertAvtale() {
     onSuccess(_, request) {
       return Promise.all([
         queryClient.invalidateQueries({
-          queryKey: QueryKeys.avtale(request.id),
+          queryKey: [QueryKeys.avtale(request.id)],
         }),
 
         queryClient.invalidateQueries({

--- a/frontend/mr-admin-flate/src/api/avtaler/useUpsertAvtale.ts
+++ b/frontend/mr-admin-flate/src/api/avtaler/useUpsertAvtale.ts
@@ -11,7 +11,7 @@ export function useUpsertAvtale() {
     onSuccess(_, request) {
       return Promise.all([
         queryClient.invalidateQueries({
-          queryKey: [QueryKeys.avtale(request.id)],
+          queryKey: QueryKeys.avtale(request.id),
         }),
 
         queryClient.invalidateQueries({

--- a/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingFormDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingFormDetaljer.tsx
@@ -39,7 +39,7 @@ import { GjennomforingUtdanningslopForm } from "../utdanning/GjennomforingUtdann
 import { SelectOppstartstype } from "./SelectOppstartstype";
 import { GjennomforingArrangorForm } from "./GjennomforingArrangorForm";
 import { TwoColumnGrid } from "@/layouts/TwoColumGrid";
-import { AvtaleErKladdOgArrangorManglerMelding } from "@/pages/avtaler/AvtaleDetaljer";
+import { AvtaleErUtkastOgArrangorManglerMelding } from "@/pages/avtaler/AvtaleDetaljer";
 
 interface Props {
   gjennomforing?: GjennomforingDto;
@@ -368,7 +368,7 @@ export function GjennomforingFormDetaljer({ gjennomforing, avtale }: Props) {
               <GjennomforingArrangorForm readOnly={false} arrangor={avtale.arrangor} />
             </FormGroup>
           ) : (
-            <AvtaleErKladdOgArrangorManglerMelding />
+            <AvtaleErUtkastOgArrangorManglerMelding />
           )}
         </SkjemaKolonne>
       </TwoColumnGrid>

--- a/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingFormDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingFormDetaljer.tsx
@@ -39,7 +39,7 @@ import { GjennomforingUtdanningslopForm } from "../utdanning/GjennomforingUtdann
 import { SelectOppstartstype } from "./SelectOppstartstype";
 import { GjennomforingArrangorForm } from "./GjennomforingArrangorForm";
 import { TwoColumnGrid } from "@/layouts/TwoColumGrid";
-import { AvtaleErKladdOgArrangørManglerMelding } from "@/pages/avtaler/AvtaleDetaljer";
+import { AvtaleErKladdOgArrangorManglerMelding } from "@/pages/avtaler/AvtaleDetaljer";
 
 interface Props {
   gjennomforing?: GjennomforingDto;
@@ -368,7 +368,7 @@ export function GjennomforingFormDetaljer({ gjennomforing, avtale }: Props) {
               <GjennomforingArrangorForm readOnly={false} arrangor={avtale.arrangor} />
             </FormGroup>
           ) : (
-            <AvtaleErKladdOgArrangørManglerMelding />
+            <AvtaleErKladdOgArrangorManglerMelding />
           )}
         </SkjemaKolonne>
       </TwoColumnGrid>

--- a/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingFormDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingFormDetaljer.tsx
@@ -39,6 +39,7 @@ import { GjennomforingUtdanningslopForm } from "../utdanning/GjennomforingUtdann
 import { SelectOppstartstype } from "./SelectOppstartstype";
 import { GjennomforingArrangorForm } from "./GjennomforingArrangorForm";
 import { TwoColumnGrid } from "@/layouts/TwoColumGrid";
+import { AvtaleErKladdOgArrangørManglerMelding } from "@/pages/avtaler/AvtaleDetaljer";
 
 interface Props {
   gjennomforing?: GjennomforingDto;
@@ -362,10 +363,12 @@ export function GjennomforingFormDetaljer({ gjennomforing, avtale }: Props) {
               </div>
             </FormGroup>
           </div>
-          {avtale.arrangor && (
+          {avtale.arrangor ? (
             <FormGroup>
               <GjennomforingArrangorForm readOnly={false} arrangor={avtale.arrangor} />
             </FormGroup>
+          ) : (
+            <AvtaleErKladdOgArrangørManglerMelding />
           )}
         </SkjemaKolonne>
       </TwoColumnGrid>

--- a/frontend/mr-admin-flate/src/components/statuselementer/AvtalestatusTag.tsx
+++ b/frontend/mr-admin-flate/src/components/statuselementer/AvtalestatusTag.tsx
@@ -20,6 +20,8 @@ export function AvtalestatusTag({ avtale, showAvbruttAarsak = false }: Props) {
         return { variant: "neutral", name: "Avsluttet" };
       case "AVBRUTT":
         return { variant: "error", name: "Avbrutt" };
+      case "UTKAST":
+        return { variant: "neutral", name: "Utkast" };
     }
   }
   const { variant, name } = variantAndName();

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
@@ -240,7 +240,7 @@ export function AvtaleDetaljer() {
             />
           </VStack>
         ) : (
-          <AvtaleErKladdOgArrangørManglerMelding />
+          <AvtaleErKladdOgArrangorManglerMelding />
         )}
 
         <Separator />
@@ -264,6 +264,6 @@ export function AvtaleDetaljer() {
   );
 }
 
-export const AvtaleErKladdOgArrangørManglerMelding = () => {
+export const AvtaleErKladdOgArrangorManglerMelding = () => {
   return <Alert variant="warning">Arrangør mangler</Alert>;
 };

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
@@ -264,6 +264,6 @@ export function AvtaleDetaljer() {
   );
 }
 
-const AvtaleErKladdOgArrangørManglerMelding = () => {
+export const AvtaleErKladdOgArrangørManglerMelding = () => {
   return <Alert variant="warning">Arrangør mangler</Alert>;
 };

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtaleDetaljer.tsx
@@ -240,7 +240,7 @@ export function AvtaleDetaljer() {
             />
           </VStack>
         ) : (
-          <AvtaleErKladdOgArrangorManglerMelding />
+          <AvtaleErUtkastOgArrangorManglerMelding />
         )}
 
         <Separator />
@@ -264,6 +264,6 @@ export function AvtaleDetaljer() {
   );
 }
 
-export const AvtaleErKladdOgArrangorManglerMelding = () => {
+export const AvtaleErUtkastOgArrangorManglerMelding = () => {
   return <Alert variant="warning">Arrangør mangler</Alert>;
 };

--- a/frontend/mr-admin-flate/src/pages/avtaler/avtaleLoader.ts
+++ b/frontend/mr-admin-flate/src/pages/avtaler/avtaleLoader.ts
@@ -27,7 +27,7 @@ export const avtaleLoader =
     }
 
     const [{ data: avtale }, { data: ansatt }] = await Promise.all([
-      queryClient.ensureQueryData(avtaleQuery(params.avtaleId)),
+      AvtalerService.getAvtale({ path: { id: params.avtaleId } }),
       queryClient.ensureQueryData(ansattQuery),
     ]);
     return { avtale, ansatt };
@@ -53,7 +53,7 @@ export const avtaleSkjemaLoader =
     const [{ data: avtale }, tiltakstyper, { data: ansatt }, { data: enheter }] = await Promise.all(
       [
         params.avtaleId
-          ? await queryClient.ensureQueryData(avtaleQuery(params.avtaleId))
+          ? await AvtalerService.getAvtale({ path: { id: params.avtaleId } })
           : { data: undefined },
         await queryClient.ensureQueryData(tiltakstyperQuery),
         await queryClient.ensureQueryData(ansattQuery),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/model/AvtaleDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/model/AvtaleDto.kt
@@ -154,6 +154,7 @@ fun AvtaleDto.toArenaAvtaleDbo(): ArenaAvtaleDbo? {
                 is AvtaleStatus.AKTIV -> Avslutningsstatus.IKKE_AVSLUTTET
                 is AvtaleStatus.AVBRUTT -> Avslutningsstatus.AVBRUTT
                 is AvtaleStatus.AVSLUTTET -> Avslutningsstatus.AVSLUTTET
+                is AvtaleStatus.UTKAST -> Avslutningsstatus.IKKE_AVSLUTTET
             },
             prisbetingelser = prisbetingelser,
         )

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__avtale_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__avtale_admin_view.sql
@@ -26,6 +26,7 @@ select avtale.id,
        case
            when avtale.avbrutt_tidspunkt is not null then 'AVBRUTT'
            when avtale.slutt_dato is not null and date(now()) > avtale.slutt_dato then 'AVSLUTTET'
+           when arrangor is null then 'UTKAST'
            else 'AKTIV'
            end                                          as status,
        tiltakstype.id                                   as tiltakstype_id,

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2957,6 +2957,7 @@ components:
           enum:
             - AKTIV
             - AVSLUTTET
+            - UTKAST
       required:
         - name
 


### PR DESCRIPTION
For en eller annen grunn så funker ikke invalidateQueries i det hele tatt. Så bare endret til AvtalerService.getAvtale. Hvis ikke så viste den forrige state når man gikk tilbake til formen eller inn på gjennomføringer siden. Eneste måten det funket på var å kjøre queryClient.clear() som sletter alt. 