### PR TITLE
lagre roller uavhengig av NavAnsattDbo

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattService.kt
@@ -47,11 +47,8 @@ class NavAnsattService(
             return
         }
 
-        val dbo = NavAnsattDbo.fromNavAnsattDto(ansatt).copy(
-            roller = ansatt.roller.plus(NavAnsattRolle.KONTAKTPERSON),
-        )
-
-        queries.ansatt.upsert(dbo)
+        val roller = ansatt.roller + NavAnsattRolle.KONTAKTPERSON
+        queries.ansatt.setRoller(ansatt.navIdent, roller)
 
         microsoftGraphClient.addToGroup(ansatt.azureId, kontaktPersonGruppeId)
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncService.kt
@@ -38,6 +38,7 @@ class NavAnsattSyncService(
         logger.info("Oppdaterer ${ansatteToUpsert.size} NavAnsatt fra Azure")
         ansatteToUpsert.forEach { ansatt ->
             queries.ansatt.upsert(NavAnsattDbo.fromNavAnsattDto(ansatt))
+            queries.ansatt.setRoller(ansatt.navIdent, ansatt.roller)
         }
         upsertSanityAnsatte(ansatteToUpsert)
 
@@ -47,8 +48,9 @@ class NavAnsattSyncService(
         }
         ansatteToScheduleForDeletion.forEach { ansatt ->
             logger.info("Oppdaterer NavAnsatt med dato for sletting azureId=${ansatt.azureId} dato=$deletionDate")
-            val ansattToDelete = ansatt.copy(roller = emptySet(), skalSlettesDato = deletionDate)
-            queries.ansatt.upsert(NavAnsattDbo.fromNavAnsattDto(ansattToDelete))
+            val ansattToDelete = NavAnsattDbo.fromNavAnsattDto(ansatt).copy(skalSlettesDato = deletionDate)
+            queries.ansatt.upsert(ansattToDelete)
+            queries.ansatt.setRoller(ansattToDelete.navIdent, setOf())
         }
 
         val ansatteToDelete = queries.ansatt.getAll(skalSlettesDatoLte = today)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/db/NavAnsattDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/db/NavAnsattDbo.kt
@@ -1,7 +1,6 @@
 package no.nav.mulighetsrommet.api.navansatt.db
 
 import no.nav.mulighetsrommet.api.navansatt.model.NavAnsattDto
-import no.nav.mulighetsrommet.api.navansatt.model.NavAnsattRolle
 import no.nav.mulighetsrommet.model.NavIdent
 import java.time.LocalDate
 import java.util.*
@@ -17,7 +16,6 @@ data class NavAnsattDbo(
     val azureId: UUID,
     val mobilnummer: String?,
     val epost: String,
-    val roller: Set<NavAnsattRolle>,
     val skalSlettesDato: LocalDate?,
 ) {
     companion object {
@@ -29,7 +27,6 @@ data class NavAnsattDbo(
             azureId = dto.azureId,
             mobilnummer = dto.mobilnummer,
             epost = dto.epost,
-            roller = dto.roller,
             skalSlettesDato = dto.skalSlettesDato,
         )
     }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/oppgaver/OppgaverRoutes.kt
@@ -1,6 +1,6 @@
 package no.nav.mulighetsrommet.oppgaver
 
-import io.ktor.server.request.receive
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/NavAnsattFixture.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/NavAnsattFixture.kt
@@ -1,7 +1,6 @@
 package no.nav.mulighetsrommet.api.fixtures
 
 import no.nav.mulighetsrommet.api.navansatt.db.NavAnsattDbo
-import no.nav.mulighetsrommet.api.navansatt.model.NavAnsattRolle
 import no.nav.mulighetsrommet.model.NavIdent
 import java.util.*
 
@@ -14,11 +13,6 @@ object NavAnsattFixture {
         azureId = UUID.randomUUID(),
         mobilnummer = "12345678",
         epost = "donald.duck@nav.no",
-        roller = setOf(
-            NavAnsattRolle.TILTAKADMINISTRASJON_GENERELL,
-            NavAnsattRolle.TILTAKSGJENNOMFORINGER_SKRIV,
-            NavAnsattRolle.AVTALER_SKRIV,
-        ),
         skalSlettesDato = null,
     )
     val ansatt2: NavAnsattDbo = NavAnsattDbo(
@@ -29,11 +23,6 @@ object NavAnsattFixture {
         azureId = UUID.randomUUID(),
         mobilnummer = "48243214",
         epost = "dolly.duck@nav.no",
-        roller = setOf(
-            NavAnsattRolle.TILTAKADMINISTRASJON_GENERELL,
-            NavAnsattRolle.TILTAKSGJENNOMFORINGER_SKRIV,
-            NavAnsattRolle.AVTALER_SKRIV,
-        ),
         skalSlettesDato = null,
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncServiceTest.kt
@@ -28,8 +28,20 @@ class NavAnsattSyncServiceTest : FunSpec({
     val database = extension(ApiDatabaseTestListener(databaseConfig))
 
     val domain = MulighetsrommetTestDomain(
+        navEnheter = listOf(NavEnhetFixtures.Innlandet),
+        ansatte = listOf(NavAnsattFixture.ansatt1, NavAnsattFixture.ansatt2),
+        arrangorer = listOf(),
         avtaler = listOf(),
-    )
+    ) {
+        queries.ansatt.setRoller(
+            NavAnsattFixture.ansatt1.navIdent,
+            setOf(TILTAKADMINISTRASJON_GENERELL),
+        )
+        queries.ansatt.setRoller(
+            NavAnsattFixture.ansatt2.navIdent,
+            setOf(TILTAKADMINISTRASJON_GENERELL),
+        )
+    }
 
     beforeEach {
         domain.initialize(database.db)


### PR DESCRIPTION
Setter roller via egen metode i queries i stedet for via dbo. Et steg på veien til å koble roller mot kostnadssteder.