### PR TITLE
Legg til datastream dato kolonner for periode

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/DelutbetalingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/DelutbetalingQueries.kt
@@ -33,7 +33,9 @@ class DelutbetalingQueries(private val session: Session) {
                 lopenummer,
                 fakturanummer,
                 faktura_status,
-                faktura_status_sist_oppdatert
+                faktura_status_sist_oppdatert,
+                datastream_periode_start,
+                datastream_periode_slutt
             ) values (
                 :id::uuid,
                 :tilsagn_id::uuid,
@@ -45,7 +47,9 @@ class DelutbetalingQueries(private val session: Session) {
                 :lopenummer,
                 :fakturanummer,
                 :faktura_status,
-                :faktura_status_sist_oppdatert::date
+                :faktura_status_sist_oppdatert::date,
+                :datastream_periode_start::date,
+                :datastream_periode_slutt::date
             ) on conflict (id) do update set
                 status                        = excluded.status,
                 belop                         = excluded.belop,
@@ -54,7 +58,9 @@ class DelutbetalingQueries(private val session: Session) {
                 lopenummer                    = excluded.lopenummer,
                 fakturanummer                 = excluded.fakturanummer,
                 faktura_status                = excluded.faktura_status,
-                faktura_status_sist_oppdatert = excluded.faktura_status_sist_oppdatert
+                faktura_status_sist_oppdatert = excluded.faktura_status_sist_oppdatert,
+                datastream_periode_start      = excluded.datastream_periode_start,
+                datastream_periode_slutt      = excluded.datastream_periode_slutt
         """.trimIndent()
 
         val params = mapOf(
@@ -69,6 +75,8 @@ class DelutbetalingQueries(private val session: Session) {
             "lopenummer" to delutbetaling.lopenummer,
             "fakturanummer" to delutbetaling.fakturanummer,
             "faktura_status" to delutbetaling.fakturaStatus?.name,
+            "datastream_periode_start" to delutbetaling.periode.start,
+            "datastream_periode_slutt" to delutbetaling.periode.getLastInclusiveDate(),
         )
 
         session.execute(queryOf(query, params))

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/UtbetalingQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/db/UtbetalingQueries.kt
@@ -32,7 +32,9 @@ class UtbetalingQueries(private val session: Session) {
                 innsender,
                 tilskuddstype,
                 beskrivelse,
-                godkjent_av_arrangor_tidspunkt
+                godkjent_av_arrangor_tidspunkt,
+                datastream_periode_start,
+                datastream_periode_slutt
             ) values (
                 :id::uuid,
                 :gjennomforing_id::uuid,
@@ -44,7 +46,9 @@ class UtbetalingQueries(private val session: Session) {
                 :innsender,
                 :tilskuddstype::tilskuddstype,
                 :beskrivelse,
-                :godkjent_av_arrangor_tidspunkt
+                :godkjent_av_arrangor_tidspunkt,
+                :datastream_periode_start::date,
+                :datastream_periode_slutt::date
             ) on conflict (id) do update set
                 gjennomforing_id = excluded.gjennomforing_id,
                 kontonummer = excluded.kontonummer,
@@ -55,7 +59,9 @@ class UtbetalingQueries(private val session: Session) {
                 innsender = excluded.innsender,
                 tilskuddstype = excluded.tilskuddstype,
                 beskrivelse = excluded.beskrivelse,
-                godkjent_av_arrangor_tidspunkt = excluded.godkjent_av_arrangor_tidspunkt
+                godkjent_av_arrangor_tidspunkt = excluded.godkjent_av_arrangor_tidspunkt,
+                datastream_periode_start      = excluded.datastream_periode_start,
+                datastream_periode_slutt      = excluded.datastream_periode_slutt
         """.trimIndent()
 
         val params = mapOf(
@@ -75,6 +81,8 @@ class UtbetalingQueries(private val session: Session) {
             "beskrivelse" to dbo.beskrivelse,
             "tilskuddstype" to dbo.tilskuddstype.name,
             "godkjent_av_arrangor_tidspunkt" to dbo.godkjentAvArrangorTidspunkt,
+            "datastream_periode_start" to dbo.periode.start,
+            "datastream_periode_slutt" to dbo.periode.getLastInclusiveDate(),
         )
 
         execute(queryOf(utbetalingQuery, params))

--- a/mulighetsrommet-api/src/main/resources/db/migration/V331__datastream_periods_utbetaling_delutbetaling_.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V331__datastream_periods_utbetaling_delutbetaling_.sql
@@ -1,0 +1,17 @@
+-- Legger til datastream spesifikke kolonner, da data range ikke støttes, og heller ikke genererte/trigger endret kolonner
+alter table utbetaling
+    add column datastream_periode_start date,
+    add column datastream_periode_slutt date;
+
+update utbetaling set datastream_periode_start = lower(periode),
+                   datastream_periode_slutt = (upper(periode) - INTERVAL '1 day')::DATE;
+
+alter table delutbetaling
+    add column datastream_periode_start date,
+    add column datastream_periode_slutt date;
+
+update delutbetaling set datastream_periode_start = lower(periode),
+                      datastream_periode_slutt = (upper(periode) - INTERVAL '1 day')::DATE;
+
+
+


### PR DESCRIPTION
Har det samme for tilsagn: https://github.com/navikt/mulighetsrommet/pull/5528

Datastream støtter ikke daterange typen, og plukker ikke opp andre DB eventer enn kolonne endringer.