### PR TITLE
Lagre enhetsnummer til kontaktperson i Sanity

### DIFF
--- a/frontend/mr-admin-flate/src/components/utbetaling/DelutbetalingTag.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/DelutbetalingTag.tsx
@@ -23,7 +23,7 @@ export function DelutbetalingTag({ status }: Props) {
       );
     case DelutbetalingStatus.TIL_GODKJENNING:
       return (
-        <Tag size="small" variant="alt1" className={baseTagClasses}>
+        <Tag size="small" variant="warning" className={baseTagClasses}>
           Til godkjenning
         </Tag>
       );

--- a/frontend/mulighetsrommet-cms/schemas/navKontaktperson.ts
+++ b/frontend/mulighetsrommet-cms/schemas/navKontaktperson.ts
@@ -40,6 +40,13 @@ export const navKontaktperson = defineType({
       validation: (rule) => rule.required().min(2).max(200),
     }),
     defineField({
+      name: "enhetsnummer",
+      title: "Nav-enhetsnummer",
+      type: "string",
+      hidden: true,
+      validation: (rule) => rule.required().length(4),
+    }),
+    defineField({
       name: "telefonnummer",
       title: "Telefonnummer",
       type: "string",

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncService.kt
@@ -14,6 +14,7 @@ import no.nav.mulighetsrommet.api.navenhet.db.NavEnhetStatus
 import no.nav.mulighetsrommet.api.sanity.SanityService
 import no.nav.mulighetsrommet.api.sanity.SanityTiltaksgjennomforing
 import no.nav.mulighetsrommet.api.sanity.Slug
+import no.nav.mulighetsrommet.model.NavEnhetNummer
 import no.nav.mulighetsrommet.notifications.NotificationMetadata
 import no.nav.mulighetsrommet.notifications.NotificationTask
 import no.nav.mulighetsrommet.notifications.NotificationType
@@ -181,6 +182,7 @@ class NavAnsattSyncService(
                         telefonnummer = ansatt.mobilnummer,
                         epost = ansatt.epost,
                         navn = "${ansatt.fornavn} ${ansatt.etternavn}",
+                        enhetsnummer = ansatt.hovedenhet.enhetsnummer,
                     ),
                 )
             }
@@ -195,6 +197,7 @@ class NavAnsattSyncService(
                         navn = "${ansatt.fornavn} ${ansatt.etternavn}",
                         navIdent = Slug(current = ansatt.navIdent.value),
                         epost = Slug(current = ansatt.epost),
+                        enhetsnummer = ansatt.hovedenhet.enhetsnummer,
                     ),
                 )
             }
@@ -210,6 +213,7 @@ data class SanityNavKontaktperson(
     val _type: String,
     val navIdent: Slug,
     val enhet: String,
+    val enhetsnummer: NavEnhetNummer,
     val telefonnummer: String? = null,
     val epost: String,
     val navn: String,
@@ -221,6 +225,7 @@ data class SanityRedaktor(
     val _type: String,
     val navIdent: Slug,
     val enhet: String,
+    val enhetsnummer: NavEnhetNummer,
     val epost: Slug,
     val navn: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncService.kt
@@ -213,7 +213,7 @@ data class SanityNavKontaktperson(
     val _type: String,
     val navIdent: Slug,
     val enhet: String,
-    val enhetsnummer: NavEnhetNummer,
+    val enhetsnummer: NavEnhetNummer? = null,
     val telefonnummer: String? = null,
     val epost: String,
     val navn: String,
@@ -225,7 +225,7 @@ data class SanityRedaktor(
     val _type: String,
     val navIdent: Slug,
     val enhet: String,
-    val enhetsnummer: NavEnhetNummer,
+    val enhetsnummer: NavEnhetNummer? = null,
     val epost: Slug,
     val navn: String,
 )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/sanity/SanityResponseDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/sanity/SanityResponseDto.kt
@@ -77,6 +77,7 @@ data class KontaktinfoTiltaksansvarlig(
     val telefonnummer: String? = null,
     val _id: String? = null,
     val enhet: String? = null,
+    val enhetsnummer: NavEnhetNummer? = null,
     val _updatedAt: String? = null,
     val _createdAt: String? = null,
     val epost: String? = null,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/VeilederflateService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/VeilederflateService.kt
@@ -161,8 +161,7 @@ class VeilederflateService(
                 VeilederflateKontaktinfoTiltaksansvarlig(
                     navn = it.navn,
                     telefon = it.telefonnummer,
-                    // TODO: enhet fra kontaktperson i sanity er ikke kodet som et enhetsnummer og kan derfor ikke benyttes til å hente enhet her enda
-                    enhet = null, // it.enhet?.let { enhet -> navEnhetService.hentEnhet(enhet) },
+                    enhet = it.enhetsnummer?.let { enhet -> navEnhetService.hentEnhet(enhet) },
                     epost = it.epost,
                     beskrivelse = it.beskrivelse,
                 )


### PR DESCRIPTION
Innfører eget felt 'enhetsnummer' i Sanity-schema for kontaktperson i Nav. Her lagres firesiffer-enhetsnummer for Nav-enheten til kontaktpersonen. Dette blir srå brukt for å utlede nav-enhet til bruk i Modia