### PR TITLE
Refactor/kafka config

### DIFF
--- a/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerOrchestrator.kt
+++ b/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerOrchestrator.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import net.javacrumbs.shedlock.provider.jdbc.JdbcLockProvider
 import no.nav.common.kafka.consumer.KafkaConsumerClient
 import no.nav.common.kafka.consumer.feilhandtering.KafkaConsumerRecordProcessor
+import no.nav.common.kafka.consumer.feilhandtering.KafkaConsumerRepository
 import no.nav.common.kafka.consumer.feilhandtering.StoredConsumerRecord
 import no.nav.common.kafka.consumer.feilhandtering.util.KafkaConsumerRecordProcessorBuilder
 import no.nav.common.kafka.consumer.util.ConsumerUtils.findConsumerConfigsWithStoreOnFailure
@@ -12,15 +13,16 @@ import no.nav.common.kafka.consumer.util.KafkaConsumerClientBuilder.TopicConfig
 import no.nav.mulighetsrommet.database.Database
 import no.nav.mulighetsrommet.metrics.Metrikker
 import org.slf4j.LoggerFactory
+import java.util.*
 import java.util.function.Consumer
 
 class KafkaConsumerOrchestrator(
     config: Config = Config(),
     db: Database,
-    consumers: List<KafkaTopicConsumer<*, *>>,
+    consumers: Map<KafkaTopicConsumer.Config, KafkaTopicConsumer<*, *>>,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val consumerClients: Map<String, Consumer>
+    private val consumersById: Map<String, Consumer>
     private val consumerRecordProcessor: KafkaConsumerRecordProcessor
     private val topicPoller: Poller
     private val topicRepository = TopicRepository(db)
@@ -48,15 +50,13 @@ class KafkaConsumerOrchestrator(
 
         validateConsumers(consumers)
 
-        resetTopics(config, consumers)
+        resetTopics(config, consumers.keys)
 
-        consumerClients = consumers.associate { consumer ->
-            val topicConfig = toTopicConfig(consumer)
-            val client = toKafkaConsumerClient(consumer, topicConfig)
-            consumer.getConsumerId() to Consumer(topicConfig, client)
+        consumersById = consumers.entries.associate { (config, consumer) ->
+            config.id to createConsumer(config, consumer)
         }
 
-        val topicConfigs = consumerClients.map { it.value.topicConfig }
+        val topicConfigs = consumersById.values.map { it.topicConfig }
         consumerRecordProcessor = KafkaConsumerRecordProcessorBuilder
             .builder()
             .withLockProvider(JdbcLockProvider(db.getDatasource()))
@@ -86,7 +86,7 @@ class KafkaConsumerOrchestrator(
     }
 
     fun getConsumers(): List<KafkaConsumerClient> {
-        return consumerClients.map { it.value.client }
+        return consumersById.map { it.value.client }
     }
 
     fun updateRunningTopics(topics: List<Topic>): List<Topic> {
@@ -103,36 +103,18 @@ class KafkaConsumerOrchestrator(
         return kafkaConsumerRepository.getAll()
     }
 
-    private fun <K, V> toTopicConfig(consumer: KafkaTopicConsumer<K, V>): TopicConfig<K, V> {
-        return TopicConfig<K, V>()
-            .withMetrics(Metrikker.appMicrometerRegistry)
-            .withLogging()
-            .withStoreOnFailure(kafkaConsumerRepository)
-            .withConsumerConfig(
-                consumer.getConsumerTopic(),
-                consumer.keyDeserializer,
-                consumer.valueDeserializer,
-                Consumer { event ->
-                    runBlocking {
-                        consumer.consume(event.key(), event.value())
-                    }
-                },
-            )
-    }
-
-    private fun toKafkaConsumerClient(
+    private fun createConsumer(
+        config: KafkaTopicConsumer.Config,
         consumer: KafkaTopicConsumer<*, *>,
-        topicConfig: TopicConfig<out Any?, out Any?>,
-    ): KafkaConsumerClient {
-        return KafkaConsumerClientBuilder.builder()
-            .withProperties(consumer.getConsumerProperties())
-            .withTopicConfig(topicConfig)
-            .build()
+    ): KafkaConsumerOrchestrator.Consumer {
+        val topicConfig = toTopicConfig(config.topic, consumer, kafkaConsumerRepository)
+        val client = toKafkaConsumerClient(config.consumerProperties, topicConfig)
+        return Consumer(topicConfig, client)
     }
 
     private fun updateClientRunningState() {
         getTopics().forEach {
-            val client = consumerClients[it.id]?.client
+            val client = consumersById[it.id]?.client
             if (client != null) {
                 if (client.isRunning && !it.running) {
                     client.stop()
@@ -145,17 +127,18 @@ class KafkaConsumerOrchestrator(
         }
     }
 
-    private fun resetTopics(config: Config, consumers: List<KafkaTopicConsumer<*, *>>) {
+    private fun resetTopics(config: Config, consumerConfigs: Set<KafkaTopicConsumer.Config>) {
         val currentTopics = topicRepository.getAll()
 
-        val topics = consumers.map { consumer ->
-            val id = consumer.getConsumerId()
+        val topics = consumerConfigs.map { consumerConfig ->
+            val id = consumerConfig.id
+            val topic = consumerConfig.topic
 
             val running = currentTopics.firstOrNull { it.id == id }
                 ?.running
                 ?: config.consumerInitialRunningState
 
-            Topic(id = id, topic = consumer.getConsumerTopic(), type = TopicType.CONSUMER, running = running)
+            Topic(id = id, topic = topic, type = TopicType.CONSUMER, running = running)
         }
         topicRepository.setAll(topics)
     }
@@ -165,8 +148,39 @@ class KafkaConsumerOrchestrator(
     }
 }
 
-private fun validateConsumers(consumers: List<KafkaTopicConsumer<*, *>>) {
-    require(consumers.distinctBy { it.getConsumerId() }.size == consumers.size) {
+private fun validateConsumers(consumers: Map<KafkaTopicConsumer.Config, KafkaTopicConsumer<*, *>>) {
+    require(consumers.keys.distinctBy { it.id }.size == consumers.size) {
         "Each consumer must have a unique 'id'. At least two consumers share the same 'id'."
     }
+}
+
+private fun toKafkaConsumerClient(
+    consumerProperties: Properties,
+    topicConfig: TopicConfig<out Any?, out Any?>,
+): KafkaConsumerClient {
+    return KafkaConsumerClientBuilder.builder()
+        .withProperties(consumerProperties)
+        .withTopicConfig(topicConfig)
+        .build()
+}
+
+private fun <K, V> toTopicConfig(
+    topic: String,
+    consumer: KafkaTopicConsumer<K, V>,
+    consumerRecordRepository: KafkaConsumerRepository,
+): TopicConfig<K, V> {
+    return TopicConfig<K, V>()
+        .withMetrics(Metrikker.appMicrometerRegistry)
+        .withLogging()
+        .withStoreOnFailure(consumerRecordRepository)
+        .withConsumerConfig(
+            topic,
+            consumer.keyDeserializer,
+            consumer.valueDeserializer,
+            Consumer { event ->
+                runBlocking {
+                    consumer.consume(event.key(), event.value())
+                }
+            },
+        )
 }

--- a/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaTopicConsumer.kt
+++ b/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaTopicConsumer.kt
@@ -4,7 +4,6 @@ import org.apache.kafka.common.serialization.Deserializer
 import java.util.*
 
 abstract class KafkaTopicConsumer<K, V>(
-    private val config: Config,
     val keyDeserializer: Deserializer<K>,
     val valueDeserializer: Deserializer<V>,
 ) {
@@ -14,12 +13,6 @@ abstract class KafkaTopicConsumer<K, V>(
         val topic: String,
         val consumerProperties: Properties,
     )
-
-    fun getConsumerId(): String = config.id
-
-    fun getConsumerTopic(): String = config.topic
-
-    fun getConsumerProperties(): Properties = config.consumerProperties
 
     abstract suspend fun consume(key: K, message: V)
 }

--- a/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaTopicConsumer.kt
+++ b/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaTopicConsumer.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.kafka
 
 import org.apache.kafka.common.serialization.Deserializer
+import java.util.*
 
 abstract class KafkaTopicConsumer<K, V>(
     private val config: Config,
@@ -11,14 +12,14 @@ abstract class KafkaTopicConsumer<K, V>(
     data class Config(
         val id: String,
         val topic: String,
-        val consumerGroupId: String? = null,
+        val consumerProperties: Properties,
     )
 
     fun getConsumerId(): String = config.id
 
-    fun getConsumerGroupId(): String? = config.consumerGroupId
-
     fun getConsumerTopic(): String = config.topic
+
+    fun getConsumerProperties(): Properties = config.consumerProperties
 
     abstract suspend fun consume(key: K, message: V)
 }

--- a/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerOrchestratorTest.kt
+++ b/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerOrchestratorTest.kt
@@ -56,12 +56,15 @@ class KafkaConsumerOrchestratorTest : FunSpec({
     )
 
     test("should store topics based on provided consumers during setup") {
-        val consumer = TestConsumer(id = "1", topic = "foo", properties = kafka.getConsumerProperties())
+        val config = KafkaTopicConsumer.Config(id = "1", topic = "foo", kafka.getConsumerProperties())
+        val consumer = TestConsumer()
 
         val orchestrator = KafkaConsumerOrchestrator(
             defaultConfig,
             database.db,
-            listOf(consumer),
+            mapOf(
+                config to consumer,
+            ),
         )
 
         orchestrator.getTopics() shouldContainExactly listOf(
@@ -75,12 +78,15 @@ class KafkaConsumerOrchestratorTest : FunSpec({
     }
 
     test("should update the consumer running state based on the topic configuration") {
-        val consumer = TestConsumer(id = "1", topic = "foo", properties = kafka.getConsumerProperties())
+        val config = KafkaTopicConsumer.Config(id = "1", topic = "foo", kafka.getConsumerProperties())
+        val consumer = TestConsumer()
 
         val orchestrator = KafkaConsumerOrchestrator(
             KafkaConsumerOrchestrator.Config(consumerInitialRunningState = true, consumerRunningStatePollDelay = 10),
             database.db,
-            listOf(consumer),
+            mapOf(
+                config to consumer,
+            ),
         )
 
         orchestrator.getConsumers().first().isRunning shouldBe true
@@ -103,12 +109,15 @@ class KafkaConsumerOrchestratorTest : FunSpec({
         producer.send(ProducerRecord(topic, "key2", null))
         producer.close()
 
-        val consumer = spyk(TestConsumer(id = "1", topic, properties = kafka.getConsumerProperties()))
+        val config = KafkaTopicConsumer.Config(id = "1", topic = topic, kafka.getConsumerProperties())
+        val consumer = spyk(TestConsumer())
 
         KafkaConsumerOrchestrator(
             defaultConfig,
             database.db,
-            listOf(consumer),
+            mapOf(
+                config to consumer,
+            ),
         )
 
         eventually(5.seconds) {
@@ -127,13 +136,19 @@ class KafkaConsumerOrchestratorTest : FunSpec({
         producer.send(ProducerRecord(topic, "key1", "true"))
         producer.close()
 
-        val consumer1 = spyk(TestConsumer("1", topic, properties = kafka.getConsumerProperties("group-1")))
-        val consumer2 = spyk(TestConsumer("2", topic, properties = kafka.getConsumerProperties("group-2")))
+        val config1 = KafkaTopicConsumer.Config(id = "1", topic = topic, kafka.getConsumerProperties("group-1"))
+        val consumer1 = spyk(TestConsumer())
+
+        val config2 = KafkaTopicConsumer.Config(id = "2", topic = topic, kafka.getConsumerProperties("group-2"))
+        val consumer2 = spyk(TestConsumer())
 
         KafkaConsumerOrchestrator(
             defaultConfig,
             database.db,
-            listOf(consumer1, consumer2),
+            mapOf(
+                config1 to consumer1,
+                config2 to consumer2,
+            ),
         )
 
         eventually(5.seconds) {
@@ -152,12 +167,15 @@ class KafkaConsumerOrchestratorTest : FunSpec({
         producer.send(ProducerRecord(topic, "key2", null))
         producer.close()
 
-        val consumer = spyk(JsonTestConsumer(topic, properties = kafka.getConsumerProperties()))
+        val config = KafkaTopicConsumer.Config(id = "2", topic, kafka.getConsumerProperties())
+        val consumer = spyk(JsonTestConsumer())
 
         KafkaConsumerOrchestrator(
             defaultConfig,
             database.db,
-            listOf(consumer),
+            mapOf(
+                config to consumer,
+            ),
         )
         eventually(5.seconds) {
             coVerify(exactly = 1) {
@@ -174,12 +192,15 @@ class KafkaConsumerOrchestratorTest : FunSpec({
         producer.send(ProducerRecord(topic, "false"))
         producer.close()
 
-        val consumer = spyk(TestConsumer(id = "1", topic, properties = kafka.getConsumerProperties()))
+        val config = KafkaTopicConsumer.Config(id = "1", topic, kafka.getConsumerProperties())
+        val consumer = spyk(TestConsumer())
 
         val orchestrator = KafkaConsumerOrchestrator(
             defaultConfig,
             database.db,
-            listOf(consumer),
+            mapOf(
+                config to consumer,
+            ),
         )
 
         eventually(5.seconds) {

--- a/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/TestConsumer.kt
+++ b/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/TestConsumer.kt
@@ -6,10 +6,8 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.nav.common.kafka.consumer.util.deserializer.Deserializers.stringDeserializer
 import no.nav.mulighetsrommet.kafka.serialization.JsonElementDeserializer
-import java.util.Properties
 
-class TestConsumer(id: String, topic: String, properties: Properties) : KafkaTopicConsumer<String?, String?>(
-    Config(id, topic, properties),
+class TestConsumer : KafkaTopicConsumer<String?, String?>(
     stringDeserializer(),
     stringDeserializer(),
 ) {
@@ -20,8 +18,7 @@ class TestConsumer(id: String, topic: String, properties: Properties) : KafkaTop
     }
 }
 
-class JsonTestConsumer(name: String, properties: Properties) : KafkaTopicConsumer<String?, JsonElement>(
-    Config(name, name, properties),
+class JsonTestConsumer : KafkaTopicConsumer<String?, JsonElement>(
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/TestConsumer.kt
+++ b/common/kafka/src/test/kotlin/no/nav/mulighetsrommet/kafka/TestConsumer.kt
@@ -6,9 +6,10 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.nav.common.kafka.consumer.util.deserializer.Deserializers.stringDeserializer
 import no.nav.mulighetsrommet.kafka.serialization.JsonElementDeserializer
+import java.util.Properties
 
-class TestConsumer(id: String, topic: String, group: String? = null) : KafkaTopicConsumer<String?, String?>(
-    Config(id, topic, group),
+class TestConsumer(id: String, topic: String, properties: Properties) : KafkaTopicConsumer<String?, String?>(
+    Config(id, topic, properties),
     stringDeserializer(),
     stringDeserializer(),
 ) {
@@ -19,8 +20,8 @@ class TestConsumer(id: String, topic: String, group: String? = null) : KafkaTopi
     }
 }
 
-class JsonTestConsumer(name: String) : KafkaTopicConsumer<String?, JsonElement>(
-    Config(name, name),
+class JsonTestConsumer(name: String, properties: Properties) : KafkaTopicConsumer<String?, JsonElement>(
+    Config(name, name, properties),
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfig.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfig.kt
@@ -4,8 +4,6 @@ import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import no.nav.mulighetsrommet.api.avtale.task.NotifySluttdatoForAvtalerNarmerSeg
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
-import no.nav.mulighetsrommet.api.datavarehus.kafka.DatavarehusTiltakV1KafkaProducer
-import no.nav.mulighetsrommet.api.gjennomforing.kafka.ArenaMigreringGjennomforingKafkaProducer
 import no.nav.mulighetsrommet.api.gjennomforing.task.NotifySluttdatoForGjennomforingerNarmerSeg
 import no.nav.mulighetsrommet.api.gjennomforing.task.UpdateApentForPamelding
 import no.nav.mulighetsrommet.api.navansatt.model.Rolle
@@ -79,60 +77,72 @@ data class EntraGroupNavAnsattRolleMapping(
 
 data class KafkaConfig(
     val producerProperties: Properties,
-    val consumerPreset: Properties,
+    val topics: KafkaTopics = KafkaTopics(),
     val clients: KafkaClients,
 )
 
-data class KafkaClients(
+data class KafkaTopics(
     val okonomiBestillingTopic: String = "team-mulighetsrommet.tiltaksokonomi.bestillinger-v1",
     val sisteTiltaksgjennomforingerTopic: String = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
     val sisteTiltakstyperTopic: String = "team-mulighetsrommet.siste-tiltakstyper-v3",
+    val arenaMigreringGjennomforingTopic: String = "team-mulighetsrommet.arena-migrering-tiltaksgjennomforinger-v1",
+    val datavaehusTiltakTopic: String = "team-mulighetsrommet.datavarehus-tiltak-v1",
+)
 
-    val arenaMigreringProducer: ArenaMigreringGjennomforingKafkaProducer.Config = ArenaMigreringGjennomforingKafkaProducer.Config(
-        consumerId = "arena-migrering-gjennomforinger",
-        consumerGroupId = "mulighetsrommet-api-kafka-consumer.v1",
-        consumerTopic = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
-        producerTopic = "team-mulighetsrommet.arena-migrering-tiltaksgjennomforinger-v1",
-    ),
-    val dvhGjennomforing: DatavarehusTiltakV1KafkaProducer.Config = DatavarehusTiltakV1KafkaProducer.Config(
-        consumerId = "dvh-gjennomforing-consumer",
-        consumerGroupId = "mulighetsrommet-api.datavarehus-gjennomforing.v1",
-        consumerTopic = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
-        producerTopic = "team-mulighetsrommet.datavarehus-tiltak-v1",
-    ),
-    val oppdaterUtbetalingForGjennomforing: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+class KafkaClients(
+    getConsumerProperties: (consumerGroupId: String) -> Properties,
+    block: (KafkaClients.() -> Unit)? = null,
+) {
+    var arenaMigreringGjennomforingerConsumer: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        id = "arena-migrering-gjennomforinger",
+        topic = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.arena-migrering-gjennomforing.v1"),
+    )
+    var datavarehusGjennomforingerConsumer: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        id = "dvh-gjennomforing-consumer",
+        topic = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.datavarehus-gjennomforing.v1"),
+    )
+    var oppdaterUtbetalingForGjennomforing: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
         id = "oppdater-utbetaling-for-gjennomforing",
         topic = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
-        consumerGroupId = "mulighetsrommet-api.oppdater-utbetaling-for-gjennomforing.v1",
-    ),
-    val replicateBestillingStatus: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.oppdater-utbetaling-for-gjennomforing.v1"),
+    )
+    var replicateBestillingStatus: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
         id = "replicate-bestilling-status",
         topic = "team-mulighetsrommet.tiltaksokonomi.bestilling-status-v1",
-        consumerGroupId = "mulighetsrommet-api.bestilling-status.v1",
-    ),
-    val replicateFakturaStatus: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.bestilling-status.v1"),
+    )
+    var replicateFakturaStatus: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
         id = "replicate-faktura-status",
         topic = "team-mulighetsrommet.tiltaksokonomi.faktura-status-v1",
-        consumerGroupId = "mulighetsrommet-api.faktura-status.v1",
-    ),
-    val amtDeltakerV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.faktura-status.v1"),
+    )
+    var amtDeltakerV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
         id = "amt-deltaker",
         topic = "amt.deltaker-v1",
-        consumerGroupId = "mulighetsrommet-api.deltaker.v1",
-    ),
-    val amtVirksomheterV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.deltaker.v1"),
+    )
+    var amtVirksomheterV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
         id = "amt-virksomheter",
         topic = "amt.virksomheter-v1",
-    ),
-    val amtArrangorMeldingV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.amt-virksomheter.v1"),
+    )
+    var amtArrangorMeldingV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
         id = "amt-arrangor-melding",
         topic = "amt.arrangor-melding-v1",
-    ),
-    val amtKoordinatorMeldingV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.amt-arrangor-melding.v1"),
+    )
+    var amtKoordinatorMeldingV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
         id = "amt-tiltakskoordinators-deltakerliste",
         topic = "amt.tiltakskoordinators-deltakerliste-v1",
-    ),
-)
+        consumerProperties = getConsumerProperties("mulighetsrommet-api.tiltakskoordinators-deltakerliste.v1"),
+    )
+
+    init {
+        block?.invoke(this)
+    }
+}
 
 data class AuthProvider(
     val issuer: String,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigDev.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigDev.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api
 
 import no.nav.common.kafka.util.KafkaPropertiesPreset
+import no.nav.common.kafka.util.KafkaPropertiesPreset.aivenDefaultConsumerProperties
 import no.nav.mulighetsrommet.api.avtale.task.NotifySluttdatoForAvtalerNarmerSeg
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.gjennomforing.task.NotifySluttdatoForGjennomforingerNarmerSeg
@@ -35,14 +36,13 @@ val ApplicationConfigDev = AppConfig(
     ),
     kafka = KafkaConfig(
         producerProperties = KafkaPropertiesPreset.aivenByteProducerProperties("mulighetsrommet-api-kafka-producer.v1"),
-        consumerPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties("mulighetsrommet-api-kafka-consumer.v1"),
-        clients = KafkaClients(
+        clients = KafkaClients(::aivenDefaultConsumerProperties) {
             amtDeltakerV1 = KafkaTopicConsumer.Config(
                 id = "amt-deltaker",
                 topic = "amt.deltaker-v1",
-                consumerGroupId = "mulighetsrommet-api.deltaker.v2",
-            ),
-        ),
+                consumerProperties = aivenDefaultConsumerProperties("mulighetsrommet-api.deltaker.v2"),
+            )
+        },
     ),
     auth = AuthConfig(
         azure = AuthProvider(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigLocal.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigLocal.kt
@@ -7,6 +7,7 @@ import io.ktor.utils.io.*
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import no.nav.common.kafka.util.KafkaPropertiesBuilder
+import no.nav.common.kafka.util.KafkaPropertiesBuilder.consumerBuilder
 import no.nav.mulighetsrommet.api.avtale.task.NotifySluttdatoForAvtalerNarmerSeg
 import no.nav.mulighetsrommet.api.clients.pdl.GraphqlRequest
 import no.nav.mulighetsrommet.api.clients.pdl.GraphqlRequest.Identer
@@ -47,13 +48,16 @@ val ApplicationConfigLocal = AppConfig(
             .withBrokerUrl("localhost:29092")
             .withSerializers(ByteArraySerializer::class.java, ByteArraySerializer::class.java)
             .build(),
-        consumerPreset = KafkaPropertiesBuilder.consumerBuilder()
-            .withBaseProperties()
-            .withConsumerGroupId("mulighetsrommet-api-kafka-consumer.v1")
-            .withBrokerUrl("localhost:29092")
-            .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
-            .build(),
-        clients = KafkaClients(),
+        clients = KafkaClients(
+            { consumerGroupId ->
+                consumerBuilder()
+                    .withBaseProperties()
+                    .withConsumerGroupId(consumerGroupId)
+                    .withBrokerUrl("localhost:29092")
+                    .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
+                    .build()
+            },
+        ),
     ),
     auth = AuthConfig(
         azure = AuthProvider(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigProd.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/ApplicationConfigProd.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api
 
 import no.nav.common.kafka.util.KafkaPropertiesPreset
+import no.nav.common.kafka.util.KafkaPropertiesPreset.aivenDefaultConsumerProperties
 import no.nav.mulighetsrommet.api.avtale.task.NotifySluttdatoForAvtalerNarmerSeg
 import no.nav.mulighetsrommet.api.clients.sanity.SanityClient
 import no.nav.mulighetsrommet.api.gjennomforing.task.NotifySluttdatoForGjennomforingerNarmerSeg
@@ -34,8 +35,7 @@ val ApplicationConfigProd = AppConfig(
     ),
     kafka = KafkaConfig(
         producerProperties = KafkaPropertiesPreset.aivenByteProducerProperties("mulighetsrommet-api-kafka-producer.v1"),
-        consumerPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties("mulighetsrommet-api-kafka-consumer.v1"),
-        clients = KafkaClients(),
+        clients = KafkaClients(::aivenDefaultConsumerProperties),
     ),
     auth = AuthConfig(
         azure = AuthProvider(

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/kafka/AmtVirksomheterV1KafkaConsumer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/kafka/AmtVirksomheterV1KafkaConsumer.kt
@@ -12,10 +12,8 @@ import no.nav.mulighetsrommet.serialization.json.JsonIgnoreUnknownKeys
 import org.slf4j.LoggerFactory
 
 class AmtVirksomheterV1KafkaConsumer(
-    config: Config,
     private val arrangorService: ArrangorService,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    config,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/datavarehus/kafka/DatavarehusTiltakV1KafkaProducer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/datavarehus/kafka/DatavarehusTiltakV1KafkaProducer.kt
@@ -19,13 +19,11 @@ class DatavarehusTiltakV1KafkaProducer(
     private val kafkaProducerClient: KafkaProducerClient<ByteArray, ByteArray?>,
     private val db: ApiDatabase,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    config.consumer,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {
 
     data class Config(
-        val consumer: KafkaTopicConsumer.Config,
         val producerTopic: String,
     )
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/datavarehus/kafka/DatavarehusTiltakV1KafkaProducer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/datavarehus/kafka/DatavarehusTiltakV1KafkaProducer.kt
@@ -19,15 +19,13 @@ class DatavarehusTiltakV1KafkaProducer(
     private val kafkaProducerClient: KafkaProducerClient<ByteArray, ByteArray?>,
     private val db: ApiDatabase,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    Config(config.consumerId, config.consumerTopic, config.consumerGroupId),
+    config.consumer,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {
 
     data class Config(
-        val consumerId: String,
-        val consumerGroupId: String,
-        val consumerTopic: String,
+        val consumer: KafkaTopicConsumer.Config,
         val producerTopic: String,
     )
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/AmtKoordinatorGjennomforingV1KafkaConsumer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/AmtKoordinatorGjennomforingV1KafkaConsumer.kt
@@ -14,10 +14,8 @@ import org.slf4j.LoggerFactory
 import java.util.*
 
 class AmtKoordinatorGjennomforingV1KafkaConsumer(
-    config: Config,
     private val db: ApiDatabase,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    config,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/ArenaMigreringGjennomforingKafkaProducer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/ArenaMigreringGjennomforingKafkaProducer.kt
@@ -10,7 +10,6 @@ import no.nav.mulighetsrommet.api.arenaadapter.ArenaAdapterClient
 import no.nav.mulighetsrommet.api.gjennomforing.model.ArenaMigreringTiltaksgjennomforingDto
 import no.nav.mulighetsrommet.api.tiltakstype.TiltakstypeService
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer.Config
 import no.nav.mulighetsrommet.kafka.serialization.JsonElementDeserializer
 import no.nav.mulighetsrommet.model.TiltaksgjennomforingEksternV1Dto
 import no.nav.mulighetsrommet.serialization.json.JsonIgnoreUnknownKeys
@@ -24,15 +23,13 @@ class ArenaMigreringGjennomforingKafkaProducer(
     private val arenaAdapterClient: ArenaAdapterClient,
     private val kafkaProducerClient: KafkaProducerClient<ByteArray, ByteArray?>,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    Config(config.consumerId, config.consumerTopic, config.consumerGroupId),
+    config.consumer,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {
 
     data class Config(
-        val consumerId: String,
-        val consumerGroupId: String,
-        val consumerTopic: String,
+        val consumer: KafkaTopicConsumer.Config,
         val producerTopic: String,
     )
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/ArenaMigreringGjennomforingKafkaProducer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/ArenaMigreringGjennomforingKafkaProducer.kt
@@ -23,13 +23,11 @@ class ArenaMigreringGjennomforingKafkaProducer(
     private val arenaAdapterClient: ArenaAdapterClient,
     private val kafkaProducerClient: KafkaProducerClient<ByteArray, ByteArray?>,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    config.consumer,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {
 
     data class Config(
-        val consumer: KafkaTopicConsumer.Config,
         val producerTopic: String,
     )
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -149,12 +149,18 @@ private fun kafka(appConfig: AppConfig) = module {
     single {
         val consumers = listOf(
             DatavarehusTiltakV1KafkaProducer(
-                config = config.clients.dvhGjennomforing,
-                kafkaProducerClient = get(),
-                db = get(),
+                DatavarehusTiltakV1KafkaProducer.Config(
+                    config.clients.datavarehusGjennomforingerConsumer,
+                    config.topics.datavaehusTiltakTopic,
+                ),
+                get(),
+                get(),
             ),
             ArenaMigreringGjennomforingKafkaProducer(
-                config.clients.arenaMigreringProducer,
+                ArenaMigreringGjennomforingKafkaProducer.Config(
+                    config.clients.arenaMigreringGjennomforingerConsumer,
+                    config.topics.arenaMigreringGjennomforingTopic,
+                ),
                 get(),
                 get(),
                 get(),
@@ -177,7 +183,6 @@ private fun kafka(appConfig: AppConfig) = module {
             ),
         )
         KafkaConsumerOrchestrator(
-            consumerPreset = config.consumerPreset,
             db = get(),
             consumers = consumers,
         )
@@ -356,7 +361,7 @@ private fun services(appConfig: AppConfig) = module {
     }
     single {
         ArenaAdapterService(
-            ArenaAdapterService.Config(appConfig.kafka.clients.sisteTiltaksgjennomforingerTopic),
+            ArenaAdapterService.Config(appConfig.kafka.topics.sisteTiltaksgjennomforingerTopic),
             get(),
             get(),
             get(),
@@ -380,7 +385,7 @@ private fun services(appConfig: AppConfig) = module {
     single { DelMedBrukerService(get(), get(), get()) }
     single {
         GjennomforingService(
-            GjennomforingService.Config(appConfig.kafka.clients.sisteTiltaksgjennomforingerTopic),
+            GjennomforingService.Config(appConfig.kafka.topics.sisteTiltaksgjennomforingerTopic),
             get(),
             get(),
             get(),
@@ -393,7 +398,7 @@ private fun services(appConfig: AppConfig) = module {
     single {
         UtbetalingService(
             UtbetalingService.Config(
-                bestillingTopic = appConfig.kafka.clients.okonomiBestillingTopic,
+                bestillingTopic = appConfig.kafka.topics.okonomiBestillingTopic,
             ),
             get(),
             get(),
@@ -417,7 +422,7 @@ private fun services(appConfig: AppConfig) = module {
         TilsagnService(
             config = TilsagnService.Config(
                 okonomiConfig = appConfig.okonomi,
-                bestillingTopic = appConfig.kafka.clients.okonomiBestillingTopic,
+                bestillingTopic = appConfig.kafka.topics.okonomiBestillingTopic,
             ),
             db = get(),
             navAnsattService = get(),
@@ -440,14 +445,14 @@ private fun tasks(config: AppConfig) = module {
     single { GenerateValidationReport(tasks.generateValidationReport, get(), get(), get()) }
     single {
         InitialLoadGjennomforinger(
-            InitialLoadGjennomforinger.Config(config.kafka.clients.sisteTiltaksgjennomforingerTopic),
+            InitialLoadGjennomforinger.Config(config.kafka.topics.sisteTiltaksgjennomforingerTopic),
             get(),
             get(),
         )
     }
     single {
         InitialLoadTiltakstyper(
-            InitialLoadTiltakstyper.Config(config.kafka.clients.sisteTiltakstyperTopic),
+            InitialLoadTiltakstyper.Config(config.kafka.topics.sisteTiltakstyperTopic),
             get(),
             get(),
             get(),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -147,37 +147,29 @@ private fun kafka(appConfig: AppConfig) = module {
     }
 
     single {
-        val consumers = listOf(
-            DatavarehusTiltakV1KafkaProducer(
-                DatavarehusTiltakV1KafkaProducer.Config(
-                    config.clients.datavarehusGjennomforingerConsumer,
-                    config.topics.datavaehusTiltakTopic,
-                ),
+        val consumers = mapOf(
+            config.clients.datavarehusGjennomforingerConsumer to DatavarehusTiltakV1KafkaProducer(
+                DatavarehusTiltakV1KafkaProducer.Config(config.topics.datavaehusTiltakTopic),
                 get(),
                 get(),
             ),
-            ArenaMigreringGjennomforingKafkaProducer(
-                ArenaMigreringGjennomforingKafkaProducer.Config(
-                    config.clients.arenaMigreringGjennomforingerConsumer,
-                    config.topics.arenaMigreringGjennomforingTopic,
-                ),
+            config.clients.arenaMigreringGjennomforingerConsumer to ArenaMigreringGjennomforingKafkaProducer(
+                ArenaMigreringGjennomforingKafkaProducer.Config(config.topics.arenaMigreringGjennomforingTopic),
                 get(),
                 get(),
                 get(),
                 get(),
             ),
-            AmtDeltakerV1KafkaConsumer(
-                config = config.clients.amtDeltakerV1,
+            config.clients.amtDeltakerV1 to AmtDeltakerV1KafkaConsumer(
                 db = get(),
                 oppdaterUtbetaling = get(),
             ),
-            AmtVirksomheterV1KafkaConsumer(config.clients.amtVirksomheterV1, get()),
-            AmtArrangorMeldingV1KafkaConsumer(config.clients.amtArrangorMeldingV1, get()),
-            AmtKoordinatorGjennomforingV1KafkaConsumer(config.clients.amtKoordinatorMeldingV1, get()),
-            ReplicateOkonomiBestillingStatus(config.clients.replicateBestillingStatus, get()),
-            ReplicateOkonomiFakturaStatus(config.clients.replicateFakturaStatus, get()),
-            OppdaterUtbetalingBeregningForGjennomforingConsumer(
-                config.clients.oppdaterUtbetalingForGjennomforing,
+            config.clients.amtVirksomheterV1 to AmtVirksomheterV1KafkaConsumer(get()),
+            config.clients.amtArrangorMeldingV1 to AmtArrangorMeldingV1KafkaConsumer(get()),
+            config.clients.amtKoordinatorMeldingV1 to AmtKoordinatorGjennomforingV1KafkaConsumer(get()),
+            config.clients.replicateBestillingStatus to ReplicateOkonomiBestillingStatus(get()),
+            config.clients.replicateFakturaStatus to ReplicateOkonomiFakturaStatus(get()),
+            config.clients.oppdaterUtbetalingForGjennomforing to OppdaterUtbetalingBeregningForGjennomforingConsumer(
                 get(),
                 get(),
             ),

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/kafka/ReplicateOkonomiBestillingStatus.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/kafka/ReplicateOkonomiBestillingStatus.kt
@@ -11,10 +11,8 @@ import no.nav.tiltak.okonomi.BestillingStatus
 import org.slf4j.LoggerFactory
 
 class ReplicateOkonomiBestillingStatus(
-    config: Config,
     private val db: ApiDatabase,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    config,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtArrangorMeldingV1KafkaConsumer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtArrangorMeldingV1KafkaConsumer.kt
@@ -13,10 +13,8 @@ import org.slf4j.LoggerFactory
 import java.util.*
 
 class AmtArrangorMeldingV1KafkaConsumer(
-    config: Config,
     private val db: ApiDatabase,
 ) : KafkaTopicConsumer<UUID, JsonElement>(
-    config,
     uuidDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumer.kt
@@ -22,12 +22,10 @@ import java.time.Period
 import java.util.*
 
 class AmtDeltakerV1KafkaConsumer(
-    config: Config,
     private val relevantDeltakerSluttDatoPeriod: Period = Period.ofMonths(3),
     private val db: ApiDatabase,
     private val oppdaterUtbetaling: OppdaterUtbetalingBeregning,
 ) : KafkaTopicConsumer<UUID, JsonElement>(
-    config,
     uuidDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/OppdaterUtbetalingBeregningForGjennomforingConsumer.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/OppdaterUtbetalingBeregningForGjennomforingConsumer.kt
@@ -13,11 +13,9 @@ import java.time.Instant
 import java.util.*
 
 class OppdaterUtbetalingBeregningForGjennomforingConsumer(
-    config: Config,
     private val db: ApiDatabase,
     private val oppdaterUtbetaling: OppdaterUtbetalingBeregning,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    config,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/ReplicateOkonomiFakturaStatus.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/ReplicateOkonomiFakturaStatus.kt
@@ -11,10 +11,8 @@ import no.nav.tiltak.okonomi.FakturaStatus
 import org.slf4j.LoggerFactory
 
 class ReplicateOkonomiFakturaStatus(
-    config: Config,
     private val db: ApiDatabase,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    config,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {
@@ -23,7 +21,8 @@ class ReplicateOkonomiFakturaStatus(
     override suspend fun consume(key: String, message: JsonElement): Unit = db.session {
         logger.info("Konsumerer statusmelding fakturanummer=$key")
 
-        val (fakturanummer, status, fakturaStatusSistOppdatert) = JsonIgnoreUnknownKeys.decodeFromJsonElement<FakturaStatus>(message)
+        val (fakturanummer, status, fakturaStatusSistOppdatert) =
+            JsonIgnoreUnknownKeys.decodeFromJsonElement<FakturaStatus>(message)
 
         queries.delutbetaling.setFakturaStatus(fakturanummer, status, fakturaStatusSistOppdatert)
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/arrangor/kafka/AmtVirksomheterV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/arrangor/kafka/AmtVirksomheterV1KafkaConsumerTest.kt
@@ -16,11 +16,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import no.nav.mulighetsrommet.api.arrangor.ArrangorService
 import no.nav.mulighetsrommet.api.arrangor.model.ArrangorDto
 import no.nav.mulighetsrommet.api.databaseConfig
-import no.nav.mulighetsrommet.brreg.BrregClient
-import no.nav.mulighetsrommet.brreg.BrregError
-import no.nav.mulighetsrommet.brreg.BrregHovedenhetDto
-import no.nav.mulighetsrommet.brreg.BrregUnderenhetDto
-import no.nav.mulighetsrommet.brreg.FjernetBrregEnhetDto
+import no.nav.mulighetsrommet.brreg.*
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.Organisasjonsnummer
@@ -67,7 +63,7 @@ class AmtVirksomheterV1KafkaConsumerTest : FunSpec({
             brregClient = brregClient,
         )
         val virksomhetConsumer = AmtVirksomheterV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(id = "virksomheter", topic = "virksomheter"),
+            config = KafkaTopicConsumer.Config(id = "virksomheter", topic = "virksomheter", Properties()),
             arrangorService = arrangorService,
         )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/arrangor/kafka/AmtVirksomheterV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/arrangor/kafka/AmtVirksomheterV1KafkaConsumerTest.kt
@@ -18,7 +18,6 @@ import no.nav.mulighetsrommet.api.arrangor.model.ArrangorDto
 import no.nav.mulighetsrommet.api.databaseConfig
 import no.nav.mulighetsrommet.brreg.*
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.Organisasjonsnummer
 import java.time.LocalDate
 import java.util.*
@@ -63,7 +62,6 @@ class AmtVirksomheterV1KafkaConsumerTest : FunSpec({
             brregClient = brregClient,
         )
         val virksomhetConsumer = AmtVirksomheterV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(id = "virksomheter", topic = "virksomheter", Properties()),
             arrangorService = arrangorService,
         )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/datavarehus/kafka/DatavarehusTiltakV1KafkaProducerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/datavarehus/kafka/DatavarehusTiltakV1KafkaProducerTest.kt
@@ -14,6 +14,7 @@ import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures.AFT1
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.fixtures.TiltakstypeFixtures
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
+import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.GjennomforingOppstartstype
 import no.nav.mulighetsrommet.model.GjennomforingStatus
 import no.nav.mulighetsrommet.model.TiltaksgjennomforingEksternV1Dto
@@ -25,9 +26,7 @@ class DatavarehusTiltakV1KafkaProducerTest : FunSpec({
     val database = extension(ApiDatabaseTestListener(databaseConfig))
 
     val config = DatavarehusTiltakV1KafkaProducer.Config(
-        consumerId = "id",
-        consumerGroupId = "group-id",
-        consumerTopic = "consumer-topic",
+        consumer = KafkaTopicConsumer.Config("id", "consumer-topic", Properties()),
         producerTopic = "producer-topic",
     )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/datavarehus/kafka/DatavarehusTiltakV1KafkaProducerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/datavarehus/kafka/DatavarehusTiltakV1KafkaProducerTest.kt
@@ -14,7 +14,6 @@ import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures.AFT1
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.fixtures.TiltakstypeFixtures
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.GjennomforingOppstartstype
 import no.nav.mulighetsrommet.model.GjennomforingStatus
 import no.nav.mulighetsrommet.model.TiltaksgjennomforingEksternV1Dto
@@ -26,7 +25,6 @@ class DatavarehusTiltakV1KafkaProducerTest : FunSpec({
     val database = extension(ApiDatabaseTestListener(databaseConfig))
 
     val config = DatavarehusTiltakV1KafkaProducer.Config(
-        consumer = KafkaTopicConsumer.Config("id", "consumer-topic", Properties()),
         producerTopic = "producer-topic",
     )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/ArenaMigreringGjennomforingKafkaProducerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/ArenaMigreringGjennomforingKafkaProducerTest.kt
@@ -20,10 +20,11 @@ import no.nav.mulighetsrommet.api.gjennomforing.model.ArenaMigreringTiltaksgjenn
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingDto
 import no.nav.mulighetsrommet.api.tiltakstype.TiltakstypeService
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
+import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.ArenaTiltaksgjennomforingDto
 import no.nav.mulighetsrommet.model.Tiltakskode
 import org.apache.kafka.clients.producer.ProducerRecord
-import java.util.UUID
+import java.util.*
 
 class ArenaMigreringGjennomforingKafkaProducerTest : FunSpec({
     val database = extension(ApiDatabaseTestListener(databaseConfig))
@@ -46,9 +47,7 @@ class ArenaMigreringGjennomforingKafkaProducerTest : FunSpec({
             arenaAdapterClient: ArenaAdapterClient,
         ) = ArenaMigreringGjennomforingKafkaProducer(
             ArenaMigreringGjennomforingKafkaProducer.Config(
-                consumerId = "id",
-                consumerGroupId = "id",
-                consumerTopic = "consumer-topic",
+                consumer = KafkaTopicConsumer.Config("id", "consumer-topic", Properties()),
                 producerTopic = "producer-topic",
             ),
             database.db,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/ArenaMigreringGjennomforingKafkaProducerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/ArenaMigreringGjennomforingKafkaProducerTest.kt
@@ -20,7 +20,6 @@ import no.nav.mulighetsrommet.api.gjennomforing.model.ArenaMigreringTiltaksgjenn
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingDto
 import no.nav.mulighetsrommet.api.tiltakstype.TiltakstypeService
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.ArenaTiltaksgjennomforingDto
 import no.nav.mulighetsrommet.model.Tiltakskode
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -47,7 +46,6 @@ class ArenaMigreringGjennomforingKafkaProducerTest : FunSpec({
             arenaAdapterClient: ArenaAdapterClient,
         ) = ArenaMigreringGjennomforingKafkaProducer(
             ArenaMigreringGjennomforingKafkaProducer.Config(
-                consumer = KafkaTopicConsumer.Config("id", "consumer-topic", Properties()),
                 producerTopic = "producer-topic",
             ),
             database.db,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/KoordinatorGjennomforingV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/KoordinatorGjennomforingV1KafkaConsumerTest.kt
@@ -11,7 +11,6 @@ import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.fixtures.TiltakstypeFixtures
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.NavIdent
 import org.intellij.lang.annotations.Language
 import java.util.*
@@ -33,7 +32,6 @@ class KoordinatorGjennomforingV1KafkaConsumerTest : FunSpec({
 
     fun createConsumer(): AmtKoordinatorGjennomforingV1KafkaConsumer {
         return AmtKoordinatorGjennomforingV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config("id", "tiltakskoordinators-deltakerliste-v1", Properties()),
             db = database.db,
         )
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/KoordinatorGjennomforingV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/KoordinatorGjennomforingV1KafkaConsumerTest.kt
@@ -33,10 +33,7 @@ class KoordinatorGjennomforingV1KafkaConsumerTest : FunSpec({
 
     fun createConsumer(): AmtKoordinatorGjennomforingV1KafkaConsumer {
         return AmtKoordinatorGjennomforingV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(
-                id = "amt-tiltakskoordinators-deltakerliste",
-                topic = "tiltakskoordinators-deltakerliste-v1",
-            ),
+            config = KafkaTopicConsumer.Config("id", "tiltakskoordinators-deltakerliste-v1", Properties()),
             db = database.db,
         )
     }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtArrangorMeldingV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtArrangorMeldingV1KafkaConsumerTest.kt
@@ -12,7 +12,6 @@ import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.utbetaling.db.DeltakerForslag
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.utils.toUUID
 import java.util.*
 
@@ -20,7 +19,6 @@ class AmtArrangorMeldingV1KafkaConsumerTest : FunSpec({
     val database = extension(ApiDatabaseTestListener(databaseConfig))
 
     fun createArrangorMeldingConsumer() = AmtArrangorMeldingV1KafkaConsumer(
-        config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker", Properties()),
         db = database.db,
     )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtArrangorMeldingV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtArrangorMeldingV1KafkaConsumerTest.kt
@@ -20,7 +20,7 @@ class AmtArrangorMeldingV1KafkaConsumerTest : FunSpec({
     val database = extension(ApiDatabaseTestListener(databaseConfig))
 
     fun createArrangorMeldingConsumer() = AmtArrangorMeldingV1KafkaConsumer(
-        config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker"),
+        config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker", Properties()),
         db = database.db,
     )
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumerTest.kt
@@ -25,7 +25,6 @@ import no.nav.mulighetsrommet.api.utbetaling.db.DeltakerDbo
 import no.nav.mulighetsrommet.api.utbetaling.model.Deltaker
 import no.nav.mulighetsrommet.api.utbetaling.task.OppdaterUtbetalingBeregning
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.DeltakerStatus
 import no.nav.mulighetsrommet.model.NorskIdent
 import no.nav.mulighetsrommet.model.Prismodell
@@ -42,7 +41,6 @@ class AmtDeltakerV1KafkaConsumerTest : FunSpec({
         oppdaterUtbetaling: OppdaterUtbetalingBeregning = mockk(),
     ): AmtDeltakerV1KafkaConsumer {
         return AmtDeltakerV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker", Properties()),
             db = database.db,
             relevantDeltakerSluttDatoPeriod = period,
             oppdaterUtbetaling = oppdaterUtbetaling,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumerTest.kt
@@ -42,7 +42,7 @@ class AmtDeltakerV1KafkaConsumerTest : FunSpec({
         oppdaterUtbetaling: OppdaterUtbetalingBeregning = mockk(),
     ): AmtDeltakerV1KafkaConsumer {
         return AmtDeltakerV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker"),
+            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker", Properties()),
             db = database.db,
             relevantDeltakerSluttDatoPeriod = period,
             oppdaterUtbetaling = oppdaterUtbetaling,
@@ -97,7 +97,8 @@ class AmtDeltakerV1KafkaConsumerTest : FunSpec({
             deltakerConsumer.consume(amtDeltaker2.id, Json.encodeToJsonElement(amtDeltaker2))
 
             database.run {
-                queries.deltaker.getAll().shouldContainExactlyInAnyOrder(deltaker1Dbo.toDeltaker(), deltaker2Dbo.toDeltaker())
+                queries.deltaker.getAll()
+                    .shouldContainExactlyInAnyOrder(deltaker1Dbo.toDeltaker(), deltaker2Dbo.toDeltaker())
             }
         }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Application.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/Application.kt
@@ -34,7 +34,7 @@ fun main() {
         Netty,
         port = config.server.port,
         host = config.server.host,
-        module = { configure(config.app) },
+        module = { configure(config) },
     ).start(wait = true)
 }
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationConfig.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationConfig.kt
@@ -7,14 +7,9 @@ import no.nav.mulighetsrommet.database.DatabaseConfig
 import no.nav.mulighetsrommet.database.FlywayMigrationManager
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.ktor.ServerConfig
-import java.util.Properties
-
-data class Config(
-    val server: ServerConfig,
-    val app: AppConfig,
-)
 
 data class AppConfig(
+    val server: ServerConfig,
     val enableFailedRecordProcessor: Boolean,
     val tasks: TaskConfig,
     val services: ServiceConfig,
@@ -55,7 +50,6 @@ data class ServiceClientConfig(
 )
 
 data class KafkaConfig(
-    val consumerPreset: Properties,
     val consumers: KafkaConsumers,
 )
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationConfigDev.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationConfigDev.kt
@@ -9,88 +9,94 @@ import no.nav.mulighetsrommet.database.FlywayMigrationManager
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.ktor.ServerConfig
 
-val ApplicationConfigDev = Config(
+private val arenaAdapterConsumerProperties =
+    KafkaPropertiesPreset.aivenDefaultConsumerProperties("mulighetsrommet-kafka-consumer.v1")
+
+val ApplicationConfigDev = AppConfig(
     server = ServerConfig(
         port = 8084,
         host = "0.0.0.0",
     ),
-    app = AppConfig(
-        enableFailedRecordProcessor = true,
-        tasks = TaskConfig(
-            retryFailedEvents = RetryFailedEvents.Config(
-                delayOfMinutes = 15,
+    enableFailedRecordProcessor = true,
+    tasks = TaskConfig(
+        retryFailedEvents = RetryFailedEvents.Config(
+            delayOfMinutes = 15,
+        ),
+        notifyFailedEvents = NotifyFailedEvents.Config(
+            maxRetries = 5,
+            cron = "0 0 7 * * MON-FRI",
+        ),
+    ),
+    services = ServiceConfig(
+        mulighetsrommetApi = ServiceClientConfig(
+            url = "http://mulighetsrommet-api",
+            scope = "api://dev-gcp.team-mulighetsrommet.mulighetsrommet-api/.default",
+        ),
+        tiltakshistorikk = ServiceClientConfig(
+            url = "http://tiltakshistorikk",
+            scope = "api://dev-gcp.team-mulighetsrommet.tiltakshistorikk/.default",
+        ),
+        arenaEventService = ArenaEventService.Config(
+            channelCapacity = 10000,
+            numChannelConsumers = 100,
+            maxRetries = 5,
+        ),
+        arenaOrdsProxy = ServiceClientConfig(
+            url = "https://amt-arena-ords-proxy.dev-fss-pub.nais.io/api",
+            scope = "api://dev-fss.amt.amt-arena-ords-proxy/.default",
+        ),
+    ),
+    database = DatabaseConfig(
+        jdbcUrl = System.getenv("DB_JDBC_URL"),
+        maximumPoolSize = 10,
+    ),
+    flyway = FlywayMigrationManager.MigrationConfig(),
+    kafka = KafkaConfig(
+        consumers = KafkaConsumers(
+            arenaTiltakEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakstype-endret",
+                topic = "teamarenanais.aapen-arena-tiltakendret-v1-q2",
+                consumerProperties = arenaAdapterConsumerProperties,
             ),
-            notifyFailedEvents = NotifyFailedEvents.Config(
-                maxRetries = 5,
-                cron = "0 0 7 * * MON-FRI",
+            arenaTiltakgjennomforingEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakgjennomforing-endret",
+                topic = "teamarenanais.aapen-arena-tiltakgjennomforingendret-v1-q2",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaTiltakdeltakerEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakdeltaker-endret",
+                topic = "teamarenanais.aapen-arena-tiltakdeltakerendret-v1-q2",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaHistTiltakdeltakerEndret = KafkaTopicConsumer.Config(
+                id = "arena-hist-tiltakdeltaker-endret",
+                topic = "teamarenanais.aapen-arena-histtiltakdeltakerendret-v1-q2",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaSakEndret = KafkaTopicConsumer.Config(
+                id = "arena-sakendret-endret",
+                topic = "teamarenanais.aapen-arena-sakendret-v1-q2",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaAvtaleInfoEndret = KafkaTopicConsumer.Config(
+                id = "arena-avtaleinfo-endret",
+                topic = "teamarenanais.aapen-arena-avtaleinfoendret-v1-q2",
+                consumerProperties = arenaAdapterConsumerProperties,
             ),
         ),
-        services = ServiceConfig(
-            mulighetsrommetApi = ServiceClientConfig(
-                url = "http://mulighetsrommet-api",
-                scope = "api://dev-gcp.team-mulighetsrommet.mulighetsrommet-api/.default",
-            ),
-            tiltakshistorikk = ServiceClientConfig(
-                url = "http://tiltakshistorikk",
-                scope = "api://dev-gcp.team-mulighetsrommet.tiltakshistorikk/.default",
-            ),
-            arenaEventService = ArenaEventService.Config(
-                channelCapacity = 10000,
-                numChannelConsumers = 100,
-                maxRetries = 5,
-            ),
-            arenaOrdsProxy = ServiceClientConfig(
-                url = "https://amt-arena-ords-proxy.dev-fss-pub.nais.io/api",
-                scope = "api://dev-fss.amt.amt-arena-ords-proxy/.default",
-            ),
+    ),
+    auth = AuthConfig(
+        azure = AuthProvider(
+            issuer = System.getenv("AZURE_OPENID_CONFIG_ISSUER"),
+            jwksUri = System.getenv("AZURE_OPENID_CONFIG_JWKS_URI"),
+            audience = System.getenv("AZURE_APP_CLIENT_ID"),
+            tokenEndpointUrl = System.getenv("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
+            privateJwk = System.getenv("AZURE_APP_JWK"),
         ),
-        database = DatabaseConfig(
-            jdbcUrl = System.getenv("DB_JDBC_URL"),
-            maximumPoolSize = 10,
-        ),
-        flyway = FlywayMigrationManager.MigrationConfig(),
-        kafka = KafkaConfig(
-            consumerPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties("mulighetsrommet-kafka-consumer.v1"),
-            consumers = KafkaConsumers(
-                arenaTiltakEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakstype-endret",
-                    topic = "teamarenanais.aapen-arena-tiltakendret-v1-q2",
-                ),
-                arenaTiltakgjennomforingEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakgjennomforing-endret",
-                    topic = "teamarenanais.aapen-arena-tiltakgjennomforingendret-v1-q2",
-                ),
-                arenaTiltakdeltakerEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakdeltaker-endret",
-                    topic = "teamarenanais.aapen-arena-tiltakdeltakerendret-v1-q2",
-                ),
-                arenaHistTiltakdeltakerEndret = KafkaTopicConsumer.Config(
-                    id = "arena-hist-tiltakdeltaker-endret",
-                    topic = "teamarenanais.aapen-arena-histtiltakdeltakerendret-v1-q2",
-                ),
-                arenaSakEndret = KafkaTopicConsumer.Config(
-                    id = "arena-sakendret-endret",
-                    topic = "teamarenanais.aapen-arena-sakendret-v1-q2",
-                ),
-                arenaAvtaleInfoEndret = KafkaTopicConsumer.Config(
-                    id = "arena-avtaleinfo-endret",
-                    topic = "teamarenanais.aapen-arena-avtaleinfoendret-v1-q2",
-                ),
-            ),
-        ),
-        auth = AuthConfig(
-            azure = AuthProvider(
-                issuer = System.getenv("AZURE_OPENID_CONFIG_ISSUER"),
-                jwksUri = System.getenv("AZURE_OPENID_CONFIG_JWKS_URI"),
-                audience = System.getenv("AZURE_APP_CLIENT_ID"),
-                tokenEndpointUrl = System.getenv("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
-                privateJwk = System.getenv("AZURE_APP_JWK"),
-            ),
-        ),
-        slack = SlackConfig(
-            token = System.getenv("SLACK_TOKEN"),
-            channel = "#team-valp-monitorering-dev",
-            enable = true,
-        ),
+    ),
+    slack = SlackConfig(
+        token = System.getenv("SLACK_TOKEN"),
+        channel = "#team-valp-monitorering-dev",
+        enable = true,
     ),
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationConfigLocal.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationConfigLocal.kt
@@ -11,93 +11,98 @@ import no.nav.mulighetsrommet.ktor.ServerConfig
 import no.nav.mulighetsrommet.tokenprovider.createMockRSAKey
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
-val ApplicationConfigLocal = Config(
+private val arenaAdapterConsumerProperties = KafkaPropertiesBuilder.consumerBuilder()
+    .withBaseProperties()
+    .withConsumerGroupId("mulighetsrommet-kafka-consumer.v1")
+    .withBrokerUrl("localhost:29092")
+    .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
+    .build()
+
+val ApplicationConfigLocal = AppConfig(
     server = ServerConfig(
         port = 8084,
         host = "0.0.0.0",
     ),
-    app = AppConfig(
-        enableFailedRecordProcessor = true,
-        tasks = TaskConfig(
-            retryFailedEvents = RetryFailedEvents.Config(
-                delayOfMinutes = 1,
+    enableFailedRecordProcessor = true,
+    tasks = TaskConfig(
+        retryFailedEvents = RetryFailedEvents.Config(
+            delayOfMinutes = 1,
+        ),
+        notifyFailedEvents = NotifyFailedEvents.Config(
+            maxRetries = 5,
+            cron = "0 0 7 * * MON-FRI",
+        ),
+    ),
+    services = ServiceConfig(
+        mulighetsrommetApi = ServiceClientConfig(
+            url = "http://localhost:8080",
+            scope = "default",
+        ),
+        tiltakshistorikk = ServiceClientConfig(
+            url = "http://localhost:8080",
+            scope = "default",
+        ),
+        arenaEventService = ArenaEventService.Config(
+            channelCapacity = 100,
+            numChannelConsumers = 10,
+            maxRetries = 5,
+        ),
+        arenaOrdsProxy = ServiceClientConfig(
+            url = "http://localhost:8090/arena-ords-proxy",
+            scope = "default",
+        ),
+    ),
+    database = DatabaseConfig(
+        jdbcUrl = "jdbc:postgresql://localhost:5442/mr-arena-adapter?user=valp&password=valp",
+        maximumPoolSize = 10,
+    ),
+    flyway = FlywayMigrationManager.MigrationConfig(),
+    kafka = KafkaConfig(
+        consumers = KafkaConsumers(
+            arenaTiltakEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakstype-endret",
+                topic = "tiltak-endret",
+                consumerProperties = arenaAdapterConsumerProperties,
             ),
-            notifyFailedEvents = NotifyFailedEvents.Config(
-                maxRetries = 5,
-                cron = "0 0 7 * * MON-FRI",
+            arenaTiltakgjennomforingEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakgjennomforing-endret",
+                topic = "tiltakgjennomforingendret",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaTiltakdeltakerEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakdeltaker-endret",
+                topic = "tiltakdeltakerendret",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaHistTiltakdeltakerEndret = KafkaTopicConsumer.Config(
+                id = "arena-hist-tiltakdeltaker-endret",
+                topic = "histtiltakdeltakerendret",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaSakEndret = KafkaTopicConsumer.Config(
+                id = "arena-sakendret-endret",
+                topic = "sakendret",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaAvtaleInfoEndret = KafkaTopicConsumer.Config(
+                id = "arena-avtaleinfo-endret",
+                topic = "avtaleinfo-endret",
+                consumerProperties = arenaAdapterConsumerProperties,
             ),
         ),
-        services = ServiceConfig(
-            mulighetsrommetApi = ServiceClientConfig(
-                url = "http://localhost:8080",
-                scope = "default",
-            ),
-            tiltakshistorikk = ServiceClientConfig(
-                url = "http://localhost:8080",
-                scope = "default",
-            ),
-            arenaEventService = ArenaEventService.Config(
-                channelCapacity = 100,
-                numChannelConsumers = 10,
-                maxRetries = 5,
-            ),
-            arenaOrdsProxy = ServiceClientConfig(
-                url = "http://localhost:8090/arena-ords-proxy",
-                scope = "default",
-            ),
+    ),
+    auth = AuthConfig(
+        azure = AuthProvider(
+            issuer = "http://localhost:8081/azure",
+            jwksUri = "http://localhost:8081/azure/jwks",
+            audience = "mulighetsrommet-api",
+            tokenEndpointUrl = "http://localhost:8081/azure/token",
+            privateJwk = createMockRSAKey("azure"),
         ),
-        database = DatabaseConfig(
-            jdbcUrl = "jdbc:postgresql://localhost:5442/mr-arena-adapter?user=valp&password=valp",
-            maximumPoolSize = 10,
-        ),
-        flyway = FlywayMigrationManager.MigrationConfig(),
-        kafka = KafkaConfig(
-            consumerPreset = KafkaPropertiesBuilder.consumerBuilder()
-                .withBaseProperties()
-                .withConsumerGroupId("mulighetsrommet-kafka-consumer.v1")
-                .withBrokerUrl("localhost:29092")
-                .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
-                .build(),
-            consumers = KafkaConsumers(
-                arenaTiltakEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakstype-endret",
-                    topic = "tiltak-endret",
-                ),
-                arenaTiltakgjennomforingEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakgjennomforing-endret",
-                    topic = "tiltakgjennomforingendret",
-                ),
-                arenaTiltakdeltakerEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakdeltaker-endret",
-                    topic = "tiltakdeltakerendret",
-                ),
-                arenaHistTiltakdeltakerEndret = KafkaTopicConsumer.Config(
-                    id = "arena-hist-tiltakdeltaker-endret",
-                    topic = "histtiltakdeltakerendret",
-                ),
-                arenaSakEndret = KafkaTopicConsumer.Config(
-                    id = "arena-sakendret-endret",
-                    topic = "sakendret",
-                ),
-                arenaAvtaleInfoEndret = KafkaTopicConsumer.Config(
-                    id = "arena-avtaleinfo-endret",
-                    topic = "avtaleinfo-endret",
-                ),
-            ),
-        ),
-        auth = AuthConfig(
-            azure = AuthProvider(
-                issuer = "http://localhost:8081/azure",
-                jwksUri = "http://localhost:8081/azure/jwks",
-                audience = "mulighetsrommet-api",
-                tokenEndpointUrl = "http://localhost:8081/azure/token",
-                privateJwk = createMockRSAKey("azure"),
-            ),
-        ),
-        slack = SlackConfig(
-            token = "SLACK_TOKEN",
-            channel = "#team-valp-monitoring",
-            enable = false,
-        ),
+    ),
+    slack = SlackConfig(
+        token = "SLACK_TOKEN",
+        channel = "#team-valp-monitoring",
+        enable = false,
     ),
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationConfigProd.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationConfigProd.kt
@@ -9,88 +9,94 @@ import no.nav.mulighetsrommet.database.FlywayMigrationManager
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.ktor.ServerConfig
 
-val ApplicationConfigProd = Config(
+private val arenaAdapterConsumerProperties =
+    KafkaPropertiesPreset.aivenDefaultConsumerProperties("mulighetsrommet-kafka-consumer.v1")
+
+val ApplicationConfigProd = AppConfig(
     server = ServerConfig(
         port = 8084,
         host = "0.0.0.0",
     ),
-    app = AppConfig(
-        enableFailedRecordProcessor = true,
-        tasks = TaskConfig(
-            retryFailedEvents = RetryFailedEvents.Config(
-                delayOfMinutes = 15,
+    enableFailedRecordProcessor = true,
+    tasks = TaskConfig(
+        retryFailedEvents = RetryFailedEvents.Config(
+            delayOfMinutes = 15,
+        ),
+        notifyFailedEvents = NotifyFailedEvents.Config(
+            maxRetries = 5,
+            cron = "0 0 7 * * MON-FRI",
+        ),
+    ),
+    services = ServiceConfig(
+        mulighetsrommetApi = ServiceClientConfig(
+            url = "http://mulighetsrommet-api",
+            scope = "api://prod-gcp.team-mulighetsrommet.mulighetsrommet-api/.default",
+        ),
+        tiltakshistorikk = ServiceClientConfig(
+            url = "http://tiltakshistorikk",
+            scope = "api://prod-gcp.team-mulighetsrommet.tiltakshistorikk/.default",
+        ),
+        arenaEventService = ArenaEventService.Config(
+            channelCapacity = 10000,
+            numChannelConsumers = 100,
+            maxRetries = 10,
+        ),
+        arenaOrdsProxy = ServiceClientConfig(
+            url = "https://amt-arena-ords-proxy.prod-fss-pub.nais.io/api",
+            scope = "api://prod-fss.amt.amt-arena-ords-proxy/.default",
+        ),
+    ),
+    database = DatabaseConfig(
+        jdbcUrl = System.getenv("DB_JDBC_URL"),
+        maximumPoolSize = 20,
+    ),
+    flyway = FlywayMigrationManager.MigrationConfig(),
+    kafka = KafkaConfig(
+        consumers = KafkaConsumers(
+            arenaTiltakEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakstype-endret",
+                topic = "teamarenanais.aapen-arena-tiltakendret-v1-p",
+                consumerProperties = arenaAdapterConsumerProperties,
             ),
-            notifyFailedEvents = NotifyFailedEvents.Config(
-                maxRetries = 5,
-                cron = "0 0 7 * * MON-FRI",
+            arenaTiltakgjennomforingEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakgjennomforing-endret",
+                topic = "teamarenanais.aapen-arena-tiltakgjennomforingendret-v1-p",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaTiltakdeltakerEndret = KafkaTopicConsumer.Config(
+                id = "arena-tiltakdeltaker-endret",
+                topic = "teamarenanais.aapen-arena-tiltakdeltakerendret-v1-p",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaHistTiltakdeltakerEndret = KafkaTopicConsumer.Config(
+                id = "arena-hist-tiltakdeltaker-endret",
+                topic = "teamarenanais.aapen-arena-histtiltakdeltakerendret-v1-p",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaSakEndret = KafkaTopicConsumer.Config(
+                id = "arena-sakendret-endret",
+                topic = "teamarenanais.aapen-arena-tiltakssakendret-v1-p",
+                consumerProperties = arenaAdapterConsumerProperties,
+            ),
+            arenaAvtaleInfoEndret = KafkaTopicConsumer.Config(
+                id = "arena-avtaleinfo-endret",
+                topic = "teamarenanais.aapen-arena-avtaleinfoendret-v1-p",
+                consumerProperties = arenaAdapterConsumerProperties,
             ),
         ),
-        services = ServiceConfig(
-            mulighetsrommetApi = ServiceClientConfig(
-                url = "http://mulighetsrommet-api",
-                scope = "api://prod-gcp.team-mulighetsrommet.mulighetsrommet-api/.default",
-            ),
-            tiltakshistorikk = ServiceClientConfig(
-                url = "http://tiltakshistorikk",
-                scope = "api://prod-gcp.team-mulighetsrommet.tiltakshistorikk/.default",
-            ),
-            arenaEventService = ArenaEventService.Config(
-                channelCapacity = 10000,
-                numChannelConsumers = 100,
-                maxRetries = 10,
-            ),
-            arenaOrdsProxy = ServiceClientConfig(
-                url = "https://amt-arena-ords-proxy.prod-fss-pub.nais.io/api",
-                scope = "api://prod-fss.amt.amt-arena-ords-proxy/.default",
-            ),
+    ),
+    auth = AuthConfig(
+        azure = AuthProvider(
+            issuer = System.getenv("AZURE_OPENID_CONFIG_ISSUER"),
+            jwksUri = System.getenv("AZURE_OPENID_CONFIG_JWKS_URI"),
+            audience = System.getenv("AZURE_APP_CLIENT_ID"),
+            tokenEndpointUrl = System.getenv("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
+            privateJwk = System.getenv("AZURE_APP_JWK"),
         ),
-        database = DatabaseConfig(
-            jdbcUrl = System.getenv("DB_JDBC_URL"),
-            maximumPoolSize = 20,
-        ),
-        flyway = FlywayMigrationManager.MigrationConfig(),
-        kafka = KafkaConfig(
-            consumerPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties("mulighetsrommet-kafka-consumer.v1"),
-            consumers = KafkaConsumers(
-                arenaTiltakEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakstype-endret",
-                    topic = "teamarenanais.aapen-arena-tiltakendret-v1-p",
-                ),
-                arenaTiltakgjennomforingEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakgjennomforing-endret",
-                    topic = "teamarenanais.aapen-arena-tiltakgjennomforingendret-v1-p",
-                ),
-                arenaTiltakdeltakerEndret = KafkaTopicConsumer.Config(
-                    id = "arena-tiltakdeltaker-endret",
-                    topic = "teamarenanais.aapen-arena-tiltakdeltakerendret-v1-p",
-                ),
-                arenaHistTiltakdeltakerEndret = KafkaTopicConsumer.Config(
-                    id = "arena-hist-tiltakdeltaker-endret",
-                    topic = "teamarenanais.aapen-arena-histtiltakdeltakerendret-v1-p",
-                ),
-                arenaSakEndret = KafkaTopicConsumer.Config(
-                    id = "arena-sakendret-endret",
-                    topic = "teamarenanais.aapen-arena-tiltakssakendret-v1-p",
-                ),
-                arenaAvtaleInfoEndret = KafkaTopicConsumer.Config(
-                    id = "arena-avtaleinfo-endret",
-                    topic = "teamarenanais.aapen-arena-avtaleinfoendret-v1-p",
-                ),
-            ),
-        ),
-        auth = AuthConfig(
-            azure = AuthProvider(
-                issuer = System.getenv("AZURE_OPENID_CONFIG_ISSUER"),
-                jwksUri = System.getenv("AZURE_OPENID_CONFIG_JWKS_URI"),
-                audience = System.getenv("AZURE_APP_CLIENT_ID"),
-                tokenEndpointUrl = System.getenv("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
-                privateJwk = System.getenv("AZURE_APP_JWK"),
-            ),
-        ),
-        slack = SlackConfig(
-            token = System.getenv("SLACK_TOKEN"),
-            channel = "#team-valp-monitoring",
-            enable = true,
-        ),
+    ),
+    slack = SlackConfig(
+        token = System.getenv("SLACK_TOKEN"),
+        channel = "#team-valp-monitoring",
+        enable = true,
     ),
 )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/ArenaEventConsumer.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/events/ArenaEventConsumer.kt
@@ -12,9 +12,8 @@ import org.slf4j.MDC
 import java.util.*
 
 class ArenaEventConsumer(
-    config: Config,
     private val arenaEventService: ArenaEventService,
-) : KafkaTopicConsumer<String, JsonElement>(config, stringDeserializer(), ArenaJsonElementDeserializer()) {
+) : KafkaTopicConsumer<String, JsonElement>(stringDeserializer(), ArenaJsonElementDeserializer()) {
     override suspend fun consume(key: String, message: JsonElement) {
         MDC.put("correlationId", key)
 

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
@@ -30,7 +30,11 @@ import org.koin.logger.SLF4JLogger
 fun Application.configureDependencyInjection(
     appConfig: AppConfig,
 ) {
-    val tokenProvider = CachedTokenProvider.init(appConfig.auth.azure.audience, appConfig.auth.azure.tokenEndpointUrl, appConfig.auth.azure.privateJwk)
+    val tokenProvider = CachedTokenProvider.init(
+        appConfig.auth.azure.audience,
+        appConfig.auth.azure.tokenEndpointUrl,
+        appConfig.auth.azure.privateJwk,
+    )
     install(KoinIsolated) {
         SLF4JLogger()
         modules(
@@ -90,7 +94,6 @@ private fun kafka(config: KafkaConfig) = module {
             ArenaEventConsumer(config.consumers.arenaAvtaleInfoEndret, get()),
         )
         KafkaConsumerOrchestrator(
-            consumerPreset = config.consumerPreset,
             db = get(),
             consumers = consumers,
         )

--- a/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-arena-adapter/src/main/kotlin/no/nav/mulighetsrommet/arena/adapter/plugins/DependencyInjection.kt
@@ -85,13 +85,13 @@ private fun db(config: DatabaseConfig) = module {
 
 private fun kafka(config: KafkaConfig) = module {
     single {
-        val consumers = listOf(
-            ArenaEventConsumer(config.consumers.arenaTiltakEndret, get()),
-            ArenaEventConsumer(config.consumers.arenaTiltakgjennomforingEndret, get()),
-            ArenaEventConsumer(config.consumers.arenaTiltakdeltakerEndret, get()),
-            ArenaEventConsumer(config.consumers.arenaHistTiltakdeltakerEndret, get()),
-            ArenaEventConsumer(config.consumers.arenaSakEndret, get()),
-            ArenaEventConsumer(config.consumers.arenaAvtaleInfoEndret, get()),
+        val consumers = mapOf(
+            config.consumers.arenaTiltakEndret to ArenaEventConsumer(get()),
+            config.consumers.arenaTiltakgjennomforingEndret to ArenaEventConsumer(get()),
+            config.consumers.arenaTiltakdeltakerEndret to ArenaEventConsumer(get()),
+            config.consumers.arenaHistTiltakdeltakerEndret to ArenaEventConsumer(get()),
+            config.consumers.arenaSakEndret to ArenaEventConsumer(get()),
+            config.consumers.arenaAvtaleInfoEndret to ArenaEventConsumer(get()),
         )
         KafkaConsumerOrchestrator(
             db = get(),

--- a/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationTestConfig.kt
+++ b/mulighetsrommet-arena-adapter/src/test/kotlin/no/nav/mulighetsrommet/arena/adapter/ApplicationTestConfig.kt
@@ -1,17 +1,10 @@
 package no.nav.mulighetsrommet.arena.adapter
 
 import io.ktor.server.testing.*
-import no.nav.common.kafka.util.KafkaPropertiesBuilder
-import no.nav.mulighetsrommet.arena.adapter.services.ArenaEventService
-import no.nav.mulighetsrommet.arena.adapter.tasks.NotifyFailedEvents
-import no.nav.mulighetsrommet.arena.adapter.tasks.RetryFailedEvents
 import no.nav.mulighetsrommet.database.DatabaseConfig
-import no.nav.mulighetsrommet.database.FlywayMigrationManager
 import no.nav.mulighetsrommet.database.kotest.extensions.createRandomDatabaseConfig
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.tokenprovider.createMockRSAKey
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
 val databaseConfig: DatabaseConfig = createRandomDatabaseConfig("mr-arena-adapter")
 
@@ -29,60 +22,10 @@ fun <R> withTestApplication(
     }
 }
 
-fun createTestApplicationConfig(oauth: MockOAuth2Server) = AppConfig(
+fun createTestApplicationConfig(oauth: MockOAuth2Server) = ApplicationConfigLocal.copy(
     database = databaseConfig,
-    flyway = FlywayMigrationManager.MigrationConfig(),
     auth = createAuthConfig(oauth),
-    kafka = createKafkaConfig(),
-    enableFailedRecordProcessor = false,
-    tasks = TaskConfig(
-        retryFailedEvents = RetryFailedEvents.Config(
-            delayOfMinutes = 1,
-        ),
-        notifyFailedEvents = NotifyFailedEvents.Config(
-            maxRetries = 5,
-            cron = "0 0 0 1 1 0",
-        ),
-    ),
-    services = ServiceConfig(
-        mulighetsrommetApi = ServiceClientConfig(url = "mulighetsrommet-api", scope = ""),
-        tiltakshistorikk = ServiceClientConfig(url = "tiltakshistorikk", scope = ""),
-        arenaEventService = ArenaEventService.Config(
-            channelCapacity = 0,
-            numChannelConsumers = 0,
-            maxRetries = 0,
-        ),
-        arenaOrdsProxy = ServiceClientConfig(url = "arena-ords-proxy", scope = ""),
-    ),
-    slack = SlackConfig(
-        token = "",
-        channel = "",
-        enable = false,
-    ),
 )
-
-fun createKafkaConfig(): KafkaConfig {
-    return run {
-        val brokerUrl = "localhost:29092"
-        val consumerGroupId = "mulighetsrommet-kafka-consumer.v1"
-        KafkaConfig(
-            consumers = KafkaConsumers(
-                KafkaTopicConsumer.Config("tiltakendret", "tiltakendret"),
-                KafkaTopicConsumer.Config("tiltakgjennomforingendret", "tiltakgjennomforingendret"),
-                KafkaTopicConsumer.Config("tiltakdeltakerendret", "tiltakdeltakerendret"),
-                KafkaTopicConsumer.Config("hist-tiltakdeltakerendret", "hist-tiltakdeltakerendret"),
-                KafkaTopicConsumer.Config("sakendret", "sakendret"),
-                KafkaTopicConsumer.Config("avtaleinfoendret", "avtaleinfoendret"),
-            ),
-            consumerPreset = KafkaPropertiesBuilder.consumerBuilder()
-                .withBaseProperties()
-                .withConsumerGroupId(consumerGroupId)
-                .withBrokerUrl(brokerUrl)
-                .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
-                .build(),
-        )
-    }
-}
 
 // Default values for 'iss' og 'aud' in tokens issued by mock-oauth2-server is 'default'.
 // These values are set as the default here so that standard tokens issued by MockOAuth2Server works with a minimal amount of setup.

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/Application.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/Application.kt
@@ -51,7 +51,11 @@ fun Application.configure(config: AppConfig) {
 
     val tiltakshistorikkDb = TiltakshistorikkDatabase(db)
 
-    val cachedTokenProvider = CachedTokenProvider.init(config.auth.azure.audience, config.auth.azure.tokenEndpointUrl, config.auth.azure.privateJwk)
+    val cachedTokenProvider = CachedTokenProvider.init(
+        config.auth.azure.audience,
+        config.auth.azure.tokenEndpointUrl,
+        config.auth.azure.privateJwk,
+    )
 
     val tiltakDatadelingClient = TiltakDatadelingClient(
         engine = config.httpClientEngine,
@@ -99,7 +103,6 @@ fun configureKafka(
     )
 
     return KafkaConsumerOrchestrator(
-        consumerPreset = config.consumerPreset,
         db = db.db,
         consumers = consumers,
     )

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/Application.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/Application.kt
@@ -91,15 +91,9 @@ fun configureKafka(
     config: KafkaConfig,
     db: TiltakshistorikkDatabase,
 ): KafkaConsumerOrchestrator {
-    val consumers = listOf(
-        AmtDeltakerV1KafkaConsumer(
-            config = config.consumers.amtDeltakerV1,
-            db = db,
-        ),
-        SisteTiltaksgjennomforingerV1KafkaConsumer(
-            config = config.consumers.sisteTiltaksgjennomforingerV1,
-            db = db,
-        ),
+    val consumers = mapOf(
+        config.consumers.amtDeltakerV1 to AmtDeltakerV1KafkaConsumer(db),
+        config.consumers.sisteTiltaksgjennomforingerV1 to SisteTiltaksgjennomforingerV1KafkaConsumer(db),
     )
 
     return KafkaConsumerOrchestrator(

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/ApplicationConfig.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/ApplicationConfig.kt
@@ -2,13 +2,13 @@ package no.nav.tiltak.historikk
 
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
+import no.nav.common.kafka.util.KafkaPropertiesPreset
 import no.nav.mulighetsrommet.database.DatabaseConfig
 import no.nav.mulighetsrommet.database.FlywayMigrationManager
 import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.ktor.ServerConfig
 import no.nav.tiltak.historikk.clients.Avtale
 import java.time.LocalDate
-import java.util.Properties
 
 data class AppConfig(
     val server: ServerConfig = ServerConfig(),
@@ -48,11 +48,18 @@ data class ServiceClientConfig(
 )
 
 data class KafkaConfig(
-    val consumerPreset: Properties,
     val consumers: KafkaConsumers,
 )
 
 data class KafkaConsumers(
-    val amtDeltakerV1: KafkaTopicConsumer.Config,
-    val sisteTiltaksgjennomforingerV1: KafkaTopicConsumer.Config,
+    val amtDeltakerV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        id = "amt-deltaker",
+        topic = "amt.deltaker-v1",
+        consumerProperties = KafkaPropertiesPreset.aivenDefaultConsumerProperties("tiltakshistorikk.deltaker.v1"),
+    ),
+    val sisteTiltaksgjennomforingerV1: KafkaTopicConsumer.Config = KafkaTopicConsumer.Config(
+        id = "siste-tiltaksgjennomforinger",
+        topic = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
+        consumerProperties = KafkaPropertiesPreset.aivenDefaultConsumerProperties("tiltakshistorikk.gjennomforing.v1"),
+    ),
 )

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/ApplicationConfigDev.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/ApplicationConfigDev.kt
@@ -1,8 +1,6 @@
 package no.nav.tiltak.historikk
 
-import no.nav.common.kafka.util.KafkaPropertiesPreset
 import no.nav.mulighetsrommet.database.DatabaseConfig
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 
 val ApplicationConfigDev = AppConfig(
     database = DatabaseConfig(
@@ -19,17 +17,7 @@ val ApplicationConfigDev = AppConfig(
         ),
     ),
     kafka = KafkaConfig(
-        consumerPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties("tiltakshistorikk-kafka-consumer.v1"),
-        consumers = KafkaConsumers(
-            amtDeltakerV1 = KafkaTopicConsumer.Config(
-                id = "amt-deltaker",
-                topic = "amt.deltaker-v1",
-            ),
-            sisteTiltaksgjennomforingerV1 = KafkaTopicConsumer.Config(
-                id = "siste-tiltaksgjennomforinger",
-                topic = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
-            ),
-        ),
+        consumers = KafkaConsumers(),
     ),
     clients = ClientConfig(
         tiltakDatadeling = ServiceClientConfig(

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/ApplicationConfigLocal.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/ApplicationConfigLocal.kt
@@ -8,6 +8,13 @@ import no.nav.mulighetsrommet.ktor.ServerConfig
 import no.nav.mulighetsrommet.tokenprovider.createMockRSAKey
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
+private val consumerProperties = KafkaPropertiesBuilder.consumerBuilder()
+    .withBaseProperties()
+    .withConsumerGroupId("tiltakshistorikk.v1")
+    .withBrokerUrl("localhost:29092")
+    .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
+    .build()
+
 val ApplicationConfigLocal = AppConfig(
     server = ServerConfig(port = 8070),
     database = DatabaseConfig(
@@ -25,20 +32,16 @@ val ApplicationConfigLocal = AppConfig(
         ),
     ),
     kafka = KafkaConfig(
-        consumerPreset = KafkaPropertiesBuilder.consumerBuilder()
-            .withBaseProperties()
-            .withConsumerGroupId("tiltakshistorikk.v1")
-            .withBrokerUrl("localhost:29092")
-            .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
-            .build(),
         consumers = KafkaConsumers(
             amtDeltakerV1 = KafkaTopicConsumer.Config(
                 id = "amt-deltaker",
                 topic = "amt-deltaker-v1",
+                consumerProperties = consumerProperties,
             ),
             sisteTiltaksgjennomforingerV1 = KafkaTopicConsumer.Config(
                 id = "siste-tiltaksgjennomforinger",
                 topic = "siste-tiltaksgjennomforinger-v1",
+                consumerProperties = consumerProperties,
             ),
         ),
     ),

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/ApplicationConfigProd.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/ApplicationConfigProd.kt
@@ -1,8 +1,6 @@
 package no.nav.tiltak.historikk
 
-import no.nav.common.kafka.util.KafkaPropertiesPreset
 import no.nav.mulighetsrommet.database.DatabaseConfig
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 
 val ApplicationConfigProd = AppConfig(
     database = DatabaseConfig(
@@ -19,17 +17,7 @@ val ApplicationConfigProd = AppConfig(
         ),
     ),
     kafka = KafkaConfig(
-        consumerPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties("tiltakshistorikk-kafka-consumer.v1"),
-        consumers = KafkaConsumers(
-            amtDeltakerV1 = KafkaTopicConsumer.Config(
-                id = "amt-deltaker",
-                topic = "amt.deltaker-v1",
-            ),
-            sisteTiltaksgjennomforingerV1 = KafkaTopicConsumer.Config(
-                id = "siste-tiltaksgjennomforinger",
-                topic = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1",
-            ),
-        ),
+        consumers = KafkaConsumers(),
     ),
     clients = ClientConfig(
         tiltakDatadeling = ServiceClientConfig(

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/kafka/consumers/AmtDeltakerV1KafkaConsumer.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/kafka/consumers/AmtDeltakerV1KafkaConsumer.kt
@@ -14,10 +14,8 @@ import org.slf4j.LoggerFactory
 import java.util.*
 
 class AmtDeltakerV1KafkaConsumer(
-    config: Config,
     private val db: TiltakshistorikkDatabase,
 ) : KafkaTopicConsumer<UUID, JsonElement>(
-    config,
     uuidDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/kafka/consumers/SisteTiltaksgjennomforingerV1KafkaConsumer.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/kafka/consumers/SisteTiltaksgjennomforingerV1KafkaConsumer.kt
@@ -11,10 +11,8 @@ import no.nav.tiltak.historikk.db.TiltakshistorikkDatabase
 import java.util.*
 
 class SisteTiltaksgjennomforingerV1KafkaConsumer(
-    config: Config,
     private val db: TiltakshistorikkDatabase,
 ) : KafkaTopicConsumer<UUID, JsonElement>(
-    config,
     uuidDeserializer(),
     JsonElementDeserializer(),
 ) {

--- a/mulighetsrommet-tiltakshistorikk/src/test/kotlin/no/nav/tiltak/historikk/kafka/consumers/AmtDeltakerV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/test/kotlin/no/nav/tiltak/historikk/kafka/consumers/AmtDeltakerV1KafkaConsumerTest.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.encodeToJsonElement
 import no.nav.amt.model.AmtDeltakerV1Dto
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.*
 import no.nav.tiltak.historikk.databaseConfig
 import no.nav.tiltak.historikk.db.TiltakshistorikkDatabase
@@ -20,10 +19,7 @@ class AmtDeltakerV1KafkaConsumerTest : FunSpec({
     context("consume deltakere") {
         val db = TiltakshistorikkDatabase(database.db)
 
-        val deltakerConsumer = AmtDeltakerV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker", Properties()),
-            db,
-        )
+        val deltakerConsumer = AmtDeltakerV1KafkaConsumer(db)
 
         val tiltak = TiltaksgjennomforingEksternV1Dto(
             id = UUID.randomUUID(),

--- a/mulighetsrommet-tiltakshistorikk/src/test/kotlin/no/nav/tiltak/historikk/kafka/consumers/AmtDeltakerV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/test/kotlin/no/nav/tiltak/historikk/kafka/consumers/AmtDeltakerV1KafkaConsumerTest.kt
@@ -21,7 +21,7 @@ class AmtDeltakerV1KafkaConsumerTest : FunSpec({
         val db = TiltakshistorikkDatabase(database.db)
 
         val deltakerConsumer = AmtDeltakerV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker"),
+            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker", Properties()),
             db,
         )
 

--- a/mulighetsrommet-tiltakshistorikk/src/test/kotlin/no/nav/tiltak/historikk/kafka/consumers/SisteTiltaksgjennomforingV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/test/kotlin/no/nav/tiltak/historikk/kafka/consumers/SisteTiltaksgjennomforingV1KafkaConsumerTest.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.encodeToJsonElement
 import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListener
-import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.model.GjennomforingOppstartstype
 import no.nav.mulighetsrommet.model.GjennomforingStatus
 import no.nav.mulighetsrommet.model.TiltaksgjennomforingEksternV1Dto
@@ -26,10 +25,7 @@ class SisteTiltaksgjennomforingV1KafkaConsumerTest : FunSpec({
     context("konsumer gjennomføringer") {
         val db = TiltakshistorikkDatabase(database.db)
 
-        val consumer = SisteTiltaksgjennomforingerV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker", Properties()),
-            db,
-        )
+        val consumer = SisteTiltaksgjennomforingerV1KafkaConsumer(db)
 
         val tiltak = TiltaksgjennomforingEksternV1Dto(
             id = UUID.randomUUID(),

--- a/mulighetsrommet-tiltakshistorikk/src/test/kotlin/no/nav/tiltak/historikk/kafka/consumers/SisteTiltaksgjennomforingV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/test/kotlin/no/nav/tiltak/historikk/kafka/consumers/SisteTiltaksgjennomforingV1KafkaConsumerTest.kt
@@ -16,7 +16,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
-class TiltaksgjennomforingV1KafkaConsumerTest : FunSpec({
+class SisteTiltaksgjennomforingV1KafkaConsumerTest : FunSpec({
     val database = extension(FlywayDatabaseTestListener(databaseConfig))
 
     afterEach {
@@ -27,7 +27,7 @@ class TiltaksgjennomforingV1KafkaConsumerTest : FunSpec({
         val db = TiltakshistorikkDatabase(database.db)
 
         val consumer = SisteTiltaksgjennomforingerV1KafkaConsumer(
-            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker"),
+            config = KafkaTopicConsumer.Config(id = "deltaker", topic = "deltaker", Properties()),
             db,
         )
 

--- a/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/Application.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/Application.kt
@@ -170,7 +170,6 @@ private fun Application.configureKafka(
         .build()
 
     val kafkaConsumerOrchestrator = KafkaConsumerOrchestrator(
-        consumerPreset = config.consumerPropertiesPreset,
         db = db,
         consumers = listOf(bestilling),
     )

--- a/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/ApplicationConfig.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/ApplicationConfig.kt
@@ -23,7 +23,6 @@ data class AppConfig(
 )
 
 data class KafkaConfig(
-    val consumerPropertiesPreset: Properties,
     val producerPropertiesPreset: Properties,
     val topics: KafkaTopics,
     val clients: KafkaClients,

--- a/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/ApplicationConfigDev.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/ApplicationConfigDev.kt
@@ -46,7 +46,6 @@ val ApplicationConfigDev = AppConfig(
         enable = true,
     ),
     kafka = KafkaConfig(
-        consumerPropertiesPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties("team-mulighetsrommet.tiltaksokonomi.v1"),
         producerPropertiesPreset = KafkaPropertiesPreset.aivenByteProducerProperties("team-mulighetsrommet.tiltaksokonomi.v1"),
         topics = KafkaTopics(
             bestillingStatus = "team-mulighetsrommet.tiltaksokonomi.bestilling-status-v1",
@@ -55,8 +54,8 @@ val ApplicationConfigDev = AppConfig(
         clients = KafkaClients(
             okonomiBestillingConsumer = KafkaTopicConsumer.Config(
                 id = "bestilling",
-                consumerGroupId = "tiltaksokonomi.bestilling.v1",
                 topic = "team-mulighetsrommet.tiltaksokonomi.bestillinger-v1",
+                consumerProperties = KafkaPropertiesPreset.aivenDefaultConsumerProperties("tiltaksokonomi.bestilling.v1"),
             ),
         ),
     ),

--- a/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/ApplicationConfigLocal.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/ApplicationConfigLocal.kt
@@ -84,12 +84,6 @@ val ApplicationConfigLocal = AppConfig(
         enable = false,
     ),
     kafka = KafkaConfig(
-        consumerPropertiesPreset = KafkaPropertiesBuilder.consumerBuilder()
-            .withBaseProperties()
-            .withConsumerGroupId("tiltaksokonomi.v1")
-            .withBrokerUrl("localhost:29092")
-            .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
-            .build(),
         producerPropertiesPreset = KafkaPropertiesBuilder.producerBuilder()
             .withBaseProperties()
             .withProducerId("tiltaksokonomi.v1")
@@ -104,6 +98,12 @@ val ApplicationConfigLocal = AppConfig(
             okonomiBestillingConsumer = KafkaTopicConsumer.Config(
                 id = "bestilling",
                 topic = "tiltaksokonomi.bestillinger-v1",
+                consumerProperties = KafkaPropertiesBuilder.consumerBuilder()
+                    .withBaseProperties()
+                    .withConsumerGroupId("tiltaksokonomi.v1")
+                    .withBrokerUrl("localhost:29092")
+                    .withDeserializers(ByteArrayDeserializer::class.java, ByteArrayDeserializer::class.java)
+                    .build(),
             ),
         ),
     ),

--- a/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/ApplicationConfigProd.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/ApplicationConfigProd.kt
@@ -46,7 +46,6 @@ val ApplicationConfigProd = AppConfig(
         enable = true,
     ),
     kafka = KafkaConfig(
-        consumerPropertiesPreset = KafkaPropertiesPreset.aivenDefaultConsumerProperties("team-mulighetsrommet.tiltaksokonomi.v1"),
         producerPropertiesPreset = KafkaPropertiesPreset.aivenByteProducerProperties("team-mulighetsrommet.tiltaksokonomi.v1"),
         topics = KafkaTopics(
             bestillingStatus = "team-mulighetsrommet.tiltaksokonomi.bestilling-status-v1",
@@ -55,8 +54,8 @@ val ApplicationConfigProd = AppConfig(
         clients = KafkaClients(
             okonomiBestillingConsumer = KafkaTopicConsumer.Config(
                 id = "bestilling",
-                consumerGroupId = "tiltaksokonomi.bestilling.v1",
                 topic = "team-mulighetsrommet.tiltaksokonomi.bestillinger-v1",
+                consumerProperties = KafkaPropertiesPreset.aivenDefaultConsumerProperties("tiltaksokonomi.bestilling.v1"),
             ),
         ),
     ),

--- a/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/kafka/OkonomiBestillingConsumer.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/kafka/OkonomiBestillingConsumer.kt
@@ -12,10 +12,8 @@ import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 
 class OkonomiBestillingConsumer(
-    config: Config,
     private val okonomi: OkonomiService,
 ) : KafkaTopicConsumer<String, JsonElement>(
-    config,
     stringDeserializer(),
     JsonElementDeserializer(),
 ) {


### PR DESCRIPTION
- Skiller config av kafka consumers ut fra constructor slik at det blir enklere å definere/teste consumer-logikk uavhengig av hvilken config som benyttes av selve kafka-klienten.
- consumer properties settes nå eksplisitt per consumer client (inkludert consumer group id)
