### PR TITLE
Grafana: Utbetaling dashboard i prod

### DIFF
--- a/iac/bigquery-terraform/prod/datastreams.tf
+++ b/iac/bigquery-terraform/prod/datastreams.tf
@@ -182,6 +182,41 @@ module "mr_api_datastream" {
         project_id = var.gcp_project["project"]
         table_id   = "tilsagn_feilet_view"
       }
-    }
+    },
+    # {
+    #   view = {
+    #     dataset_id = local.grafana_dataset_id
+    #     project_id = var.gcp_project["project"]
+    #     table_id   = "utbetaling_arrangor_innsending_stats_view"
+    #   }
+    # },
+    # {
+    #   view = {
+    #     dataset_id = local.grafana_dataset_id
+    #     project_id = var.gcp_project["project"]
+    #     table_id   = "utbetaling_arrangor_utestaende_innsendinger_view"
+    #   }
+    # },
+    # {
+    #   view = {
+    #     dataset_id = local.grafana_dataset_id
+    #     project_id = var.gcp_project["project"]
+    #     table_id   = "utbetaling_antall_godkjente_per_prosess_view"
+    #   }
+    # },
+    # {
+    #   view = {
+    #     dataset_id = local.grafana_dataset_id
+    #     project_id = var.gcp_project["project"]
+    #     table_id   = "utbetaling_feilet_view"
+    #   }
+    # },
+    # {
+    #   view = {
+    #     dataset_id = local.grafana_dataset_id
+    #     project_id = var.gcp_project["project"]
+    #     table_id   = "utbetaling_admin_korreksjoner_view"
+    #   }
+    # },
   ]
 }


### PR DESCRIPTION
Siden vi ikke har data i utbetaling og delutbetalingstabellene, finnes de ikke i bigquery enda (ingenting å strømme, si!)

Når vi har åpnet opp for utbetaling, og det finnes rader i databasen:
 - Sjekk at datastream tabellene `public_utbetaling` og `public_delutbetaling` [eksister i bigquery](https://console.cloud.google.com/bigquery?inv=1&invt=Ab3b4w&project=team-mulighetsrommet-prod-5492&ws=!1m5!1m4!4m3!1steam-mulighetsrommet-prod-5492!2smulighetsrommet_api_datastream!3spublic_utbetaling)
 - Merge først viewene (denne PRen), slik at de blir opprettet.
 - Lag ny PR hvor de utkommenterte authorized-view-statementene i `datastreams.tf` er kommentert inn.

Voilá

[Trello](https://trello.com/c/acXt8qdR/2670-monitorering-utbetalinger)