### PR TITLE
always recreate views during flyway migrate

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigDev.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigDev.kt
@@ -29,7 +29,7 @@ val ApplicationConfigDev = AppConfig(
         maximumPoolSize = 10,
     ),
     flyway = FlywayMigrationManager.MigrationConfig(
-        strategy = FlywayMigrationManager.InitializationStrategy.Migrate,
+        strategy = FlywayMigrationManager.InitializationStrategy.RepairAndMigrate,
     ),
     kafka = KafkaConfig(
         producerProperties = KafkaPropertiesPreset.aivenDefaultProducerProperties("mulighetsrommet-api-kafka-producer.v1"),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigProd.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigProd.kt
@@ -29,7 +29,7 @@ val ApplicationConfigProd = AppConfig(
         maximumPoolSize = 10,
     ),
     flyway = FlywayMigrationManager.MigrationConfig(
-        strategy = FlywayMigrationManager.InitializationStrategy.Migrate,
+        strategy = FlywayMigrationManager.InitializationStrategy.RepairAndMigrate,
     ),
     kafka = KafkaConfig(
         producerProperties = KafkaPropertiesPreset.aivenDefaultProducerProperties("mulighetsrommet-api-kafka-producer.v1"),

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_avtale_admin.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_avtale_admin.sql
@@ -1,3 +1,5 @@
+-- ${flyway:timestamp}
+
 drop view if exists avtale_admin_dto_view;
 
 create view avtale_admin_dto_view as

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_gjennomforing_admin.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_gjennomforing_admin.sql
@@ -1,4 +1,5 @@
--- Recreate view
+-- ${flyway:timestamp}
+
 drop view if exists gjennomforing_admin_dto_view;
 
 create view gjennomforing_admin_dto_view as

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_gjennomforing_veilederflate.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_gjennomforing_veilederflate.sql
@@ -1,3 +1,5 @@
+-- ${flyway:timestamp}
+
 drop view if exists veilederflate_tiltak_view;
 
 create view veilederflate_tiltak_view as

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_admin.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_admin.sql
@@ -1,3 +1,5 @@
+-- ${flyway:timestamp}
+
 drop view if exists tilsagn_admin_dto_view;
 
 create view tilsagn_admin_dto_view as

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_arrangorflate.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_arrangorflate.sql
@@ -1,3 +1,5 @@
+-- ${flyway:timestamp}
+
 drop view if exists tilsagn_arrangorflate_view;
 
 create view tilsagn_arrangorflate_view as

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_tiltakstype_admin.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_tiltakstype_admin.sql
@@ -1,3 +1,5 @@
+-- ${flyway:timestamp}
+
 drop view if exists tiltakstype_admin_dto_view;
 
 create view tiltakstype_admin_dto_view as

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_utbetaling_admin.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_utbetaling_admin.sql
@@ -1,4 +1,5 @@
--- bump
+-- ${flyway:timestamp}
+
 drop view if exists utbetaling_aft_view;
 drop view if exists utbetaling_dto_view;
 


### PR DESCRIPTION
Ved å legge til ${flyway:timestamp} så vil repetable scripts trigge en ny sjekksum basert på tidspunktet det kjøres på, se [0] for mer ifno. Dette burde minske risikoen for at vi glemmer å oppdatere views etter hvert som ny migrasjoner blir lagt til.

[0]: https://www.red-gate.com/blog/timestamps-and-repeatable-migrations