### PR TITLE
Feature/roller okonomi

### DIFF
--- a/frontend/frontend-common/components/varsel/VarselModal.tsx
+++ b/frontend/frontend-common/components/varsel/VarselModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "@navikt/aksel-icons";
 
 interface Props {
-  modalRef: RefObject<HTMLDialogElement | null>;
+  modalRef?: RefObject<HTMLDialogElement | null>;
   open?: boolean;
   handleClose: () => void;
   headingIconType?: "warning" | "error" | "info";

--- a/frontend/mr-admin-flate/src/components/utbetaling/DelutbetalingRow.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/DelutbetalingRow.tsx
@@ -5,11 +5,9 @@ import {
   Besluttelse,
   DelutbetalingDto,
   DelutbetalingStatus,
-  NavAnsatt,
-  NavAnsattRolle,
   ProblemDetail,
   TilsagnDto,
-  Totrinnskontroll,
+  TotrinnskontrollDto,
 } from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import { Alert, Button, Checkbox, HStack, Table } from "@navikt/ds-react";
@@ -20,22 +18,16 @@ import { AarsakerOgForklaringModal } from "../modal/AarsakerOgForklaringModal";
 import { DelutbetalingTag } from "./DelutbetalingTag";
 
 interface Props {
-  ansatt: NavAnsatt;
   tilsagn: TilsagnDto;
   delutbetaling: DelutbetalingDto;
-  opprettelse: Totrinnskontroll;
+  opprettelse: TotrinnskontrollDto;
 }
 
-export function DelutbetalingRow({ ansatt, tilsagn, delutbetaling, opprettelse }: Props) {
+export function DelutbetalingRow({ tilsagn, delutbetaling, opprettelse }: Props) {
   const [avvisModalOpen, setAvvisModalOpen] = useState(false);
   const queryClient = useQueryClient();
 
   const besluttMutation = useBesluttDelutbetaling(delutbetaling.id);
-
-  const kanBeslutte =
-    delutbetaling.status === DelutbetalingStatus.TIL_GODKJENNING &&
-    ansatt.roller.includes(NavAnsattRolle.ATTESTANT_UTBETALING) &&
-    opprettelse.behandletAv !== ansatt.navIdent;
 
   const godkjentUtbetaling = [DelutbetalingStatus.GODKJENT, DelutbetalingStatus.UTBETALT].includes(
     delutbetaling.status,
@@ -60,15 +52,15 @@ export function DelutbetalingRow({ ansatt, tilsagn, delutbetaling, opprettelse }
           flere utbetalinger fra tilsagnet
         </Alert>
       );
-    } else if (godkjentUtbetaling) {
+    } else {
       return (
         <HStack gap="4">
           <Metadata horizontal header="Behandlet av" verdi={opprettelse.behandletAv} />
-          <Metadata horizontal header="Besluttet av" verdi={opprettelse.besluttetAv} />
+          {opprettelse.type === "BESLUTTET" && (
+            <Metadata horizontal header="Besluttet av" verdi={opprettelse.besluttetAv} />
+          )}
         </HStack>
       );
-    } else {
-      return null;
     }
   }
 
@@ -93,7 +85,7 @@ export function DelutbetalingRow({ ansatt, tilsagn, delutbetaling, opprettelse }
         <DelutbetalingTag status={delutbetaling.status} />
       </Table.DataCell>
       <Table.DataCell>
-        {kanBeslutte && (
+        {opprettelse.kanBesluttes && (
           <HStack gap="4">
             <Button
               size="small"

--- a/frontend/mr-admin-flate/src/components/utbetaling/OpprettDelutbetalingRow.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/OpprettDelutbetalingRow.tsx
@@ -1,9 +1,10 @@
 import { formaterPeriodeSlutt, formaterPeriodeStart, tilsagnTypeToString } from "@/utils/Utils";
 import {
+  Besluttelse,
+  DelutbetalingStatus,
   TilsagnDto,
   TilsagnStatus,
-  Totrinnskontroll,
-  DelutbetalingStatus,
+  TotrinnskontrollDto,
 } from "@mr/api-client-v2";
 import { Alert, Checkbox, Table, TextField } from "@navikt/ds-react";
 import { useState } from "react";
@@ -18,7 +19,7 @@ interface Props {
   tilsagn: TilsagnDto;
   belop: number;
   gjorOppTilsagn: boolean;
-  opprettelse?: Totrinnskontroll;
+  opprettelse?: TotrinnskontrollDto;
   status?: DelutbetalingStatus;
   kanRedigere: boolean;
   onDelutbetalingChange: (d: NyDelutbetaling) => void;
@@ -60,7 +61,7 @@ export function OpprettDelutbetalingRow({
       key={tilsagn.id}
       content={
         <>
-          {opprettelse && (
+          {opprettelse?.type === "BESLUTTET" && opprettelse.besluttelse === Besluttelse.AVVIST && (
             <AvvistAlert
               entitet="utbetalingen"
               header="Utbetaling returnert"

--- a/frontend/mr-admin-flate/src/mocks/endpoints/tilsagnHandler.ts
+++ b/frontend/mr-admin-flate/src/mocks/endpoints/tilsagnHandler.ts
@@ -1,4 +1,5 @@
 import {
+  Besluttelse,
   GetForhandsgodkjenteSatserResponse,
   TilsagnAvvisningAarsak,
   TilsagnDefaults,
@@ -7,6 +8,8 @@ import {
   TilsagnRequest,
   TilsagnStatus,
   TilsagnTilAnnulleringAarsak,
+  TotrinnskontrollBesluttetDto,
+  TotrinnskontrollTilBeslutningDto,
 } from "@mr/api-client-v2";
 import { http, HttpResponse, PathParams } from "msw";
 import { mockTilsagn } from "../fixtures/mock_tilsagn";
@@ -74,36 +77,55 @@ export const tilsagnHandlers = [
   }),
 ];
 
+const tilBeslutning: TotrinnskontrollTilBeslutningDto = {
+  type: "TIL_BESLUTNING",
+  behandletAv: "B123456",
+  behandletTidspunkt: "2024-01-01T22:00:00",
+  aarsaker: [],
+  kanBesluttes: true,
+};
+
+const godkjent: TotrinnskontrollBesluttetDto = {
+  type: "BESLUTTET",
+  behandletAv: "B123456",
+  behandletTidspunkt: "2024-01-01T22:00:00",
+  besluttetAv: "F123456",
+  besluttetTidspunkt: "2024-01-01T22:00:00",
+  aarsaker: [],
+  kanBesluttes: false,
+  besluttelse: Besluttelse.GODKJENT,
+};
+
+const avvist: TotrinnskontrollBesluttetDto = {
+  type: "BESLUTTET",
+  behandletAv: "B123456",
+  behandletTidspunkt: "2024-01-01T22:00:00",
+  besluttetAv: "F123456",
+  besluttetTidspunkt: "2024-01-01T22:00:00",
+  aarsaker: [],
+  kanBesluttes: false,
+  besluttelse: Besluttelse.AVVIST,
+};
+
 function toTilsagnDetaljerDto(tilsagn: TilsagnDto): TilsagnDetaljerDto {
   switch (tilsagn.status) {
     case TilsagnStatus.TIL_GODKJENNING:
       return {
         tilsagn,
-        opprettelse: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
-        },
+        opprettelse: tilBeslutning,
       };
 
     case TilsagnStatus.GODKJENT:
       return {
         tilsagn,
-        opprettelse: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
-          besluttetAv: "F123456",
-          besluttetTidspunkt: "2024-01-01T22:00:00",
-        },
+        opprettelse: godkjent,
       };
 
     case TilsagnStatus.RETURNERT:
       return {
         tilsagn,
         opprettelse: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-09",
-          besluttetAv: "N12345",
-          besluttetTidspunkt: "2024-01-10",
+          ...avvist,
           aarsaker: [TilsagnAvvisningAarsak.FEIL_ANTALL_PLASSER, TilsagnAvvisningAarsak.FEIL_ANNET],
           forklaring: "Du må fikse antall plasser. Det skal være 25 plasser.",
         },
@@ -112,15 +134,9 @@ function toTilsagnDetaljerDto(tilsagn: TilsagnDto): TilsagnDetaljerDto {
     case TilsagnStatus.TIL_ANNULLERING:
       return {
         tilsagn,
-        opprettelse: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
-          besluttetAv: "F123456",
-          besluttetTidspunkt: "2024-01-01T22:00:00",
-        },
+        opprettelse: godkjent,
         annullering: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
+          ...tilBeslutning,
           aarsaker: [
             TilsagnTilAnnulleringAarsak.FEIL_REGISTRERING,
             TilsagnTilAnnulleringAarsak.FEIL_ANNET,
@@ -132,55 +148,29 @@ function toTilsagnDetaljerDto(tilsagn: TilsagnDto): TilsagnDetaljerDto {
     case TilsagnStatus.ANNULLERT:
       return {
         tilsagn,
-        opprettelse: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
-          besluttetAv: "F123456",
-          besluttetTidspunkt: "2024-01-01T22:00:00",
-        },
+        opprettelse: godkjent,
         annullering: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
+          ...godkjent,
           aarsaker: [
             TilsagnTilAnnulleringAarsak.FEIL_REGISTRERING,
             TilsagnTilAnnulleringAarsak.FEIL_ANNET,
           ],
           forklaring: "Du må fikse antall plasser. Det skal være 25 plasser.",
-          besluttetAv: "F123456",
-          besluttetTidspunkt: "2024-01-01T22:00:00",
         },
       };
 
     case TilsagnStatus.TIL_OPPGJOR:
       return {
         tilsagn,
-        opprettelse: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
-          besluttetAv: "F123456",
-          besluttetTidspunkt: "2024-01-01T22:00:00",
-        },
-        tilOppgjor: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
-        },
+        opprettelse: godkjent,
+        tilOppgjor: tilBeslutning,
       };
 
     case TilsagnStatus.OPPGJORT:
       return {
         tilsagn,
-        opprettelse: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
-          besluttetAv: "F123456",
-          besluttetTidspunkt: "2024-01-01T22:00:00",
-        },
-        tilOppgjor: {
-          behandletAv: "B123456",
-          behandletTidspunkt: "2024-01-01T22:00:00",
-          besluttetAv: "F123456",
-          besluttetTidspunkt: "2024-01-01T22:00:00",
-        },
+        opprettelse: godkjent,
+        tilOppgjor: godkjent,
       };
   }
 }

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/AarsakerAlert.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/AarsakerAlert.tsx
@@ -1,12 +1,12 @@
 import {
   TilsagnAvvisningAarsak,
   TilsagnTilAnnulleringAarsak,
-  Totrinnskontroll,
+  TotrinnskontrollDto,
 } from "@mr/api-client-v2";
 import { Alert, Heading } from "@navikt/ds-react";
-import { formaterDato, tilsagnAarsakTilTekst } from "../../../utils/Utils";
+import { formaterDato, tilsagnAarsakTilTekst } from "@/utils/Utils";
 
-export function TilAnnulleringAlert({ annullering }: { annullering: Totrinnskontroll }) {
+export function TilAnnulleringAlert({ annullering }: { annullering: TotrinnskontrollDto }) {
   const aarsaker =
     annullering.aarsaker?.map((aarsak) =>
       tilsagnAarsakTilTekst(aarsak as TilsagnTilAnnulleringAarsak),
@@ -34,7 +34,7 @@ export function TilAnnulleringAlert({ annullering }: { annullering: Totrinnskont
   );
 }
 
-export function TilOppgjorAlert({ oppgjor }: { oppgjor: Totrinnskontroll }) {
+export function TilOppgjorAlert({ oppgjor }: { oppgjor: TotrinnskontrollDto }) {
   const aarsaker =
     oppgjor.aarsaker?.map((aarsak) =>
       tilsagnAarsakTilTekst(aarsak as TilsagnTilAnnulleringAarsak),

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/TilsagnTag.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/TilsagnTag.tsx
@@ -1,4 +1,4 @@
-import { TilsagnStatus, TilsagnTilAnnulleringAarsak, Totrinnskontroll } from "@mr/api-client-v2";
+import { TilsagnStatus, TilsagnTilAnnulleringAarsak, TotrinnskontrollDto } from "@mr/api-client-v2";
 import { BodyLong, List, Tag, VStack } from "@navikt/ds-react";
 import { useState } from "react";
 import { tilsagnAarsakTilTekst } from "@/utils/Utils";
@@ -6,7 +6,7 @@ import { tilsagnAarsakTilTekst } from "@/utils/Utils";
 interface Props {
   status: TilsagnStatus;
   expandable?: boolean;
-  annullering?: Totrinnskontroll;
+  annullering?: TotrinnskontrollDto;
 }
 
 export function TilsagnTag(props: Props) {

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
@@ -92,51 +92,43 @@ export function TilsagnDetaljer() {
   }
 
   function besluttTilsagn(request: BesluttTilsagnRequest) {
-    if (tilsagn) {
-      besluttMutation.mutate(
-        {
-          id: tilsagn.id,
-          body: {
-            ...request,
-          },
+    besluttMutation.mutate(
+      {
+        id: tilsagn.id,
+        body: {
+          ...request,
         },
-        {
-          onSuccess: navigerTilTilsagnTabell,
-        },
-      );
-    }
+      },
+      {
+        onSuccess: navigerTilTilsagnTabell,
+      },
+    );
   }
 
   function tilAnnullering(request: TilsagnTilAnnulleringRequest) {
-    if (tilsagn) {
-      tilAnnulleringMutation.mutate(
-        {
-          id: tilsagn.id,
-          aarsaker: request.aarsaker,
-          forklaring: request.forklaring || null,
-        },
-        { onSuccess: navigerTilTilsagnTabell },
-      );
-    }
+    tilAnnulleringMutation.mutate(
+      {
+        id: tilsagn.id,
+        aarsaker: request.aarsaker,
+        forklaring: request.forklaring || null,
+      },
+      { onSuccess: navigerTilTilsagnTabell },
+    );
   }
 
   function upsertTilOppgjor(request: TilsagnTilAnnulleringRequest) {
-    if (tilsagn) {
-      tilOppgjorMutation.mutate(
-        {
-          id: tilsagn.id,
-          aarsaker: request.aarsaker,
-          forklaring: request.forklaring || null,
-        },
-        { onSuccess: navigerTilTilsagnTabell },
-      );
-    }
+    tilOppgjorMutation.mutate(
+      {
+        id: tilsagn.id,
+        aarsaker: request.aarsaker,
+        forklaring: request.forklaring || null,
+      },
+      { onSuccess: navigerTilTilsagnTabell },
+    );
   }
 
   function slettTilsagn() {
-    if (tilsagn) {
-      slettMutation.mutate({ id: tilsagn.id }, { onSuccess: navigerTilTilsagnTabell });
-    }
+    slettMutation.mutate({ id: tilsagn.id }, { onSuccess: navigerTilTilsagnTabell });
   }
 
   function visBesluttKnapp(endretAv?: string): boolean {

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
@@ -33,7 +33,7 @@ import {
 } from "@navikt/aksel-icons";
 import { ActionMenu, Alert, BodyShort, Box, Button, Heading, HStack } from "@navikt/ds-react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useHentAnsatt } from "@/api/ansatt/useHentAnsatt";
 import { useAdminGjennomforingById } from "@/api/gjennomforing/useAdminGjennomforingById";
@@ -66,7 +66,7 @@ export function TilsagnDetaljer() {
   const navigate = useNavigate();
   const [tilAnnulleringModalOpen, setTilAnnulleringModalOpen] = useState<boolean>(false);
   const [tilOppgjorModalOpen, setTilOppgjorModalOpen] = useState<boolean>(false);
-  const slettTilsagnModalRef = useRef<HTMLDialogElement>(null);
+  const [slettTilsagnModalOpen, setSlettTilsagnModalOpen] = useState<boolean>(false);
   const [avvisModalOpen, setAvvisModalOpen] = useState(false);
 
   const brodsmuler: Array<Brodsmule | undefined> = [
@@ -180,7 +180,7 @@ export function TilsagnDetaljer() {
                       </ActionMenu.Item>
                       <ActionMenu.Item
                         variant="danger"
-                        onSelect={() => slettTilsagnModalRef.current?.showModal()}
+                        onSelect={() => setSlettTilsagnModalOpen(true)}
                         icon={<TrashIcon />}
                       >
                         Slett tilsagn
@@ -393,8 +393,8 @@ export function TilsagnDetaljer() {
               <VarselModal
                 headingIconType="warning"
                 headingText="Slette tilsagnet?"
-                modalRef={slettTilsagnModalRef}
-                handleClose={() => slettTilsagnModalRef.current?.close()}
+                open={slettTilsagnModalOpen}
+                handleClose={() => setTilOppgjorModalOpen(false)}
                 body={
                   <p>
                     Er du sikker på at du vil slette tilsagnet?
@@ -407,7 +407,7 @@ export function TilsagnDetaljer() {
                   </Button>
                 }
                 secondaryButton
-                secondaryButtonHandleAction={() => slettTilsagnModalRef.current?.close()}
+                secondaryButtonHandleAction={() => setTilOppgjorModalOpen(false)}
               />
             </div>
           </Box>

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljerForhandsgodkjent.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljerForhandsgodkjent.tsx
@@ -3,7 +3,11 @@ import { Metadata } from "@/components/detaljside/Metadata";
 import { TwoColumnGrid } from "@/layouts/TwoColumGrid";
 import { TilsagnTag } from "@/pages/gjennomforing/tilsagn/TilsagnTag";
 import { formaterPeriodeSlutt, formaterPeriodeStart } from "@/utils/Utils";
-import { TilsagnBeregningForhandsgodkjent, TilsagnDto, Totrinnskontroll } from "@mr/api-client-v2";
+import {
+  TilsagnBeregningForhandsgodkjent,
+  TilsagnDto,
+  TotrinnskontrollDto,
+} from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import { Heading, VStack } from "@navikt/ds-react";
 import { avtaletekster } from "@/components/ledetekster/avtaleLedetekster";
@@ -11,7 +15,7 @@ import { tilsagnTekster } from "@/components/tilsagn/TilsagnTekster";
 
 interface Props {
   tilsagn: TilsagnDto & { beregning: TilsagnBeregningForhandsgodkjent };
-  annullering?: Totrinnskontroll;
+  annullering?: TotrinnskontrollDto;
 }
 
 export function TilsagnDetaljerForhandsgodkjent({ tilsagn, annullering }: Props) {

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljerFri.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljerFri.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "@/components/detaljside/Metadata";
 import { TwoColumnGrid } from "@/layouts/TwoColumGrid";
 import { TilsagnTag } from "@/pages/gjennomforing/tilsagn/TilsagnTag";
 import { formaterPeriodeSlutt, formaterPeriodeStart } from "@/utils/Utils";
-import { TilsagnDto, Totrinnskontroll } from "@mr/api-client-v2";
+import { TilsagnDto, TotrinnskontrollDto } from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import { Heading, VStack } from "@navikt/ds-react";
 import { avtaletekster } from "@/components/ledetekster/avtaleLedetekster";
@@ -11,7 +11,7 @@ import { tilsagnTekster } from "@/components/tilsagn/TilsagnTekster";
 
 interface Props {
   tilsagn: TilsagnDto;
-  annullering?: Totrinnskontroll;
+  annullering?: TotrinnskontrollDto;
 }
 
 export function TilsagnDetaljerFri({ tilsagn, annullering }: Props) {

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/tilsagnDetaljerLoader.ts
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/tilsagnDetaljerLoader.ts
@@ -1,7 +1,7 @@
 import { TilsagnService } from "@mr/api-client-v2";
 
 import { queryOptions } from "@tanstack/react-query";
-import { QueryKeys } from "../../../../api/QueryKeys";
+import { QueryKeys } from "@/api/QueryKeys";
 
 export const tilsagnQuery = (tilsagnId?: string) =>
   queryOptions({

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
@@ -320,7 +320,6 @@ export function UtbetalingPage() {
                           return (
                             <DelutbetalingRow
                               key={t.id}
-                              ansatt={ansatt}
                               tilsagn={t}
                               delutbetaling={delutbetaling}
                               opprettelse={opprettelse}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnDetaljerDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnDetaljerDto.kt
@@ -1,12 +1,12 @@
 package no.nav.mulighetsrommet.api.tilsagn.api
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.api.totrinnskontroll.model.Totrinnskontroll
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.TotrinnskontrollDto
 
 @Serializable
 data class TilsagnDetaljerDto(
     val tilsagn: TilsagnDto,
-    val opprettelse: Totrinnskontroll,
-    val annullering: Totrinnskontroll?,
-    val tilOppgjor: Totrinnskontroll?,
+    val opprettelse: TotrinnskontrollDto,
+    val annullering: TotrinnskontrollDto?,
+    val tilOppgjor: TotrinnskontrollDto?,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnRoutes.kt
@@ -13,6 +13,8 @@ import no.nav.mulighetsrommet.api.ApiDatabase
 import no.nav.mulighetsrommet.api.OkonomiConfig
 import no.nav.mulighetsrommet.api.gjennomforing.GjennomforingService
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingDto
+import no.nav.mulighetsrommet.api.navansatt.model.NavAnsattDto
+import no.nav.mulighetsrommet.api.navansatt.model.NavAnsattRolle
 import no.nav.mulighetsrommet.api.plugins.AuthProvider
 import no.nav.mulighetsrommet.api.plugins.authenticate
 import no.nav.mulighetsrommet.api.plugins.getNavIdent
@@ -20,6 +22,7 @@ import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
 import no.nav.mulighetsrommet.api.tilsagn.model.*
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.TotrinnskontrollDto
 import no.nav.mulighetsrommet.api.totrinnskontroll.model.Besluttelse
 import no.nav.mulighetsrommet.api.totrinnskontroll.model.Totrinnskontroll
 import no.nav.mulighetsrommet.ktor.exception.StatusException
@@ -56,14 +59,28 @@ fun Route.tilsagnRoutes() {
         route("/{id}") {
             get {
                 val id = call.parameters.getOrFail<UUID>("id")
+                val navIdent = getNavIdent()
 
                 val result = db.session {
                     val tilsagn = queries.tilsagn.get(id) ?: return@get call.respond(HttpStatusCode.NotFound)
+
+                    val ansatt = queries.ansatt.getByNavIdent(navIdent)
+                        ?: throw IllegalStateException("Fant ikke ansatt med navIdent $navIdent")
+
+                    val opprettelse = queries.totrinnskontroll.getOrError(id, Totrinnskontroll.Type.OPPRETT).let {
+                        getTotrinnskontrollForAnsatt(it, ansatt)
+                    }
+                    val annullering = queries.totrinnskontroll.get(id, Totrinnskontroll.Type.ANNULLER)?.let {
+                        getTotrinnskontrollForAnsatt(it, ansatt)
+                    }
+                    val tilOppgjor = queries.totrinnskontroll.get(id, Totrinnskontroll.Type.GJOR_OPP)?.let {
+                        getTotrinnskontrollForAnsatt(it, ansatt)
+                    }
                     TilsagnDetaljerDto(
                         tilsagn = TilsagnDto.fromTilsagn(tilsagn),
-                        opprettelse = queries.totrinnskontroll.getOrError(id, Totrinnskontroll.Type.OPPRETT),
-                        annullering = queries.totrinnskontroll.get(id, Totrinnskontroll.Type.ANNULLER),
-                        tilOppgjor = queries.totrinnskontroll.get(id, Totrinnskontroll.Type.GJOR_OPP),
+                        opprettelse = opprettelse,
+                        annullering = annullering,
+                        tilOppgjor = tilOppgjor,
                     )
                 }
 
@@ -372,4 +389,13 @@ private fun resolveEkstraTilsagnDefaults(
             beregning = null,
         )
     }
+}
+
+private fun getTotrinnskontrollForAnsatt(
+    totrinnskontroll: Totrinnskontroll,
+    ansatt: NavAnsattDto,
+): TotrinnskontrollDto {
+    val kanBesluttesAvAnsatt = totrinnskontroll.behandletAv != ansatt.navIdent &&
+        NavAnsattRolle.BESLUTTER_TILSAGN in ansatt.roller
+    return TotrinnskontrollDto.fromTotrinnskontroll(totrinnskontroll, kanBesluttesAvAnsatt)
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/totrinnskontroll/api/TotrinnskontrollDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/totrinnskontroll/api/TotrinnskontrollDto.kt
@@ -1,0 +1,71 @@
+package no.nav.mulighetsrommet.api.totrinnskontroll.api
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.api.totrinnskontroll.model.Besluttelse
+import no.nav.mulighetsrommet.api.totrinnskontroll.model.Totrinnskontroll
+import no.nav.mulighetsrommet.model.Agent
+import no.nav.mulighetsrommet.serializers.AgentSerializer
+import no.nav.mulighetsrommet.serializers.LocalDateTimeSerializer
+import java.time.LocalDateTime
+
+@Serializable
+sealed class TotrinnskontrollDto {
+    abstract val behandletAv: Agent
+    abstract val behandletTidspunkt: LocalDateTime
+    abstract val aarsaker: List<String>
+    abstract val forklaring: String?
+    abstract val kanBesluttes: Boolean
+
+    @Serializable
+    @SerialName("TIL_BESLUTNING")
+    data class TilBeslutning(
+        @Serializable(with = AgentSerializer::class)
+        override val behandletAv: Agent,
+        @Serializable(with = LocalDateTimeSerializer::class)
+        override val behandletTidspunkt: LocalDateTime,
+        override val aarsaker: List<String>,
+        override val forklaring: String?,
+        override val kanBesluttes: Boolean,
+    ) : TotrinnskontrollDto()
+
+    @Serializable
+    @SerialName("BESLUTTET")
+    data class Besluttet(
+        @Serializable(with = AgentSerializer::class)
+        override val behandletAv: Agent,
+        @Serializable(with = LocalDateTimeSerializer::class)
+        override val behandletTidspunkt: LocalDateTime,
+        override val aarsaker: List<String>,
+        override val forklaring: String?,
+        @Serializable(with = AgentSerializer::class)
+        val besluttetAv: Agent,
+        @Serializable(with = LocalDateTimeSerializer::class)
+        val besluttetTidspunkt: LocalDateTime,
+        val besluttelse: Besluttelse,
+    ) : TotrinnskontrollDto() {
+        override val kanBesluttes = false
+    }
+
+    companion object {
+        fun fromTotrinnskontroll(totrinnskontroll: Totrinnskontroll, kanBesluttes: Boolean) = when {
+            totrinnskontroll.besluttetAv == null -> TilBeslutning(
+                behandletAv = totrinnskontroll.behandletAv,
+                behandletTidspunkt = totrinnskontroll.behandletTidspunkt,
+                aarsaker = totrinnskontroll.aarsaker,
+                forklaring = totrinnskontroll.forklaring,
+                kanBesluttes = kanBesluttes,
+            )
+
+            else -> Besluttet(
+                behandletAv = totrinnskontroll.behandletAv,
+                behandletTidspunkt = totrinnskontroll.behandletTidspunkt,
+                aarsaker = totrinnskontroll.aarsaker,
+                forklaring = totrinnskontroll.forklaring,
+                besluttetAv = totrinnskontroll.besluttetAv,
+                besluttetTidspunkt = checkNotNull(totrinnskontroll.besluttetTidspunkt),
+                besluttelse = checkNotNull(totrinnskontroll.besluttelse),
+            )
+        }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingDetaljerDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingDetaljerDto.kt
@@ -1,7 +1,7 @@
 package no.nav.mulighetsrommet.api.utbetaling.api
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.api.totrinnskontroll.model.Totrinnskontroll
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.TotrinnskontrollDto
 import no.nav.mulighetsrommet.api.utbetaling.model.Delutbetaling
 
 @Serializable
@@ -13,5 +13,5 @@ data class UtbetalingDetaljerDto(
 @Serializable
 data class DelutbetalingDto(
     val delutbetaling: Delutbetaling,
-    val opprettelse: Totrinnskontroll,
+    val opprettelse: TotrinnskontrollDto,
 )

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -5461,11 +5461,11 @@ components:
         tilsagn:
           $ref: "#/components/schemas/TilsagnDto"
         opprettelse:
-          $ref: "#/components/schemas/Totrinnskontroll"
+          $ref: "#/components/schemas/TotrinnskontrollDto"
         annullering:
-          $ref: "#/components/schemas/Totrinnskontroll"
+          $ref: "#/components/schemas/TotrinnskontrollDto"
         tilOppgjor:
-          $ref: "#/components/schemas/Totrinnskontroll"
+          $ref: "#/components/schemas/TotrinnskontrollDto"
       required:
         - tilsagn
         - opprettelse
@@ -5692,7 +5692,7 @@ components:
         delutbetaling:
           $ref: "#/components/schemas/DelutbetalingDto"
         opprettelse:
-          $ref: "#/components/schemas/Totrinnskontroll"
+          $ref: "#/components/schemas/TotrinnskontrollDto"
       required:
         - delutbetaling
         - opprettelse
@@ -6242,14 +6242,48 @@ components:
           type: [string, "null"]
       required: [besluttelse, aarsaker, forklaring]
 
-    Totrinnskontroll:
+    TotrinnskontrollDto:
+      oneOf:
+        - $ref: "#/components/schemas/TotrinnskontrollTilBeslutningDto"
+        - $ref: "#/components/schemas/TotrinnskontrollBesluttetDto"
+
+    TotrinnskontrollTilBeslutningDto:
       type: object
       properties:
+        type:
+          const: TIL_BESLUTNING
         behandletAv:
           type: string
         behandletTidspunkt:
           type: string
           format: date-time
+        kanBesluttes:
+          type: boolean
+        aarsaker:
+          type: array
+          items:
+            type: string
+        forklaring:
+          type: string
+      required:
+        - type
+        - behandletAv
+        - behandletTidspunkt
+        - kanBesluttes
+        - aarsaker
+
+    TotrinnskontrollBesluttetDto:
+      type: object
+      properties:
+        type:
+          const: BESLUTTET
+        behandletAv:
+          type: string
+        behandletTidspunkt:
+          type: string
+          format: date-time
+        kanBesluttes:
+          type: boolean
         aarsaker:
           type: array
           items:
@@ -6261,4 +6295,14 @@ components:
         besluttetTidspunkt:
           type: string
           format: date-time
-      required: [behandletAv, behandletTidspunkt]
+        besluttelse:
+          $ref: "#/components/schemas/Besluttelse"
+      required:
+        - type
+        - behandletAv
+        - behandletTidspunkt
+        - aarsaker
+        - kanBesluttes
+        - besluttetAv
+        - besluttetTidspunkt
+        - besluttelse


### PR DESCRIPTION
Forslag til noen endringer på logikk ifm. totrinnskontroll

- Totrinnskontroll blir mappet til TotrinnskontrollDto i backend
- TotrinnskontrollDto inneholder et felt `kanBesluttes`
    - dette blir satt til `true` i backend basert på hvem som har sendt tilsagn (opprettelse, annullering, til oppgjør)/delutbetaling til godkjenning og at den ansatte har riktig rolle (beslutter/attestant)
    - har også lagt til en sjekk på at beslutter av tilsagn og attestant av delutbetaling ikke kan være den samme personen
    - Frontend benytter dette feltet direkte til å rendre knappene i stedet