### PR TITLE
Bruker increase og ny metrikk for å sjekke om app har krasjet

### DIFF
--- a/iac/alerts/alerts-dev.yaml
+++ b/iac/alerts/alerts-dev.yaml
@@ -27,8 +27,8 @@ spec:
             namespace: team-mulighetsrommet
             severity: critical
         - alert: "Applikasjon starter ikke"
-          expr: kube_deployment_status_replicas_unavailable{namespace="team-mulighetsrommet"} > 0
-          for: 7m
+          expr: increase(kube_pod_container_status_restarts_total{namespace="team-mulighetsrommet"}[5m]) > 0
+          for: 5m
           annotations:
             consequence: Minst én pod er utilgjengelig og nye kodeendringer har sannsynligvis ikke blitt produksjonssatt.
             action: "`kubectl describe pod -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for events, og `kubectl logs -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for logger"

--- a/iac/alerts/alerts-prod.yaml
+++ b/iac/alerts/alerts-prod.yaml
@@ -27,8 +27,8 @@ spec:
             namespace: team-mulighetsrommet
             severity: critical
         - alert: "Applikasjon starter ikke"
-          expr: kube_deployment_status_replicas_unavailable{namespace="team-mulighetsrommet"} > 0
-          for: 7m
+          expr: increase(kube_pod_container_status_restarts_total{namespace="team-mulighetsrommet"}[5m]) > 0
+          for: 5m
           annotations:
             consequence: Minst én pod er utilgjengelig og nye kodeendringer har sannsynligvis ikke blitt produksjonssatt.
             action: "`kubectl describe pod -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for events, og `kubectl logs -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for logger"


### PR DESCRIPTION
The increase(kube_pod_container_status_restarts_total[5m]) function calculates the increase in the restart counter over the last 5 minutes. Combined with for: 5m, this alert will fire if:
1. There are any container restarts detected in a 5-minute window
This condition persists for 5 minutes
This helps avoid alert noise from single quick restarts while still catching problematic restart patterns. You can adjust both time windows (the one in increase() and in for:) to make the alert more or less sensitive to restart patterns.
