### PR TITLE
gjør prismodell påkrevd for alle avtaler

### DIFF
--- a/frontend/mr-admin-flate/src/components/avtaler/AvtaleFormContainer.tsx
+++ b/frontend/mr-admin-flate/src/components/avtaler/AvtaleFormContainer.tsx
@@ -112,7 +112,7 @@ export function AvtaleFormContainer({
         customOpsjonsmodellNavn: data.opsjonsmodell.customOpsjonsmodellNavn || null,
       },
       utdanningslop: getUtdanningslop(data),
-      prismodell: enableTilsagn ? data.prismodell : null,
+      prismodell: data.prismodell ?? Prismodell.FRI,
     };
 
     mutation.mutate(requestBody, {

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_avtaler.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_avtaler.ts
@@ -136,7 +136,7 @@ export const mockAvtaler: AvtaleDto[] = [
     },
     opsjonerRegistrert: [],
     utdanningslop: null,
-    prismodell: null,
+    prismodell: Prismodell.FRI,
   },
   {
     id: "6374b285-989d-4f78-a59e-29481b64ba92",
@@ -186,7 +186,7 @@ export const mockAvtaler: AvtaleDto[] = [
     },
     opsjonerRegistrert: [],
     utdanningslop: null,
-    prismodell: null,
+    prismodell: Prismodell.FRI,
   },
   {
     id: "6374b285-989d-4f78-a59e-29481b64ba93",
@@ -293,6 +293,6 @@ for (let i = 0; i < x; i++) {
     },
     opsjonerRegistrert: [],
     utdanningslop: null,
-    prismodell: null,
+    prismodell: Prismodell.FRI,
   });
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/AvtaleRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/AvtaleRoutes.kt
@@ -51,7 +51,7 @@ data class AvtaleRequest(
     val opsjonsmodell: Opsjonsmodell,
     val amoKategorisering: AmoKategorisering?,
     val utdanningslop: UtdanningslopDbo?,
-    val prismodell: Prismodell?,
+    val prismodell: Prismodell,
 ) {
 
     @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/AvtaleValidator.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/AvtaleValidator.kt
@@ -17,14 +17,11 @@ import no.nav.mulighetsrommet.api.tiltakstype.TiltakstypeService
 import no.nav.mulighetsrommet.api.utils.DatoUtils.formaterDatoTilEuropeiskDatoformat
 import no.nav.mulighetsrommet.arena.ArenaMigrering
 import no.nav.mulighetsrommet.model.*
-import no.nav.mulighetsrommet.unleash.Toggle
-import no.nav.mulighetsrommet.unleash.UnleashService
 
 class AvtaleValidator(
     private val db: ApiDatabase,
     private val tiltakstyper: TiltakstypeService,
     private val navEnheterService: NavEnhetService,
-    private val unleash: UnleashService,
 ) {
     private val opsjonsmodellerUtenValidering = listOf(
         OpsjonsmodellType.INGEN_OPSJONSMULIGHET,
@@ -112,21 +109,10 @@ class AvtaleValidator(
                 }
             }
 
-            if (unleash.isEnabledForTiltakstype(Toggle.MIGRERING_TILSAGN, tiltakskode)) {
-                if (avtale.prismodell == null) {
-                    add(FieldError.of(AvtaleDbo::prismodell, "Du må velge en prismodell"))
-                } else if (avtale.avtaletype == Avtaletype.FORHANDSGODKJENT && avtale.prismodell != Prismodell.FORHANDSGODKJENT) {
-                    add(FieldError.of(AvtaleDbo::prismodell, "Prismodellen må være forhåndsgodkjent"))
-                } else if (avtale.avtaletype != Avtaletype.FORHANDSGODKJENT && avtale.prismodell == Prismodell.FORHANDSGODKJENT) {
-                    add(FieldError.of(AvtaleDbo::prismodell, "Prismodellen kan ikke være forhåndsgodkjent"))
-                }
-            } else if (avtale.prismodell != null) {
-                add(
-                    FieldError.of(
-                        AvtaleDbo::prismodell,
-                        "Prismodell kan foreløpig ikke velges for tiltakstype ${tiltakstype.navn}",
-                    ),
-                )
+            if (avtale.avtaletype == Avtaletype.FORHANDSGODKJENT && avtale.prismodell != Prismodell.FORHANDSGODKJENT) {
+                add(FieldError.of(AvtaleDbo::prismodell, "Prismodellen må være forhåndsgodkjent"))
+            } else if (avtale.avtaletype != Avtaletype.FORHANDSGODKJENT && avtale.prismodell == Prismodell.FORHANDSGODKJENT) {
+                add(FieldError.of(AvtaleDbo::prismodell, "Prismodellen kan ikke være forhåndsgodkjent"))
             }
 
             if (tiltakskode == Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING && avtale.amoKategorisering == null) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/db/AvtaleDbo.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/db/AvtaleDbo.kt
@@ -28,7 +28,7 @@ data class AvtaleDbo(
     val amoKategorisering: AmoKategorisering?,
     val opsjonsmodell: Opsjonsmodell,
     val utdanningslop: UtdanningslopDbo?,
-    val prismodell: Prismodell?,
+    val prismodell: Prismodell,
 ) {
     data class Arrangor(
         val hovedenhet: UUID,

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/model/AvtaleDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/avtale/model/AvtaleDto.kt
@@ -39,7 +39,7 @@ data class AvtaleDto(
     val opsjonsmodell: Opsjonsmodell,
     val opsjonerRegistrert: List<OpsjonLoggRegistrert>?,
     val utdanningslop: UtdanningslopDto?,
-    val prismodell: Prismodell?,
+    val prismodell: Prismodell,
 ) {
 
     @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -403,7 +403,7 @@ private fun services(appConfig: AppConfig) = module {
     }
     single { DeltakerService(get(), get(), get()) }
     single { UnleashService(appConfig.unleash) }
-    single { AvtaleValidator(get(), get(), get(), get()) }
+    single { AvtaleValidator(get(), get(), get()) }
     single { GjennomforingValidator(get()) }
     single { LagretFilterService(get()) }
     single {

--- a/mulighetsrommet-api/src/main/resources/db/migration/V323__avtale_prismodell.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V323__avtale_prismodell.sql
@@ -1,0 +1,6 @@
+update avtale
+set prismodell = 'FRI'
+where prismodell is null;
+
+alter table avtale
+    alter prismodell set not null;

--- a/mulighetsrommet-api/src/main/resources/web/openapi.yaml
+++ b/mulighetsrommet-api/src/main/resources/web/openapi.yaml
@@ -3008,9 +3008,7 @@ components:
             - type: ["null"]
             - $ref: "#/components/schemas/Utdanningslop"
         prismodell:
-          anyOf:
-            - type: ["null"]
-            - $ref: "#/components/schemas/Prismodell"
+          $ref: "#/components/schemas/Prismodell"
       required:
         - id
         - tiltakstype
@@ -3106,9 +3104,7 @@ components:
             - type: "null"
             - $ref: "#/components/schemas/UtdanningslopDbo"
         prismodell:
-          anyOf:
-            - type: "null"
-            - $ref: "#/components/schemas/Prismodell"
+          $ref: "#/components/schemas/Prismodell"
       required:
         - id
         - navn
@@ -6002,24 +5998,24 @@ components:
       required: [id, status, periode, beregning, createdAt, tilskuddstype]
 
     UtbetalingKompaktDto:
-        type: object
-        properties:
-          id:
-            type: string
-            format: uuid
-          status:
-            $ref: "#/components/schemas/AdminUtbetalingStatus"
-          periode:
-            $ref: "#/components/schemas/Periode"
-          kostnadssteder:
-            type: array
-            items:
-              $ref: "#/components/schemas/NavEnhet"
-          belopUtbetalt:
-            type: [number, "null"]
-          type:
-            $ref: "#/components/schemas/UtbetalingType"
-        required: [ id, status, periode, kostnadssteder, belopUtbetalt ]
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: "#/components/schemas/AdminUtbetalingStatus"
+        periode:
+          $ref: "#/components/schemas/Periode"
+        kostnadssteder:
+          type: array
+          items:
+            $ref: "#/components/schemas/NavEnhet"
+        belopUtbetalt:
+          type: [number, "null"]
+        type:
+          $ref: "#/components/schemas/UtbetalingType"
+      required: [id, status, periode, kostnadssteder, belopUtbetalt]
 
     UtbetalingType:
       type: string
@@ -6257,7 +6253,6 @@ components:
       oneOf:
         - $ref: "#/components/schemas/BeregningForhandsgodkjent"
         - $ref: "#/components/schemas/BeregningFri"
-
 
     UtbetalingStengtPeriode:
       type: object
@@ -6589,8 +6584,8 @@ components:
           type: string
           format: UUID
         tilsagnId:
-            type: string
-            format: UUID
+          type: string
+          format: UUID
         periodeStart:
           type: string
         periodeSlutt:

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/fixtures/AvtaleFixtures.kt
@@ -35,7 +35,7 @@ object AvtaleFixtures {
         amoKategorisering = null,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.TO_PLUSS_EN, LocalDate.now().plusYears(3)),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FRI,
     )
 
     val oppfolgingMedAvtale = AvtaleDbo(
@@ -64,7 +64,7 @@ object AvtaleFixtures {
         amoKategorisering = null,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.TO_PLUSS_EN, LocalDate.now().plusYears(3)),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FRI,
     )
 
     val gruppeAmo = AvtaleDbo(
@@ -93,7 +93,7 @@ object AvtaleFixtures {
         amoKategorisering = AmoKategorisering.Studiespesialisering,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.TO_PLUSS_EN, LocalDate.now().plusYears(3)),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FRI,
     )
 
     val gruppeFagYrke = AvtaleDbo(
@@ -122,7 +122,7 @@ object AvtaleFixtures {
         amoKategorisering = null,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.TO_PLUSS_EN, LocalDate.now().plusYears(3)),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FRI,
     )
 
     val VTA = AvtaleDbo(
@@ -151,7 +151,7 @@ object AvtaleFixtures {
         amoKategorisering = null,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.VALGFRI_SLUTTDATO, null),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FORHANDSGODKJENT,
     )
 
     val AFT = AvtaleDbo(
@@ -180,7 +180,7 @@ object AvtaleFixtures {
         amoKategorisering = null,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.VALGFRI_SLUTTDATO, null),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FORHANDSGODKJENT,
     )
 
     val EnkelAmo = AvtaleDbo(
@@ -209,7 +209,7 @@ object AvtaleFixtures {
         amoKategorisering = null,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.TO_PLUSS_EN, LocalDate.now().plusYears(3)),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FRI,
     )
 
     val jobbklubb = AvtaleDbo(
@@ -238,7 +238,7 @@ object AvtaleFixtures {
         amoKategorisering = null,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.TO_PLUSS_EN, LocalDate.now().plusYears(3)),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FRI,
     )
 
     val avtaleRequest = AvtaleRequest(
@@ -269,7 +269,7 @@ object AvtaleFixtures {
             customOpsjonsmodellNavn = null,
         ),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FRI,
     )
 
     /**
@@ -301,6 +301,6 @@ object AvtaleFixtures {
         amoKategorisering = null,
         opsjonsmodell = Opsjonsmodell(OpsjonsmodellType.TO_PLUSS_EN, LocalDate.now().plusYears(3)),
         utdanningslop = null,
-        prismodell = null,
+        prismodell = Prismodell.FRI,
     )
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumerTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/kafka/AmtDeltakerV1KafkaConsumerTest.kt
@@ -136,8 +136,8 @@ class AmtDeltakerV1KafkaConsumerTest : FunSpec({
         test("tolker deltakelsesprosent som 100 hvis den mangler for tiltak med forhåndsgodkjent prismodell") {
             MulighetsrommetTestDomain(
                 avtaler = listOf(
-                    AvtaleFixtures.AFT.copy(prismodell = Prismodell.FORHANDSGODKJENT),
-                    AvtaleFixtures.VTA.copy(prismodell = null),
+                    AvtaleFixtures.AFT,
+                    AvtaleFixtures.oppfolging,
                 ),
             ).initialize(database.db)
 
@@ -148,7 +148,7 @@ class AmtDeltakerV1KafkaConsumerTest : FunSpec({
             )
             deltakerConsumer.consume(
                 amtDeltaker2.id,
-                Json.encodeToJsonElement(amtDeltaker2.copy(gjennomforingId = VTA1.id)),
+                Json.encodeToJsonElement(amtDeltaker2.copy(gjennomforingId = Oppfolging1.id)),
             )
 
             database.run {
@@ -157,7 +157,7 @@ class AmtDeltakerV1KafkaConsumerTest : FunSpec({
                         .copy(gjennomforingId = AFT1.id, deltakelsesprosent = 100.0)
                         .toDeltaker(),
                     deltaker2Dbo
-                        .copy(gjennomforingId = VTA1.id, deltakelsesprosent = null)
+                        .copy(gjennomforingId = Oppfolging1.id, deltakelsesprosent = null)
                         .toDeltaker(),
                 )
             }


### PR DESCRIPTION
- migrerer eksisterende avtaler til FRI prismodell
- økonomi-fane vises fortsatt kun tilsagn har blitt skrudd på for gjeldende tiltakstype, men nye avtaler får FRI som standard