### PR TITLE
Revert "midlertidig fallback for modeller som mangler timestamps i prod"

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/TiltaksgjennomforingEksternV1Dto.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/TiltaksgjennomforingEksternV1Dto.kt
@@ -26,9 +26,9 @@ data class TiltaksgjennomforingEksternV1Dto(
     val apentForPamelding: Boolean,
     val antallPlasser: Int,
     @Serializable(with = LocalDateTimeSerializer::class)
-    val opprettetTidspunkt: LocalDateTime? = null,
+    val opprettetTidspunkt: LocalDateTime,
     @Serializable(with = LocalDateTimeSerializer::class)
-    val oppdatertTidspunkt: LocalDateTime? = null,
+    val oppdatertTidspunkt: LocalDateTime,
 ) {
     @Serializable
     data class Tiltakstype(


### PR DESCRIPTION
This reverts commit ca475d8f50000e3d014f3f0b76b405bcb40acee9.