### PR TITLE
fjern azure fra navn på auth providers

### DIFF
--- a/mulighetsrommet-api/.nais/nais-dev.yaml
+++ b/mulighetsrommet-api/.nais/nais-dev.yaml
@@ -116,6 +116,9 @@ spec:
       rules:
         - application: arrangor-flate
         - application: mulighetsrommet-arena-adapter
+          permissions:
+            roles:
+              - arena-adapter
         - application: mulighetsrommet-arena-adapter-manager
         - application: mr-admin-flate
         - application: nav-arbeidsmarkedstiltak

--- a/mulighetsrommet-api/.nais/nais-prod.yaml
+++ b/mulighetsrommet-api/.nais/nais-prod.yaml
@@ -149,6 +149,9 @@ spec:
       rules:
         - application: arrangor-flate
         - application: mulighetsrommet-arena-adapter
+          permissions:
+            roles:
+              - arena-adapter
         - application: mulighetsrommet-arena-adapter-manager
         - application: mr-admin-flate
         - application: nav-arbeidsmarkedstiltak

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MsGraphClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/msgraph/MsGraphClient.kt
@@ -59,14 +59,14 @@ class MsGraphClient(
         }
     }
 
-    private val azureAdNavAnsattFields =
+    private val entraIdNavAnsattFields =
         "id,streetAddress,city,givenName,surname,onPremisesSamAccountName,mail,mobilePhone"
 
     suspend fun getNavAnsatt(navAnsattOid: UUID, accessType: AccessType): EntraIdNavAnsatt {
         return CacheUtils.tryCacheFirstNotNull(ansattDataCache, navAnsattOid) {
             val response = client.get("$baseUrl/v1.0/users/$navAnsattOid") {
                 bearerAuth(tokenProvider.exchange(accessType))
-                parameter($$"$select", azureAdNavAnsattFields)
+                parameter($$"$select", entraIdNavAnsattFields)
             }
 
             if (!response.status.isSuccess()) {
@@ -84,7 +84,7 @@ class MsGraphClient(
             val response = client.get("$baseUrl/v1.0/users") {
                 bearerAuth(tokenProvider.exchange(accessType))
                 parameter($$"$search", "\"onPremisesSamAccountName:${navIdent.value}\"")
-                parameter($$"$select", azureAdNavAnsattFields)
+                parameter($$"$select", entraIdNavAnsattFields)
                 header("ConsistencyLevel", "eventual")
             }
 
@@ -109,12 +109,12 @@ class MsGraphClient(
             bearerAuth(tokenProvider.exchange(AccessType.M2M))
             parameter($$"$search", "\"displayName:$nameQuery\"")
             parameter($$"$orderBy", "displayName")
-            parameter($$"$select", azureAdNavAnsattFields)
+            parameter($$"$select", entraIdNavAnsattFields)
             header("ConsistencyLevel", "eventual")
         }
 
         if (!response.status.isSuccess()) {
-            logAndThrowError("Feil under user search mot Azure", response)
+            logAndThrowError("Feil under user search mot Entra", response)
         }
 
         return response.body<GetUserSearchResponse>()
@@ -142,7 +142,7 @@ class MsGraphClient(
     suspend fun getGroupMembers(groupId: UUID): List<EntraIdNavAnsatt> {
         val response = client.get("$baseUrl/v1.0/groups/$groupId/members") {
             bearerAuth(tokenProvider.exchange(AccessType.M2M))
-            parameter($$"$select", azureAdNavAnsattFields)
+            parameter($$"$select", entraIdNavAnsattFields)
             parameter($$"$top", "999")
         }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/Authentication.kt
@@ -20,16 +20,17 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 enum class AuthProvider {
-    AZURE_AD_NAV_IDENT,
-    AZURE_AD_DEFAULT_APP,
-    AZURE_AD_TILTAKSGJENNOMFORING_APP,
+    NAIS_APP_ARENA_ADAPTER_ACCESS,
+    NAIS_APP_GJENNOMFORING_ACCESS,
+    NAV_ANSATT,
     NAV_ANSATT_WITH_ROLES,
     TOKEN_X_ARRANGOR_FLATE,
 }
 
 object AppRoles {
     const val ACCESS_AS_APPLICATION = "access_as_application"
-    const val READ_TILTAKSGJENNOMFORING = "tiltaksgjennomforing-read"
+    const val READ_GJENNOMFORING = "tiltaksgjennomforing-read"
+    const val ARENA_ADAPTER = "arena-adapter"
 }
 
 /**
@@ -113,7 +114,7 @@ fun Application.configureAuthentication(
             }
         }
 
-        jwt(AuthProvider.AZURE_AD_NAV_IDENT) {
+        jwt(AuthProvider.NAV_ANSATT) {
             verifier(azureJwkProvider, auth.azure.issuer) {
                 withAudience(auth.azure.audience)
             }
@@ -125,13 +126,13 @@ fun Application.configureAuthentication(
             }
         }
 
-        jwt(AuthProvider.AZURE_AD_DEFAULT_APP) {
+        jwt(AuthProvider.NAIS_APP_ARENA_ADAPTER_ACCESS) {
             verifier(azureJwkProvider, auth.azure.issuer) {
                 withAudience(auth.azure.audience)
             }
 
             validate { credentials ->
-                if (!hasApplicationRoles(credentials, AppRoles.ACCESS_AS_APPLICATION)) {
+                if (!hasApplicationRoles(credentials, AppRoles.ACCESS_AS_APPLICATION, AppRoles.ARENA_ADAPTER)) {
                     return@validate null
                 }
 
@@ -139,18 +140,13 @@ fun Application.configureAuthentication(
             }
         }
 
-        jwt(AuthProvider.AZURE_AD_TILTAKSGJENNOMFORING_APP) {
+        jwt(AuthProvider.NAIS_APP_GJENNOMFORING_ACCESS) {
             verifier(azureJwkProvider, auth.azure.issuer) {
                 withAudience(auth.azure.audience)
             }
 
             validate { credentials ->
-                if (!hasApplicationRoles(
-                        credentials,
-                        AppRoles.ACCESS_AS_APPLICATION,
-                        AppRoles.READ_TILTAKSGJENNOMFORING,
-                    )
-                ) {
+                if (!hasApplicationRoles(credentials, AppRoles.ACCESS_AS_APPLICATION, AppRoles.READ_GJENNOMFORING)) {
                     return@validate null
                 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/ApiRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/ApiRoutes.kt
@@ -35,16 +35,16 @@ fun Route.apiRoutes() {
         }
     }
 
-    authenticate(AuthProvider.AZURE_AD_TILTAKSGJENNOMFORING_APP) {
+    authenticate(AuthProvider.NAIS_APP_GJENNOMFORING_ACCESS) {
         externalRoutes()
     }
 
-    authenticate(AuthProvider.AZURE_AD_DEFAULT_APP) {
+    authenticate(AuthProvider.NAIS_APP_ARENA_ADAPTER_ACCESS) {
         arenaAdapterRoutes()
     }
 
     route("/api/v1/intern") {
-        authenticate(AuthProvider.AZURE_AD_NAV_IDENT) {
+        authenticate(AuthProvider.NAV_ANSATT) {
             featureTogglesRoute()
             lagretFilterRoutes()
             navEnhetRoutes()

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/AuthenticationTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/AuthenticationTest.kt
@@ -34,7 +34,7 @@ class AuthenticationTest : FunSpec({
         oauth.shutdown()
     }
 
-    test("verify provider AZURE_AD_NAV_IDENT") {
+    test("verify provider NAV_ANSATT") {
         val requestWithoutBearerToken = { _: HttpRequestBuilder -> }
         val requestWithWrongAudience = { request: HttpRequestBuilder ->
             request.bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
@@ -54,8 +54,8 @@ class AuthenticationTest : FunSpec({
         )
         withTestApplication(config, additionalConfiguration = {
             routing {
-                authenticate(AuthProvider.AZURE_AD_NAV_IDENT) {
-                    get("AZURE_AD_NAV_IDENT") { call.respond(HttpStatusCode.OK) }
+                authenticate(AuthProvider.NAV_ANSATT) {
+                    get("NAV_ANSATT") { call.respond(HttpStatusCode.OK) }
                 }
             }
         }) {
@@ -66,7 +66,7 @@ class AuthenticationTest : FunSpec({
                 row(requestWithoutNAVident, HttpStatusCode.Unauthorized),
                 row(requestWithNAVident, HttpStatusCode.OK),
             ) { buildRequest, responseStatusCode ->
-                val response = client.get("/AZURE_AD_NAV_IDENT") { buildRequest(this) }
+                val response = client.get("/NAV_ANSATT") { buildRequest(this) }
 
                 response.status shouldBe responseStatusCode
             }
@@ -133,7 +133,7 @@ class AuthenticationTest : FunSpec({
         }
     }
 
-    test("verify provider AZURE_AD_DEFAULT_APP") {
+    test("verify provider NAIS_APP_ARENA_ADAPTER_ACCESS") {
         val requestWithoutBearerToken = { _: HttpRequestBuilder -> }
         val requestWithWrongAudience = { request: HttpRequestBuilder ->
             request.bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
@@ -148,14 +148,18 @@ class AuthenticationTest : FunSpec({
             val claims = mapOf("roles" to listOf(AppRoles.ACCESS_AS_APPLICATION))
             request.bearerAuth(oauth.issueToken(claims = claims).serialize())
         }
+        val requestWithClaimsArenaAdapter = { request: HttpRequestBuilder ->
+            val claims = mapOf("roles" to listOf(AppRoles.ACCESS_AS_APPLICATION, AppRoles.ARENA_ADAPTER))
+            request.bearerAuth(oauth.issueToken(claims = claims).serialize())
+        }
 
         val config = createTestApplicationConfig().copy(
             auth = createAuthConfig(oauth, roles = setOf()),
         )
         withTestApplication(config, additionalConfiguration = {
             routing {
-                authenticate(AuthProvider.AZURE_AD_DEFAULT_APP) {
-                    get("AZURE_AD_DEFAULT_APP") { call.respond(HttpStatusCode.OK) }
+                authenticate(AuthProvider.NAIS_APP_ARENA_ADAPTER_ACCESS) {
+                    get("NAIS_APP_ARENA_ADAPTER_ACCESS") { call.respond(HttpStatusCode.OK) }
                 }
             }
         }) {
@@ -164,16 +168,17 @@ class AuthenticationTest : FunSpec({
                 row(requestWithWrongAudience, HttpStatusCode.Unauthorized),
                 row(requestWithWrongIssuer, HttpStatusCode.Unauthorized),
                 row(requestWithoutClaimAccessAsApplication, HttpStatusCode.Unauthorized),
-                row(requestWithClaimAccessAsApplication, HttpStatusCode.OK),
+                row(requestWithClaimAccessAsApplication, HttpStatusCode.Unauthorized),
+                row(requestWithClaimsArenaAdapter, HttpStatusCode.OK),
             ) { buildRequest, responseStatusCode ->
-                val response = client.get("/AZURE_AD_DEFAULT_APP") { buildRequest(this) }
+                val response = client.get("/NAIS_APP_ARENA_ADAPTER_ACCESS") { buildRequest(this) }
 
                 response.status shouldBe responseStatusCode
             }
         }
     }
 
-    test("verify provider AZURE_AD_TILTAKSGJENNOMFORING_APP") {
+    test("verify provider NAIS_APP_GJENNOMFORING_ACCESS") {
         val requestWithoutBearerToken = { _: HttpRequestBuilder -> }
         val requestWithWrongAudience = { request: HttpRequestBuilder ->
             request.bearerAuth(oauth.issueToken(audience = "skatteetaten").serialize())
@@ -189,7 +194,7 @@ class AuthenticationTest : FunSpec({
             request.bearerAuth(oauth.issueToken(claims = claims).serialize())
         }
         val requestWithClaimsReadTiltaksgjennomforing = { request: HttpRequestBuilder ->
-            val claims = mapOf("roles" to listOf(AppRoles.ACCESS_AS_APPLICATION, AppRoles.READ_TILTAKSGJENNOMFORING))
+            val claims = mapOf("roles" to listOf(AppRoles.ACCESS_AS_APPLICATION, AppRoles.READ_GJENNOMFORING))
             request.bearerAuth(oauth.issueToken(claims = claims).serialize())
         }
 
@@ -198,8 +203,8 @@ class AuthenticationTest : FunSpec({
         )
         withTestApplication(config, additionalConfiguration = {
             routing {
-                authenticate(AuthProvider.AZURE_AD_TILTAKSGJENNOMFORING_APP) {
-                    get("AZURE_AD_TILTAKSGJENNOMFORING_APP") { call.respond(HttpStatusCode.OK) }
+                authenticate(AuthProvider.NAIS_APP_GJENNOMFORING_ACCESS) {
+                    get("NAIS_APP_GJENNOMFORING_ACCESS") { call.respond(HttpStatusCode.OK) }
                 }
             }
         }) {
@@ -211,7 +216,7 @@ class AuthenticationTest : FunSpec({
                 row(requestWithClaimAccessAsApplication, HttpStatusCode.Unauthorized),
                 row(requestWithClaimsReadTiltaksgjennomforing, HttpStatusCode.OK),
             ) { buildRequest, responseStatusCode ->
-                val response = client.get("/AZURE_AD_TILTAKSGJENNOMFORING_APP") { buildRequest(this) }
+                val response = client.get("/NAIS_APP_GJENNOMFORING_ACCESS") { buildRequest(this) }
 
                 response.status shouldBe responseStatusCode
             }


### PR DESCRIPTION
Gjør noen endringer fra Azure AD -> Entra Id. 

Jeg synes fortsatt navneendringer er litt forvirrende, så jeg har ikke endret fra "azure" -> "entra" helt ukritisk. Bl.a. er står `azure` igjen i applikasjonskonfigurasjonen siden det samsvarer godt med samme konfigurasjon i `nais.yaml`