### PR TITLE
Går mot q1 for kontoregister

### DIFF
--- a/mulighetsrommet-api/.nais/nais-dev.yaml
+++ b/mulighetsrommet-api/.nais/nais-dev.yaml
@@ -145,7 +145,7 @@ spec:
         - host: platform.tt02.altinn.no
         - host: test.maskinporten.no
         - host: dokarkiv-q2.dev-fss-pub.nais.io
-        - host: sokos-kontoregister-q2.dev-fss-pub.nais.io
+        - host: sokos-kontoregister-q1.dev-fss-pub.nais.io
   envFrom:
     - secret: mulighetsrommet-api
     - secret: mr-admin-flate-unleash-api-token

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigDev.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigDev.kt
@@ -1,8 +1,5 @@
 package no.nav.mulighetsrommet.api
 
-import io.ktor.client.engine.mock.*
-import io.ktor.http.*
-import io.ktor.utils.io.*
 import no.nav.common.kafka.util.KafkaPropertiesPreset
 import no.nav.mulighetsrommet.api.avtale.task.NotifySluttdatoForAvtalerNarmerSeg
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
@@ -181,25 +178,8 @@ val ApplicationConfigDev = AppConfig(
         scope = "api://dev-fss.teamdokumenthandtering.dokarkiv/.default",
     ),
     kontoregisterOrganisasjon = AuthenticatedHttpClientConfig(
-        /**
-         * Vi mocker ut kontoregisteret fordi q2-miljøet til kontoregisteret benytter fiktive organisasjoner, mens vår app benytter reelle fra Brreg
-         * */
-        engine = MockEngine { _ ->
-            respond(
-                content = ByteReadChannel(
-                    """
-                    {
-                        "mottaker": "973674471",
-                        "kontonr": "63728787114"
-                    }
-                    """.trimIndent(),
-                ),
-                status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, "application/json"),
-            )
-        },
-        url = "https://sokos-kontoregister-q2.dev-fss-pub.nais.io",
-        scope = "api://dev-fss.okonomi.sokos-kontoregister-q2/.default",
+        url = "https://sokos-kontoregister-q1.dev-fss-pub.nais.io",
+        scope = "api://dev-fss.okonomi.sokos-kontoregister/.default",
     ),
     tasks = TaskConfig(
         synchronizeNorgEnheter = SynchronizeNorgEnheter.Config(


### PR DESCRIPTION
sokos-kontoregister har fjernet tenant nav.no fra nais-yaml så vi kan gå mot q1-miljø istedenfor å mocke ut en respons fra dem i dev-miljøet