### PR TITLE
Justerer utbetalingslinjer med skille på tilsagn og utbetalingsdetaljer

### DIFF
--- a/frontend/mr-admin-flate/src/components/detaljside/Metadata.tsx
+++ b/frontend/mr-admin-flate/src/components/detaljside/Metadata.tsx
@@ -5,7 +5,6 @@ import { ReactNode } from "react";
 export interface MetadataProps {
   header: string | ReactNode;
   verdi: string | number | undefined | null | ReactNode;
-  horizontal?: boolean;
 }
 
 export function Metadata({ header, verdi }: MetadataProps) {

--- a/frontend/mr-admin-flate/src/components/utbetaling/BesluttUtbetalingLinjeView.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/BesluttUtbetalingLinjeView.tsx
@@ -41,7 +41,9 @@ export function BesluttUtbetalingLinjeView({ linjer, utbetaling }: Props) {
 
   return (
     <>
-      <Heading size="medium">Utbetalingslinjer</Heading>
+      <Heading spacing size="medium">
+        Utbetalingslinjer
+      </Heading>
       <UtbetalingLinjeTable
         linjer={linjer}
         utbetaling={utbetaling}
@@ -51,6 +53,7 @@ export function BesluttUtbetalingLinjeView({ linjer, utbetaling }: Props) {
               readOnly
               key={linje.id}
               linje={linje}
+              grayBackground
               knappeColumn={
                 <>
                   {linje?.status === DelutbetalingStatus.TIL_GODKJENNING &&

--- a/frontend/mr-admin-flate/src/components/utbetaling/RedigerUtbetalingLinjeView.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/RedigerUtbetalingLinjeView.tsx
@@ -114,7 +114,9 @@ export function RedigerUtbetalingLinjeView({ linjer, utbetaling, tilsagn }: Prop
     <>
       <VStack>
         <HStack justify="space-between">
-          <Heading size="medium">Utbetalingslinjer</Heading>
+          <Heading spacing size="medium">
+            Utbetalingslinjer
+          </Heading>
           <ActionMenu>
             <ActionMenu.Trigger>
               <Button variant="primary" size="small">
@@ -146,6 +148,7 @@ export function RedigerUtbetalingLinjeView({ linjer, utbetaling, tilsagn }: Prop
                     Fjern
                   </Button>
                 }
+                grayBackground
                 onChange={(updated) => {
                   setLinjerState((prev) =>
                     prev.map((linje) => (linje.id === updated.id ? updated : linje)),

--- a/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
@@ -1,10 +1,10 @@
 import { formaterPeriodeSlutt, formaterPeriodeStart, tilsagnTypeToString } from "@/utils/Utils";
 import { FieldError, UtbetalingLinje } from "@mr/api-client-v2";
+import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import { Alert, BodyShort, Checkbox, HStack, Table, TextField, VStack } from "@navikt/ds-react";
 import { useState } from "react";
+import { MetadataHorisontal } from "../detaljside/Metadata";
 import { DelutbetalingTag } from "./DelutbetalingTag";
-import { formaterNOK } from "@mr/frontend-common/utils/utils";
-import { Metadata } from "../detaljside/Metadata";
 
 interface Props {
   readOnly?: boolean;
@@ -12,6 +12,7 @@ interface Props {
   knappeColumn: React.ReactNode;
   onChange?: (linje: UtbetalingLinje) => void;
   errors?: FieldError[];
+  grayBackground?: boolean;
 }
 
 export function UtbetalingLinjeRow({
@@ -20,13 +21,17 @@ export function UtbetalingLinjeRow({
   onChange,
   knappeColumn,
   readOnly = false,
+  grayBackground = false,
 }: Props) {
   const [belopError, setBelopError] = useState<string | undefined>(undefined);
+
+  const grayBgClass = grayBackground ? "bg-gray-100" : "";
 
   return (
     <Table.ExpandableRow
       open={errors.length > 0 || Boolean(linje.opprettelse) || linje.gjorOppTilsagn}
       key={linje.id}
+      className={grayBackground ? "[&>td:first-child]:bg-gray-100" : ""}
       content={
         <VStack gap="2">
           <VStack className="bg-[var(--a-surface-danger-subtle)]">
@@ -42,20 +47,31 @@ export function UtbetalingLinjeRow({
           )}
           {linje.opprettelse && (
             <HStack gap="4">
-              <Metadata horizontal header="Behandlet av" verdi={linje.opprettelse.behandletAv} />
+              <MetadataHorisontal header="Behandlet av" verdi={linje.opprettelse.behandletAv} />
               {linje.opprettelse.type === "BESLUTTET" && (
-                <Metadata horizontal header="Besluttet av" verdi={linje.opprettelse.besluttetAv} />
+                <MetadataHorisontal header="Besluttet av" verdi={linje.opprettelse.besluttetAv} />
               )}
             </HStack>
           )}
         </VStack>
       }
     >
-      <Table.DataCell>{formaterPeriodeStart(linje.tilsagn.periode)}</Table.DataCell>
-      <Table.DataCell>{formaterPeriodeSlutt(linje.tilsagn.periode)}</Table.DataCell>
-      <Table.DataCell>{tilsagnTypeToString(linje.tilsagn.type)}</Table.DataCell>
-      <Table.DataCell>{linje.tilsagn.kostnadssted.navn}</Table.DataCell>
-      <Table.DataCell>{formaterNOK(linje.tilsagn.belopGjenstaende)}</Table.DataCell>
+      <Table.DataCell className={grayBgClass}>
+        {linje.tilsagn.bestilling.bestillingsnummer}
+      </Table.DataCell>
+      <Table.DataCell className={grayBgClass}>
+        {tilsagnTypeToString(linje.tilsagn.type)}
+      </Table.DataCell>
+      <Table.DataCell className={grayBgClass}>
+        {formaterPeriodeStart(linje.tilsagn.periode)}
+      </Table.DataCell>
+      <Table.DataCell className={grayBgClass}>
+        {formaterPeriodeSlutt(linje.tilsagn.periode)}
+      </Table.DataCell>
+      <Table.DataCell className={grayBgClass}>{linje.tilsagn.kostnadssted.navn}</Table.DataCell>
+      <Table.DataCell className={grayBgClass}>
+        {formaterNOK(linje.tilsagn.belopGjenstaende)}
+      </Table.DataCell>
       <Table.DataCell>
         <Checkbox
           hideLabel
@@ -96,7 +112,7 @@ export function UtbetalingLinjeRow({
         />
       </Table.DataCell>
       <Table.DataCell>{linje.status && <DelutbetalingTag status={linje.status} />}</Table.DataCell>
-      <Table.DataCell>{knappeColumn}</Table.DataCell>
+      <Table.DataCell className="flex justify-end">{knappeColumn}</Table.DataCell>
     </Table.ExpandableRow>
   );
 }

--- a/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeTable.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeTable.tsx
@@ -18,12 +18,29 @@ export function UtbetalingLinjeTable({ linjer, utbetaling, renderRow }: Props) {
     <Table>
       <Table.Header>
         <Table.Row>
-          <Table.HeaderCell />
-          <Table.HeaderCell scope="col">Periodestart</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Periodeslutt</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Type</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Kostnadssted</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Tilgjengelig på tilsagn</Table.HeaderCell>
+          <Table.HeaderCell colSpan={7} className="bg-gray-100">
+            Tilgjengelige tilsagn
+          </Table.HeaderCell>
+          <Table.HeaderCell colSpan={6}>Utbetalingdetaljer</Table.HeaderCell>
+        </Table.Row>
+        <Table.Row>
+          <Table.HeaderCell className="bg-gray-100" />
+          <Table.HeaderCell className="bg-gray-100">Tilsagnsnummer</Table.HeaderCell>
+          <Table.HeaderCell scope="col" className="bg-gray-100">
+            Type
+          </Table.HeaderCell>
+          <Table.HeaderCell scope="col" className="bg-gray-100">
+            Periodestart
+          </Table.HeaderCell>
+          <Table.HeaderCell scope="col" className="bg-gray-100">
+            Periodeslutt
+          </Table.HeaderCell>
+          <Table.HeaderCell scope="col" className="bg-gray-100">
+            Kostnadssted
+          </Table.HeaderCell>
+          <Table.HeaderCell scope="col" className="bg-gray-100">
+            Tilgjengelig
+          </Table.HeaderCell>
           <Table.HeaderCell scope="col">Gjør opp tilsagn</Table.HeaderCell>
           <Table.HeaderCell scope="col">Utbetales</Table.HeaderCell>
           <Table.HeaderCell scope="col">Status</Table.HeaderCell>
@@ -35,14 +52,14 @@ export function UtbetalingLinjeTable({ linjer, utbetaling, renderRow }: Props) {
         <Table.Row>
           <Table.DataCell
             className="font-bold"
-            colSpan={5}
+            colSpan={6}
           >{`${utbetalingTekster.beregning.belop.label}: ${formaterNOK(utbetaling.beregning.belop)}`}</Table.DataCell>
           <Table.DataCell colSpan={2} className="font-bold">
             {formaterNOK(totalGjenstaendeBelop)}
           </Table.DataCell>
           <Table.DataCell className="font-bold">{formaterNOK(utbetalesTotal)}</Table.DataCell>
-          <Table.DataCell colSpan={2} className="font-bold">
-            <HStack align="center" className="w-80">
+          <Table.DataCell colSpan={4} className="font-bold">
+            <HStack align="center">
               <CopyButton variant="action" copyText={differanse.toString()} size="small" />
               <BodyShort weight="semibold">{`Differanse ${formaterNOK(differanse)}`}</BodyShort>
             </HStack>

--- a/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingerTable.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingerTable.tsx
@@ -64,6 +64,7 @@ export function UtbetalingerTable({ utbetalinger }: Props) {
     <Table
       sort={sort}
       onSortChange={(sortKey) => handleSort(sortKey as ScopedSortState["orderBy"])}
+      aria-label="Utbetalinger"
     >
       <Table.Header>
         <Table.Row>

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_tilsagn.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_tilsagn.ts
@@ -1,4 +1,5 @@
 import {
+  BestillingStatusType,
   NavEnhetStatus,
   NavEnhetType,
   TilsagnDto,
@@ -28,6 +29,10 @@ export const mockTilsagn: TilsagnDto[] = [
       slutt: "2024-01-06",
     },
     status: TilsagnStatus.TIL_GODKJENNING,
+    bestilling: {
+      bestillingsnummer: "A-2024/123-1",
+      status: BestillingStatusType.AKTIV,
+    },
   },
   {
     belopGjenstaende: 10000,
@@ -50,6 +55,10 @@ export const mockTilsagn: TilsagnDto[] = [
       slutt: "2024-01-04",
     },
     status: TilsagnStatus.TIL_ANNULLERING,
+    bestilling: {
+      bestillingsnummer: "A-2024/123-1",
+      status: BestillingStatusType.AKTIV,
+    },
   },
   {
     belopGjenstaende: 10000,
@@ -72,6 +81,10 @@ export const mockTilsagn: TilsagnDto[] = [
       slutt: "2024-01-02",
     },
     status: TilsagnStatus.GODKJENT,
+    bestilling: {
+      bestillingsnummer: "A-2024/123-1",
+      status: BestillingStatusType.AKTIV,
+    },
   },
   {
     type: TilsagnType.TILSAGN,
@@ -94,6 +107,10 @@ export const mockTilsagn: TilsagnDto[] = [
       slutt: "2024-01-02",
     },
     status: TilsagnStatus.ANNULLERT,
+    bestilling: {
+      bestillingsnummer: "A-2024/123-1",
+      status: BestillingStatusType.AKTIV,
+    },
   },
   {
     type: TilsagnType.TILSAGN,
@@ -116,5 +133,9 @@ export const mockTilsagn: TilsagnDto[] = [
       slutt: "2024-01-02",
     },
     status: TilsagnStatus.RETURNERT,
+    bestilling: {
+      bestillingsnummer: "A-2024/123-1",
+      status: BestillingStatusType.AKTIV,
+    },
   },
 ];

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
@@ -1,5 +1,6 @@
+import { useHentAnsatt } from "@/api/ansatt/useHentAnsatt";
 import { Header } from "@/components/detaljside/Header";
-import { Metadata, MetadataHorisontal, Separator } from "@/components/detaljside/Metadata";
+import { MetadataHorisontal, Separator } from "@/components/detaljside/Metadata";
 import { EndringshistorikkPopover } from "@/components/endringshistorikk/EndringshistorikkPopover";
 import { ViewEndringshistorikk } from "@/components/endringshistorikk/ViewEndringshistorikk";
 import { GjennomforingDetaljerMini } from "@/components/gjennomforing/GjennomforingDetaljerMini";
@@ -10,20 +11,19 @@ import { formaterDato, formaterPeriode } from "@/utils/Utils";
 import { AdminUtbetalingStatus, NavAnsattRolle } from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import { BankNoteIcon } from "@navikt/aksel-icons";
-import { Alert, Box, Heading, HStack, List, VStack } from "@navikt/ds-react";
+import { Alert, Box, Heading, HGrid, HStack, List, VStack } from "@navikt/ds-react";
 import { useParams } from "react-router";
-import { useHentAnsatt } from "@/api/ansatt/useHentAnsatt";
 import {
   tilsagnTilUtbetalingQuery,
   utbetalingHistorikkQuery,
   utbetalingQuery,
 } from "./utbetalingPageLoader";
 
+import { useAdminGjennomforingById } from "@/api/gjennomforing/useAdminGjennomforingById";
+import { BesluttUtbetalingLinjeView } from "@/components/utbetaling/BesluttUtbetalingLinjeView";
+import { RedigerUtbetalingLinjeView } from "@/components/utbetaling/RedigerUtbetalingLinjeView";
 import { utbetalingTekster } from "@/components/utbetaling/UtbetalingTekster";
 import { useApiSuspenseQuery } from "@mr/frontend-common";
-import { useAdminGjennomforingById } from "@/api/gjennomforing/useAdminGjennomforingById";
-import { RedigerUtbetalingLinjeView } from "@/components/utbetaling/RedigerUtbetalingLinjeView";
-import { BesluttUtbetalingLinjeView } from "@/components/utbetaling/BesluttUtbetalingLinjeView";
 
 function useUtbetalingPageData() {
   const { gjennomforingId, utbetalingId } = useParams();
@@ -70,9 +70,7 @@ export function UtbetalingPage() {
       <Header>
         <BankNoteIcon className="w-10 h-10" />
         <Heading size="large" level="2">
-          <HStack gap="2" align={"center"}>
-            Utbetaling for {gjennomforing.navn}
-          </HStack>
+          Utbetaling for {gjennomforing.navn}
         </Heading>
       </Header>
       <ContentBox>
@@ -100,9 +98,11 @@ export function UtbetalingPage() {
             )}
             <Box borderColor="border-subtle" padding="4" borderWidth="1" borderRadius="large">
               <VStack gap="4" id="kostnadsfordeling">
-                <HStack justify="space-between">
+                <HGrid columns="1fr 1fr">
                   <VStack>
-                    <Heading size="medium">Til utbetaling</Heading>
+                    <Heading size="medium" spacing>
+                      Til utbetaling
+                    </Heading>
                     <VStack gap="2">
                       <MetadataHorisontal
                         header="Utbetalingsperiode"
@@ -131,23 +131,21 @@ export function UtbetalingPage() {
                     </VStack>
                   </VStack>
                   <VStack>
-                    <Heading size="medium" className="mt-4">
+                    <Heading size="medium" spacing className="mt-8">
                       Betalingsinformasjon
                     </Heading>
                     <VStack gap="2">
-                      <Metadata
-                        horizontal
+                      <MetadataHorisontal
                         header="Kontonummer"
                         verdi={utbetaling.betalingsinformasjon?.kontonummer}
                       />
-                      <Metadata
-                        horizontal
-                        header="KID"
-                        verdi={utbetaling.betalingsinformasjon?.kid || "-"}
+                      <MetadataHorisontal
+                        header="KID (valgfritt)"
+                        verdi={utbetaling.betalingsinformasjon?.kid || "Ikke oppgitt fra arrangør"}
                       />
                     </VStack>
                   </VStack>
-                </HStack>
+                </HGrid>
                 <Separator />
                 {erSaksbehandlerOkonomi &&
                 [AdminUtbetalingStatus.BEHANDLES_AV_NAV, AdminUtbetalingStatus.RETURNERT].includes(

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -5452,6 +5452,8 @@ components:
           $ref: "#/components/schemas/TilsagnBeregning"
         status:
           $ref: "#/components/schemas/TilsagnStatus"
+        bestilling:
+          $ref: "#/components/schemas/Bestilling"
       required:
         - id
         - type
@@ -5460,6 +5462,26 @@ components:
         - kostnadssted
         - beregning
         - status
+        - bestilling
+
+    Bestilling:
+      type: object
+      properties:
+        bestillingsnummer:
+          type: string
+        status:
+          $ref: "#/components/schemas/BestillingStatusType"
+          nullable: true
+      required:
+        - bestillingsnummer
+
+    BestillingStatusType:
+      type: string
+      enum:
+      - SENDT
+      - AKTIV
+      - ANNULLERT
+      - OPPGJORT
 
     TilsagnDetaljerDto:
       type: object


### PR DESCRIPTION
Justerer tabell for å vise utbetalingslinjer. Tilsagnsdetaljer viser tilsagnsnummer (les bestillingsnummer) og alt som gjelder tilsagn får en grå bakgrunn, mens utbetalingsdetaljer har en hvit bakgrunn. I tilegg justerer det på rekkefølgen på noen kolonner

![image](https://github.com/user-attachments/assets/c556d0a7-3681-4c19-a293-c92b6dbbfd4b)
