### PR TITLE
opprett custom task for å generere avtaler for forhåndsgodkjente tiltak

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/task/BackfillAvtale.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/task/BackfillAvtale.kt
@@ -1,0 +1,118 @@
+package no.nav.mulighetsrommet.api.avtale.task
+
+import arrow.core.getOrElse
+import kotliquery.queryOf
+import no.nav.mulighetsrommet.api.ApiDatabase
+import no.nav.mulighetsrommet.api.arrangor.ArrangorService
+import no.nav.mulighetsrommet.api.avtale.db.AvtaleDbo
+import no.nav.mulighetsrommet.api.avtale.model.Opsjonsmodell
+import no.nav.mulighetsrommet.api.avtale.model.OpsjonsmodellType
+import no.nav.mulighetsrommet.brreg.BrregError
+import no.nav.mulighetsrommet.model.AvtaleStatus
+import no.nav.mulighetsrommet.model.Avtaletype
+import no.nav.mulighetsrommet.model.GjennomforingStatus
+import no.nav.mulighetsrommet.model.Prismodell
+import org.intellij.lang.annotations.Language
+import org.slf4j.LoggerFactory
+import java.util.*
+
+class BackfillAvtale(
+    private val db: ApiDatabase,
+    private val arrangorService: ArrangorService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    suspend fun execute() {
+        val gjennomforinger = getForhandsgodkjenteGjennomforingerUtenAvtale()
+
+        gjennomforinger.forEach {
+            generateAvtale(it)
+        }
+    }
+
+    private suspend fun generateAvtale(gjennomforingId: UUID): Unit = db.transaction {
+        logger.info("Genererer avtale for gjennomføring id=$gjennomforingId")
+
+        val gjennomforing = checkNotNull(queries.gjennomforing.get(gjennomforingId))
+
+        val orgnr = gjennomforing.arrangor.organisasjonsnummer
+        logger.info("Utleder arrangør for orgnr=$orgnr")
+
+        val arrangor = arrangorService.getArrangorOrSyncFromBrreg(orgnr).getOrElse {
+            if (it is BrregError.FjernetAvJuridiskeArsaker) {
+                logger.warn("Arrangør med orgnr $orgnr er fjernet fra brreg. Kan ikke opprette avtale for gjennomføring id=$gjennomforingId")
+                return
+            }
+
+            throw IllegalStateException("Klarte ikke hente arrangør med orgnr: $orgnr Error: $it")
+        }
+
+        val arrangorHovedenhet = arrangor.overordnetEnhet?.let { orgnr ->
+            arrangorService.getArrangorOrSyncFromBrreg(orgnr).getOrElse {
+                if (it is BrregError.FjernetAvJuridiskeArsaker) {
+                    logger.warn("Bedrift med orgnr $orgnr er fjernet fra brreg. Kan ikke opprette avtale for gjennomføring id=$gjennomforingId")
+                    return
+                }
+
+                throw IllegalStateException("Klarte ikke hente overordnet enhet for arrangor $it Error: $it")
+            }
+        }
+
+        if (arrangorHovedenhet == null) {
+            logger.warn("Arrangør med orgnr $orgnr har ikke en overordnet enhet i Brønnøysundregistrene. Kan ikke opprette avtale for gjennomføring id=$gjennomforingId")
+            return
+        }
+
+        val avtale = AvtaleDbo(
+            id = UUID.randomUUID(),
+            navn = gjennomforing.navn,
+            tiltakstypeId = gjennomforing.tiltakstype.id,
+            avtalenummer = null,
+            sakarkivNummer = null,
+            arrangor = AvtaleDbo.Arrangor(
+                hovedenhet = arrangorHovedenhet.id,
+                underenheter = listOf(gjennomforing.arrangor.id),
+                kontaktpersoner = listOf(),
+            ),
+            startDato = gjennomforing.startDato,
+            sluttDato = gjennomforing.sluttDato,
+            status = when (gjennomforing.status.type) {
+                GjennomforingStatus.GJENNOMFORES -> AvtaleStatus.AKTIV
+                GjennomforingStatus.AVSLUTTET -> AvtaleStatus.AVSLUTTET
+                GjennomforingStatus.AVLYST, GjennomforingStatus.AVBRUTT -> AvtaleStatus.AVBRUTT
+            },
+            navEnheter = listOf(),
+            avtaletype = Avtaletype.FORHANDSGODKJENT,
+            prisbetingelser = null,
+            antallPlasser = null,
+            administratorer = listOf(),
+            beskrivelse = null,
+            faneinnhold = null,
+            personopplysninger = listOf(),
+            personvernBekreftet = false,
+            amoKategorisering = null,
+            opsjonsmodell = Opsjonsmodell(
+                type = OpsjonsmodellType.VALGFRI_SLUTTDATO,
+                opsjonMaksVarighet = null,
+            ),
+            utdanningslop = null,
+            prismodell = Prismodell.FORHANDSGODKJENT,
+        )
+
+        logger.info("Oppretter avtale for gjennomføring uten avtale avtaleId=${avtale.id}, gjennomforingId=${gjennomforing.id}")
+        queries.avtale.upsert(avtale)
+        queries.gjennomforing.setAvtaleId(gjennomforing.id, avtale.id)
+    }
+
+    private fun getForhandsgodkjenteGjennomforingerUtenAvtale(): List<UUID> = db.session {
+        @Language("PostgreSQL")
+        val query = """
+            select id
+            from gjennomforing_admin_dto_view
+            where avtale_id is null
+              and (tiltakstype_tiltakskode = 'ARBEIDSFORBEREDENDE_TRENING' or tiltakstype_tiltakskode = 'VARIG_TILRETTELAGT_ARBEID_SKJERMET')
+        """.trimIndent()
+
+        session.list(queryOf(query)) { it.uuid("id") }
+    }
+}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -23,6 +23,7 @@ import no.nav.mulighetsrommet.api.arrangor.kafka.AmtVirksomheterV1KafkaConsumer
 import no.nav.mulighetsrommet.api.arrangorflate.ArrangorFlateService
 import no.nav.mulighetsrommet.api.avtale.AvtaleService
 import no.nav.mulighetsrommet.api.avtale.AvtaleValidator
+import no.nav.mulighetsrommet.api.avtale.task.BackfillAvtale
 import no.nav.mulighetsrommet.api.avtale.task.NotifySluttdatoForAvtalerNarmerSeg
 import no.nav.mulighetsrommet.api.avtale.task.UpdateAvtaleStatus
 import no.nav.mulighetsrommet.api.clients.amtDeltaker.AmtDeltakerClient
@@ -218,6 +219,9 @@ private fun services(appConfig: AppConfig) = module {
         privateJwk = appConfig.auth.maskinporten.privateJwk,
     )
 
+    single {
+        BackfillAvtale(get(), get())
+    }
     single {
         VeilarboppfolgingClient(
             baseUrl = appConfig.veilarboppfolgingConfig.url,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/MaamRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/MaamRoutes.kt
@@ -7,6 +7,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.api.arrangor.ArrangorService
+import no.nav.mulighetsrommet.api.avtale.task.BackfillAvtale
 import no.nav.mulighetsrommet.api.gjennomforing.task.InitialLoadGjennomforinger
 import no.nav.mulighetsrommet.api.navansatt.task.SynchronizeNavAnsatte
 import no.nav.mulighetsrommet.api.tasks.GenerateValidationReport
@@ -35,6 +36,7 @@ fun Route.maamRoutes() {
     val synchronizeNavAnsatte: SynchronizeNavAnsatte by inject()
     val synchronizeUtdanninger: SynchronizeUtdanninger by inject()
     val generateUtbetaling: GenerateUtbetaling by inject()
+    val backfillAvtale: BackfillAvtale by inject()
 
     route("/api/intern/maam") {
         route("/tasks") {
@@ -117,6 +119,11 @@ fun Route.maamRoutes() {
                 val utbetalinger = generateUtbetaling.runTask(month)
                 val response = ExecutedTaskResponse("Genererte ${utbetalinger.size} utbetalinger for måned $month")
                 call.respond(HttpStatusCode.OK, response)
+            }
+
+            post("backfill-avtale") {
+                backfillAvtale.execute()
+                call.respond(HttpStatusCode.OK, ExecutedTaskResponse("Fullført"))
             }
         }
 


### PR DESCRIPTION
En midlertidig rutine for generere avtale-objekter for AFT/VTA-tiltak. 

Navn, arrangør, datoer og status utledes basert på gjennomføringen.