### PR TITLE
implementer retry for henting av arrangør-navn

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/TiltakshistorikkService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/TiltakshistorikkService.kt
@@ -257,7 +257,7 @@ class TiltakshistorikkService(
     }
 }
 
-fun DeltakelseFraKomet.toDeltakelse(): Deltakelse {
+private fun DeltakelseFraKomet.toDeltakelse(): Deltakelse {
     return Deltakelse.DeltakelseGruppetiltak(
         id = deltakerId,
         gjennomforingId = deltakerlisteId,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/TiltakshistorikkServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/TiltakshistorikkServiceTest.kt
@@ -289,13 +289,14 @@ class TiltakshistorikkServiceTest : FunSpec({
             AccessType.OBO("token"),
         )
 
+        val expectedDeltakelseUtenStartdato = deltakelseOppfolging.copy(
+            id = deltakelseOppfolgingUtenStartdato.deltakerId,
+            periode = Deltakelse.Periode(null, null),
+            status = Deltakelse.DeltakelseGruppetiltak.Status(DeltakerStatus.Type.KLADD, "Kladd", null),
+        )
         historikk shouldBe Deltakelser(
             meldinger = setOf(),
-            aktive = listOf(
-                deltakelseOppfolgingUtenStartdato.toDeltakelse(),
-                deltakelseOppfolging,
-                deltakelseAvklaring,
-            ),
+            aktive = listOf(expectedDeltakelseUtenStartdato, deltakelseOppfolging, deltakelseAvklaring),
             historiske = emptyList(),
         )
     }


### PR DESCRIPTION
Vi har opplevd at parallelle requester har ført til en error. Dette er et forsøk på en enkel patch der vi forsøker å hente navn på nytt om exception oppstår.

Retry-mekanismen er implementert i TiltakshistorikkService fordi det er her problemet oppstår for å gjøre det tydeligere hvorfor det er nødvendig å ha denne funksjonaliteten.