### PR TITLE
La grafana views få tilgang til datastream tabeller via authroized views

### DIFF
--- a/iac/bigquery-terraform/dev/datastreams.tf
+++ b/iac/bigquery-terraform/dev/datastreams.tf
@@ -105,6 +105,28 @@ module "mr_api_datastream" {
         project_id = var.gcp_project["project"]
         table_id   = "del_med_bruker_view"
       }
-    }
+    },
+    # Grafana dataset read access:
+    {
+      view = {
+        dataset_id = local.grafana_dataset_id
+        project_id = var.gcp_project["project"]
+        table_id   = "tilsagn_type_antall_view"
+      }
+    },
+    {
+      view = {
+        dataset_id = local.grafana_dataset_id
+        project_id = var.gcp_project["project"]
+        table_id   = "tilsagn_status_antall_view"
+      }
+    },
+    {
+      view = {
+        dataset_id = local.grafana_dataset_id
+        project_id = var.gcp_project["project"]
+        table_id   = "tilsagn_nye_siste_maaned_view"
+      }
+    },
   ]
 }

--- a/iac/bigquery-terraform/dev/grafana.tf
+++ b/iac/bigquery-terraform/dev/grafana.tf
@@ -26,16 +26,3 @@ resource "google_bigquery_dataset" "grafana_views" {
     user_by_email = "grafana@nais-management-233d.iam.gserviceaccount.com"
   }
 }
-
-# Authorize the views dataset to access the source dataset
-resource "google_bigquery_dataset_access" "grafana_viewing_datastream" {
-  dataset_id = module.mr_api_datastream.dataset_id
-  depends_on = [module.mr_api_datastream.dataset_id]
-  dataset {
-    dataset {
-      project_id = google_bigquery_dataset.grafana_views.project
-      dataset_id = google_bigquery_dataset.grafana_views.dataset_id
-    }
-    target_types = ["VIEWS"]
-  }
-}

--- a/iac/bigquery-terraform/prod/datastreams.tf
+++ b/iac/bigquery-terraform/prod/datastreams.tf
@@ -118,5 +118,27 @@ module "mr_api_datastream" {
         table_id   = "del_med_bruker_view"
       }
     },
+    # Grafana dataset read access:
+    {
+      view = {
+        dataset_id = local.grafana_dataset_id
+        project_id = var.gcp_project["project"]
+        table_id   = "tilsagn_type_antall_view"
+      }
+    },
+    {
+      view = {
+        dataset_id = local.grafana_dataset_id
+        project_id = var.gcp_project["project"]
+        table_id   = "tilsagn_status_antall_view"
+      }
+    },
+    {
+      view = {
+        dataset_id = local.grafana_dataset_id
+        project_id = var.gcp_project["project"]
+        table_id   = "tilsagn_nye_siste_maaned_view"
+      }
+    },
   ]
 }

--- a/iac/bigquery-terraform/prod/grafana.tf
+++ b/iac/bigquery-terraform/prod/grafana.tf
@@ -26,16 +26,3 @@ resource "google_bigquery_dataset" "grafana_views" {
     user_by_email = "grafana@nais-management-233d.iam.gserviceaccount.com"
   }
 }
-
-# Authorize views in grafana dataset access to datastream dataset
-resource "google_bigquery_dataset_access" "grafana_viewing_datastream" {
-  dataset_id = module.mr_api_datastream.dataset_id
-  depends_on = [module.mr_api_datastream.dataset_id]
-  dataset {
-    dataset {
-      project_id = google_bigquery_dataset.grafana_views.project
-      dataset_id = google_bigquery_dataset.grafana_views.dataset_id
-    }
-    target_types = ["VIEWS"]
-  }
-}


### PR DESCRIPTION
Managed endringer kunne ødelegge grafana views sin lesetilgang mot datastream tabellene.

Nå må vi manuelt spesifisere hvilke views vi ønsker skal ha tilgang til tabellene. Opprettholder at grafana service principalen bare har lesetilgang mot grafana datasettet. ✅ 