### PR TITLE
Viser returnerte årsaker i delutbetalingslinjer

### DIFF
--- a/frontend/mr-admin-flate/src/api/utbetaling/useBesluttDelutbetaling.ts
+++ b/frontend/mr-admin-flate/src/api/utbetaling/useBesluttDelutbetaling.ts
@@ -4,6 +4,6 @@ import { BesluttDelutbetalingRequest, ProblemDetail, UtbetalingService } from "@
 export function useBesluttDelutbetaling() {
   return useMutation<unknown, ProblemDetail, { id: string; body: BesluttDelutbetalingRequest }>({
     mutationFn: ({ id, body }: { id: string; body: BesluttDelutbetalingRequest }) =>
-      UtbetalingService.besluttDeltbetaling({ path: { id }, body }),
+      UtbetalingService.besluttDelutbetaling({ path: { id }, body }),
   });
 }

--- a/frontend/mr-admin-flate/src/components/utbetaling/BesluttUtbetalingLinjeView.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/BesluttUtbetalingLinjeView.tsx
@@ -1,6 +1,7 @@
 import {
   BesluttDelutbetalingRequest,
   Besluttelse,
+  DelutbetalingReturnertAarsak,
   DelutbetalingStatus,
   ProblemDetail,
   UtbetalingDto,
@@ -77,13 +78,13 @@ export function BesluttUtbetalingLinjeView({ linjer, utbetaling }: Props) {
                     >
                       Send i retur
                     </Button>
-                    <AarsakerOgForklaringModal
+                    <AarsakerOgForklaringModal<DelutbetalingReturnertAarsak>
                       open={avvisModalOpen}
                       header="Send i retur med forklaring"
                       buttonLabel="Send i retur"
                       aarsaker={[
-                        { value: "FEIL_BELOP", label: "Feil beløp" },
-                        { value: "FEIL_ANNET", label: "Annet" },
+                        { value: DelutbetalingReturnertAarsak.FEIL_BELOP, label: "Feil beløp" },
+                        { value: DelutbetalingReturnertAarsak.FEIL_ANNET, label: "Annet" },
                       ]}
                       onClose={() => setAvvisModalOpen(false)}
                       onConfirm={({ aarsaker, forklaring }) => {

--- a/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
@@ -1,7 +1,21 @@
-import { formaterPeriodeSlutt, formaterPeriodeStart, tilsagnTypeToString } from "@/utils/Utils";
+import {
+  delutbetalingAarsakTilTekst,
+  formaterPeriodeSlutt,
+  formaterPeriodeStart,
+  tilsagnTypeToString,
+} from "@/utils/Utils";
 import { FieldError, UtbetalingLinje } from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
-import { Alert, BodyShort, Checkbox, HStack, Table, TextField, VStack } from "@navikt/ds-react";
+import {
+  Alert,
+  BodyShort,
+  Checkbox,
+  HStack,
+  List,
+  Table,
+  TextField,
+  VStack,
+} from "@navikt/ds-react";
 import { useState } from "react";
 import { Metadata } from "../detaljside/Metadata";
 import { DelutbetalingTag } from "./DelutbetalingTag";
@@ -25,24 +39,49 @@ export function UtbetalingLinjeRow({
 }: Props) {
   const [belopError, setBelopError] = useState<string | undefined>(undefined);
   const [openRow, setOpenRow] = useState(
-    errors.length > 0 || Boolean(linje.opprettelse) || linje.gjorOppTilsagn,
+    errors.length > 0 || linje.opprettelse?.type === "BESLUTTET" || linje.gjorOppTilsagn,
   );
   const grayBgClass = grayBackground ? "bg-gray-100" : "";
+
   return (
     <Table.ExpandableRow
       shadeOnHover={false}
-      open={openRow}
+      defaultOpen={openRow}
       onOpenChange={() => setOpenRow(!openRow)}
       onClick={() => setOpenRow(!openRow)}
       key={linje.id}
       className={`${grayBackground ? "[&>td:first-child]:bg-gray-100" : ""}`}
       content={
         <VStack gap="2">
-          <VStack className="bg-[var(--a-surface-danger-subtle)]">
-            {errors.map((error) => (
-              <BodyShort>{error.detail}</BodyShort>
-            ))}
-          </VStack>
+          {linje.opprettelse?.aarsaker && linje.opprettelse.aarsaker.length > 0 ? (
+            <VStack>
+              <Alert size="small" variant="warning">
+                <BodyShort>Linjen ble returnert på grunn av følgende årsaker:</BodyShort>
+                <List>
+                  {linje.opprettelse.aarsaker.map((error) => (
+                    <List.Item>{delutbetalingAarsakTilTekst(error)}</List.Item>
+                  ))}
+                </List>
+                {linje.opprettelse.forklaring && (
+                  <BodyShort>
+                    <b>Forklaring:</b> {linje.opprettelse.forklaring}
+                  </BodyShort>
+                )}
+              </Alert>
+            </VStack>
+          ) : null}
+          {errors.length > 0 && (
+            <VStack className="bg-[var(--a-surface-danger-subtle)]">
+              <Alert size="small" variant="error">
+                <BodyShort>Følgende feil må fikses:</BodyShort>
+                <List>
+                  {errors.map((error) => (
+                    <List.Item>{error.detail}</List.Item>
+                  ))}
+                </List>
+              </Alert>
+            </VStack>
+          )}
           {linje.gjorOppTilsagn && (
             <Alert variant="info">
               Når denne utbetalingen godkjennes av beslutter vil det ikke lenger være mulig å gjøre

--- a/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
@@ -4,7 +4,7 @@ import {
   formaterPeriodeStart,
   tilsagnTypeToString,
 } from "@/utils/Utils";
-import { FieldError, UtbetalingLinje } from "@mr/api-client-v2";
+import { DelutbetalingReturnertAarsak, FieldError, UtbetalingLinje } from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import {
   Alert,
@@ -16,7 +16,7 @@ import {
   TextField,
   VStack,
 } from "@navikt/ds-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Metadata } from "../detaljside/Metadata";
 import { DelutbetalingTag } from "./DelutbetalingTag";
 
@@ -38,15 +38,19 @@ export function UtbetalingLinjeRow({
   grayBackground = false,
 }: Props) {
   const [belopError, setBelopError] = useState<string | undefined>(undefined);
-  const [openRow, setOpenRow] = useState(
-    errors.length > 0 || linje.opprettelse?.type === "BESLUTTET" || linje.gjorOppTilsagn,
-  );
+  const skalApneRad =
+    errors.length > 0 || Boolean(linje.opprettelse?.type === "BESLUTTET") || linje.gjorOppTilsagn;
+  const [openRow, setOpenRow] = useState(skalApneRad);
   const grayBgClass = grayBackground ? "bg-gray-100" : "";
+
+  useEffect(() => {
+    setOpenRow(skalApneRad);
+  }, [errors, linje.opprettelse, linje.gjorOppTilsagn, skalApneRad]);
 
   return (
     <Table.ExpandableRow
       shadeOnHover={false}
-      defaultOpen={openRow}
+      open={openRow}
       onOpenChange={() => setOpenRow(!openRow)}
       onClick={() => setOpenRow(!openRow)}
       key={linje.id}
@@ -59,7 +63,9 @@ export function UtbetalingLinjeRow({
                 <BodyShort>Linjen ble returnert på grunn av følgende årsaker:</BodyShort>
                 <List>
                   {linje.opprettelse.aarsaker.map((error) => (
-                    <List.Item>{delutbetalingAarsakTilTekst(error)}</List.Item>
+                    <List.Item>
+                      {delutbetalingAarsakTilTekst(error as DelutbetalingReturnertAarsak)}
+                    </List.Item>
                   ))}
                 </List>
                 {linje.opprettelse.forklaring && (

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/utbetaling/UtbetalingPage.tsx
@@ -11,7 +11,7 @@ import { formaterDato, formaterPeriode } from "@/utils/Utils";
 import { AdminUtbetalingStatus, NavAnsattRolle } from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import { BankNoteIcon } from "@navikt/aksel-icons";
-import { Alert, Box, Heading, HGrid, HStack, List, VStack } from "@navikt/ds-react";
+import { Box, Heading, HGrid, HStack, VStack } from "@navikt/ds-react";
 import { useParams } from "react-router";
 import {
   tilsagnTilUtbetalingQuery,
@@ -22,9 +22,9 @@ import {
 import { useAdminGjennomforingById } from "@/api/gjennomforing/useAdminGjennomforingById";
 import { BesluttUtbetalingLinjeView } from "@/components/utbetaling/BesluttUtbetalingLinjeView";
 import { RedigerUtbetalingLinjeView } from "@/components/utbetaling/RedigerUtbetalingLinjeView";
+import { UtbetalingStatusTag } from "@/components/utbetaling/UtbetalingStatusTag";
 import { utbetalingTekster } from "@/components/utbetaling/UtbetalingTekster";
 import { useApiSuspenseQuery } from "@mr/frontend-common";
-import { UtbetalingStatusTag } from "@/components/utbetaling/UtbetalingStatusTag";
 
 function useUtbetalingPageData() {
   const { gjennomforingId, utbetalingId } = useParams();
@@ -64,7 +64,6 @@ export function UtbetalingPage() {
     },
     { tittel: "Utbetaling" },
   ];
-
   return (
     <>
       <Brodsmuler brodsmuler={brodsmuler} />
@@ -83,20 +82,6 @@ export function UtbetalingPage() {
           </HStack>
           <VStack gap="4">
             <GjennomforingDetaljerMini gjennomforing={gjennomforing} />
-            {utbetaling.status === "RETURNERT" && (
-              <Alert variant="warning" size="small" style={{ marginTop: "1rem" }}>
-                <Heading size="xsmall" level="3">
-                  Utbetaling returnert
-                </Heading>
-                <List as="ol">
-                  {linjer.map((linje) => (
-                    <List.Item>
-                      <div>{`Årsaker: ${linje.opprettelse?.aarsaker}, forklaring: ${linje.opprettelse?.forklaring}`}</div>
-                    </List.Item>
-                  ))}
-                </List>
-              </Alert>
-            )}
             <Box borderColor="border-subtle" padding="4" borderWidth="1" borderRadius="large">
               <VStack gap="4" id="kostnadsfordeling">
                 <VStack>

--- a/frontend/mr-admin-flate/src/utils/Utils.ts
+++ b/frontend/mr-admin-flate/src/utils/Utils.ts
@@ -3,6 +3,7 @@ import {
   AvtaleDto,
   Avtaletype,
   Bransje,
+  DelutbetalingReturnertAarsak,
   EstimertVentetidEnhet,
   ForerkortKlasse,
   InnholdElement,
@@ -418,6 +419,17 @@ export function tilsagnAarsakTilTekst(
       return "Arrangør har ikke sendt krav";
     case TilsagnTilAnnulleringAarsak.FEIL_ANNET:
       return "Annet";
+  }
+}
+
+export function delutbetalingAarsakTilTekst(aarsak: DelutbetalingReturnertAarsak): string {
+  switch (aarsak) {
+    case DelutbetalingReturnertAarsak.FEIL_BELOP:
+      return "Feil beløp";
+    case DelutbetalingReturnertAarsak.FEIL_ANNET:
+      return "Annet";
+    case DelutbetalingReturnertAarsak.AUTOMATISK_RETURNERT:
+      return "Automatisk returnert av NAV Tiltaksadministrasjon";
   }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
@@ -450,7 +450,7 @@ class UtbetalingService(
                     it,
                     automatiskReturnertAarsak(),
                     "Tilsagn er ikke godkjent",
-                    Tiltaksadministrasjon
+                    Tiltaksadministrasjon,
                 )
                 return@godkjennUtbetaling
             }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
@@ -267,6 +267,7 @@ class UtbetalingService(
             is BesluttDelutbetalingRequest.AvvistDelutbetalingRequest -> {
                 returnerDelutbetaling(delutbetaling, request.aarsaker, request.forklaring, navIdent)
             }
+
             is BesluttDelutbetalingRequest.GodkjentDelutbetalingRequest -> {
                 godkjennDelutbetaling(delutbetaling, navIdent)
             }
@@ -445,7 +446,12 @@ class UtbetalingService(
         delutbetalinger.forEach {
             val tilsagn = requireNotNull(queries.tilsagn.get(it.tilsagnId))
             if (tilsagn.status != TilsagnStatus.GODKJENT) {
-                returnerDelutbetaling(it, emptyList(), "Tilsagn er ikke godkjent", Tiltaksadministrasjon)
+                returnerDelutbetaling(
+                    it,
+                    automatiskReturnertAarsak(),
+                    "Tilsagn er ikke godkjent",
+                    Tiltaksadministrasjon
+                )
                 return@godkjennUtbetaling
             }
             queries.tilsagn.setGjenstaendeBelop(tilsagn.id, tilsagn.belopGjenstaende - it.belop)
@@ -474,8 +480,12 @@ class UtbetalingService(
         queries.delutbetaling.getByUtbetalingId(delutbetaling.utbetalingId)
             .filter { it.id != delutbetaling.id }
             .forEach {
-                setReturnertDelutbetaling(it, emptyList(), null, Tiltaksadministrasjon)
+                setReturnertDelutbetaling(it, automatiskReturnertAarsak(), null, Tiltaksadministrasjon)
             }
+    }
+
+    private fun automatiskReturnertAarsak(): List<String> {
+        return listOf("AUTOMATISK_RETURNERT")
     }
 
     private fun QueryContext.setReturnertDelutbetaling(
@@ -564,6 +574,7 @@ class UtbetalingService(
             Json.encodeToJsonElement(dto)
         }
     }
+
     private fun QueryContext.storeOpprettFaktura(
         delutbetaling: Delutbetaling,
         tilsagn: Tilsagn,

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -2041,7 +2041,7 @@ paths:
     post:
       tags:
         - Utbetaling
-      operationId: besluttDeltbetaling
+      operationId: besluttDelutbetaling
       requestBody:
         content:
           application/json:
@@ -6257,7 +6257,7 @@ components:
         aarsaker:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/DelutbetalingReturnertAarsak"
         forklaring:
           type: [string, "null"]
       required: [besluttelse, aarsaker, forklaring]

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -6260,7 +6260,7 @@ components:
         aarsaker:
           type: array
           items:
-            $ref: "#/components/schemas/DelutbetalingReturnertAarsak"
+            type: string
         forklaring:
           type: string
       required:
@@ -6285,7 +6285,7 @@ components:
         aarsaker:
           type: array
           items:
-            $ref: "#/components/schemas/DelutbetalingReturnertAarsak"
+            type: string
         forklaring:
           type: string
         besluttetAv:

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -5560,6 +5560,13 @@ components:
         - FEIL_BELOP
         - FEIL_ANNET
 
+    DelutbetalingReturnertAarsak:
+      type: string
+      enum:
+        - FEIL_BELOP
+        - FEIL_ANNET
+        - AUTOMATISK_RETURNERT
+
     TilsagnBeregning:
       oneOf:
         - $ref: "#/components/schemas/TilsagnBeregningForhandsgodkjent"
@@ -6253,7 +6260,7 @@ components:
         aarsaker:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/DelutbetalingReturnertAarsak"
         forklaring:
           type: string
       required:
@@ -6278,7 +6285,7 @@ components:
         aarsaker:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/DelutbetalingReturnertAarsak"
         forklaring:
           type: string
         besluttetAv:


### PR DESCRIPTION
Flytter visning av returnerte årsaker og forklaring til hver utbetalingslinje. For alle linjer som blir automatisk returnert så gir vi beskjed om at systemet automatisk har returnert linjen

![image](https://github.com/user-attachments/assets/87a69647-e0c1-42f3-b0a2-e0a0e156229e)
