### PR TITLE
normaliser tilsagn-beregning

### DIFF
--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_admin.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_admin.sql
@@ -3,30 +3,30 @@
 drop view if exists tilsagn_admin_dto_view;
 
 create view tilsagn_admin_dto_view as
-select
-    tilsagn.id,
-    tilsagn.gjennomforing_id,
-    tilsagn.belop_gjenstaende,
-    tilsagn.periode,
-    tilsagn.beregning,
-    tilsagn.lopenummer,
-    tilsagn.bestillingsnummer,
-    tilsagn.kostnadssted,
-    tilsagn.status,
-    tilsagn.type,
-    nav_enhet.navn                                                            as kostnadssted_navn,
-    nav_enhet.overordnet_enhet                                                as kostnadssted_overordnet_enhet,
-    nav_enhet.type                                                            as kostnadssted_type,
-    nav_enhet.status                                                          as kostnadssted_status,
-    arrangor.id                                                               as arrangor_id,
-    arrangor.organisasjonsnummer                                              as arrangor_organisasjonsnummer,
-    arrangor.navn                                                             as arrangor_navn,
-    arrangor.slettet_dato is not null                                         as arrangor_slettet,
-    gjennomforing.tiltaksnummer                                               as tiltaksnummer,
-    gjennomforing.navn                                                        as gjennomforing_navn,
-    tiltakstype.tiltakskode                                                   as tiltakskode
+select tilsagn.id,
+       tilsagn.gjennomforing_id,
+       tilsagn.belop_gjenstaende,
+       tilsagn.belop_beregnet,
+       tilsagn.periode,
+       tilsagn.lopenummer,
+       tilsagn.bestillingsnummer,
+       tilsagn.kostnadssted,
+       tilsagn.status,
+       tilsagn.type,
+       tilsagn.prismodell,
+       nav_enhet.navn                    as kostnadssted_navn,
+       nav_enhet.overordnet_enhet        as kostnadssted_overordnet_enhet,
+       nav_enhet.type                    as kostnadssted_type,
+       nav_enhet.status                  as kostnadssted_status,
+       arrangor.id                       as arrangor_id,
+       arrangor.organisasjonsnummer      as arrangor_organisasjonsnummer,
+       arrangor.navn                     as arrangor_navn,
+       arrangor.slettet_dato is not null as arrangor_slettet,
+       gjennomforing.tiltaksnummer       as tiltaksnummer,
+       gjennomforing.navn                as gjennomforing_navn,
+       tiltakstype.tiltakskode           as tiltakskode
 from tilsagn
-    inner join nav_enhet on nav_enhet.enhetsnummer = tilsagn.kostnadssted
-    inner join arrangor on arrangor.id = tilsagn.arrangor_id
-    inner join gjennomforing on gjennomforing.id = tilsagn.gjennomforing_id
-    inner join tiltakstype on tiltakstype.id = gjennomforing.tiltakstype_id;
+         inner join nav_enhet on nav_enhet.enhetsnummer = tilsagn.kostnadssted
+         inner join arrangor on arrangor.id = tilsagn.arrangor_id
+         inner join gjennomforing on gjennomforing.id = tilsagn.gjennomforing_id
+         inner join tiltakstype on tiltakstype.id = gjennomforing.tiltakstype_id;

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_arrangorflate.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_arrangorflate.sql
@@ -4,14 +4,14 @@ drop view if exists tilsagn_arrangorflate_view;
 
 create view tilsagn_arrangorflate_view as
 select tilsagn.id,
-       gjennomforing.navn           as gjennomforing_navn,
-       gjennomforing.id             as gjennomforing_id,
-       tiltakstype.navn             as tiltakstype_navn,
        tilsagn.type,
        tilsagn.belop_gjenstaende,
        tilsagn.periode,
-       tilsagn.beregning,
        tilsagn.status,
+       tilsagn.prismodell,
+       gjennomforing.navn           as gjennomforing_navn,
+       gjennomforing.id             as gjennomforing_id,
+       tiltakstype.navn             as tiltakstype_navn,
        arrangor.id                  as arrangor_id,
        arrangor.organisasjonsnummer as arrangor_organisasjonsnummer,
        arrangor.navn                as arrangor_navn

--- a/mulighetsrommet-api/src/main/resources/db/migration/V258__tilsagn_beregning.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V258__tilsagn_beregning.sql
@@ -1,0 +1,33 @@
+drop view if exists tilsagn_admin_dto_view;
+drop view if exists tilsagn_arrangorflate_view;
+
+alter table tilsagn
+    add belop_beregnet integer,
+    add prismodell     prismodell;
+
+create table tilsagn_forhandsgodkjent_beregning
+(
+    tilsagn_id     uuid    not null references tilsagn (id),
+    sats           integer not null,
+    antall_plasser integer not null
+);
+
+create index on tilsagn_forhandsgodkjent_beregning (tilsagn_id);
+
+update tilsagn
+set belop_beregnet = (beregning -> 'output' ->> 'belop')::integer,
+    prismodell     = (beregning ->> 'type')::prismodell;
+
+alter table tilsagn
+    alter belop_beregnet set not null,
+    alter prismodell set not null;
+
+insert into tilsagn_forhandsgodkjent_beregning (tilsagn_id, sats, antall_plasser)
+select id,
+       (beregning -> 'input' ->> 'sats')::integer,
+       (beregning -> 'input' ->> 'antallPlasser')::integer
+from tilsagn
+where (beregning ->> 'type') = 'FORHANDSGODKJENT';
+
+alter table tilsagn
+    drop column beregning;


### PR DESCRIPTION
Normaliserer tilsagn-beregning i stedet for å lagre som json, da er det litt mer fleksibelt i forhold til evt. fremtidige endringer i beregningsmodell.