### PR TITLE
Gjør lopenummer en del av fritekstsøk på gjennomføringer

### DIFF
--- a/frontend/mr-admin-flate/src/components/ledetekster/gjennomforingLedetekster.ts
+++ b/frontend/mr-admin-flate/src/components/ledetekster/gjennomforingLedetekster.ts
@@ -1,6 +1,6 @@
 export const gjennomforingTekster = {
   tiltaksnavnLabel: "Tiltaksnavn",
-  tiltaksnummerLabel: "Tiltaksnummer",
+  tiltaksnummerLabel: "Tiltaksnummer i Arena",
   avtaleLabel: "Avtale",
   avtaleMedTiltakstype: (tiltakstype: string) => `Avtale (tiltakstype: ${tiltakstype})`,
   ingenAvtaleForGjennomforingenLabel: "Ingen avtale for gjennomføringen",

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/database/utils/DatabaseUtils.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/database/utils/DatabaseUtils.kt
@@ -94,7 +94,6 @@ object DatabaseUtils {
     fun String.toFTSPrefixQuery() = this
         .trim()
         .split("\\s+".toRegex())
-        .map { it.filter { char -> char.isLetterOrDigit() } }
         .filter { it.isNotEmpty() }
         .joinToString(separator = "&") { "$it:*" }
 }

--- a/mulighetsrommet-api/src/main/resources/db/migration/V318__gjennomforing_fts_lopenummer.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V318__gjennomforing_fts_lopenummer.sql
@@ -1,0 +1,16 @@
+drop view if exists gjennomforing_admin_dto_view;
+drop view if exists veilederflate_tiltak_view;
+
+alter table gjennomforing
+    drop column fts;
+
+alter table gjennomforing
+    add fts tsvector generated always as (
+        to_tsvector('norwegian',
+            coalesce(tiltaksnummer, '') || ' ' ||
+            coalesce(navn, '') || ' ' ||
+            coalesce(lopenummer, '')
+        )
+    ) stored;
+
+create index gjennomforing_fts_idx on gjennomforing using gin (fts);

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/db/GjennomforingQueriesTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/db/GjennomforingQueriesTest.kt
@@ -552,6 +552,29 @@ class GjennomforingQueriesTest : FunSpec({
             }
         }
 
+        test("søk på lopenummer") {
+            database.runAndRollback { session ->
+                MulighetsrommetTestDomain(
+                    arrangorer = listOf(
+                        ArrangorFixtures.hovedenhet,
+                        ArrangorFixtures.underenhet1,
+                    ),
+                    avtaler = listOf(AvtaleFixtures.oppfolging),
+                    gjennomforinger = listOf(
+                        Oppfolging1.copy(arrangorId = ArrangorFixtures.underenhet1.id),
+                    ),
+                ).setup(session)
+
+                val queries = GjennomforingQueries(session)
+                val lopenummer = queries.get(Oppfolging1.id)!!.lopenummer
+
+                queries.getAll(search = lopenummer).should {
+                    it.items.size shouldBe 1
+                    it.items[0].id shouldBe Oppfolging1.id
+                }
+            }
+        }
+
         test("skal migreres henter kun der tiltakstypen har egen tiltakskode") {
             database.runAndRollback { session ->
                 MulighetsrommetTestDomain(


### PR DESCRIPTION
Og kall Tiltaksnummer for Tiltaksnummer i Arena for å klargjøre visning av lopenummer i stedet/i tillegg.