### PR TITLE
Refactor/utbetaling

### DIFF
--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_utbetalinger.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_utbetalinger.ts
@@ -9,7 +9,6 @@ export const mockUtbetalinger: UtbetalingKompakt[] = [
     },
     id: "",
     status: AdminUtbetalingStatus.VENTER_PA_ARRANGOR,
-    delutbetalinger: [],
     createdAt: "2020-01-01",
   },
 ];

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
@@ -265,9 +265,7 @@ export function UtbetalingPage() {
                             key={t.id}
                             utbetaling={utbetaling}
                             tilsagn={t}
-                            delutbetaling={utbetaling.delutbetalinger.find(
-                              (d) => d.tilsagnId === t.id,
-                            )}
+                            delutbetaling={delutbetalinger.find((d) => d.tilsagnId === t.id)}
                             ansatt={ansatt}
                             endreUtbetaling={endreUtbetaling}
                             onBelopChange={(belop) =>

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
@@ -39,23 +39,18 @@ import { useOpprettDelutbetalinger } from "@/api/utbetaling/useOpprettDelutbetal
 import { v4 as uuidv4 } from "uuid";
 
 export function UtbetalingPage() {
-  const { gjennomforing, historikk, utbetaling, tilsagn, ansatt } =
+  const { gjennomforing, historikk, utbetaling, delutbetalinger, tilsagn, ansatt } =
     useLoaderData<LoaderData<typeof utbetalingPageLoader>>();
   const [belopPerTilsagn, setBelopPerTilsagn] = useState<Map<string, number>>(
     new Map(
       tilsagn
         .filter((tilsagn) => tilsagn.status === TilsagnStatus.GODKJENT)
-        .map((t) => [
-          t.id,
-          utbetaling.delutbetalinger.find((d) => d.tilsagnId === t.id)?.belop ?? 0,
-        ]),
+        .map((t) => [t.id, delutbetalinger.find((d) => d.tilsagnId === t.id)?.belop ?? 0]),
     ),
   );
 
   const skriveTilgang = ansatt?.roller.includes(NavAnsattRolle.TILTAKSGJENNOMFORINGER_SKRIV);
-  const avvistUtbetaling = utbetaling.delutbetalinger.find(
-    (d) => d.type === "DELUTBETALING_AVVIST",
-  );
+  const avvistUtbetaling = delutbetalinger.find((d) => d.type === "DELUTBETALING_AVVIST");
   const [endreUtbetaling, setEndreUtbetaling] = useState<boolean>(!avvistUtbetaling);
   const [error, setError] = useState<string | undefined>(undefined);
 
@@ -67,7 +62,7 @@ export function UtbetalingPage() {
   const kanRedigeres =
     skriveTilgang &&
     tilsagn.some((t) => t.status === TilsagnStatus.GODKJENT) &&
-    (utbetaling.delutbetalinger.length != tilsagn.length || (endreUtbetaling && avvistUtbetaling));
+    (delutbetalinger.length != tilsagn.length || (endreUtbetaling && avvistUtbetaling));
 
   const brodsmuler: Brodsmule[] = [
     { tittel: "Gjennomføringer", lenke: `/gjennomforinger` },
@@ -139,13 +134,12 @@ export function UtbetalingPage() {
           ...tilsagn
             .filter(
               (t) =>
-                !utbetaling.delutbetalinger.find(
+                !delutbetalinger.find(
                   (d) => d.tilsagnId === t.id && d.type !== "DELUTBETALING_AVVIST",
                 ) && belopPerTilsagn.get(t.id),
             )
             .map((tilsagn) => ({
-              id:
-                utbetaling.delutbetalinger?.find((d) => d.tilsagnId === tilsagn.id)?.id ?? uuidv4(),
+              id: delutbetalinger?.find((d) => d.tilsagnId === tilsagn.id)?.id ?? uuidv4(),
               tilsagnId: tilsagn.id,
               belop: belopPerTilsagn.get(tilsagn.id) ?? 0,
             })),

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/utbetalingPageLoader.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/utbetalingPageLoader.tsx
@@ -10,6 +10,12 @@ const utbetalingQuery = (utbetalingId: string) =>
     queryFn: () => UtbetalingService.getUtbetaling({ path: { id: utbetalingId } }),
   });
 
+const delutbetalingerQuery = (utbetalingId: string) =>
+  queryOptions({
+    queryKey: ["utbetaling", utbetalingId, "delutbetalinger"],
+    queryFn: () => UtbetalingService.getDelutbetalinger({ path: { id: utbetalingId } }),
+  });
+
 const tilsagnTilUtbetalingQuery = (utbetalingId: string) =>
   queryOptions({
     queryKey: ["utbetaling", utbetalingId, "tilsagn"],
@@ -38,15 +44,17 @@ export const utbetalingPageLoader =
       ansatt,
       { data: gjennomforing },
       { data: utbetaling },
+      { data: delutbetalinger },
       { data: tilsagn },
       { data: historikk },
     ] = await Promise.all([
       queryClient.ensureQueryData(ansattQuery),
       queryClient.ensureQueryData(gjennomforingQuery(gjennomforingId)),
       queryClient.ensureQueryData(utbetalingQuery(utbetalingId)),
+      queryClient.ensureQueryData(delutbetalingerQuery(utbetalingId)),
       queryClient.ensureQueryData(tilsagnTilUtbetalingQuery(utbetalingId)),
       queryClient.ensureQueryData(utbetalingHistorikkQuery(utbetalingId)),
     ]);
 
-    return { ansatt, gjennomforing, utbetaling, tilsagn, historikk };
+    return { ansatt, gjennomforing, utbetaling, delutbetalinger, tilsagn, historikk };
   };

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorflateRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorflateRoutes.kt
@@ -170,18 +170,6 @@ fun Route.arrangorflateRoutes() {
                 call.respond(tilsagn)
             }
         }
-
-        /*
-        fun getUtbetaling(id: UUID): UtbetalingDto {
-            return db.session {
-                queries.utbetaling.get(id) ?: throw NotFoundException("Fant ikke utbetaling med id=$id")
-            }
-        }
-            return db.session {
-                queries.tilsagn.getArrangorflateTilsagn(id) ?: throw NotFoundException("Fant ikke tilsagn")
-            }
-
-         */
     }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/model/ArrFlateUtbetaling.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/model/ArrFlateUtbetaling.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.api.arrangorflate.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.api.utbetaling.model.DelutbetalingDto
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingDto
 import no.nav.mulighetsrommet.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.serializers.LocalDateTimeSerializer
@@ -37,7 +36,7 @@ sealed class Beregning {
 data class ArrFlateUtbetaling(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    val status: Status,
+    val status: ArrFlateUtbetalingStatus,
     @Serializable(with = LocalDateTimeSerializer::class)
     val fristForGodkjenning: LocalDateTime,
     val tiltakstype: UtbetalingDto.Tiltakstype,
@@ -49,29 +48,7 @@ data class ArrFlateUtbetaling(
     val periodeStart: LocalDate,
     @Serializable(with = LocalDateSerializer::class)
     val periodeSlutt: LocalDate,
-) {
-    enum class Status {
-        KLAR_FOR_GODKJENNING,
-        BEHANDLES_AV_NAV,
-        UTBETALT,
-        VENTER_PA_ENDRING,
-        ;
-
-        companion object {
-            fun fromUtbetaling(utbetaling: UtbetalingDto, harRelevanteForslag: Boolean): Status {
-                return if (utbetaling.delutbetalinger.isNotEmpty() && utbetaling.delutbetalinger.all { it is DelutbetalingDto.DelutbetalingUtbetalt }) {
-                    UTBETALT
-                } else if (utbetaling.innsender != null) {
-                    BEHANDLES_AV_NAV
-                } else if (harRelevanteForslag) {
-                    VENTER_PA_ENDRING
-                } else {
-                    KLAR_FOR_GODKJENNING
-                }
-            }
-        }
-    }
-}
+)
 
 @Serializable
 data class UtbetalingDeltakelse(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/model/ArrFlateUtbetalingKompakt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/model/ArrFlateUtbetalingKompakt.kt
@@ -13,7 +13,7 @@ import java.util.*
 data class ArrFlateUtbetalingKompakt(
     @Serializable(with = UUIDSerializer::class)
     val id: UUID,
-    val status: ArrFlateUtbetaling.Status,
+    val status: ArrFlateUtbetalingStatus,
     @Serializable(with = LocalDateTimeSerializer::class)
     val fristForGodkjenning: LocalDateTime,
     val tiltakstype: UtbetalingDto.Tiltakstype,
@@ -26,9 +26,9 @@ data class ArrFlateUtbetalingKompakt(
     val belop: Int,
 ) {
     companion object {
-        fun fromUtbetalingDto(utbetaling: UtbetalingDto, harRelevanteForslag: Boolean) = ArrFlateUtbetalingKompakt(
+        fun fromUtbetalingDto(utbetaling: UtbetalingDto, status: ArrFlateUtbetalingStatus) = ArrFlateUtbetalingKompakt(
             id = utbetaling.id,
-            status = ArrFlateUtbetaling.Status.fromUtbetaling(utbetaling, harRelevanteForslag),
+            status = status,
             fristForGodkjenning = utbetaling.fristForGodkjenning,
             tiltakstype = utbetaling.tiltakstype,
             gjennomforing = utbetaling.gjennomforing,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/model/ArrFlateUtbetalingStatus.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/model/ArrFlateUtbetalingStatus.kt
@@ -1,0 +1,31 @@
+package no.nav.mulighetsrommet.api.arrangorflate.model
+
+import no.nav.mulighetsrommet.api.arrangorflate.RelevanteForslag
+import no.nav.mulighetsrommet.api.utbetaling.model.DelutbetalingDto
+import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingDto
+
+enum class ArrFlateUtbetalingStatus {
+    KLAR_FOR_GODKJENNING,
+    BEHANDLES_AV_NAV,
+    UTBETALT,
+    VENTER_PA_ENDRING,
+    ;
+
+    companion object {
+        fun fromUtbetaling(
+            utbetaling: UtbetalingDto,
+            delutbetalinger: List<DelutbetalingDto>,
+            relevanteForslag: List<RelevanteForslag>,
+        ): ArrFlateUtbetalingStatus {
+            return if (delutbetalinger.isNotEmpty() && delutbetalinger.all { it is DelutbetalingDto.DelutbetalingUtbetalt }) {
+                UTBETALT
+            } else if (utbetaling.innsender != null) {
+                BEHANDLES_AV_NAV
+            } else if (relevanteForslag.any { it.antallRelevanteForslag > 0 }) {
+                VENTER_PA_ENDRING
+            } else {
+                KLAR_FOR_GODKJENNING
+            }
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingRoutes.kt
@@ -22,11 +22,9 @@ import no.nav.mulighetsrommet.api.utbetaling.model.*
 import no.nav.mulighetsrommet.model.Kid
 import no.nav.mulighetsrommet.model.Kontonummer
 import no.nav.mulighetsrommet.serializers.LocalDateSerializer
-import no.nav.mulighetsrommet.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.serializers.UUIDSerializer
 import org.koin.ktor.ext.inject
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.*
 
 fun Route.utbetalingRoutes() {
@@ -37,10 +35,7 @@ fun Route.utbetalingRoutes() {
         get {
             val id = call.parameters.getOrFail<UUID>("id")
 
-            val utbetaling = db.session {
-                val utbetaling = queries.utbetaling.get(id) ?: return@get call.respond(HttpStatusCode.NotFound)
-                UtbetalingKompakt.fromUtbetalingDto(utbetaling)
-            }
+            val utbetaling = service.getUtbetalingKompakt(id)
 
             call.respond(utbetaling)
         }
@@ -102,20 +97,17 @@ fun Route.utbetalingRoutes() {
                     val request = call.receive<DelutbetalingRequest>()
                     val navIdent = getNavIdent()
 
-                    call.respondWithStatusResponse(
-                        service.validateAndUpsertDelutbetaling(
-                            utbetalingId,
-                            request,
-                            navIdent,
-                        ),
-                    )
+                    val result = service.validateAndUpsertDelutbetaling(utbetalingId, request, navIdent)
+                    call.respondWithStatusResponse(result)
                 }
+
                 put("/bulk") {
                     val utbetalingId = call.parameters.getOrFail<UUID>("id")
                     val request = call.receive<DelutbetalingBulkRequest>()
                     val navIdent = getNavIdent()
 
-                    call.respondWithStatusResponse(service.opprettDelutbetalinger(utbetalingId, request, navIdent))
+                    val result = service.opprettDelutbetalinger(utbetalingId, request, navIdent)
+                    call.respondWithStatusResponse(result)
                 }
             }
 
@@ -135,12 +127,7 @@ fun Route.utbetalingRoutes() {
         get {
             val id = call.parameters.getOrFail<UUID>("id")
 
-            val utbetalinger = db.session {
-                queries.utbetaling.getByGjennomforing(id)
-                    .map { utbetaling ->
-                        UtbetalingKompakt.fromUtbetalingDto(utbetaling)
-                    }
-            }
+            val utbetalinger = service.getUtbetalingKompaktByGjennomforing(id)
 
             call.respond(utbetalinger)
         }
@@ -207,60 +194,4 @@ data class OpprettManuellUtbetalingRequest(
         @Serializable(with = LocalDateSerializer::class)
         val slutt: LocalDate,
     )
-}
-
-@Serializable
-data class UtbetalingKompakt(
-    @Serializable(with = UUIDSerializer::class)
-    val id: UUID,
-    val status: AdminUtbetalingStatus,
-    val beregning: Beregning,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val godkjentAvArrangorTidspunkt: LocalDateTime?,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val createdAt: LocalDateTime,
-    val betalingsinformasjon: UtbetalingDto.Betalingsinformasjon,
-) {
-    @Serializable
-    data class Beregning(
-        @Serializable(with = LocalDateSerializer::class)
-        val periodeStart: LocalDate,
-        @Serializable(with = LocalDateSerializer::class)
-        val periodeSlutt: LocalDate,
-        val belop: Int,
-    )
-
-    companion object {
-        fun fromUtbetalingDto(utbetaling: UtbetalingDto) = UtbetalingKompakt(
-            id = utbetaling.id,
-            status = AdminUtbetalingStatus.fromUtbetaling(utbetaling),
-            beregning = Beregning(
-                periodeStart = utbetaling.periode.start,
-                periodeSlutt = utbetaling.periode.getLastInclusiveDate(),
-                belop = utbetaling.beregning.output.belop,
-            ),
-            godkjentAvArrangorTidspunkt = utbetaling.godkjentAvArrangorTidspunkt,
-            betalingsinformasjon = utbetaling.betalingsinformasjon,
-            createdAt = utbetaling.createdAt,
-        )
-    }
-
-    enum class AdminUtbetalingStatus {
-        UTBETALT,
-        VENTER_PA_ARRANGOR,
-        BEHANDLES_AV_NAV,
-        ;
-
-        companion object {
-            fun fromUtbetaling(utbetaling: UtbetalingDto): AdminUtbetalingStatus {
-                return if (utbetaling.delutbetalinger.isNotEmpty() && utbetaling.delutbetalinger.all { it is DelutbetalingDto.DelutbetalingUtbetalt }) {
-                    UTBETALT
-                } else if (utbetaling.innsender != null) {
-                    BEHANDLES_AV_NAV
-                } else {
-                    VENTER_PA_ARRANGOR
-                }
-            }
-        }
-    }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
@@ -61,12 +61,6 @@ class UtbetalingService(
     }
 
     fun recalculateUtbetalingForGjennomforing(id: UUID): Unit = db.transaction {
-        // TODO: hvorfor ikke beregne når delutbetalinger finnes? Impliserer godkjent utbetaling?
-        if (queries.delutbetaling.getByUtbetalingId(id).isNotEmpty()) {
-            log.info("Utbetaling id=$id skal ikke beregnes fordi delutbetalinger allerede finnes.")
-            return
-        }
-
         queries.utbetaling
             .getByGjennomforing(id)
             .filter { it.innsender == null }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
@@ -61,7 +61,7 @@ class UtbetalingService(
     }
 
     fun recalculateUtbetalingForGjennomforing(id: UUID): Unit = db.transaction {
-        // TODO: hvorfor ble dette lagt til?
+        // TODO: hvorfor ikke beregne når delutbetalinger finnes? Impliserer godkjent utbetaling?
         if (queries.delutbetaling.getByUtbetalingId(id).isNotEmpty()) {
             log.info("Utbetaling id=$id skal ikke beregnes fordi delutbetalinger allerede finnes.")
             return

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/UtbetalingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/UtbetalingQueries.kt
@@ -332,7 +332,6 @@ class UtbetalingQueries(private val session: Session) {
         val beregningsmodell = Beregningsmodell.valueOf(string("beregningsmodell"))
         val beregning = getBeregning(uuid("id"), beregningsmodell)
         val id = uuid("id")
-        val delutbetalinger = DelutbetalingQueries(session).getByUtbetalingId(id)
         val innsender = stringOrNull("innsender")?.let { UtbetalingDto.Innsender.fromString(it) }
 
         return UtbetalingDto(
@@ -365,7 +364,6 @@ class UtbetalingQueries(private val session: Session) {
             ),
             innsender = innsender,
             createdAt = localDateTime("created_at"),
-            delutbetalinger = delutbetalinger,
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumer.kt
@@ -62,6 +62,7 @@ class AmtDeltakerV1KafkaConsumer(
         }
     }
 
+    // TODO: oppdater logikk ifm. prodsetting av tiltaksøkonomi
     private fun isRelevantForUtbetaling(deltaker: AmtDeltakerV1Dto): Boolean {
         if (NaisEnv.current().isProdGCP()) {
             return false

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/AdminUtbetalingKompakt.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/AdminUtbetalingKompakt.kt
@@ -1,0 +1,46 @@
+package no.nav.mulighetsrommet.api.utbetaling.model
+
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.serializers.LocalDateSerializer
+import no.nav.mulighetsrommet.serializers.LocalDateTimeSerializer
+import no.nav.mulighetsrommet.serializers.UUIDSerializer
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+@Serializable
+data class AdminUtbetalingKompakt(
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID,
+    val status: AdminUtbetalingStatus,
+    val beregning: Beregning,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val godkjentAvArrangorTidspunkt: LocalDateTime?,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val createdAt: LocalDateTime,
+    val betalingsinformasjon: UtbetalingDto.Betalingsinformasjon,
+) {
+    @Serializable
+    data class Beregning(
+        @Serializable(with = LocalDateSerializer::class)
+        val periodeStart: LocalDate,
+        @Serializable(with = LocalDateSerializer::class)
+        val periodeSlutt: LocalDate,
+        val belop: Int,
+    )
+
+    companion object {
+        fun fromUtbetalingDto(utbetaling: UtbetalingDto, status: AdminUtbetalingStatus) = AdminUtbetalingKompakt(
+            id = utbetaling.id,
+            status = status,
+            beregning = Beregning(
+                periodeStart = utbetaling.periode.start,
+                periodeSlutt = utbetaling.periode.getLastInclusiveDate(),
+                belop = utbetaling.beregning.output.belop,
+            ),
+            godkjentAvArrangorTidspunkt = utbetaling.godkjentAvArrangorTidspunkt,
+            betalingsinformasjon = utbetaling.betalingsinformasjon,
+            createdAt = utbetaling.createdAt,
+        )
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/AdminUtbetalingStatus.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/AdminUtbetalingStatus.kt
@@ -1,0 +1,23 @@
+package no.nav.mulighetsrommet.api.utbetaling.model
+
+enum class AdminUtbetalingStatus {
+    UTBETALT,
+    VENTER_PA_ARRANGOR,
+    BEHANDLES_AV_NAV,
+    ;
+
+    companion object {
+        fun fromUtbetaling(
+            utbetaling: UtbetalingDto,
+            delutbetalinger: List<DelutbetalingDto>,
+        ): AdminUtbetalingStatus {
+            return if (delutbetalinger.isNotEmpty() && delutbetalinger.all { it is DelutbetalingDto.DelutbetalingUtbetalt }) {
+                UTBETALT
+            } else if (utbetaling.innsender != null) {
+                BEHANDLES_AV_NAV
+            } else {
+                VENTER_PA_ARRANGOR
+            }
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/UtbetalingDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/UtbetalingDto.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.model.*
 import no.nav.mulighetsrommet.serializers.LocalDateTimeSerializer
 import no.nav.mulighetsrommet.serializers.UUIDSerializer
-import no.nav.tiltak.okonomi.OkonomiPart.NavAnsatt
 import java.time.LocalDateTime
 import java.util.*
 
@@ -31,7 +30,6 @@ data class UtbetalingDto(
     val godkjentAvArrangorTidspunkt: LocalDateTime?,
     @Serializable(with = LocalDateTimeSerializer::class)
     val createdAt: LocalDateTime,
-    val delutbetalinger: List<DelutbetalingDto>,
 ) {
     @Serializable
     data class Gjennomforing(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverService.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.oppgaver
 
 import no.nav.mulighetsrommet.api.ApiDatabase
+import no.nav.mulighetsrommet.api.QueryContext
 import no.nav.mulighetsrommet.api.navansatt.db.NavAnsattRolle
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnDto
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatus
@@ -99,24 +100,28 @@ class OppgaverService(val db: ApiDatabase) {
         tiltakskoder: List<Tiltakskode>,
         kostnadssteder: List<String>,
         roller: Set<NavAnsattRolle>,
-    ): List<Oppgave> {
-        return db.session {
-            queries.utbetaling
-                .getOppgaveData(
-                    tiltakskoder = tiltakskoder.ifEmpty { null },
-                )
-                .filter {
-                    if (kostnadssteder.isEmpty()) {
-                        true
-                    } else {
-                        val tilsagn =
-                            db.session { queries.tilsagn.getAll(gjennomforingId = it.gjennomforing.id, periode = it.periode) }
-                        tilsagn.isEmpty() || tilsagn.any { it.kostnadssted.enhetsnummer in kostnadssteder }
-                    }
-                }
-                .mapNotNull { it.toOppgave() }
-                .filter { oppgavetyper.isEmpty() || it.type in oppgavetyper }
-                .filter { it.type.rolle in roller }
+    ): List<Oppgave> = db.session {
+        queries.utbetaling
+            .getOppgaveData(tiltakskoder = tiltakskoder.ifEmpty { null })
+            .asSequence()
+            .filter { utbetaling -> utbetaling.innsender == UtbetalingDto.Innsender.ArrangorAnsatt }
+            .filter { utbetaling -> queries.delutbetaling.getByUtbetalingId(utbetaling.id).isEmpty() }
+            .filter { utbetaling -> byKostnadssted(utbetaling, kostnadssteder) }
+            .map { it.toOppgave() }
+            .filter { oppgavetyper.isEmpty() || it.type in oppgavetyper }
+            .filter { it.type.rolle in roller }
+            .toList()
+    }
+
+    private fun QueryContext.byKostnadssted(
+        utbetaling: UtbetalingDto,
+        kostnadssteder: List<String>,
+    ): Boolean = when {
+        kostnadssteder.isEmpty() -> true
+        else -> {
+            queries.tilsagn
+                .getAll(gjennomforingId = utbetaling.gjennomforing.id, periode = utbetaling.periode)
+                .let { tilsagn -> tilsagn.isEmpty() || tilsagn.any { it.kostnadssted.enhetsnummer in kostnadssteder } }
         }
     }
 
@@ -220,21 +225,17 @@ class OppgaverService(val db: ApiDatabase) {
         -> null
     }
 
-    private fun UtbetalingDto.toOppgave(): Oppgave? = if (innsender == UtbetalingDto.Innsender.ArrangorAnsatt && delutbetalinger.isEmpty()) {
-        Oppgave(
-            id = UUID.randomUUID(),
-            type = OppgaveType.UTBETALING_TIL_BEHANDLING,
-            title = "Utbetaling klar til behandling",
-            description = "Innsendt utbetaling for ${gjennomforing.navn} er klar til behandling",
-            tiltakstype = tiltakstype.tiltakskode,
-            link = OppgaveLink(
-                linkText = "Se utbetaling",
-                link = "/gjennomforinger/${gjennomforing.id}/utbetalinger/$id",
-            ),
-            createdAt = createdAt,
-            oppgaveIcon = OppgaveIcon.UTBETALING,
-        )
-    } else {
-        null
-    }
+    private fun UtbetalingDto.toOppgave(): Oppgave = Oppgave(
+        id = UUID.randomUUID(),
+        type = OppgaveType.UTBETALING_TIL_BEHANDLING,
+        title = "Utbetaling klar til behandling",
+        description = "Innsendt utbetaling for ${gjennomforing.navn} er klar til behandling",
+        tiltakstype = tiltakstype.tiltakskode,
+        link = OppgaveLink(
+            linkText = "Se utbetaling",
+            link = "/gjennomforinger/${gjennomforing.id}/utbetalinger/$id",
+        ),
+        createdAt = createdAt,
+        oppgaveIcon = OppgaveIcon.UTBETALING,
+    )
 }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -1954,6 +1954,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/UtbetalingKompakt"
 
+  /api/v1/intern/utbetaling/{id}/delutbetalinger:
+    parameters:
+      - $ref: "#/components/parameters/ID"
+    get:
+      tags:
+        - Utbetaling
+      operationId: getDelutbetalinger
+      responses:
+        200:
+          description: Delutbetalinger
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DelutbetalingDto"
+
   /api/v1/intern/utbetaling/{id}/historikk:
     get:
       tags:
@@ -5619,10 +5636,6 @@ components:
           $ref: "#/components/schemas/AdminUtbetalingStatus"
         beregning:
           $ref: "#/components/schemas/UtbetalingKompaktBeregning"
-        delutbetalinger:
-          type: array
-          items:
-            $ref: "#/components/schemas/DelutbetalingDto"
         godkjentAvArrangorTidspunkt:
           type: string
           format: date-time
@@ -5631,7 +5644,7 @@ components:
           format: date-time
         betalingsinformasjon:
           $ref: "#/components/schemas/Betalingsinformasjon"
-      required: [id, status, beregning, delutbetalinger, createdAt]
+      required: [id, status, beregning, createdAt]
 
     ArrFlateUtbetalingKompakt:
       type: object

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/oppgaver/OppgaverServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/oppgaver/OppgaverServiceTest.kt
@@ -1,3 +1,4 @@
+package no.nav.mulighetsrommet.api.oppgaver
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -172,7 +173,10 @@ class OppgaverServiceTest : FunSpec({
                     UtbetalingFixtures.delutbetaling2,
                 ),
             ) {
-                setDelutbetalingStatus(UtbetalingFixtures.delutbetaling2, UtbetalingFixtures.DelutbetalingStatus.RETURNERT)
+                setDelutbetalingStatus(
+                    UtbetalingFixtures.delutbetaling2,
+                    UtbetalingFixtures.DelutbetalingStatus.RETURNERT,
+                )
             }.initialize(database.db)
 
             var oppgaver = service.delutbetalingOppgaver(
@@ -234,9 +238,24 @@ class OppgaverServiceTest : FunSpec({
                     UtbetalingFixtures.delutbetaling1.copy(utbetalingId = UtbetalingFixtures.utbetaling2.id),
                 ),
             ).initialize(database.db)
-            database.run { queries.utbetaling.setGodkjentAvArrangor(UtbetalingFixtures.utbetaling1.id, LocalDateTime.now()) }
-            database.run { queries.utbetaling.setGodkjentAvArrangor(UtbetalingFixtures.utbetaling2.id, LocalDateTime.now()) }
-            database.run { queries.utbetaling.setGodkjentAvArrangor(UtbetalingFixtures.utbetaling3.id, LocalDateTime.now()) }
+            database.run {
+                queries.utbetaling.setGodkjentAvArrangor(
+                    UtbetalingFixtures.utbetaling1.id,
+                    LocalDateTime.now(),
+                )
+            }
+            database.run {
+                queries.utbetaling.setGodkjentAvArrangor(
+                    UtbetalingFixtures.utbetaling2.id,
+                    LocalDateTime.now(),
+                )
+            }
+            database.run {
+                queries.utbetaling.setGodkjentAvArrangor(
+                    UtbetalingFixtures.utbetaling3.id,
+                    LocalDateTime.now(),
+                )
+            }
 
             service.utbetalingOppgaver(
                 oppgavetyper = emptyList(),

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingServiceTest.kt
@@ -647,6 +647,16 @@ class UtbetalingServiceTest : FunSpec({
     }
 
     context("Automatisk utbetaling") {
+        val godkjennUtbetaling = GodkjennUtbetaling(
+            betalingsinformasjon = GodkjennUtbetaling.Betalingsinformasjon(
+                kontonummer = Kontonummer("12312312312"),
+                kid = null,
+            ),
+            digest = "digest",
+        )
+
+        val utbetalingId = UtbetalingFixtures.utbetaling1.id
+
         test("happy case") {
             MulighetsrommetTestDomain(
                 ansatte = listOf(NavAnsattFixture.ansatt1, NavAnsattFixture.ansatt2),
@@ -659,25 +669,15 @@ class UtbetalingServiceTest : FunSpec({
             }.initialize(database.db)
 
             val service = createUtbetalingService()
-            service.godkjentAvArrangor(
-                UtbetalingFixtures.utbetaling1.id,
-                request = GodkjennUtbetaling(
-                    betalingsinformasjon = GodkjennUtbetaling.Betalingsinformasjon(
-                        kontonummer = Kontonummer("12312312312"),
-                        kid = null,
-                    ),
-                    digest = "digest",
-                ),
-            )
+            service.godkjentAvArrangor(utbetalingId, godkjennUtbetaling)
 
-            val dto = requireNotNull(database.run { queries.utbetaling.get(UtbetalingFixtures.utbetaling1.id) })
-            dto.delutbetalinger shouldHaveSize 1
-
-            val delutbetaling = dto.delutbetalinger[0]
-            delutbetaling.shouldBeTypeOf<DelutbetalingDto.DelutbetalingOverfortTilUtbetaling>()
-            delutbetaling.belop shouldBe UtbetalingFixtures.utbetaling1.beregning.output.belop
-            delutbetaling.opprettelse.behandletAv shouldBe Tiltaksadministrasjon
-            delutbetaling.opprettelse.besluttetAv shouldBe Tiltaksadministrasjon
+            val delutbetalinger = database.run { queries.delutbetaling.getByUtbetalingId(utbetalingId) }
+            delutbetalinger.shouldHaveSize(1).first().should {
+                it.shouldBeTypeOf<DelutbetalingDto.DelutbetalingOverfortTilUtbetaling>()
+                it.belop shouldBe UtbetalingFixtures.utbetaling1.beregning.output.belop
+                it.opprettelse.behandletAv shouldBe Tiltaksadministrasjon
+                it.opprettelse.besluttetAv shouldBe Tiltaksadministrasjon
+            }
         }
 
         test("ingen automatisk utbetaling hvis tilsagn ikke er godkjent") {
@@ -690,18 +690,10 @@ class UtbetalingServiceTest : FunSpec({
             ).initialize(database.db)
 
             val service = createUtbetalingService()
-            service.godkjentAvArrangor(
-                UtbetalingFixtures.utbetaling1.id,
-                request = GodkjennUtbetaling(
-                    betalingsinformasjon = GodkjennUtbetaling.Betalingsinformasjon(
-                        kontonummer = Kontonummer("12312312312"),
-                        kid = null,
-                    ),
-                    digest = "digest",
-                ),
-            )
-            val dto = requireNotNull(database.run { queries.utbetaling.get(UtbetalingFixtures.utbetaling1.id) })
-            dto.delutbetalinger shouldHaveSize 0
+            service.godkjentAvArrangor(utbetalingId, godkjennUtbetaling)
+
+            val delutbetalinger = database.run { queries.delutbetaling.getByUtbetalingId(utbetalingId) }
+            delutbetalinger shouldHaveSize 0
         }
 
         test("ingen automatisk utbetaling hvis ingen tilsagn") {
@@ -713,18 +705,10 @@ class UtbetalingServiceTest : FunSpec({
             ).initialize(database.db)
 
             val service = createUtbetalingService()
-            service.godkjentAvArrangor(
-                UtbetalingFixtures.utbetaling1.id,
-                request = GodkjennUtbetaling(
-                    betalingsinformasjon = GodkjennUtbetaling.Betalingsinformasjon(
-                        kontonummer = Kontonummer("12312312312"),
-                        kid = null,
-                    ),
-                    digest = "digest",
-                ),
-            )
-            val dto = requireNotNull(database.run { queries.utbetaling.get(UtbetalingFixtures.utbetaling1.id) })
-            dto.delutbetalinger shouldHaveSize 0
+            service.godkjentAvArrangor(utbetalingId, godkjennUtbetaling)
+
+            val delutbetalinger = database.run { queries.delutbetaling.getByUtbetalingId(utbetalingId) }
+            delutbetalinger shouldHaveSize 0
         }
 
         test("ingen automatisk utbetaling hvis flere tilsagn") {
@@ -740,18 +724,10 @@ class UtbetalingServiceTest : FunSpec({
             }.initialize(database.db)
 
             val service = createUtbetalingService()
-            service.godkjentAvArrangor(
-                UtbetalingFixtures.utbetaling1.id,
-                request = GodkjennUtbetaling(
-                    betalingsinformasjon = GodkjennUtbetaling.Betalingsinformasjon(
-                        kontonummer = Kontonummer("12312312312"),
-                        kid = null,
-                    ),
-                    digest = "digest",
-                ),
-            )
-            val dto = requireNotNull(database.run { queries.utbetaling.get(UtbetalingFixtures.utbetaling1.id) })
-            dto.delutbetalinger shouldHaveSize 0
+            service.godkjentAvArrangor(utbetalingId, godkjennUtbetaling)
+
+            val delutbetalinger = database.run { queries.delutbetaling.getByUtbetalingId(utbetalingId) }
+            delutbetalinger shouldHaveSize 0
         }
 
         test("ingen automatisk utbetaling hvis tilsagn ikke har nok penger") {
@@ -773,18 +749,10 @@ class UtbetalingServiceTest : FunSpec({
             }.initialize(database.db)
 
             val service = createUtbetalingService()
-            service.godkjentAvArrangor(
-                UtbetalingFixtures.utbetaling1.id,
-                request = GodkjennUtbetaling(
-                    betalingsinformasjon = GodkjennUtbetaling.Betalingsinformasjon(
-                        kontonummer = Kontonummer("12312312312"),
-                        kid = null,
-                    ),
-                    digest = "digest",
-                ),
-            )
-            val dto = requireNotNull(database.run { queries.utbetaling.get(UtbetalingFixtures.utbetaling1.id) })
-            dto.delutbetalinger shouldHaveSize 0
+            service.godkjentAvArrangor(utbetalingId, godkjennUtbetaling)
+
+            val delutbetalinger = database.run { queries.delutbetaling.getByUtbetalingId(utbetalingId) }
+            delutbetalinger shouldHaveSize 0
         }
 
         test("ingen automatisk utbetaling hvis feil tiltakskode") {
@@ -799,18 +767,10 @@ class UtbetalingServiceTest : FunSpec({
             }.initialize(database.db)
 
             val service = createUtbetalingService()
-            service.godkjentAvArrangor(
-                UtbetalingFixtures.utbetaling1.id,
-                request = GodkjennUtbetaling(
-                    betalingsinformasjon = GodkjennUtbetaling.Betalingsinformasjon(
-                        kontonummer = Kontonummer("12312312312"),
-                        kid = null,
-                    ),
-                    digest = "digest",
-                ),
-            )
-            val dto = requireNotNull(database.run { queries.utbetaling.get(UtbetalingFixtures.utbetaling1.id) })
-            dto.delutbetalinger shouldHaveSize 0
+            service.godkjentAvArrangor(utbetalingId, godkjennUtbetaling)
+
+            val delutbetalinger = database.run { queries.delutbetaling.getByUtbetalingId(utbetalingId) }
+            delutbetalinger shouldHaveSize 0
         }
     }
 })


### PR DESCRIPTION
Trekker `delutbetalinger` ut fra `UtbetalingDto`. 

Gjør dette for løfte en del skjulte avhengigheter, som at `DelutbetalingerQueries` ble new'et opp som del av  `toUtbetalingDto`-mapperen.
Det blir opp til servicelaget å hente delutbetalingene for en utbetaling, der dette er relevant.

En sideeffekt av dette er at frontend har fått et nytt endepunkt og må hente delutbetalingene selv, men oppnår vi også at vi kun henter delutbetalingene når er faktiske er relevante for visning i frontend.