### PR TITLE
definer tabell for nav-enheter per rolle

### DIFF
--- a/mulighetsrommet-api/src/main/resources/db/migration/R__view_gjennomforing_admin.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/R__view_gjennomforing_admin.sql
@@ -65,8 +65,8 @@ from gjennomforing
                                                    'overordnetEnhet', enhet.overordnet_enhet
                                            )
                                    ) as nav_enheter_json
-                            from gjennomforing_nav_enhet
-                                     natural join nav_enhet enhet
+                            from gjennomforing_nav_enhet gjennomforing_enhet
+                                     join nav_enhet enhet on enhet.enhetsnummer = gjennomforing_enhet.enhetsnummer
                             where gjennomforing_id = gjennomforing.id) on true
          left join lateral (select jsonb_agg(
                                            jsonb_build_object(
@@ -89,7 +89,7 @@ from gjennomforing
                                            )
                                    ) as administratorer_json
                             from gjennomforing_administrator administrator
-                                     natural join nav_ansatt ansatt
+                                     join nav_ansatt ansatt on ansatt.nav_ident = administrator.nav_ident
                             where administrator.gjennomforing_id = gjennomforing.id) on true
          left join lateral (select jsonb_agg(
                                            jsonb_build_object(
@@ -98,7 +98,7 @@ from gjennomforing
                                            )
                                    ) as koordinator_json
                             from gjennomforing_koordinator koordinator
-                                     natural join nav_ansatt ansatt
+                                     join nav_ansatt ansatt on ansatt.nav_ident = koordinator.nav_ident
                             where koordinator.gjennomforing_id = gjennomforing.id) on true
          left join lateral (select jsonb_agg(
                                            jsonb_build_object(

--- a/mulighetsrommet-api/src/main/resources/db/migration/V278__nav_ansatt_rolle.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V278__nav_ansatt_rolle.sql
@@ -1,0 +1,35 @@
+alter table nav_ansatt
+    add created_at timestamp default now(),
+    add updated_at timestamp default now();
+
+create trigger set_timestamp
+    before update
+    on nav_ansatt
+    for each row
+execute procedure trigger_set_timestamp();
+
+create table nav_ansatt_rolle_nav_enhet
+(
+    id                     integer primary key generated always as identity,
+    nav_ansatt_rolle_id    integer not null references nav_ansatt_rolle on delete cascade,
+    nav_enhet_enhetsnummer text    not null references nav_enhet (enhetsnummer),
+    created_at             timestamp default now(),
+    updated_at             timestamp default now(),
+    unique (nav_ansatt_rolle_id, nav_enhet_enhetsnummer)
+);
+
+create trigger set_timestamp
+    before update
+    on nav_ansatt_rolle_nav_enhet
+    for each row
+execute procedure trigger_set_timestamp();
+
+alter table nav_ansatt_rolle
+    add created_at timestamp default now(),
+    add updated_at timestamp default now();
+
+create trigger set_timestamp
+    before update
+    on nav_ansatt_rolle
+    for each row
+execute procedure trigger_set_timestamp();


### PR DESCRIPTION
Egen pr for databaseendringene som originalt var definert i #5464 

Siden disse endringene ikke påvirker tjenesten kan denne merges først. Det gjør det mulig å teste #5464 i dev-miljøet uten å gjøre ekstra endringer i db.