### PR TITLE
utfør duplikatsjekk før upsert ved sync av ansatte

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/NavAnsattSyncService.kt
@@ -40,7 +40,10 @@ class NavAnsattSyncService(
 
         logger.info("Oppdaterer ${ansatteToUpsert.size} NavAnsatt fra Azure")
         ansatteToUpsert.forEach { ansatt ->
-            queries.ansatt.upsert(NavAnsattDbo.fromNavAnsatt(ansatt))
+            val currentAnsattDbo = queries.ansatt.getNavAnsattDbo(ansatt.navIdent)
+            NavAnsattDbo.fromNavAnsatt(ansatt).takeIf { it != currentAnsattDbo }?.also {
+                queries.ansatt.upsert(it)
+            }
             queries.ansatt.setRoller(ansatt.navIdent, ansatt.roller)
         }
         upsertSanityAnsatte(ansatteToUpsert)

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/db/NavAnsattQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/db/NavAnsattQueries.kt
@@ -168,6 +168,17 @@ class NavAnsattQueries(private val session: Session) {
 
         return update(queryOf(query, azureId))
     }
+
+    fun getNavAnsattDbo(navIdent: NavIdent): NavAnsattDbo? = with(session) {
+        @Language("PostgreSQL")
+        val query = """
+            select *
+            from nav_ansatt
+            where nav_ident = ?
+        """.trimIndent()
+
+        return single(queryOf(query, navIdent.value)) { it.toNavAnsattDbo() }
+    }
 }
 
 private fun Row.toNavAnsattDto(): NavAnsatt {
@@ -189,6 +200,17 @@ private fun Row.toNavAnsattDto(): NavAnsatt {
         skalSlettesDato = localDateOrNull("skal_slettes_dato"),
     )
 }
+
+private fun Row.toNavAnsattDbo(): NavAnsattDbo = NavAnsattDbo(
+    navIdent = NavIdent(string("nav_ident")),
+    fornavn = string("fornavn"),
+    etternavn = string("etternavn"),
+    hovedenhet = NavEnhetNummer(string("hovedenhet")),
+    azureId = uuid("azure_id"),
+    mobilnummer = stringOrNull("mobilnummer"),
+    epost = string("epost"),
+    skalSlettesDato = localDateOrNull("skal_slettes_dato"),
+)
 
 fun Session.createArrayOfRolle(
     values: Collection<Rolle>,


### PR DESCRIPTION
for å sørge for at updated_at timestamp kun settes når det er endringer i data