### PR TITLE
Sender nav-enheter som en kommaseparert string til backend

### DIFF
--- a/frontend/mr-admin-flate/src/api/gjennomforing/useAdminGjennomforinger.ts
+++ b/frontend/mr-admin-flate/src/api/gjennomforing/useAdminGjennomforinger.ts
@@ -11,7 +11,7 @@ export function useAdminGjennomforinger(filter: Partial<GjennomforingFilter>) {
   const queryFilter: Pick<GetGjennomforingerData, "query"> = {
     query: {
       search: debouncedSok || undefined,
-      navEnheter: filter.navEnheter?.map((e) => e.enhetsnummer) ?? [],
+      navEnheter: filter.navEnheter?.map((n) => n.enhetsnummer).join(",") ?? "",
       tiltakstyper: filter.tiltakstyper,
       statuser: filter.statuser,
       sort: filter.sortering ? filter.sortering.sortString : undefined,

--- a/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingTable.tsx
+++ b/frontend/mr-admin-flate/src/components/gjennomforing/GjennomforingTable.tsx
@@ -37,7 +37,6 @@ export function GjennomforingTable({ skjulKolonner, filterAtom, tagsHeight, filt
   const sort = filter.sortering.tableSort;
   const { data, isLoading } = useAdminGjennomforinger(filter);
   const link = createRef<HTMLAnchorElement>();
-
   async function lastNedFil(filter: GjennomforingFilter) {
     const query = createQueryParamsForExcelDownloadForGjennomforing(filter);
     const { data } = await GjennomforingerService.lastNedGjennomforingerSomExcel(query);

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/GjennomforingRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/GjennomforingRoutes.kt
@@ -314,7 +314,7 @@ data class AdminTiltaksgjennomforingFilter(
 
 fun RoutingContext.getAdminTiltaksgjennomforingsFilter(): AdminTiltaksgjennomforingFilter {
     val search = call.request.queryParameters["search"]
-    val navEnheter = call.parameters.getAll("navEnheter")?.map { NavEnhetNummer(it) } ?: emptyList()
+    val navEnheter = call.parameters["navEnheter"]?.split(",")?.map { NavEnhetNummer(it) } ?: emptyList()
     val tiltakstypeIder = call.parameters.getAll("tiltakstyper")?.map { UUID.fromString(it) } ?: emptyList()
     val statuser = call.parameters.getAll("statuser")
         ?.map { GjennomforingStatus.valueOf(it) }

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -438,10 +438,7 @@ paths:
         - in: query
           name: navEnheter
           schema:
-            type: array
-            items:
-              type: string
-          description: 4 digit enhetskode
+            type: string
         - in: query
           name: tiltakstyper
           schema:
@@ -524,10 +521,7 @@ paths:
         - in: query
           name: navEnheter
           schema:
-            type: array
-            items:
-              type: string
-          description: 4 digit enhetskode
+            type: string
         - in: query
           name: tiltakstyper
           schema:


### PR DESCRIPTION
Oppdaget at dersom en bruker i NAV Tiltaksadministrasjon velger alle nav-enheter så blir ikke requesten sendt til backend. Fant ut at når vi sender >= 250 nav-enhet-queryparams så feiler requesten med en 400-feil på klienten. Jeg endrer så vi heller sender en kommaseparert liste til backend som vi gjør om til en liste i backend istedenfor.

Eventuelt burde kanskje requesten skrives om til en POST istedenfor GET, men det har jeg ikke gjort i denne omgang.