### PR TITLE
Refactor/prismodell

### DIFF
--- a/frontend/mr-admin-flate/src/components/tilsagn/TilsagnFormContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/tilsagn/TilsagnFormContainer.tsx
@@ -1,15 +1,10 @@
 import { TilsagnFormForhandsgodkjent } from "@/components/tilsagn/prismodell/TilsagnFormForhandsgodkjent";
 import { TilsagnFormFri } from "@/components/tilsagn/prismodell/TilsagnFormFri";
-import {
-  AvtaleDto,
-  Avtaletype,
-  TilsagnType,
-  GjennomforingDto,
-  Prismodell,
-} from "@mr/api-client-v2";
+import { AvtaleDto, GjennomforingDto, Prismodell, TilsagnType } from "@mr/api-client-v2";
 import { useNavigate } from "react-router";
 import { InferredTilsagn } from "@/components/tilsagn/prismodell/TilsagnSchema";
 import { DeepPartial } from "react-hook-form";
+import { Alert } from "@navikt/ds-react";
 
 interface Props {
   avtale: AvtaleDto;
@@ -33,16 +28,7 @@ export function TilsagnFormContainer({ avtale, gjennomforing, defaults }: Props)
     onAvbryt: navigerTilTilsagn,
   };
 
-  function prismodell(avtaleType: Avtaletype, defaultPrismodell?: Prismodell): Prismodell {
-    if (defaultPrismodell) {
-      return defaultPrismodell;
-    }
-    return avtaleType === Avtaletype.FORHAANDSGODKJENT
-      ? Prismodell.FORHANDSGODKJENT
-      : Prismodell.FRI;
-  }
-
-  switch (prismodell(avtale.avtaletype, defaults.beregning?.type as Prismodell)) {
+  switch (defaults.beregning?.type ?? avtale.prismodell) {
     case Prismodell.FORHANDSGODKJENT:
       return (
         <TilsagnFormForhandsgodkjent
@@ -53,7 +39,7 @@ export function TilsagnFormContainer({ avtale, gjennomforing, defaults }: Props)
           {...props}
         />
       );
-    default:
+    case Prismodell.FRI:
       return (
         <TilsagnFormFri
           defaultValues={{
@@ -63,6 +49,8 @@ export function TilsagnFormContainer({ avtale, gjennomforing, defaults }: Props)
           {...props}
         />
       );
+    default:
+      return <Alert variant={"warning"}>Prismodell mangler</Alert>;
   }
 }
 

--- a/frontend/mr-admin-flate/src/pages/avtaler/AvtalePrisOgFakturering.tsx
+++ b/frontend/mr-admin-flate/src/pages/avtaler/AvtalePrisOgFakturering.tsx
@@ -27,10 +27,7 @@ export function AvtalePrisOgFakturering({ tiltakstype }: Props) {
       <FormGroup>
         <Metadata header={avtaletekster.tiltakstypeLabel} verdi={tiltakstype.navn} />
 
-        <SelectPrismodell
-          readOnly={avtaletype === Avtaletype.FORHAANDSGODKJENT}
-          options={resolvePrismodellOptions(avtaletype)}
-        />
+        <SelectPrismodell options={resolvePrismodellOptions(avtaletype)} />
 
         {prismodell === Prismodell.FORHANDSGODKJENT && (
           <ForhandsgodkjentAvtalePrismodell tiltakstype={tiltakstype.tiltakskode} />

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/AvtaleValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/AvtaleValidator.kt
@@ -230,15 +230,6 @@ class AvtaleValidator(
                 )
             }
 
-            if (avtale.prismodell != currentAvtale.prismodell) {
-                add(
-                    FieldError.of(
-                        detail = "Prismodell kan ikke endres fordi det finnes gjennomføringer for avtalen",
-                        AvtaleDbo::prismodell,
-                    ),
-                )
-            }
-
             gjennomforinger.forEach { gjennomforing ->
                 val arrangorId = gjennomforing.arrangor.id
 


### PR DESCRIPTION
Fikser deadlocken vi så under prod-testen på onsdag der mangel på prismodell i VTA-tiltaket krevde manuell patching i db. Gjør validering litt mindre streng, fjerner et readOnly-flagg for prismodell og benytter avtalens prismodell i stedet for avtaletypen som kilde for hvilket tilsagn som skal opprettes