### PR TITLE
flytt logikk til arrangørflate-service

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorflateRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorflateRoutes.kt
@@ -15,7 +15,6 @@ import no.nav.mulighetsrommet.api.pdfgen.PdfGenClient
 import no.nav.mulighetsrommet.api.plugins.ArrangorflatePrincipal
 import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
-import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
 import no.nav.mulighetsrommet.api.utbetaling.UtbetalingService
 import no.nav.mulighetsrommet.api.utbetaling.UtbetalingValidator
 import no.nav.mulighetsrommet.ktor.exception.StatusException
@@ -27,7 +26,6 @@ import org.koin.ktor.ext.inject
 import java.util.*
 
 fun Route.arrangorflateRoutes() {
-    val tilsagnService: TilsagnService by inject()
     val arrangorService: ArrangorService by inject()
     val utbetalingService: UtbetalingService by inject()
     val pdfClient: PdfGenClient by inject()
@@ -128,7 +126,7 @@ fun Route.arrangorflateRoutes() {
                     ?: throw NotFoundException("Fant ikke utbetaling med id=$id")
                 requireTilgangHosArrangor(utbetaling.arrangor.organisasjonsnummer)
 
-                val tilsagn = tilsagnService.getArrangorflateTilsagnTilUtbetaling(
+                val tilsagn = arrangorFlateService.getArrangorflateTilsagnTilUtbetaling(
                     gjennomforingId = utbetaling.gjennomforing.id,
                     periode = utbetaling.periode,
                 )
@@ -150,7 +148,7 @@ fun Route.arrangorflateRoutes() {
                     ?: throw NotFoundException("Fant ikke utbetaling med id=$id")
                 requireTilgangHosArrangor(utbetaling.arrangor.organisasjonsnummer)
 
-                val tilsagn = tilsagnService.getArrangorflateTilsagnTilUtbetaling(
+                val tilsagn = arrangorFlateService.getArrangorflateTilsagnTilUtbetaling(
                     gjennomforingId = utbetaling.gjennomforing.id,
                     periode = utbetaling.periode,
                 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -375,7 +375,7 @@ private fun tasks(config: TaskConfig) = module {
     single { SynchronizeNavAnsatte(config.synchronizeNavAnsatte, get(), get()) }
     single { SynchronizeUtdanninger(config.synchronizeUtdanninger, get(), get()) }
     single { GenerateUtbetaling(config.generateUtbetaling, get()) }
-    single { JournalforUtbetaling(get(), get(), get(), get(), get()) }
+    single { JournalforUtbetaling(get(), get(), get(), get()) }
     single { NotificationTask(get()) }
     single {
         val updateGjennomforingStatus = UpdateGjennomforingStatus(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
@@ -386,13 +386,6 @@ class TilsagnService(
         queries.tilsagn.getAll()
     }
 
-    fun getArrangorflateTilsagnTilUtbetaling(
-        gjennomforingId: UUID,
-        periode: Periode,
-    ): List<ArrangorflateTilsagn> = db.session {
-        return queries.tilsagn.getArrangorflateTilsagnTilUtbetaling(gjennomforingId, periode)
-    }
-
     fun getEndringshistorikk(id: UUID): EndringshistorikkDto = db.session {
         queries.endringshistorikk.getEndringshistorikk(DocumentClass.TILSAGN, id)
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnDto.kt
@@ -20,13 +20,27 @@ data class TilsagnDto(
     val beregning: TilsagnBeregning,
     val lopenummer: Int,
     val bestillingsnummer: String,
-    val arrangor: Arrangor,
+    val tiltakstype: Tiltakstype,
     val gjennomforing: Gjennomforing,
+    val arrangor: Arrangor,
     val status: TilsagnStatus,
     val opprettelse: Totrinnskontroll,
     val annullering: Totrinnskontroll?,
     val frigjoring: Totrinnskontroll?,
 ) {
+    @Serializable
+    data class Tiltakstype(
+        val tiltakskode: Tiltakskode,
+        val navn: String,
+    )
+
+    @Serializable
+    data class Gjennomforing(
+        @Serializable(with = UUIDSerializer::class)
+        val id: UUID,
+        val navn: String,
+    )
+
     @Serializable
     data class Arrangor(
         @Serializable(with = UUIDSerializer::class)
@@ -34,13 +48,5 @@ data class TilsagnDto(
         val organisasjonsnummer: Organisasjonsnummer,
         val navn: String,
         val slettet: Boolean,
-    )
-
-    @Serializable
-    data class Gjennomforing(
-        @Serializable(with = UUIDSerializer::class)
-        val id: UUID,
-        val tiltakskode: Tiltakskode,
-        val navn: String,
     )
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/JournalforUtbetaling.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/JournalforUtbetaling.kt
@@ -12,7 +12,6 @@ import no.nav.mulighetsrommet.api.clients.dokark.DokarkError
 import no.nav.mulighetsrommet.api.clients.dokark.DokarkResponse
 import no.nav.mulighetsrommet.api.clients.dokark.Journalpost
 import no.nav.mulighetsrommet.api.pdfgen.PdfGenClient
-import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingDto
 import no.nav.mulighetsrommet.serializers.UUIDSerializer
 import no.nav.mulighetsrommet.tasks.executeSuspend
@@ -25,7 +24,6 @@ import java.util.*
 
 class JournalforUtbetaling(
     private val db: ApiDatabase,
-    private val tilsagnService: TilsagnService,
     private val dokarkClient: DokarkClient,
     private val arrangorFlateService: ArrangorFlateService,
     private val pdf: PdfGenClient,
@@ -64,7 +62,7 @@ class JournalforUtbetaling(
         val fagsakId = gjennomforing.tiltaksnummer ?: gjennomforing.lopenummer
 
         val pdf = run {
-            val tilsagn = tilsagnService.getArrangorflateTilsagnTilUtbetaling(
+            val tilsagn = arrangorFlateService.getArrangorflateTilsagnTilUtbetaling(
                 gjennomforingId = utbetaling.gjennomforing.id,
                 periode = utbetaling.periode,
             )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverService.kt
@@ -68,7 +68,7 @@ class OppgaverService(val db: ApiDatabase) {
                 .filter { oppgave ->
                     kostnadssteder.isEmpty() || oppgave.kostnadssted.enhetsnummer in kostnadssteder
                 }
-                .filter { tiltakskoder.isEmpty() || it.gjennomforing.tiltakskode in tiltakskoder }
+                .filter { tiltakskoder.isEmpty() || it.tiltakstype.tiltakskode in tiltakskoder }
                 .mapNotNull { it.toOppgave() }
                 .filter { oppgavetyper.isEmpty() || it.type in oppgavetyper }
                 .filter { it.type.rolle in roller }
@@ -140,7 +140,7 @@ class OppgaverService(val db: ApiDatabase) {
             type = OppgaveType.TILSAGN_TIL_GODKJENNING,
             title = "Tilsagn til godkjenning",
             description = "Tilsagnet for ${gjennomforing.navn} er sendt til godkjenning",
-            tiltakstype = gjennomforing.tiltakskode,
+            tiltakstype = tiltakstype.tiltakskode,
             link = OppgaveLink(
                 linkText = "Se tilsagn",
                 link = "/gjennomforinger/${gjennomforing.id}/tilsagn/$id",
@@ -156,7 +156,7 @@ class OppgaverService(val db: ApiDatabase) {
                 type = OppgaveType.TILSAGN_RETURNERT,
                 title = "Tilsagn returnert",
                 description = "Tilsagnet for ${gjennomforing.navn} ble returnert av beslutter",
-                tiltakstype = gjennomforing.tiltakskode,
+                tiltakstype = tiltakstype.tiltakskode,
                 link = OppgaveLink(
                     linkText = "Se tilsagn",
                     link = "/gjennomforinger/${gjennomforing.id}/tilsagn/$id",
@@ -173,7 +173,7 @@ class OppgaverService(val db: ApiDatabase) {
                 type = OppgaveType.TILSAGN_TIL_ANNULLERING,
                 title = "Tilsagn til annullering",
                 description = "Tilsagnet for ${gjennomforing.navn} er sendt til annullering",
-                tiltakstype = gjennomforing.tiltakskode,
+                tiltakstype = tiltakstype.tiltakskode,
                 link = OppgaveLink(
                     linkText = "Se tilsagn",
                     link = "/gjennomforinger/${gjennomforing.id}/tilsagn/$id",
@@ -190,7 +190,7 @@ class OppgaverService(val db: ApiDatabase) {
                 type = OppgaveType.TILSAGN_TIL_FRIGJORING,
                 title = "Tilsagn til frigjøring",
                 description = "Tilsagnet for ${gjennomforing.navn} er sendt til frigjøring",
-                tiltakstype = gjennomforing.tiltakskode,
+                tiltakstype = tiltakstype.tiltakskode,
                 link = OppgaveLink(
                     linkText = "Se tilsagn",
                     link = "/gjennomforinger/${gjennomforing.id}/tilsagn/$id",

--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_admin.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_tilsagn_admin.sql
@@ -24,7 +24,8 @@ select tilsagn.id,
        arrangor.slettet_dato is not null as arrangor_slettet,
        gjennomforing.tiltaksnummer       as tiltaksnummer,
        gjennomforing.navn                as gjennomforing_navn,
-       tiltakstype.tiltakskode           as tiltakskode
+       tiltakstype.tiltakskode           as tiltakskode,
+       tiltakstype.navn                  as tiltakstype_navn
 from tilsagn
          inner join nav_enhet on nav_enhet.enhetsnummer = tilsagn.kostnadssted
          inner join arrangor on arrangor.id = tilsagn.arrangor_id

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/JournalforUtbetalingTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/JournalforUtbetalingTest.kt
@@ -8,7 +8,6 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import no.nav.mulighetsrommet.api.ApiDatabase
 import no.nav.mulighetsrommet.api.arrangorflate.ArrangorFlateService
@@ -18,7 +17,6 @@ import no.nav.mulighetsrommet.api.clients.pdl.PdlClient
 import no.nav.mulighetsrommet.api.databaseConfig
 import no.nav.mulighetsrommet.api.fixtures.*
 import no.nav.mulighetsrommet.api.pdfgen.PdfGenClient
-import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
 import no.nav.mulighetsrommet.api.utbetaling.HentAdressebeskyttetPersonBolkPdlQuery
 import no.nav.mulighetsrommet.api.utbetaling.db.UtbetalingDbo
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregningForhandsgodkjent
@@ -93,7 +91,6 @@ class JournalforUtbetalingTest : FunSpec({
         },
         baseUrl = "http://pdfgen",
     )
-    val tilsagnService: TilsagnService = mockk()
     val dokarkClient: DokarkClient = mockk()
     val arrangorFlateSerivce = { db: ApiDatabase ->
         ArrangorFlateService(
@@ -104,7 +101,6 @@ class JournalforUtbetalingTest : FunSpec({
 
     fun createTask() = JournalforUtbetaling(
         db = database.db,
-        tilsagnService = tilsagnService,
         dokarkClient = dokarkClient,
         arrangorFlateService = arrangorFlateSerivce(database.db),
         pdf = pdf,
@@ -125,7 +121,6 @@ class JournalforUtbetalingTest : FunSpec({
             queries.utbetaling.setGodkjentAvArrangor(utbetaling.id, LocalDateTime.now())
         }
 
-        every { tilsagnService.getArrangorflateTilsagnTilUtbetaling(any(), any()) } returns emptyList()
         coEvery { dokarkClient.opprettJournalpost(any(), any()) } returns DokarkResponse(
             journalpostId = "123",
             journalstatus = "ok",


### PR DESCRIPTION
Flytter spesifikke queries relatert til arrangørflate-tilsagn fra `TilsagnQueries` til å bli mappet i `ArrangorflateService` i stedet. Årsak til endringen er at det blir en del i ha i hodet når TilsagnQueries opererer med to forskjellige modeller og logikken er enkelt nok at til at det passer i servicelaget og litt nærmere arrangørflate.
