### PR TITLE
Egen tabell for gjennomforing_koordinator

### DIFF
--- a/mulighetsrommet-api/src/main/resources/db/migration/V249__tiltaksgjennomforing_koordinator_table.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V249__tiltaksgjennomforing_koordinator_table.sql
@@ -1,0 +1,9 @@
+create table tiltaksgjennomforing_koordinator
+(
+    nav_ident               text                    not null,
+    tiltaksgjennomforing_id uuid                    not null
+        constraint fk_tiltaksgjennomforing references tiltaksgjennomforing (id) on delete cascade,
+    created_at              timestamp default now() not null,
+    updated_at              timestamp default now() not null,
+    primary key (tiltaksgjennomforing_id, nav_ident)
+);

--- a/mulighetsrommet-api/src/main/resources/db/migration/V249__tiltaksgjennomforing_koordinator_table.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V249__tiltaksgjennomforing_koordinator_table.sql
@@ -1,9 +1,9 @@
-create table tiltaksgjennomforing_koordinator
+create table gjennomforing_koordinator
 (
     nav_ident               text                    not null,
-    tiltaksgjennomforing_id uuid                    not null
-        constraint fk_tiltaksgjennomforing references tiltaksgjennomforing (id) on delete cascade,
+    gjennomforing_id uuid                    not null
+        constraint fk_gjennomforing references gjennomforing (id) on delete cascade,
     created_at              timestamp default now() not null,
     updated_at              timestamp default now() not null,
-    primary key (tiltaksgjennomforing_id, nav_ident)
+    primary key (gjennomforing_id, nav_ident)
 );

--- a/mulighetsrommet-api/src/main/resources/db/migration/V249__tiltaksgjennomforing_koordinator_table.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V249__tiltaksgjennomforing_koordinator_table.sql
@@ -1,9 +1,9 @@
 create table gjennomforing_koordinator
 (
-    nav_ident               text                    not null,
+    nav_ident        text                    not null,
     gjennomforing_id uuid                    not null
         constraint fk_gjennomforing references gjennomforing (id) on delete cascade,
-    created_at              timestamp default now() not null,
-    updated_at              timestamp default now() not null,
+    created_at       timestamp default now() not null,
+    updated_at       timestamp default now() not null,
     primary key (gjennomforing_id, nav_ident)
 );


### PR DESCRIPTION
Oppretter en egen tabell for å koble koordinatorer (fra Komet) med tiltaksgjennomføringer hos oss.
