### PR TITLE
Fjern felles header ved manuelt utbetalingskrav fra arrangør

### DIFF
--- a/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.innsendingsinformasjon.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.innsendingsinformasjon.tsx
@@ -57,8 +57,8 @@ type LoaderData = {
 
 export const meta: MetaFunction = () => {
   return [
-    { title: "Manuell innsending" },
-    { name: "description", content: "Manuell innsending av krav om utbetaling" },
+    { title: "Opprett utbetalingskrav" },
+    { name: "description", content: "Manuell opprettelse av utbetalingskrav" },
   ];
 };
 
@@ -231,7 +231,7 @@ export default function OpprettKravInnsendingsinformasjon() {
     <>
       <Form method="post">
         <VStack gap="6">
-          <Heading level="3" size="medium">
+          <Heading level="3" size="large">
             Innsendingsinformasjon
           </Heading>
           <GuidePanel className="mb-2">

--- a/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.oppsummering.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.oppsummering.tsx
@@ -34,8 +34,8 @@ import { formaterDatoSomYYYYMMDD } from "~/utils/date";
 
 export const meta: MetaFunction = () => {
   return [
-    { title: "Manuell innsending" },
-    { name: "description", content: "Manuell innsending av krav om utbetaling" },
+    { title: "Opprett utbetalingskrav" },
+    { name: "description", content: "Manuell opprettelse av utbetalingskrav" },
   ];
 };
 
@@ -183,7 +183,7 @@ export default function OpprettKravOppsummering() {
 
   return (
     <>
-      <Heading level="3" spacing size="medium">
+      <Heading level="3" spacing size="large">
         Oppsummering
       </Heading>
       <VStack gap="6">

--- a/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.utbetaling.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.opprett-krav.utbetaling.tsx
@@ -26,8 +26,8 @@ type LoaderData = {
 
 export const meta: MetaFunction = () => {
   return [
-    { title: "Manuell innsending" },
-    { name: "description", content: "Manuell innsending av krav om utbetaling" },
+    { title: "Opprett utbetalingskrav" },
+    { name: "description", content: "Manuell opprettelse av utbetalingskrav" },
   ];
 };
 
@@ -106,7 +106,7 @@ export default function OpprettKravUtbetaling() {
 
   return (
     <>
-      <Heading size="medium" spacing level="3">
+      <Heading size="large" spacing level="3">
         Utbetalingsinformasjon
       </Heading>
       <Form method="post">

--- a/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.tsx
+++ b/frontend/arrangor-flate/app/routes/$orgnr._manuell-innsending.tsx
@@ -39,9 +39,6 @@ export default function UtbetalingLayout() {
         >
           <ChevronLeftIcon /> Tilbake til oversikt
         </Link>
-        <Heading size="large" spacing level="2">
-          Manuelt utbetalingskrav
-        </Heading>
         <HStack gap="10" width="100%" justify="center" wrap={false}>
           <VStack padding="8" flexGrow="2" className="bg-bg-default rounded-lg ">
             <Outlet />
@@ -57,7 +54,7 @@ export default function UtbetalingLayout() {
                 onStepChange={setActiveStep}
                 interactive={false}
               >
-                <Stepper.Step>Tilsagn</Stepper.Step>
+                <Stepper.Step>Innsendingsinformasjon</Stepper.Step>
                 <Stepper.Step>Utbetalingsinformasjon</Stepper.Step>
                 <Stepper.Step>Oppsummering</Stepper.Step>
               </Stepper>


### PR DESCRIPTION
- Fjernet fellesheaderen
- Økte headeren i hvert steg fra medium til stor
- Endret tittelen på browser fanen fra manuell innsending til Opprett utbetalingskrav
- Endret steg navnet fra Tilsagn til å matche steg headeren Innsendingsinformasjon

![image](https://github.com/user-attachments/assets/65b5fac1-90b7-427e-9ca1-a3fca8ea6eab)
![image](https://github.com/user-attachments/assets/2a8d3f1d-0804-489d-911d-2765a95316d1)
