### PR TITLE
utled arrangør-hovedenhet fra brreg

### DIFF
--- a/common/brreg/src/main/kotlin/no/nav/mulighetsrommet/brreg/BrregClient.kt
+++ b/common/brreg/src/main/kotlin/no/nav/mulighetsrommet/brreg/BrregClient.kt
@@ -72,6 +72,7 @@ class BrregClient(
                         organisasjonsnummer = it.organisasjonsnummer,
                         organisasjonsform = it.organisasjonsform.kode,
                         navn = it.navn,
+                        overordnetEnhet = it.overordnetEnhet,
                         postadresse = it.postadresse?.toBrregAdresse(),
                         forretningsadresse = it.forretningsadresse?.toBrregAdresse(),
                     )
@@ -114,6 +115,7 @@ class BrregClient(
                 organisasjonsnummer = enhet.organisasjonsnummer,
                 organisasjonsform = enhet.organisasjonsform.kode,
                 navn = enhet.navn,
+                overordnetEnhet = enhet.overordnetEnhet,
                 postadresse = enhet.postadresse?.toBrregAdresse(),
                 forretningsadresse = enhet.forretningsadresse?.toBrregAdresse(),
             )

--- a/common/brreg/src/main/kotlin/no/nav/mulighetsrommet/brreg/BrregEnhetDto.kt
+++ b/common/brreg/src/main/kotlin/no/nav/mulighetsrommet/brreg/BrregEnhetDto.kt
@@ -45,6 +45,7 @@ data class BrregHovedenhetDto(
     override val navn: String,
     override val postadresse: BrregAdresse?,
     override val forretningsadresse: BrregAdresse?,
+    val overordnetEnhet: Organisasjonsnummer?,
 ) : BrregHovedenhet()
 
 @Serializable

--- a/common/brreg/src/test/kotlin/no/nav/mulighetsrommet/brreg/BrregClientTest.kt
+++ b/common/brreg/src/test/kotlin/no/nav/mulighetsrommet/brreg/BrregClientTest.kt
@@ -39,6 +39,7 @@ class BrregClientTest : FunSpec({
                         poststed = "OSLO",
                         adresse = listOf("Lørenfaret 1C"),
                     ),
+                    overordnetEnhet = Organisasjonsnummer("932384469"),
                 ),
             )
         }
@@ -115,6 +116,7 @@ class BrregClientTest : FunSpec({
                     poststed = "OSLO",
                     adresse = listOf("Lørenfaret 1C"),
                 ),
+                overordnetEnhet = Organisasjonsnummer("932384469"),
             )
         }
 
@@ -215,6 +217,7 @@ class BrregClientTest : FunSpec({
                     poststed = "OSLO",
                     adresse = listOf("Lørenfaret 1C"),
                 ),
+                overordnetEnhet = Organisasjonsnummer("932384469"),
             )
         }
 

--- a/common/tiltaksokonomi-client/src/main/kotlin/no/nav/tiltak/okonomi/OkonomiBestillingMelding.kt
+++ b/common/tiltaksokonomi-client/src/main/kotlin/no/nav/tiltak/okonomi/OkonomiBestillingMelding.kt
@@ -38,7 +38,7 @@ data class OpprettBestilling(
     val bestillingsnummer: String,
     val tilskuddstype: Tilskuddstype,
     val tiltakskode: Tiltakskode,
-    val arrangor: Arrangor,
+    val arrangor: Organisasjonsnummer,
     val kostnadssted: NavEnhetNummer,
     val avtalenummer: String?,
     val belop: Int,
@@ -49,13 +49,7 @@ data class OpprettBestilling(
     val besluttetAv: OkonomiPart,
     @Serializable(with = LocalDateTimeSerializer::class)
     val besluttetTidspunkt: LocalDateTime,
-) {
-    @Serializable
-    data class Arrangor(
-        val hovedenhet: Organisasjonsnummer,
-        val underenhet: Organisasjonsnummer,
-    )
-}
+)
 
 enum class Tilskuddstype {
     TILTAK_DRIFTSTILSKUDD,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/ArrangorService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/ArrangorService.kt
@@ -199,6 +199,7 @@ private fun toBrregHovedenhet(arrangor: ArrangorDto): BrregHovedenhet = when {
         organisasjonsnummer = arrangor.organisasjonsnummer,
         organisasjonsform = "IKS", // Interkommunalt selskap (X i Arena)
         navn = arrangor.navn,
+        overordnetEnhet = null,
         postadresse = null,
         forretningsadresse = null,
     )

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
@@ -542,13 +542,6 @@ class TilsagnService(
             "Gjennomføring ${gjennomforing.id} mangler avtale"
         }
 
-        val arrangor = checkNotNull(avtale.arrangor) { "Avtale ${avtale.id} mangler arrangør" }.let {
-            OpprettBestilling.Arrangor(
-                hovedenhet = avtale.arrangor.organisasjonsnummer,
-                underenhet = gjennomforing.arrangor.organisasjonsnummer,
-            )
-        }
-
         val bestilling = OpprettBestilling(
             bestillingsnummer = tilsagn.bestilling.bestillingsnummer,
             tilskuddstype = when (tilsagn.type) {
@@ -556,7 +549,7 @@ class TilsagnService(
                 else -> Tilskuddstype.TILTAK_DRIFTSTILSKUDD
             },
             tiltakskode = gjennomforing.tiltakstype.tiltakskode,
-            arrangor = arrangor,
+            arrangor = gjennomforing.arrangor.organisasjonsnummer,
             kostnadssted = tilsagn.kostnadssted.enhetsnummer,
             avtalenummer = avtale.sakarkivNummer?.value,
             belop = tilsagn.beregning.output.belop,

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/arrangor/ArrangorServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/arrangor/ArrangorServiceTest.kt
@@ -34,6 +34,7 @@ class ArrangorServiceTest : FunSpec({
         organisasjonsnummer = Organisasjonsnummer("123456789"),
         organisasjonsform = "AS",
         navn = "Testbedriften AS",
+        overordnetEnhet = null,
         postadresse = null,
         forretningsadresse = null,
     )

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/arrangor/kafka/AmtVirksomheterV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/arrangor/kafka/AmtVirksomheterV1KafkaConsumerTest.kt
@@ -49,6 +49,7 @@ class AmtVirksomheterV1KafkaConsumerTest : FunSpec({
             organisasjonsnummer = amtVirksomhet.organisasjonsnummer,
             organisasjonsform = "AS",
             navn = amtVirksomhet.navn,
+            overordnetEnhet = null,
             postadresse = null,
             forretningsadresse = null,
         )

--- a/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/model/Bestilling.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/main/kotlin/no/nav/tiltak/okonomi/model/Bestilling.kt
@@ -38,12 +38,15 @@ data class Bestilling(
     )
 
     companion object {
-        fun fromOpprettBestilling(bestilling: OpprettBestilling): Bestilling {
+        fun fromOpprettBestilling(
+            bestilling: OpprettBestilling,
+            arrangorHovedenhet: Organisasjonsnummer,
+        ): Bestilling {
             val perioder = divideBelopByMonthsInPeriode(bestilling.periode, bestilling.belop)
             return Bestilling(
                 tiltakskode = bestilling.tiltakskode,
-                arrangorHovedenhet = bestilling.arrangor.hovedenhet,
-                arrangorUnderenhet = bestilling.arrangor.underenhet,
+                arrangorHovedenhet = arrangorHovedenhet,
+                arrangorUnderenhet = bestilling.arrangor,
                 kostnadssted = bestilling.kostnadssted,
                 bestillingsnummer = bestilling.bestillingsnummer,
                 avtalenummer = bestilling.avtalenummer,

--- a/mulighetsrommet-tiltaksokonomi/src/test/kotlin/no/nav/tiltak/okonomi/TiltaksokonomiTest.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/test/kotlin/no/nav/tiltak/okonomi/TiltaksokonomiTest.kt
@@ -13,7 +13,10 @@ import no.nav.mulighetsrommet.database.kotest.extensions.FlywayDatabaseTestListe
 import no.nav.mulighetsrommet.ktor.MockEngineBuilder
 import no.nav.mulighetsrommet.ktor.createMockEngine
 import no.nav.mulighetsrommet.ktor.respondJson
-import no.nav.mulighetsrommet.model.*
+import no.nav.mulighetsrommet.model.NavEnhetNummer
+import no.nav.mulighetsrommet.model.Organisasjonsnummer
+import no.nav.mulighetsrommet.model.Periode
+import no.nav.mulighetsrommet.model.Tiltakskode
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.tiltak.okonomi.api.Bestilling
 import no.nav.tiltak.okonomi.api.Faktura
@@ -100,10 +103,7 @@ class TiltaksokonomiTest : FunSpec({
                             bestillingsnummer = bestillingsnummer,
                             tilskuddstype = Tilskuddstype.TILTAK_DRIFTSTILSKUDD,
                             tiltakskode = Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
-                            arrangor = OpprettBestilling.Arrangor(
-                                hovedenhet = Organisasjonsnummer("123456789"),
-                                underenhet = Organisasjonsnummer("234567891"),
-                            ),
+                            arrangor = Organisasjonsnummer("234567891"),
                             avtalenummer = "2025/1234",
                             belop = 1000,
                             behandletAv = OkonomiPart.System(OkonomiSystem.TILTAKSADMINISTRASJON),
@@ -182,6 +182,22 @@ private fun MockEngineBuilder.mockBrregHovedenhet() {
                     "kommune": "OSLO",
                     "kommunenummer": "0301"
                 }
+            }
+        """.trimIndent()
+        respondJson(brregResponse)
+    }
+
+    get("https://data.brreg.no/enhetsregisteret/api/enheter/234567891") {
+        @Language("json")
+        val brregResponse = """
+            {
+                "organisasjonsnummer": "234567891",
+                "navn": "Tiltaksarrangør Underenhet",
+                "organisasjonsform": {
+                    "kode": "BEDR",
+                    "beskrivelse": "Underenhet til næringsdrivende og offentlig forvaltning"
+                },
+                "overordnetEnhet": "123456789"
             }
         """.trimIndent()
         respondJson(brregResponse)

--- a/mulighetsrommet-tiltaksokonomi/src/test/kotlin/no/nav/tiltak/okonomi/avstemming/AvstemmingServiceTest.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/test/kotlin/no/nav/tiltak/okonomi/avstemming/AvstemmingServiceTest.kt
@@ -32,10 +32,7 @@ class AvstemmingServiceTest : FunSpec({
             bestillingsnummer = "1",
             tilskuddstype = Tilskuddstype.TILTAK_DRIFTSTILSKUDD,
             tiltakskode = Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
-            arrangor = OpprettBestilling.Arrangor(
-                hovedenhet = Organisasjonsnummer("123456789"),
-                underenhet = Organisasjonsnummer("234567891"),
-            ),
+            arrangor = Organisasjonsnummer("234567891"),
             avtalenummer = null,
             belop = 1000,
             behandletAv = OkonomiPart.System(OkonomiSystem.TILTAKSADMINISTRASJON),
@@ -45,6 +42,7 @@ class AvstemmingServiceTest : FunSpec({
             periode = Periode.forMonthOf(LocalDate.of(2025, 1, 1)),
             kostnadssted = NavEnhetNummer("0400"),
         ),
+        Organisasjonsnummer("123456789"),
     )
 
     val faktura = Faktura.fromOpprettFaktura(
@@ -87,7 +85,10 @@ class AvstemmingServiceTest : FunSpec({
             val tidspunkt = LocalDateTime.now()
             avstemmingService.dailyAvstemming(server.port)
 
-            val fileContent = server.getFileContent("${sftpClient.properties.directory}/${dailyAvstemmingFilename(tidspunkt)}", UTF_8)
+            val fileContent = server.getFileContent(
+                "${sftpClient.properties.directory}/${dailyAvstemmingFilename(tidspunkt)}",
+                UTF_8,
+            )
             fileContent.isEmpty() shouldBe false
             fileContent.lines().size shouldBe 2
             fileContent.lines() shouldContain bestilling.toDailyCSVRad()

--- a/mulighetsrommet-tiltaksokonomi/src/test/kotlin/no/nav/tiltak/okonomi/model/BestillingTest.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/test/kotlin/no/nav/tiltak/okonomi/model/BestillingTest.kt
@@ -14,10 +14,7 @@ class BestillingTest : FunSpec({
             bestillingsnummer = "2025/1",
             tilskuddstype = Tilskuddstype.TILTAK_DRIFTSTILSKUDD,
             tiltakskode = Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
-            arrangor = OpprettBestilling.Arrangor(
-                hovedenhet = Organisasjonsnummer("123456789"),
-                underenhet = Organisasjonsnummer("234567891"),
-            ),
+            arrangor = Organisasjonsnummer("234567891"),
             avtalenummer = null,
             belop = 1000,
             behandletAv = OkonomiPart.System(OkonomiSystem.TILTAKSADMINISTRASJON),
@@ -28,8 +25,10 @@ class BestillingTest : FunSpec({
             kostnadssted = NavEnhetNummer("0400"),
         )
 
+        val hovedenhet = Organisasjonsnummer("123456789")
+
         test("felter utledes fra OpprettBestilling") {
-            val bestilling = Bestilling.fromOpprettBestilling(opprettBestilling)
+            val bestilling = Bestilling.fromOpprettBestilling(opprettBestilling, hovedenhet)
 
             bestilling.status shouldBe BestillingStatusType.SENDT
             bestilling.periode shouldBe Periode.forMonthOf(LocalDate.of(2025, 1, 1))
@@ -45,6 +44,7 @@ class BestillingTest : FunSpec({
         test("utleder bestillingslinjer for hver måned i bestillingens periode") {
             val bestilling1 = Bestilling.fromOpprettBestilling(
                 opprettBestilling.copy(periode = Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 3, 1))),
+                hovedenhet,
             )
             bestilling1.linjer shouldBe listOf(
                 Bestilling.Linje(
@@ -61,6 +61,7 @@ class BestillingTest : FunSpec({
 
             val bestilling2 = Bestilling.fromOpprettBestilling(
                 opprettBestilling.copy(periode = Periode(LocalDate.of(2025, 7, 15), LocalDate.of(2025, 8, 15))),
+                hovedenhet,
             )
             bestilling2.linjer shouldBe listOf(
                 Bestilling.Linje(

--- a/mulighetsrommet-tiltaksokonomi/src/test/kotlin/no/nav/tiltak/okonomi/oebs/OebsRoutesTest.kt
+++ b/mulighetsrommet-tiltaksokonomi/src/test/kotlin/no/nav/tiltak/okonomi/oebs/OebsRoutesTest.kt
@@ -38,10 +38,7 @@ class OebsRoutesTest : FunSpec({
             bestillingsnummer = "1",
             tilskuddstype = Tilskuddstype.TILTAK_DRIFTSTILSKUDD,
             tiltakskode = Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
-            arrangor = OpprettBestilling.Arrangor(
-                hovedenhet = Organisasjonsnummer("123456789"),
-                underenhet = Organisasjonsnummer("234567891"),
-            ),
+            arrangor = Organisasjonsnummer("234567891"),
             avtalenummer = null,
             belop = 1000,
             behandletAv = OkonomiPart.System(OkonomiSystem.TILTAKSADMINISTRASJON),
@@ -51,6 +48,7 @@ class OebsRoutesTest : FunSpec({
             periode = Periode.forMonthOf(LocalDate.of(2025, 1, 1)),
             kostnadssted = NavEnhetNummer("0400"),
         ),
+        Organisasjonsnummer("123456789"),
     )
     val faktura = Faktura.fromOpprettFaktura(
         OpprettFaktura(


### PR DESCRIPTION
Hovedenhet utledes nå direkte fra brreg i stedet for at arrangør fra avtalen sendes med fra mr-api.
I tillegg følger vi hele organisasjonsstrukturen opp helt til øverste organisasjonsledd.

Dette gjøres fordi Oebs trenger å være oppdatert med siste organisasjonsstruktur fra brreg (uavhengig av hva som er registrert på gjennomføring/avtale i Tiltaksadministrasjon) og fordi de ikke vedlikeholder dette selv.