### PR TITLE
Datastream: totrinnskontroll prod - forbredelse utbetalinger

### DIFF
--- a/iac/bigquery-terraform/dev/datastreams.tf
+++ b/iac/bigquery-terraform/dev/datastreams.tf
@@ -43,8 +43,14 @@ module "mr_api_datastream" {
         { table = "tilsagn" },
         { table = "delutbetaling" },
         { table = "utbetaling" },
-        { table = "del_med_bruker", columns = ["id", "tiltakstype_navn", "delt_fra_fylke", "delt_fra_enhet", "created_at"] },
-        { table = "totrinnskontroll", columns = ["id", "entity_id", "behandlet_tidspunkt", "behandlet_av", "besluttet_av", "besluttet_tidspunkt", "besluttelse"] }
+        {
+          table   = "del_med_bruker",
+          columns = ["id", "tiltakstype_navn", "delt_fra_fylke", "delt_fra_enhet", "created_at"]
+        },
+        {
+          table   = "totrinnskontroll",
+          columns = ["id", "entity_id", "behandlet_tidspunkt", "behandlet_av", "besluttet_av", "besluttet_tidspunkt", "besluttelse"]
+        }
       ]
     }
   ]

--- a/iac/bigquery-terraform/prod/datastreams.tf
+++ b/iac/bigquery-terraform/prod/datastreams.tf
@@ -46,6 +46,10 @@ module "mr_api_datastream" {
         {
           table   = "del_med_bruker",
           columns = ["id", "tiltakstype_navn", "delt_fra_fylke", "delt_fra_enhet", "created_at"]
+        },
+        {
+          table   = "totrinnskontroll",
+          columns = ["id", "entity_id", "behandlet_tidspunkt", "behandlet_av", "besluttet_av", "besluttet_tidspunkt", "besluttelse"]
         }
       ]
     }


### PR DESCRIPTION
Når vi får inn utbetalinger, vil vi kunne begynne å bruke dashboardet. Trenger totrinnskontrollen til den tid