### PR TITLE
Vis brukt beløp på tilsagnssiden

### DIFF
--- a/frontend/mr-admin-flate/src/components/tilsagn/TilsagnTekster.ts
+++ b/frontend/mr-admin-flate/src/components/tilsagn/TilsagnTekster.ts
@@ -5,6 +5,9 @@ export const tilsagnTekster = {
   belopGjenstaende: {
     label: "Gjenstående beløp",
   },
+  belopBrukt: {
+    label: "Brukt beløp",
+  },
   periode: {
     label: "Periode",
     start: {

--- a/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
+++ b/frontend/mr-admin-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
@@ -123,6 +123,10 @@ export function TilsagnDetaljer({ tilsagn, meny, annullering, oppgjor }: Props) 
             verdi={formaterNOK(beregning.output.belop)}
           />
           <MetadataHorisontal
+            header={tilsagnTekster.belopBrukt.label}
+            verdi={formaterNOK(tilsagn.belopBrukt)}
+          />
+          <MetadataHorisontal
             header={tilsagnTekster.belopGjenstaende.label}
             verdi={formaterNOK(tilsagn.belopGjenstaende)}
           />


### PR DESCRIPTION
Spesielt nyttig ved oppgjort/annulert tilsagn hvor gjenstående beløp blir nullet ut

![image](https://github.com/user-attachments/assets/cdcf9a52-a952-4e28-826d-86c29530f7bc)
