### PR TITLE
Ny årsak for annullering og frigjøring av tilsagn

### DIFF
--- a/frontend/arrangor-flate/app/components/tilsagn/TilsagnStatusTag.tsx
+++ b/frontend/arrangor-flate/app/components/tilsagn/TilsagnStatusTag.tsx
@@ -56,6 +56,8 @@ function aarsakTilTekst(aarsak: TilsagnTilAnnulleringAarsak): string {
       return "Feilregistrering";
     case TilsagnTilAnnulleringAarsak.GJENNOMFORING_AVBRYTES:
       return "Gjennomføring avbrytes";
+    case TilsagnTilAnnulleringAarsak.ARRANGOR_HAR_IKKE_SENDT_KRAV:
+      return "Arrangør har ikke sendt krav";
     case TilsagnTilAnnulleringAarsak.FEIL_ANNET:
       return "Annen årsak";
   }

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
@@ -339,6 +339,10 @@ export function TilsagnDetaljer() {
               <AarsakerOgForklaringModal<TilsagnTilAnnulleringAarsak>
                 aarsaker={[
                   {
+                    value: TilsagnTilAnnulleringAarsak.ARRANGOR_HAR_IKKE_SENDT_KRAV,
+                    label: "Arrangør har ikke sendt krav",
+                  },
+                  {
                     value: TilsagnTilAnnulleringAarsak.FEIL_REGISTRERING,
                     label: "Feilregistrering",
                   },
@@ -355,7 +359,13 @@ export function TilsagnDetaljer() {
                 onConfirm={({ aarsaker, forklaring }) => tilAnnullering({ aarsaker, forklaring })}
               />
               <AarsakerOgForklaringModal<TilsagnTilAnnulleringAarsak>
-                aarsaker={[{ value: TilsagnTilAnnulleringAarsak.FEIL_ANNET, label: "Annet" }]}
+                aarsaker={[
+                  {
+                    value: TilsagnTilAnnulleringAarsak.ARRANGOR_HAR_IKKE_SENDT_KRAV,
+                    label: "Arrangør har ikke sendt krav",
+                  },
+                  { value: TilsagnTilAnnulleringAarsak.FEIL_ANNET, label: "Annet" },
+                ]}
                 header="Frigjør tilsagn med forklaring"
                 buttonLabel="Send til godkjenning"
                 open={tilFrigjoringModalOpen}

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -409,6 +409,8 @@ export function tilsagnAarsakTilTekst(
       return "Feilregistrering";
     case TilsagnTilAnnulleringAarsak.GJENNOMFORING_AVBRYTES:
       return "Gjennomføring skal avbrytes";
+    case TilsagnTilAnnulleringAarsak.ARRANGOR_HAR_IKKE_SENDT_KRAV:
+      return "Arrangør har ikke sendt krav";
     case TilsagnTilAnnulleringAarsak.FEIL_ANNET:
       return "Annet";
   }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnStatusAarsak.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnStatusAarsak.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 enum class TilsagnStatusAarsak {
     FEIL_REGISTRERING,
     GJENNOMFORING_AVBRYTES,
+    ARRANGOR_HAR_IKKE_SENDT_KRAV,
     FEIL_ANTALL_PLASSER,
     FEIL_KOSTNADSSTED,
     FEIL_PERIODE,

--- a/mulighetsrommet-api/src/main/resources/db/migration/V261__tilsagn_status_arrangor_ikke_sendt_krav.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V261__tilsagn_status_arrangor_ikke_sendt_krav.sql
@@ -1,0 +1,1 @@
+alter type tilsagn_status_aarsak add value 'ARRANGOR_HAR_IKKE_SENDT_KRAV';

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -5518,6 +5518,7 @@ components:
       enum:
         - FEIL_REGISTRERING
         - GJENNOMFORING_AVBRYTES
+        - ARRANGOR_HAR_IKKE_SENDT_KRAV
         - FEIL_ANNET
 
     TilsagnAvvisningAarsak:


### PR DESCRIPTION
Legger til årsaken 'Arrangør har ikke sendt krav' som et predefinert valg når bruker skal annullere eller frigjøre tilsagn.