### PR TITLE
Bruk avtalens prismodell når ekstratilsagn/investering opprettes fra utbetaling

### DIFF
--- a/frontend/mr-admin-flate/src/components/utbetaling/RedigerUtbetalingLinjeView.tsx
+++ b/frontend/mr-admin-flate/src/components/utbetaling/RedigerUtbetalingLinjeView.tsx
@@ -4,7 +4,6 @@ import {
   DelutbetalingRequest,
   FieldError,
   OpprettDelutbetalingerRequest,
-  Prismodell,
   TilsagnDto,
   TilsagnStatus,
   TilsagnType,
@@ -21,6 +20,7 @@ import { v4 as uuidv4 } from "uuid";
 import { useNavigate, useParams } from "react-router";
 import { UtbetalingLinjeTable } from "./UtbetalingLinjeTable";
 import { UtbetalingLinjeRow } from "./UtbetalingLinjeRow";
+import { avtaletekster } from "../ledetekster/avtaleLedetekster";
 
 export interface Props {
   utbetaling: UtbetalingDto;
@@ -51,13 +51,14 @@ export function RedigerUtbetalingLinjeView({ linjer, utbetaling, tilsagn }: Prop
 
   const opprettMutation = useOpprettDelutbetalinger(utbetaling.id);
 
+  const tilsagnsTypeFraTilskudd = tilsagnType(utbetaling.tilskuddstype);
+
   function opprettEkstraTilsagn() {
     const defaultTilsagn = tilsagn.length === 1 ? tilsagn[0] : undefined;
     const defaultBelop = tilsagn.length === 0 ? utbetaling.beregning.belop : 0;
     return navigate(
       `/gjennomforinger/${gjennomforingId}/tilsagn/opprett-tilsagn` +
-        `?type=${tilsagnType(utbetaling.tilskuddstype)}` +
-        `&prismodell=${Prismodell.FRI}` +
+        `?type=${tilsagnsTypeFraTilskudd}` +
         `&belop=${defaultBelop}` +
         `&periodeStart=${utbetaling.periode.start}` +
         `&periodeSlutt=${formaterDatoSomYYYYMMDD(subtractDays(utbetaling.periode.slutt, 1))}` +
@@ -123,7 +124,7 @@ export function RedigerUtbetalingLinjeView({ linjer, utbetaling, tilsagn }: Prop
             </ActionMenu.Trigger>
             <ActionMenu.Content>
               <ActionMenu.Item icon={<PiggybankIcon />} onSelect={opprettEkstraTilsagn}>
-                Opprett tilsagn
+                Opprett {avtaletekster.tilsagn.type(tilsagnsTypeFraTilskudd).toLowerCase()}
               </ActionMenu.Item>
               <ActionMenu.Item icon={<FileCheckmarkIcon />} onSelect={leggTilLinjer}>
                 Hent godkjente tilsagn

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnRoutes.kt
@@ -408,17 +408,7 @@ private fun resolveEkstraTilsagnDefaults(
             periodeStart = request.periodeStart,
             periodeSlutt = request.periodeSlutt,
             kostnadssted = request.kostnadssted,
-            beregning = TilsagnBeregningFri.Input(
-                prisbetingelser = prisbetingelser,
-                linjer = listOf(
-                    TilsagnBeregningFri.InputLinje(
-                        id = UUID.randomUUID(),
-                        beskrivelse = "",
-                        belop = 0,
-                        antall = 1,
-                    ),
-                ),
-            ),
+            beregning = null,
         )
     }
 }


### PR DESCRIPTION
Ved opprettelse av ekstratilsagn fra utbetalinger for AFT/VTA avtaler, dukket den nye frimodell skjemaet opp.
Fjerner hardkodet prismodell fra opprettelses linken, og hinter om hvilke type tilsagn som kan opprettes:
![image](https://github.com/user-attachments/assets/d47d8ca5-343b-4629-b239-bcb91047ea3e)
![image](https://github.com/user-attachments/assets/bd77cba5-a2be-44cb-87e2-7494ed9b4a9c)
