### PR TITLE
Egen side for innsendt utbetaling

### DIFF
--- a/frontend/arrangor-flate/app/internal-navigation.ts
+++ b/frontend/arrangor-flate/app/internal-navigation.ts
@@ -4,6 +4,7 @@ export const internalNavigation = (orgnr: string) => {
     utbetalinger: `/${orgnr}/utbetaling`,
     beregning: (id: string) => `/${orgnr}/utbetaling/${id}/beregning`,
     bekreft: (id: string) => `/${orgnr}/utbetaling/${id}/bekreft`,
+    innsendtUtbetaling: (id: string) => `/${orgnr}/utbetaling/${id}/innsendt-utbetaling`,
     kvittering: (id: string) => `/${orgnr}/utbetaling/${id}/kvittering`,
     tilsagn: (id: string) => `/${orgnr}/tilsagn/${id}`,
   };

--- a/frontend/arrangor-flate/app/mocks/arrangorflateMocks.ts
+++ b/frontend/arrangor-flate/app/mocks/arrangorflateMocks.ts
@@ -482,7 +482,7 @@ export const arrangorflateHandlers = [
     () => HttpResponse.json(mockTilsagn),
   ),
   http.get<PathParams, ArrFlateUtbetaling[]>(
-    "*/api/v1/intern/arrangorflate/:orgnr/tilsagn/:id",
+    "*/api/v1/intern/arrangorflate/tilsagn/:id",
     ({ params }) => {
       const { id } = params;
       return HttpResponse.json(mockTilsagn.find((k) => k.id === id));

--- a/frontend/arrangor-flate/app/routes/$orgnr.tilsagn.$id.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr.tilsagn.$id.tsx
@@ -26,7 +26,6 @@ export const loader: LoaderFunction = async ({ request, params }): Promise<Loade
   if (error || !tilsagn) {
     throw problemDetailResponse(error);
   }
-
   return { tilsagn };
 };
 

--- a/frontend/arrangor-flate/app/routes/$orgnr.utbetaling.$id.bekreft.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr.utbetaling.$id.bekreft.tsx
@@ -126,7 +126,7 @@ export const action: ActionFunction = async ({ request }) => {
     }
   }
   return redirect(
-    `${internalNavigation(orgnr).kvittering(utbetalingId)}?forside-tab=${currentTab}`,
+    `${internalNavigation(orgnr).innsendtUtbetaling(utbetalingId)}?forside-tab=${currentTab}`,
   );
 };
 

--- a/frontend/arrangor-flate/app/routes/$orgnr.utbetaling.$id.innsendt-utbetaling.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr.utbetaling.$id.innsendt-utbetaling.tsx
@@ -1,17 +1,16 @@
-import { ArrangorflateService, ArrangorflateTilsagn, ArrFlateUtbetaling } from "api-client";
 import { formaterKontoNummer } from "@mr/frontend-common/utils/utils";
 import { FilePdfIcon } from "@navikt/aksel-icons";
 import { Button, GuidePanel, VStack } from "@navikt/ds-react";
-import { LoaderFunction } from "react-router";
-import { useLoaderData, useParams } from "react-router";
+import { ArrangorflateService, ArrangorflateTilsagn, ArrFlateUtbetaling } from "api-client";
+import { LoaderFunction, useLoaderData, useParams } from "react-router";
+import { apiHeaders } from "~/auth/auth.server";
 import { Definisjonsliste } from "~/components/Definisjonsliste";
 import { PageHeader } from "~/components/PageHeader";
-import { UtbetalingDetaljer } from "~/components/utbetaling/UtbetalingDetaljer";
 import { Separator } from "~/components/Separator";
+import { UtbetalingDetaljer } from "~/components/utbetaling/UtbetalingDetaljer";
+import { LinkWithTabState } from "../components/LinkWithTabState";
 import { internalNavigation } from "../internal-navigation";
 import { problemDetailResponse, useOrgnrFromUrl } from "../utils";
-import { LinkWithTabState } from "../components/LinkWithTabState";
-import { apiHeaders } from "~/auth/auth.server";
 
 type UtbetalingKvitteringData = {
   utbetaling: ArrFlateUtbetaling;
@@ -57,7 +56,7 @@ export default function UtbetalingKvittering() {
   return (
     <>
       <PageHeader
-        title="Kvittering"
+        title="Innsendt krav om utbetaling"
         tilbakeLenke={{
           navn: "Tilbake til utbetalinger",
           url: internalNavigation(orgnr).utbetalinger,
@@ -73,7 +72,9 @@ export default function UtbetalingKvittering() {
         </a>
       </div>
       <Separator />
-
+      <GuidePanel className="text-center my-2" poster>
+        Krav om utbetaling er nå sendt inn og vil bli behandlet av Nav
+      </GuidePanel>
       <VStack gap="5" className="max-w-[50%] mt-5">
         <UtbetalingDetaljer utbetaling={utbetaling} tilsagn={tilsagn} />
         <Separator />

--- a/frontend/arrangor-flate/app/routes/$orgnr.utbetaling.$id.kvittering.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr.utbetaling.$id.kvittering.tsx
@@ -1,17 +1,16 @@
-import { ArrangorflateService, ArrangorflateTilsagn, ArrFlateUtbetaling } from "api-client";
 import { formaterKontoNummer } from "@mr/frontend-common/utils/utils";
 import { FilePdfIcon } from "@navikt/aksel-icons";
-import { Button, GuidePanel, VStack } from "@navikt/ds-react";
-import { LoaderFunction } from "react-router";
-import { useLoaderData, useParams } from "react-router";
+import { Button, VStack } from "@navikt/ds-react";
+import { ArrangorflateService, ArrangorflateTilsagn, ArrFlateUtbetaling } from "api-client";
+import { LoaderFunction, useLoaderData, useParams } from "react-router";
+import { apiHeaders } from "~/auth/auth.server";
 import { Definisjonsliste } from "~/components/Definisjonsliste";
 import { PageHeader } from "~/components/PageHeader";
-import { UtbetalingDetaljer } from "~/components/utbetaling/UtbetalingDetaljer";
 import { Separator } from "~/components/Separator";
+import { UtbetalingDetaljer } from "~/components/utbetaling/UtbetalingDetaljer";
+import { LinkWithTabState } from "../components/LinkWithTabState";
 import { internalNavigation } from "../internal-navigation";
 import { problemDetailResponse, useOrgnrFromUrl } from "../utils";
-import { LinkWithTabState } from "../components/LinkWithTabState";
-import { apiHeaders } from "~/auth/auth.server";
 
 type UtbetalingKvitteringData = {
   utbetaling: ArrFlateUtbetaling;

--- a/frontend/arrangor-flate/tests/arrangorflate-forside.spec.ts
+++ b/frontend/arrangor-flate/tests/arrangorflate-forside.spec.ts
@@ -46,7 +46,7 @@ test("Kan navigere gjennom hele utbetalingen", async ({ page }) => {
     .click();
   await sjekkUU(page);
   await page.getByRole("button", { name: "Bekreft og send inn" }).first().click();
-  await expect(page.getByRole("heading", { name: "Kvittering" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Innsendt krav om utbetaling" })).toBeVisible();
 
   await sjekkUU(page);
 });


### PR DESCRIPTION
Legger til en egen side for innsendt utbetaling uavhengig av kvitteringen, så blir det tydeligere når krav om utbetaling er sendt inn, og når man ser på kvitteringen

![image](https://github.com/user-attachments/assets/ab8c5f60-c554-48c7-9b84-3ce870464962)

![image](https://github.com/user-attachments/assets/ef7afaf0-6390-46ee-a3b1-0243cea2f9d3)
