### PR TITLE
Gi metabase tilgang til dataproduktet

### DIFF
--- a/iac/bigquery-terraform/prod/datastreams.tf
+++ b/iac/bigquery-terraform/prod/datastreams.tf
@@ -62,6 +62,10 @@ module "mr_api_datastream" {
     {
       role          = "roles/bigquery.metadataViewer"
       user_by_email = "effekt-j6bp@knada-gcp.iam.gserviceaccount.com"
+    },
+    {
+      role          = "roles/bigquery.metadataViewer"
+      user_by_email = "nada-metabase@nada-prod-6977.iam.gserviceaccount.com"
     }
   ]
 


### PR DESCRIPTION
https://data.ansatt.nav.no/dataproduct/48c6dab9-d236-4088-bb48-0a59007148c9/Arbeidsmarkedstiltak%20%28Valp%29/2d4102d6-80f2-4946-9bcc-95cc13ae5b7b#

Datamarkedsplassen legger til principalen på vårt datasett når man eksponerer dataene til metabase (note: rydder ikke opp ved fjerning).
Ved påfølgende terraform apply, vil den nok fjerne principalen igjen om vi ikke har gitt den eksplisitt tilgang.

![image](https://github.com/user-attachments/assets/8e834d30-038a-4835-99e6-31b70a228310)