### PR TITLE
Bruk riktig navngivning for orgnr fra url

### DIFF
--- a/frontend/arrangor-flate/app/components/arrangorvelger/Arrangorvelger.tsx
+++ b/frontend/arrangor-flate/app/components/arrangorvelger/Arrangorvelger.tsx
@@ -8,13 +8,13 @@ interface Props {
 
 export function Arrangorvelger({ arrangorer }: Props) {
   const navigate = useNavigate();
-  const { currentOrgnr } = useParams();
+  const { orgnr } = useParams();
 
   const alfabetisk = (a: Arrangor, b: Arrangor) => a.navn.localeCompare(b.navn);
 
   return (
     <Select
-      value={currentOrgnr}
+      value={orgnr}
       label="Velg arrangør du vil representere"
       hideLabel
       name="orgnr"


### PR DESCRIPTION
Navngivningen på orgnr ga undefined ettersom den ikke samsvarte med det faktiske parameteret, og ga derfor feil valg ved refresh i arrangørvelgeren.