### PR TITLE
chore/fix warnings

### DIFF
--- a/frontend/arena-adapter-manager/.nais/nais-dev.yaml
+++ b/frontend/arena-adapter-manager/.nais/nais-dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: team-mulighetsrommet
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.05.05_06.50-1fe97d204c27
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.07.22_10.47-42209197457b
   port: 8080
   ingresses:
     - https://mulighetsrommet-arena-adapter-manager.intern.dev.nav.no

--- a/frontend/arena-adapter-manager/.nais/nais-prod.yaml
+++ b/frontend/arena-adapter-manager/.nais/nais-prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: team-mulighetsrommet
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.05.05_06.50-1fe97d204c27
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.07.22_10.47-42209197457b
   port: 8080
   ingresses:
     - https://mulighetsrommet-arena-adapter-manager.intern.nav.no

--- a/frontend/mr-admin-flate/.nais/nais-dev.yaml
+++ b/frontend/mr-admin-flate/.nais/nais-dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: team-mulighetsrommet
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.05.05_06.50-1fe97d204c27
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.07.22_10.47-42209197457b
   port: 8080
   ingresses:
     - https://tiltaksadministrasjon.intern.dev.nav.no

--- a/frontend/mr-admin-flate/.nais/nais-prod.yaml
+++ b/frontend/mr-admin-flate/.nais/nais-prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: team-mulighetsrommet
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.05.05_06.50-1fe97d204c27
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.07.22_10.47-42209197457b
   port: 8080
   ingresses:
     - https://tiltaksadministrasjon.intern.nav.no

--- a/frontend/mulighetsrommet-veileder-flate/.nais/nais-dev.yaml
+++ b/frontend/mulighetsrommet-veileder-flate/.nais/nais-dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: team-mulighetsrommet
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.05.05_06.50-1fe97d204c27
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.07.22_10.47-42209197457b
   port: 8080
   ingresses:
     - https://nav-arbeidsmarkedstiltak.intern.dev.nav.no

--- a/frontend/mulighetsrommet-veileder-flate/.nais/nais-prod.yaml
+++ b/frontend/mulighetsrommet-veileder-flate/.nais/nais-prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: team-mulighetsrommet
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.05.05_06.50-1fe97d204c27
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/poao-frontend:2025.07.22_10.47-42209197457b
   port: 8080
   ingresses:
     - https://nav-arbeidsmarkedstiltak.intern.nav.no

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,6 @@ org.gradle.configuration-cache=true
 # Enable build cache
 org.gradle.caching=true
 
-# https://blog.jetbrains.com/kotlin/2022/07/a-new-approach-to-incremental-compilation-in-kotlin/
-kotlin.incremental.useClasspathSnapshot=true
-
 # Display all warnings
 org.gradle.warning.mode=all
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/TiltakshistorikkService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/TiltakshistorikkService.kt
@@ -307,7 +307,7 @@ private val deltakelseComparator: Comparator<Deltakelse> = Comparator { a, b ->
     val startDatoB = b.periode.startDato
 
     when {
-        startDatoA === startDatoB -> 0
+        startDatoA == startDatoB -> 0
         startDatoA == null -> -1
         startDatoB == null -> 1
         else -> startDatoB.compareTo(startDatoA)


### PR DESCRIPTION
- **generaliser Metrics til å eksponere MeterRegistry i stedet for PrometheusMeterRegistry**
- **bump hikaricp og fiks hikari-metrikker**
- **bump ktlint**
- **remove deprecated config option**
- **benytt vanlig equals**
- **bump poao-frontend**
