### PR TITLE
Skiller på returnert/attestert i behandlerinformasjon

### DIFF
--- a/frontend/mr-admin-flate/src/components/utbetaling/BehandlerInformasjon.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/BehandlerInformasjon.tsx
@@ -1,0 +1,20 @@
+import { DelutbetalingStatus, UtbetalingLinje } from "@mr/api-client-v2";
+import { HStack } from "@navikt/ds-react";
+import { Metadata } from "../detaljside/Metadata";
+
+export function BehandlerInformasjon({ linje }: { linje: UtbetalingLinje }) {
+  return (
+    linje.opprettelse && (
+      <HStack gap="4">
+        <Metadata header="Behandlet av" verdi={linje.opprettelse.behandletAv} />
+        {linje.status === DelutbetalingStatus.RETURNERT &&
+        linje.opprettelse.type === "BESLUTTET" ? (
+          <Metadata header="Returnert av" verdi={linje.opprettelse.besluttetAv} />
+        ) : linje.opprettelse.type === "BESLUTTET" &&
+          linje.status === DelutbetalingStatus.GODKJENT ? (
+          <Metadata header="Attestert av" verdi={linje.opprettelse.besluttetAv} />
+        ) : null}
+      </HStack>
+    )
+  );
+}

--- a/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
@@ -4,7 +4,14 @@ import {
   formaterPeriodeStart,
   tilsagnTypeToString,
 } from "@/utils/Utils";
-import { DelutbetalingReturnertAarsak, FieldError, UtbetalingLinje } from "@mr/api-client-v2";
+import {
+  DelutbetalingReturnertAarsak,
+  DelutbetalingStatus,
+  FieldError,
+  TotrinnskontrollBesluttetDto,
+  TotrinnskontrollDto,
+  UtbetalingLinje,
+} from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import {
   Alert,
@@ -22,6 +29,7 @@ import { Link, useParams } from "react-router";
 import { AarsakerOgForklaring } from "../../pages/gjennomforing/tilsagn/AarsakerOgForklaring";
 import { Metadata } from "../detaljside/Metadata";
 import { DelutbetalingTag } from "./DelutbetalingTag";
+import { BehandlerInformasjon } from "./BehandlerInformasjon";
 
 interface Props {
   readOnly?: boolean;
@@ -92,14 +100,7 @@ export function UtbetalingLinjeRow({
             </VStack>
           )}
 
-          {linje.opprettelse && (
-            <HStack gap="4">
-              <Metadata header="Behandlet av" verdi={linje.opprettelse.behandletAv} />
-              {linje.opprettelse.type === "BESLUTTET" && (
-                <Metadata header="Besluttet av" verdi={linje.opprettelse.besluttetAv} />
-              )}
-            </HStack>
-          )}
+          <BehandlerInformasjon linje={linje} />
         </VStack>
       }
     >

--- a/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/UtbetalingLinjeRow.tsx
@@ -4,14 +4,7 @@ import {
   formaterPeriodeStart,
   tilsagnTypeToString,
 } from "@/utils/Utils";
-import {
-  DelutbetalingReturnertAarsak,
-  DelutbetalingStatus,
-  FieldError,
-  TotrinnskontrollBesluttetDto,
-  TotrinnskontrollDto,
-  UtbetalingLinje,
-} from "@mr/api-client-v2";
+import { DelutbetalingReturnertAarsak, FieldError, UtbetalingLinje } from "@mr/api-client-v2";
 import { formaterNOK } from "@mr/frontend-common/utils/utils";
 import {
   Alert,
@@ -27,9 +20,8 @@ import {
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router";
 import { AarsakerOgForklaring } from "../../pages/gjennomforing/tilsagn/AarsakerOgForklaring";
-import { Metadata } from "../detaljside/Metadata";
-import { DelutbetalingTag } from "./DelutbetalingTag";
 import { BehandlerInformasjon } from "./BehandlerInformasjon";
+import { DelutbetalingTag } from "./DelutbetalingTag";
 
 interface Props {
   readOnly?: boolean;

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/GjennomforingPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/GjennomforingPage.tsx
@@ -73,7 +73,7 @@ export function GjennomforingPage() {
         <div
           className={classNames("flex justify-between gap-6 flex-wrap w-full [&>span]:self-center")}
         >
-          <div className="flex justify-start gap-6 items-start flex-wrap">
+          <div className="flex justify-start gap-6 items-center flex-wrap">
             <GjennomforingIkon />
             <VStack>
               <Heading className="max-w-[50rem]" size="large" level="2">


### PR DESCRIPTION
Når en delutbetalingslinje er returnert skal det stå _returnert av <navident>_ og hvis linjen er godkjent så skal det stå _attestert av <navident>_