### PR TITLE
Lar arrangør hente kontonummer på nytt ved knappetrykk

### DIFF
--- a/frontend/arrangor-flate/app/routes/api.$id.sync-kontonummer.tsx
+++ b/frontend/arrangor-flate/app/routes/api.$id.sync-kontonummer.tsx
@@ -1,0 +1,20 @@
+import { ArrangorflateService } from "api-client";
+import { LoaderFunction } from "react-router";
+import { apiHeaders } from "~/auth/auth.server";
+
+export const loader: LoaderFunction = async ({ request, params }) => {
+  const { id } = params;
+
+  if (!id) throw Error("Id ikke tilgjengelig");
+
+  const { data, error } = await ArrangorflateService.synkroniserKontonummerForUtbetaling({
+    path: { id },
+    headers: await apiHeaders(request),
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+};

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigLocal.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigLocal.kt
@@ -276,7 +276,7 @@ val ApplicationConfigLocal = AppConfig(
         minimumTilsagnPeriodeStart = Tiltakskode.entries.associateWith { LocalDate.of(2025, 1, 1) },
     ),
     kontoregisterOrganisasjon = AuthenticatedHttpClientConfig(
-        url = "http://localhost:8090/kontoregister",
+        url = "http://localhost:8090",
         scope = "default",
     ),
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorFlateService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorFlateService.kt
@@ -45,7 +45,7 @@ private val TILSAGN_STATUS_RELEVANT_FOR_ARRANGOR = listOf(
 class ArrangorFlateService(
     val pdl: HentAdressebeskyttetPersonBolkPdlQuery,
     val db: ApiDatabase,
-    val kontoregisterOrganisasjonClient: KontoregisterOrganisasjonClient
+    val kontoregisterOrganisasjonClient: KontoregisterOrganisasjonClient,
 ) {
     fun getUtbetalinger(orgnr: Organisasjonsnummer): List<ArrFlateUtbetalingKompaktDto> = db.session {
         return queries.utbetaling.getByArrangorIds(orgnr).map { utbetaling ->
@@ -242,11 +242,10 @@ class ArrangorFlateService(
             queries.utbetaling.setBetalingsinformasjon(
                 id = utbetaling.id,
                 kontonummer = Kontonummer(kontonummer.kontonr),
-                kid = utbetaling.betalingsinformasjon.kid
+                kid = utbetaling.betalingsinformasjon.kid,
             )
-        return kontonummer.kontonr
+            return kontonummer.kontonr
         }
-
     }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorFlateService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorFlateService.kt
@@ -7,9 +7,13 @@ import no.nav.amt.model.Melding
 import no.nav.mulighetsrommet.api.ApiDatabase
 import no.nav.mulighetsrommet.api.QueryContext
 import no.nav.mulighetsrommet.api.arrangorflate.api.*
+import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontoregisterOrganisasjonClient
 import no.nav.mulighetsrommet.api.clients.pdl.PdlGradering
 import no.nav.mulighetsrommet.api.clients.pdl.PdlIdent
-import no.nav.mulighetsrommet.api.tilsagn.model.*
+import no.nav.mulighetsrommet.api.tilsagn.model.Tilsagn
+import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatus
+import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatusAarsak
+import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnType
 import no.nav.mulighetsrommet.api.totrinnskontroll.model.Totrinnskontroll
 import no.nav.mulighetsrommet.api.utbetaling.HentAdressebeskyttetPersonBolkPdlQuery
 import no.nav.mulighetsrommet.api.utbetaling.HentPersonBolkResponse
@@ -19,6 +23,7 @@ import no.nav.mulighetsrommet.api.utbetaling.model.Utbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregningForhandsgodkjent
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregningFri
 import no.nav.mulighetsrommet.ktor.exception.StatusException
+import no.nav.mulighetsrommet.model.Kontonummer
 import no.nav.mulighetsrommet.model.NorskIdent
 import no.nav.mulighetsrommet.model.Organisasjonsnummer
 import no.nav.mulighetsrommet.model.Periode
@@ -40,6 +45,7 @@ private val TILSAGN_STATUS_RELEVANT_FOR_ARRANGOR = listOf(
 class ArrangorFlateService(
     val pdl: HentAdressebeskyttetPersonBolkPdlQuery,
     val db: ApiDatabase,
+    val kontoregisterOrganisasjonClient: KontoregisterOrganisasjonClient
 ) {
     fun getUtbetalinger(orgnr: Organisasjonsnummer): List<ArrFlateUtbetalingKompaktDto> = db.session {
         return queries.utbetaling.getByArrangorIds(orgnr).map { utbetaling ->
@@ -220,6 +226,27 @@ class ArrangorFlateService(
                 fodselsdato = null,
             )
         }
+    }
+
+    suspend fun synkroniserKontonummer(utbetaling: Utbetaling): String {
+        db.session {
+            val kontonummer =
+                kontoregisterOrganisasjonClient.getKontonummerForOrganisasjon(Organisasjonsnummer(utbetaling.arrangor.organisasjonsnummer.value))
+                    .getOrElse {
+                        throw StatusException(
+                            status = HttpStatusCode.InternalServerError,
+                            detail = "Klarte ikke hente kontonummer for arrangør",
+                        )
+                    }
+
+            queries.utbetaling.setBetalingsinformasjon(
+                id = utbetaling.id,
+                kontonummer = Kontonummer(kontonummer.kontonr),
+                kid = utbetaling.betalingsinformasjon.kid
+            )
+        return kontonummer.kontonr
+        }
+
     }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/api/ArrangorflateRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/api/ArrangorflateRoutes.kt
@@ -72,6 +72,7 @@ fun Route.arrangorflateRoutes() {
 
                 call.respond(tilsagn)
             }
+
         }
 
         route("/utbetaling/{id}") {
@@ -154,6 +155,17 @@ fun Route.arrangorflateRoutes() {
                 )
 
                 call.respond(tilsagn)
+            }
+
+            get("/sync-kontonummer") {
+                val id = call.parameters.getOrFail<UUID>("id")
+                val utbetaling = arrangorFlateService.getUtbetaling(id)
+                    ?: throw NotFoundException("Fant ikke utbetaling med id=$id")
+                requireTilgangHosArrangor(utbetaling.arrangor.organisasjonsnummer)
+
+                val kontonummer = arrangorFlateService.synkroniserKontonummer(utbetaling)
+
+                call.respond(kontonummer)
             }
         }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/api/ArrangorflateRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/api/ArrangorflateRoutes.kt
@@ -72,7 +72,6 @@ fun Route.arrangorflateRoutes() {
 
                 call.respond(tilsagn)
             }
-
         }
 
         route("/utbetaling/{id}") {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/kontoregisterOrganisasjon/KontoregisterOrganisasjonClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/kontoregisterOrganisasjon/KontoregisterOrganisasjonClient.kt
@@ -42,9 +42,9 @@ class KontoregisterOrganisasjonClient(
     }
 
     suspend fun getKontonummerForOrganisasjon(
-        requestBody: KontonummerRequest,
+        organisasjonsnummer: Organisasjonsnummer,
     ): Either<KontonummerRegisterOrganisasjonError, KontonummerResponse> {
-        val response = client.get("$baseUrl/kontoregister/api/v1/hent-kontonummer-for-organisasjon/${requestBody.organisasjonsnummer.value}") {
+        val response = client.get("$baseUrl/kontoregister/api/v1/hent-kontonummer-for-organisasjon/${organisasjonsnummer.value}") {
             bearerAuth(tokenProvider.exchange(AccessType.M2M))
             header(HttpHeaders.ContentType, ContentType.Application.Json)
         }
@@ -54,7 +54,7 @@ class KontoregisterOrganisasjonClient(
         } else if (response.status === HttpStatusCode.NotFound) {
             val error = response.body<Feilmelding>()
             SecureLog.logger.error(
-                "Fant ikke orgnummer: ${requestBody.organisasjonsnummer.value} i kontoregisteret. Feilmelding: ${error.feilmelding}",
+                "Fant ikke orgnummer: ${organisasjonsnummer.value} i kontoregisteret. Feilmelding: ${error.feilmelding}",
                 response.bodyAsText(),
             )
             log.error("Fant ikke orgnummer for arrangør i kontoregisteret. Se detaljer i secureLog.")
@@ -69,7 +69,7 @@ class KontoregisterOrganisasjonClient(
             KontonummerRegisterOrganisasjonError.UgyldigInput.left()
         } else {
             SecureLog.logger.error(
-                "Klarte ikke hente kontonummer for arrangør: ${requestBody.organisasjonsnummer.value}. Error: {}",
+                "Klarte ikke hente kontonummer for arrangør: ${organisasjonsnummer.value}. Error: {}",
                 response.bodyAsText(),
             )
             log.error("Klarte ikke hente kontonummer for arrangør. Se detaljer i secureLog.")
@@ -83,11 +83,6 @@ enum class KontonummerRegisterOrganisasjonError {
     UgyldigInput,
     Error,
 }
-
-@Serializable
-data class KontonummerRequest(
-    val organisasjonsnummer: Organisasjonsnummer,
-)
 
 @Serializable
 data class KontonummerResponse(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -368,7 +368,7 @@ private fun services(appConfig: AppConfig) = module {
     single { AltinnRettigheterService(get(), get()) }
     single { OppgaverService(get()) }
     single { OkonomiBestillingService(appConfig.kafka.clients.okonomiBestilling, get(), get()) }
-    single { ArrangorFlateService(get(), get()) }
+    single { ArrangorFlateService(get(), get(), get()) }
 }
 
 private fun tasks(config: TaskConfig) = module {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
@@ -10,7 +10,6 @@ import kotliquery.queryOf
 import no.nav.mulighetsrommet.api.ApiDatabase
 import no.nav.mulighetsrommet.api.QueryContext
 import no.nav.mulighetsrommet.api.arrangorflate.api.GodkjennUtbetaling
-import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontonummerRequest
 import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontoregisterOrganisasjonClient
 import no.nav.mulighetsrommet.api.endringshistorikk.DocumentClass
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingDto
@@ -18,7 +17,10 @@ import no.nav.mulighetsrommet.api.responses.StatusResponse
 import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.tilsagn.OkonomiBestillingService
 import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
-import no.nav.mulighetsrommet.api.tilsagn.model.*
+import no.nav.mulighetsrommet.api.tilsagn.model.ForhandsgodkjenteSatser
+import no.nav.mulighetsrommet.api.tilsagn.model.Tilsagn
+import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatus
+import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnType
 import no.nav.mulighetsrommet.api.totrinnskontroll.model.Besluttelse
 import no.nav.mulighetsrommet.api.totrinnskontroll.model.Totrinnskontroll
 import no.nav.mulighetsrommet.api.utbetaling.api.BesluttDelutbetalingRequest
@@ -126,15 +128,17 @@ class UtbetalingService(
 
         val kontonummer = when (
             val result = kontoregisterOrganisasjonClient.getKontonummerForOrganisasjon(
-                KontonummerRequest(
-                    organisasjonsnummer = gjennomforing.arrangor.organisasjonsnummer,
-                ),
+                organisasjonsnummer = gjennomforing.arrangor.organisasjonsnummer,
             )
         ) {
             is Either.Left -> {
-                log.error("Kunne ikke hente kontonummer for organisasjon ${gjennomforing.arrangor.organisasjonsnummer}. Error: {}", result.value)
-                null // TODO Skal vi heller kaste her? Hva gjør vi hvis vi ikke får hentet kontonummer?
+                log.error(
+                    "Kunne ikke hente kontonummer for organisasjon ${gjennomforing.arrangor.organisasjonsnummer}. Error: {}",
+                    result.value
+                )
+                null
             }
+
             is Either.Right -> Kontonummer(result.value.kontonr)
         }
 
@@ -271,7 +275,7 @@ class UtbetalingService(
             DelutbetalingStatus.GODKJENT,
             DelutbetalingStatus.TIL_GODKJENNING,
             DelutbetalingStatus.UTBETALT,
-            -> return BadRequest("Utbetaling kan ikke endres").left()
+                -> return BadRequest("Utbetaling kan ikke endres").left()
         }
 
         val utbetaltBelop = queries.delutbetaling.getByUtbetalingId(utbetaling.id)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
@@ -134,7 +134,7 @@ class UtbetalingService(
             is Either.Left -> {
                 log.error(
                     "Kunne ikke hente kontonummer for organisasjon ${gjennomforing.arrangor.organisasjonsnummer}. Error: {}",
-                    result.value
+                    result.value,
                 )
                 null
             }
@@ -275,7 +275,7 @@ class UtbetalingService(
             DelutbetalingStatus.GODKJENT,
             DelutbetalingStatus.TIL_GODKJENNING,
             DelutbetalingStatus.UTBETALT,
-                -> return BadRequest("Utbetaling kan ikke endres").left()
+            -> return BadRequest("Utbetaling kan ikke endres").left()
         }
 
         val utbetaltBelop = queries.delutbetaling.getByUtbetalingId(utbetaling.id)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/UtbetalingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/UtbetalingQueries.kt
@@ -4,7 +4,10 @@ import kotlinx.serialization.json.Json
 import kotliquery.Row
 import kotliquery.Session
 import kotliquery.queryOf
-import no.nav.mulighetsrommet.api.utbetaling.model.*
+import no.nav.mulighetsrommet.api.utbetaling.model.Utbetaling
+import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregning
+import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregningForhandsgodkjent
+import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregningFri
 import no.nav.mulighetsrommet.database.datatypes.periode
 import no.nav.mulighetsrommet.database.datatypes.toDaterange
 import no.nav.mulighetsrommet.database.requireSingle

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2300,6 +2300,21 @@ paths:
         default:
           $ref: "#/components/responses/ProblemDetail"
 
+  /api/v1/intern/arrangorflate/utbetaling/{id}/sync-kontonummer:
+    get:
+      tags:
+        - Arrangorflate
+      operationId: synkroniserKontonummerForUtbetaling
+      parameters:
+        - $ref: "#/components/parameters/ID"
+      responses:
+        200:
+          description: Synkroniserer kontonummer for utbetaling
+          content:
+            text/plain:
+              schema:
+                type: string
+
   /api/v1/intern/arrangorflate/utbetaling/{id}/relevante-forslag:
     get:
       tags:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/kontoregister/KontoregisterOrganisasjonClientTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/kontoregister/KontoregisterOrganisasjonClientTest.kt
@@ -50,7 +50,7 @@ class KontoregisterOrganisasjonClientTest : FunSpec({
     test("Should return KontonummerResponse for valid organisasjonsnummer") {
         runBlocking {
             val result = client.getKontonummerForOrganisasjon(
-                Organisasjonsnummer("123456789")
+                Organisasjonsnummer("123456789"),
             )
             result shouldBeRight KontonummerResponse("Test Org", "1234.56.78901")
         }
@@ -59,7 +59,7 @@ class KontoregisterOrganisasjonClientTest : FunSpec({
     test("Should return FantIkkeKontonummer error for non-existent organisasjonsnummer") {
         runBlocking {
             val result = client.getKontonummerForOrganisasjon(
-                Organisasjonsnummer("000000000")
+                Organisasjonsnummer("000000000"),
             )
             result shouldBeLeft KontonummerRegisterOrganisasjonError.FantIkkeKontonummer
         }
@@ -68,7 +68,7 @@ class KontoregisterOrganisasjonClientTest : FunSpec({
     test("Should return Error for server error") {
         runBlocking {
             val result = client.getKontonummerForOrganisasjon(
-                Organisasjonsnummer("999999999")
+                Organisasjonsnummer("999999999"),
             )
             result shouldBeLeft KontonummerRegisterOrganisasjonError.Error
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/kontoregister/KontoregisterOrganisasjonClientTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/clients/kontoregister/KontoregisterOrganisasjonClientTest.kt
@@ -7,7 +7,6 @@ import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontonummerRegisterOrganisasjonError
-import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontonummerRequest
 import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontonummerResponse
 import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontoregisterOrganisasjonClient
 import no.nav.mulighetsrommet.model.Organisasjonsnummer
@@ -51,7 +50,7 @@ class KontoregisterOrganisasjonClientTest : FunSpec({
     test("Should return KontonummerResponse for valid organisasjonsnummer") {
         runBlocking {
             val result = client.getKontonummerForOrganisasjon(
-                requestBody = KontonummerRequest(Organisasjonsnummer("123456789")),
+                Organisasjonsnummer("123456789")
             )
             result shouldBeRight KontonummerResponse("Test Org", "1234.56.78901")
         }
@@ -60,7 +59,7 @@ class KontoregisterOrganisasjonClientTest : FunSpec({
     test("Should return FantIkkeKontonummer error for non-existent organisasjonsnummer") {
         runBlocking {
             val result = client.getKontonummerForOrganisasjon(
-                requestBody = KontonummerRequest(Organisasjonsnummer("000000000")),
+                Organisasjonsnummer("000000000")
             )
             result shouldBeLeft KontonummerRegisterOrganisasjonError.FantIkkeKontonummer
         }
@@ -69,7 +68,7 @@ class KontoregisterOrganisasjonClientTest : FunSpec({
     test("Should return Error for server error") {
         runBlocking {
             val result = client.getKontonummerForOrganisasjon(
-                requestBody = KontonummerRequest(Organisasjonsnummer("999999999")),
+                Organisasjonsnummer("999999999")
             )
             result shouldBeLeft KontonummerRegisterOrganisasjonError.Error
         }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingServiceTest.kt
@@ -65,9 +65,16 @@ class UtbetalingServiceTest : FunSpec({
         kontoregisterOrganisasjonClient = kontoregisterOrganisasjonClient,
     )
 
-    coEvery { kontoregisterOrganisasjonClient.getKontonummerForOrganisasjon(any()) } returns Either.Right(
+    coEvery { kontoregisterOrganisasjonClient.getKontonummerForOrganisasjon(Organisasjonsnummer("123456789")) } returns Either.Right(
         KontonummerResponse(
-            mottaker = "Test Org",
+            mottaker = "123456789",
+            kontonr = "12345678901",
+        ),
+    )
+
+    coEvery { kontoregisterOrganisasjonClient.getKontonummerForOrganisasjon(Organisasjonsnummer("976663934")) } returns Either.Right(
+        KontonummerResponse(
+            mottaker = "976663934",
             kontonr = "12345678901",
         ),
     )

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/JournalforUtbetalingTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/JournalforUtbetalingTest.kt
@@ -98,7 +98,7 @@ class JournalforUtbetalingTest : FunSpec({
         ArrangorFlateService(
             pdl = HentAdressebeskyttetPersonBolkPdlQuery(pdl),
             db = db,
-            kontoregisterOrganisasjonClient = kontoregisterClient
+            kontoregisterOrganisasjonClient = kontoregisterClient,
         )
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/JournalforUtbetalingTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/JournalforUtbetalingTest.kt
@@ -13,6 +13,7 @@ import no.nav.mulighetsrommet.api.ApiDatabase
 import no.nav.mulighetsrommet.api.arrangorflate.ArrangorFlateService
 import no.nav.mulighetsrommet.api.clients.dokark.DokarkClient
 import no.nav.mulighetsrommet.api.clients.dokark.DokarkResponse
+import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontoregisterOrganisasjonClient
 import no.nav.mulighetsrommet.api.clients.pdl.PdlClient
 import no.nav.mulighetsrommet.api.databaseConfig
 import no.nav.mulighetsrommet.api.fixtures.*
@@ -92,10 +93,12 @@ class JournalforUtbetalingTest : FunSpec({
         baseUrl = "http://pdfgen",
     )
     val dokarkClient: DokarkClient = mockk()
+    val kontoregisterClient: KontoregisterOrganisasjonClient = mockk(relaxed = true)
     val arrangorFlateSerivce = { db: ApiDatabase ->
         ArrangorFlateService(
             pdl = HentAdressebeskyttetPersonBolkPdlQuery(pdl),
             db = db,
+            kontoregisterOrganisasjonClient = kontoregisterClient
         )
     }
 


### PR DESCRIPTION
Legger tilrette for at arrangør får beskjed om hvor kontonummer hentes fra og hva de kan gjøre for å endre det. I tillegg legger jeg ved en knapp arrangør kan trykke på for å synkronisere kontonummer etter at det er lagt inn/oppdatert i registeret. Ved å trykke på knappen vil utbetalingen få satt kontonummer fra registeret.