### PR TITLE
Arrangørflate error: Formater dato til yyyyMMdd i session

### DIFF
--- a/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.innsendingsinformasjon.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.innsendingsinformasjon.tsx
@@ -42,6 +42,7 @@ import { internalNavigation } from "../internal-navigation";
 import { errorAt } from "~/utils/validering";
 import { jsonPointerToFieldPath } from "@mr/frontend-common/utils/utils";
 import { commitSession, destroySession, getSession } from "~/sessions.server";
+import { formaterDatoSomYYYYMMDD } from "~/utils/date";
 
 type LoaderData = {
   gjennomforinger: ArrangorflateGjennomforing[];
@@ -169,8 +170,8 @@ export async function action({ request }: ActionFunctionArgs) {
     session.set("orgnr", orgnr);
     session.set("gjennomforingId", gjennomforingId);
     session.set("tilsagnId", tilsagnId);
-    session.set("periodeStart", periodeStart);
-    session.set("periodeSlutt", periodeSlutt);
+    session.set("periodeStart", formaterDatoSomYYYYMMDD(periodeStart));
+    session.set("periodeSlutt", formaterDatoSomYYYYMMDD(periodeSlutt));
     return redirect(internalNavigation(orgnr).opprettKravUtbetaling, {
       headers: {
         "Set-Cookie": await commitSession(session),

--- a/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.oppsummering.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.oppsummering.tsx
@@ -30,6 +30,7 @@ import { formaterPeriode, isValidationError, problemDetailResponse } from "~/uti
 import { FileUpload, FileUploadHandler, parseFormData } from "@mjackson/form-data-parser";
 import { FileUploader } from "~/components/fileUploader/FileUploader";
 import { errorAt } from "~/utils/validering";
+import { formaterDatoSomYYYYMMDD } from "~/utils/date";
 
 export const meta: MetaFunction = () => {
   return [
@@ -261,24 +262,4 @@ export default function OpprettKravOppsummering() {
       </VStack>
     </>
   );
-}
-
-function formaterDatoSomYYYYMMDD(dato: string | Date | null, fallback = ""): string {
-  if (!dato) return fallback;
-
-  let dateObj: Date;
-  if (typeof dato === "string") {
-    const [day, month, year] = dato.split(".").map(Number);
-    dateObj = new Date(year, month - 1, day);
-  } else {
-    dateObj = dato;
-  }
-
-  if (isNaN(dateObj.getTime())) return fallback;
-
-  const year = dateObj.getFullYear();
-  const month = String(dateObj.getMonth() + 1).padStart(2, "0");
-  const day = String(dateObj.getDate()).padStart(2, "0");
-
-  return `${year}-${month}-${day}`;
 }

--- a/frontend/arrangor-flate/app/utils/date.ts
+++ b/frontend/arrangor-flate/app/utils/date.ts
@@ -1,0 +1,36 @@
+const ddMMyyyyFormat = new RegExp("^[0-9]{2}.[0-9]{2}.[0-9]{4}$");
+const yyyyMMddFormat = new RegExp("^[0-9]{4}-[0-9]{2}-[0-9]{2}$");
+
+export function formaterDatoSomYYYYMMDD(
+  dato: string | Date | null | undefined,
+  fallback = "",
+): string {
+  if (!dato) {
+    return fallback;
+  }
+
+  if (typeof dato !== "string") {
+    return dateToyyyyMMdd(dato, fallback);
+  }
+
+  if (yyyyMMddFormat.test(dato)) {
+    return dato;
+  }
+
+  if (ddMMyyyyFormat.test(dato)) {
+    const [day, month, year] = dato.split(".").map(Number);
+    return dateToyyyyMMdd(new Date(year, month - 1, day), fallback);
+  }
+
+  return fallback;
+}
+
+function dateToyyyyMMdd(dato: Date, fallback: string): string {
+  if (isNaN(dato.getTime())) return fallback;
+
+  const year = dato.getFullYear();
+  const month = String(dato.getMonth() + 1).padStart(2, "0");
+  const day = String(dato.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
Feilen oppstår når vi forsøker å opprette en Date fra streng på formatet `dd.MM.yyyy`. Grunnen er at skjemaet plukker ut verdien fra datepickeren, som blir feil.

Lagrer nå som `yyyy-MM-dd` i session også, slik som det kreves ved innsending.

Testet ved opprettelse av manuell utbetaling.

[Trello](https://trello.com/c/JjFek3Fj/2680-feilmelding-i-arrang%C3%B8rflate-kommer-ofte)