### PR TITLE
Vis mine gjennomføringer viser også koordinators gjennomføringer

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/GjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/GjennomforingRoutes.kt
@@ -214,7 +214,7 @@ fun Route.gjennomforingRoutes() {
             val pagination = getPaginationParams()
             val filter = getAdminTiltaksgjennomforingsFilter().copy(
                 administratorNavIdent = getNavIdent(),
-                koordinatorNavIdent = getNavIdent()
+                koordinatorNavIdent = getNavIdent(),
             )
 
             call.respond(gjennomforinger.getAll(pagination, filter))

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/GjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/GjennomforingRoutes.kt
@@ -20,12 +20,12 @@ import no.nav.mulighetsrommet.api.parameters.getPaginationParams
 import no.nav.mulighetsrommet.api.plugins.AuthProvider
 import no.nav.mulighetsrommet.api.plugins.authenticate
 import no.nav.mulighetsrommet.api.plugins.getNavIdent
-import no.nav.mulighetsrommet.api.responses.*
+import no.nav.mulighetsrommet.api.responses.FieldError
+import no.nav.mulighetsrommet.api.responses.ValidationError
+import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.services.ExcelService
 import no.nav.mulighetsrommet.ktor.exception.InternalServerError
 import no.nav.mulighetsrommet.model.*
-import no.nav.mulighetsrommet.model.GjennomforingOppstartstype
-import no.nav.mulighetsrommet.model.Periode
 import no.nav.mulighetsrommet.model.Tiltakskoder.isForhaandsgodkjentTiltak
 import no.nav.mulighetsrommet.serializers.AvbruttAarsakSerializer
 import no.nav.mulighetsrommet.serializers.LocalDateSerializer
@@ -212,7 +212,10 @@ fun Route.gjennomforingRoutes() {
 
         get("mine") {
             val pagination = getPaginationParams()
-            val filter = getAdminTiltaksgjennomforingsFilter().copy(administratorNavIdent = getNavIdent())
+            val filter = getAdminTiltaksgjennomforingsFilter().copy(
+                administratorNavIdent = getNavIdent(),
+                koordinatorNavIdent = getNavIdent()
+            )
 
             call.respond(gjennomforinger.getAll(pagination, filter))
         }
@@ -306,6 +309,7 @@ data class AdminTiltaksgjennomforingFilter(
     val arrangorIds: List<UUID> = emptyList(),
     val administratorNavIdent: NavIdent? = null,
     val publisert: Boolean? = null,
+    val koordinatorNavIdent: NavIdent? = null,
 )
 
 fun RoutingContext.getAdminTiltaksgjennomforingsFilter(): AdminTiltaksgjennomforingFilter {
@@ -328,7 +332,6 @@ fun RoutingContext.getAdminTiltaksgjennomforingsFilter(): AdminTiltaksgjennomfor
         sortering = sortering,
         avtaleId = avtaleId,
         arrangorIds = arrangorIds,
-        administratorNavIdent = null,
         publisert = publisert,
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/GjennomforingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/GjennomforingService.kt
@@ -93,6 +93,7 @@ class GjennomforingService(
             avtaleId = filter.avtaleId,
             arrangorIds = filter.arrangorIds,
             administratorNavIdent = filter.administratorNavIdent,
+            koordinatorNavIdent = filter.koordinatorNavIdent,
             publisert = filter.publisert,
             sluttDatoGreaterThanOrEqualTo = TiltaksgjennomforingSluttDatoCutoffDate,
         ).let { (totalCount, data) ->

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/db/GjennomforingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/db/GjennomforingQueries.kt
@@ -299,6 +299,7 @@ class GjennomforingQueries(private val session: Session) {
         administratorNavIdent: NavIdent? = null,
         opphav: ArenaMigrering.Opphav? = null,
         publisert: Boolean? = null,
+        koordinatorNavIdent: NavIdent? = null,
     ): PaginatedResult<GjennomforingDto> = with(session) {
         val parameters = mapOf(
             "search" to search?.toFTSPrefixQuery(),
@@ -311,6 +312,7 @@ class GjennomforingQueries(private val session: Session) {
             "arrangor_orgnrs" to arrangorOrgnr.ifEmpty { null }?.map { it.value }?.let { createTextArray(it) },
             "statuser" to statuser.ifEmpty { null }?.let { createTextArray(statuser) },
             "administrator_nav_ident" to administratorNavIdent?.let { """[{ "navIdent": "${it.value}" }]""" },
+            "koordinator_nav_ident" to koordinatorNavIdent?.let { """[{ "navIdent": "${it.value}" }]""" },
             "opphav" to opphav?.name,
             "publisert" to publisert,
         )
@@ -348,7 +350,7 @@ class GjennomforingQueries(private val session: Session) {
                           from jsonb_array_elements(nav_enheter_json) as nav_enhet
                           where nav_enhet ->> 'enhetsnummer' = any (:nav_enheter)) or
                    arena_nav_enhet_enhetsnummer = any (:nav_enheter)))
-              and (:administrator_nav_ident::text is null or administratorer_json @> :administrator_nav_ident::jsonb)
+              and (:administrator_nav_ident::text is null or administratorer_json @> :administrator_nav_ident::jsonb or :koordinator_nav_ident::text is null or koordinator_json @> :koordinator_nav_ident::jsonb)
               and (:slutt_dato_cutoff::date is null or slutt_dato >= :slutt_dato_cutoff or slutt_dato is null)
               and (tiltakstype_tiltakskode is not null)
               and (:opphav::opphav is null or opphav = :opphav::opphav)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/db/GjennomforingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/db/GjennomforingQueries.kt
@@ -350,7 +350,7 @@ class GjennomforingQueries(private val session: Session) {
                           from jsonb_array_elements(nav_enheter_json) as nav_enhet
                           where nav_enhet ->> 'enhetsnummer' = any (:nav_enheter)) or
                    arena_nav_enhet_enhetsnummer = any (:nav_enheter)))
-              and (:administrator_nav_ident::text is null or administratorer_json @> :administrator_nav_ident::jsonb or :koordinator_nav_ident::text is null or koordinator_json @> :koordinator_nav_ident::jsonb)
+              and ((:administrator_nav_ident::text is null or administratorer_json @> :administrator_nav_ident::jsonb) or (:koordinator_nav_ident::text is null or koordinator_json @> :koordinator_nav_ident::jsonb))
               and (:slutt_dato_cutoff::date is null or slutt_dato >= :slutt_dato_cutoff or slutt_dato is null)
               and (tiltakstype_tiltakskode is not null)
               and (:opphav::opphav is null or opphav = :opphav::opphav)

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__gjennomforing_admin_view.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__gjennomforing_admin_view.sql
@@ -36,6 +36,7 @@ select gjennomforing.id,
                                    gjennomforing.avsluttet_tidspunkt) as status,
        nav_kontaktpersoner_json,
        administratorer_json,
+       koordinator_json,
        nav_enheter_json,
        amo_kategorisering_json,
        tiltakstype.id                                                 as tiltakstype_id,
@@ -88,6 +89,15 @@ from gjennomforing
                             from gjennomforing_administrator administrator
                                      natural join nav_ansatt ansatt
                             where administrator.gjennomforing_id = gjennomforing.id) on true
+         left join lateral (select jsonb_agg(
+                                           jsonb_build_object(
+                                                   'navIdent', ansatt.nav_ident,
+                                                   'navn', concat(ansatt.fornavn, ' ', ansatt.etternavn)
+                                           )
+                                   ) as koordinator_json
+                            from gjennomforing_koordinator koordinator
+                                     natural join nav_ansatt ansatt
+                            where koordinator.gjennomforing_id = gjennomforing.id) on true
          left join lateral (select jsonb_agg(
                                            jsonb_build_object(
                                                    'id', id,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/db/GjennomforingQueriesTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/db/GjennomforingQueriesTest.kt
@@ -34,9 +34,6 @@ import no.nav.mulighetsrommet.database.utils.IntegrityConstraintViolation
 import no.nav.mulighetsrommet.database.utils.Pagination
 import no.nav.mulighetsrommet.database.utils.query
 import no.nav.mulighetsrommet.model.*
-import no.nav.mulighetsrommet.model.GjennomforingOppstartstype
-import no.nav.mulighetsrommet.model.Periode
-import no.nav.mulighetsrommet.model.Tiltakskode
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -648,7 +645,7 @@ class GjennomforingQueriesTest : FunSpec({
             }
         }
 
-        test("administrator") {
+        test("administrator og koordinator filtrering") {
             database.runAndRollback { session ->
                 val domain = MulighetsrommetTestDomain(
                     avtaler = listOf(AvtaleFixtures.oppfolging),
@@ -669,10 +666,10 @@ class GjennomforingQueriesTest : FunSpec({
 
                 val queries = GjennomforingQueries(session)
 
-                queries.getAll(administratorNavIdent = NavAnsattFixture.ansatt1.navIdent)
+                queries.getAll(administratorNavIdent = NavAnsattFixture.ansatt1.navIdent, koordinatorNavIdent = NavAnsattFixture.ansatt1.navIdent)
                     .totalCount shouldBe 2
 
-                queries.getAll(administratorNavIdent = NavAnsattFixture.ansatt2.navIdent)
+                queries.getAll(administratorNavIdent = NavAnsattFixture.ansatt2.navIdent, koordinatorNavIdent = NavAnsattFixture.ansatt2.navIdent)
                     .should {
                         it.totalCount shouldBe 1
                         it.items shouldContainExactlyIds listOf(domain.gjennomforinger[1].id)


### PR DESCRIPTION
Oppdaterer koden for å hente "mine gjennomføringer" til å støtte verdier lagret i gjennomforing_koordinator-tabellen.
Det kommer egen PR senere for å legge til rader i tabellen (Komet må dele på Kafka hvilke koordinatorer som tilhører hvilken gjennomføring).

Jeg lurer på:
- Burde jeg generalisere filteret, eller liker vi at det er forskjell på administrator og koordinator?
