### PR TITLE
cache basert på 'uti' i stedet for 'sid'

### DIFF
--- a/mulighetsrommet-api/README.md
+++ b/mulighetsrommet-api/README.md
@@ -118,7 +118,7 @@ Følgende steg kan benyttes til å generere opp et token:
            "access_as_application"
          ],
          "oid": "0bab029e-e84e-4842-8a27-d153b29782cf",
-         "sid": "0bab029e-e84e-4842-8a27-d153b29782cf",
+         "uti": "0bab029e-e84e-4842-8a27-d153b29782cf",
          "azp_name": "test name",
          "groups": [
            "52bb9196-b071-4cc7-9472-be4942d33c4b"

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/service/NavAnsattPrincipalService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/service/NavAnsattPrincipalService.kt
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-typealias JwtSessionId = String
+typealias JwtId = String
 
 class NavAnsattPrincipalService(
     private val navAnsattService: NavAnsattService,
@@ -21,7 +21,7 @@ class NavAnsattPrincipalService(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val roleCache: Cache<JwtSessionId, Set<NavAnsattRolle>> = Caffeine.newBuilder()
+    private val roleCache: Cache<JwtId, Set<NavAnsattRolle>> = Caffeine.newBuilder()
         .expireAfterWrite(1, TimeUnit.HOURS)
         .maximumSize(10_000)
         .recordStats()
@@ -38,13 +38,13 @@ class NavAnsattPrincipalService(
             return null
         }
 
-        val sessionId = credentials["sid"] ?: run {
-            log.warn("'sid' mangler i JWT credentials")
+        val tokenId = credentials["uti"]?.takeIf { it.isNotEmpty() } ?: run {
+            log.warn("'uti' mangler i JWT credentials")
             return null
         }
 
         val groups = credentials.getListClaim("groups", UUID::class)
-        val roller = getRoles(sessionId, oid, groups)
+        val roller = getRoles(tokenId, oid, groups)
 
         return NavAnsattPrincipal(
             navAnsattObjectId = oid,
@@ -55,16 +55,16 @@ class NavAnsattPrincipalService(
     }
 
     private suspend fun getRoles(
-        sessionId: JwtSessionId,
+        tokenId: JwtId,
         oid: UUID,
         groups: List<UUID>,
     ): Set<NavAnsattRolle> {
-        roleCache.getIfPresent(sessionId)?.also { return it }
+        roleCache.getIfPresent(tokenId)?.also { return it }
 
         val roller = navAnsattService.getNavAnsattRolesFromGroups(groups)
         syncNavAnsattRoller(oid, roller)
 
-        roleCache.put(sessionId, roller)
+        roleCache.put(tokenId, roller)
 
         return roller
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestHelpers.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/ApplicationTestHelpers.kt
@@ -20,7 +20,7 @@ fun getAnsattClaims(
     return mapOf(
         "NAVident" to ansatt.navIdent.value,
         "oid" to ansatt.azureId,
-        "sid" to UUID.randomUUID().toString(),
+        "uti" to UUID.randomUUID().toString(),
         "groups" to roles.map { it.adGruppeId.toString() },
     )
 }


### PR DESCRIPTION
`uti` genereres på nytt ved reautnetisering og tillater at vi slipper å gjøre en full logout for å kunne hente oppdatert `groups` claim