### PR TITLE
oppdater bestillingsnummer til nytt format

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
@@ -48,7 +48,7 @@ class TilsagnService(
                     type = request.type,
                     periode = Periode.fromInclusiveDates(request.periodeStart, request.periodeSlutt),
                     lopenummer = lopenummer,
-                    bestillingsnummer = previous?.bestillingsnummer ?: "${gjennomforing.lopenummer}/$lopenummer",
+                    bestillingsnummer = previous?.bestillingsnummer ?: "A-${gjennomforing.lopenummer}-$lopenummer",
                     kostnadssted = request.kostnadssted,
                     beregning = beregning,
                     endretAv = navIdent,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
@@ -209,7 +209,7 @@ class UtbetalingService(
             belop = request.belop,
             opprettetAv = opprettetAv,
             lopenummer = lopenummer,
-            fakturanummer = "${tilsagn.bestillingsnummer}/$lopenummer",
+            fakturanummer = "${tilsagn.bestillingsnummer}-$lopenummer",
         )
 
         db.session {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TilsagnFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/TilsagnFixtures.kt
@@ -15,7 +15,7 @@ object TilsagnFixtures {
         gjennomforingId = GjennomforingFixtures.AFT1.id,
         periode = Periode.forMonthOf(LocalDate.of(2025, 1, 1)),
         lopenummer = 1,
-        bestillingsnummer = "2025/1",
+        bestillingsnummer = "A-2025/1-1",
         kostnadssted = NavEnhetFixtures.Innlandet.enhetsnummer,
         beregning = TilsagnBeregningFri(
             input = TilsagnBeregningFri.Input(1000),
@@ -32,7 +32,7 @@ object TilsagnFixtures {
         gjennomforingId = GjennomforingFixtures.AFT1.id,
         periode = Periode.forMonthOf(LocalDate.of(2025, 2, 1)),
         lopenummer = 2,
-        bestillingsnummer = "2025/2",
+        bestillingsnummer = "A-2025/1-2",
         kostnadssted = NavEnhetFixtures.Innlandet.enhetsnummer,
         beregning = TilsagnBeregningFri(
             input = TilsagnBeregningFri.Input(1500),
@@ -49,7 +49,7 @@ object TilsagnFixtures {
         gjennomforingId = GjennomforingFixtures.AFT1.id,
         periode = Periode.forMonthOf(LocalDate.of(2025, 3, 1)),
         lopenummer = 3,
-        bestillingsnummer = "2025/3",
+        bestillingsnummer = "A-2025/1-3",
         kostnadssted = NavEnhetFixtures.Innlandet.enhetsnummer,
         beregning = TilsagnBeregningFri(
             input = TilsagnBeregningFri.Input(2500),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/oppgaver/OppgaverServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/oppgaver/OppgaverServiceTest.kt
@@ -269,7 +269,7 @@ class OppgaverServiceTest : FunSpec({
                         id = UUID.randomUUID(),
                         gjennomforingId = UtbetalingFixtures.utbetaling3.gjennomforingId,
                         kostnadssted = NavEnhetFixtures.TiltakOslo.enhetsnummer,
-                        bestillingsnummer = "2025/4",
+                        bestillingsnummer = "A-2025/1-4",
                     ),
                 ),
                 utbetalinger = listOf(
@@ -284,7 +284,7 @@ class OppgaverServiceTest : FunSpec({
                         belop = 100,
                         periode = Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 2, 1)),
                         lopenummer = 1,
-                        fakturanummer = "2025/1",
+                        fakturanummer = "A-2025/1-1-1",
                         opprettetAv = NavAnsattFixture.ansatt1.navIdent,
                     ),
                 ),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/OkonomiBestillingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/OkonomiBestillingServiceTest.kt
@@ -60,8 +60,10 @@ class OkonomiBestillingServiceTest : FunSpec({
     }
 
     context("skedulering av oppgaver for økonomi") {
+        val bestillingsnummer = "A-2025/1-1"
+
         val tilsagn = TilsagnFixtures.Tilsagn1.copy(
-            bestillingsnummer = "2025",
+            bestillingsnummer = bestillingsnummer,
             periode = Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 7, 1)),
             beregning = TilsagnBeregningFri(
                 input = TilsagnBeregningFri.Input(1000),
@@ -90,7 +92,7 @@ class OkonomiBestillingServiceTest : FunSpec({
             belop = 100,
             periode = Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 2, 1)),
             lopenummer = 1,
-            fakturanummer = "2025/1",
+            fakturanummer = "$bestillingsnummer-1",
             opprettetAv = NavAnsattFixture.ansatt1.navIdent,
         )
         val delutbetaling2 = DelutbetalingDbo(
@@ -99,7 +101,7 @@ class OkonomiBestillingServiceTest : FunSpec({
             belop = 100,
             periode = Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 2, 1)),
             lopenummer = 2,
-            fakturanummer = "2025/2",
+            fakturanummer = "$bestillingsnummer-2",
             opprettetAv = NavAnsattFixture.ansatt1.navIdent,
         )
 
@@ -167,7 +169,7 @@ class OkonomiBestillingServiceTest : FunSpec({
                         match {
                             it.topic() shouldBe "okonomi.bestilling.v1"
 
-                            it.key() shouldBe tilsagn.bestillingsnummer
+                            it.key() shouldBe bestillingsnummer
 
                             Json.decodeFromString<OkonomiBestillingMelding>(it.value()!!)
                                 .shouldBeTypeOf<OkonomiBestillingMelding.Annullering>()
@@ -199,7 +201,7 @@ class OkonomiBestillingServiceTest : FunSpec({
                         match {
                             it.topic() shouldBe "okonomi.bestilling.v1"
 
-                            it.key() shouldBe tilsagn.bestillingsnummer
+                            it.key() shouldBe bestillingsnummer
 
                             val faktura = Json.decodeFromString<OkonomiBestillingMelding>(it.value()!!)
                                 .shouldBeTypeOf<OkonomiBestillingMelding.Faktura>()
@@ -255,7 +257,7 @@ class OkonomiBestillingServiceTest : FunSpec({
                 kafkaProducerClient.sendSync(
                     match {
                         it.topic() shouldBe "okonomi.bestilling.v1"
-                        it.key() shouldBe tilsagn.bestillingsnummer
+                        it.key() shouldBe bestillingsnummer
 
                         val faktura = Json.decodeFromString<OkonomiBestillingMelding>(it.value()!!)
                             .shouldBeTypeOf<OkonomiBestillingMelding.Faktura>()
@@ -267,7 +269,7 @@ class OkonomiBestillingServiceTest : FunSpec({
                 kafkaProducerClient.sendSync(
                     match {
                         it.topic() shouldBe "okonomi.bestilling.v1"
-                        it.key() shouldBe tilsagn.bestillingsnummer
+                        it.key() shouldBe bestillingsnummer
 
                         val faktura = Json.decodeFromString<OkonomiBestillingMelding>(it.value()!!)
                             .shouldBeTypeOf<OkonomiBestillingMelding.Faktura>()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnServiceTest.kt
@@ -116,18 +116,18 @@ class TilsagnServiceTest : FunSpec({
                 val aft1 = queries.gjennomforing.get(domain2.gjennomforinger[0].id).shouldNotBeNull()
                 queries.tilsagn.get(tilsagn.id).shouldNotBeNull().should {
                     it.lopenummer shouldBe 1
-                    it.bestillingsnummer shouldBe "${aft1.lopenummer}/1"
+                    it.bestillingsnummer shouldBe "A-${aft1.lopenummer}-1"
                 }
 
                 queries.tilsagn.get(tilsagn2).shouldNotBeNull().should {
                     it.lopenummer shouldBe 2
-                    it.bestillingsnummer shouldBe "${aft1.lopenummer}/2"
+                    it.bestillingsnummer shouldBe "A-${aft1.lopenummer}-2"
                 }
 
                 val aft2 = queries.gjennomforing.get(domain2.gjennomforinger[1].id).shouldNotBeNull()
                 queries.tilsagn.get(tilsagn3).shouldNotBeNull().should {
                     it.lopenummer shouldBe 1
-                    it.bestillingsnummer shouldBe "${aft2.lopenummer}/1"
+                    it.bestillingsnummer shouldBe "A-${aft2.lopenummer}-1"
                 }
             }
         }
@@ -160,7 +160,7 @@ class TilsagnServiceTest : FunSpec({
                 val aft1 = queries.gjennomforing.get(domain.gjennomforinger[0].id).shouldNotBeNull()
                 queries.tilsagn.get(tilsagn.id).shouldNotBeNull().should {
                     it.lopenummer shouldBe 1
-                    it.bestillingsnummer shouldBe "${aft1.lopenummer}/1"
+                    it.bestillingsnummer shouldBe "A-${aft1.lopenummer}-1"
                 }
             }
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingServiceTest.kt
@@ -410,7 +410,6 @@ class UtbetalingServiceTest : FunSpec({
         test("skal ikke kunne opprette del utbetaling hvis den er godkjent") {
             val tilsagn = TilsagnFixtures.Tilsagn1.copy(
                 periode = Periode.forMonthOf(LocalDate.of(2024, 1, 1)),
-                bestillingsnummer = "2024/1",
             )
 
             val utbetaling = UtbetalingFixtures.utbetaling1.copy(
@@ -451,7 +450,6 @@ class UtbetalingServiceTest : FunSpec({
         test("skal ikke kunne godkjenne delutbetaling hvis den er godkjent") {
             val tilsagn = TilsagnFixtures.Tilsagn1.copy(
                 periode = Periode.forMonthOf(LocalDate.of(2024, 1, 1)),
-                bestillingsnummer = "2024/1",
             )
 
             val utbetaling = UtbetalingFixtures.utbetaling1.copy(
@@ -568,12 +566,12 @@ class UtbetalingServiceTest : FunSpec({
         test("løpenummer, fakturanummer og periode blir utledet fra tilsagnet og utbetalingen") {
             val tilsagn1 = TilsagnFixtures.Tilsagn2.copy(
                 periode = Periode.forMonthOf(LocalDate.of(2024, 1, 1)),
-                bestillingsnummer = "2024/1",
+                bestillingsnummer = "A-2024/1-1",
             )
 
             val tilsagn2 = TilsagnFixtures.Tilsagn1.copy(
                 periode = Periode.forMonthOf(LocalDate.of(2024, 1, 1)),
-                bestillingsnummer = "2024/2",
+                bestillingsnummer = "A-2024/1-2",
             )
 
             val utbetaling1 = UtbetalingFixtures.utbetaling1.copy(
@@ -616,18 +614,18 @@ class UtbetalingServiceTest : FunSpec({
                     first.belop shouldBe 50
                     first.periode shouldBe Periode(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 15))
                     first.lopenummer shouldBe 1
-                    first.fakturanummer shouldBe "2024/2/1"
+                    first.fakturanummer shouldBe "A-2024/1-2-1"
 
                     second.belop shouldBe 50
                     second.periode shouldBe Periode(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 15))
                     second.lopenummer shouldBe 1
-                    second.fakturanummer shouldBe "2024/1/1"
+                    second.fakturanummer shouldBe "A-2024/1-1-1"
                 }
 
                 queries.delutbetaling.getByUtbetalingId(utbetaling2.id).should { (first) ->
                     first.belop shouldBe 100
                     first.lopenummer shouldBe 2
-                    first.fakturanummer shouldBe "2024/1/2"
+                    first.fakturanummer shouldBe "A-2024/1-1-2"
                     first.periode shouldBe Periode(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 2, 1))
                 }
             }


### PR DESCRIPTION
Oppretter bestillingsnummer og fakturanummer på formatet som Oebs ønsker seg.

Det består av følgende deler:

- `A` - for å velge et prefiks som identifiserer Tiltaks"A"dministrsajon? Evt. så er det bare en tilfeldig bokstav de har valgt på vegne av oss
- løpenummer til gjennomføring
- løpenummer for tilsagn, per gjennomføring
- løpenummer til delutbetaling, per tilsagn