### PR TITLE
legg til kolonne for tiltakstype_id ifm del_med_bruker

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/routes/DelMedBrukerRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/veilederflate/routes/DelMedBrukerRoutes.kt
@@ -12,6 +12,7 @@ import no.nav.mulighetsrommet.api.clients.dialog.VeilarbdialogError
 import no.nav.mulighetsrommet.api.plugins.getNavAnsattEntraObjectId
 import no.nav.mulighetsrommet.api.plugins.getNavIdent
 import no.nav.mulighetsrommet.api.services.PoaoTilgangService
+import no.nav.mulighetsrommet.api.tiltakstype.TiltakstypeService
 import no.nav.mulighetsrommet.api.veilederflate.models.DelMedBrukerDbo
 import no.nav.mulighetsrommet.api.veilederflate.services.DelMedBrukerService
 import no.nav.mulighetsrommet.api.veilederflate.services.TiltakDeltMedBruker

--- a/mulighetsrommet-api/src/main/resources/db/migration/V336__del_med_bruker_tiltakstype_id.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V336__del_med_bruker_tiltakstype_id.sql
@@ -1,0 +1,2 @@
+alter table del_med_bruker
+    add tiltakstype_id uuid;

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/DelMedBrukerServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/veilederflate/services/DelMedBrukerServiceTest.kt
@@ -90,7 +90,7 @@ class DelMedBrukerServiceTest : FunSpec({
                 sanityId = null,
                 gjennomforingId = GjennomforingFixtures.Oppfolging1.id,
                 dialogId = "1234",
-                tiltakstypeNavn = "Avklaring",
+                tiltakstypeNavn = TiltakstypeFixtures.Oppfolging.navn,
                 deltFraFylke = NavEnhetNummer("0300"),
                 deltFraEnhet = NavEnhetNummer("0301"),
             )
@@ -106,6 +106,9 @@ class DelMedBrukerServiceTest : FunSpec({
                 it.gjennomforingId shouldBe GjennomforingFixtures.Oppfolging1.id
                 it.sanityId shouldBe null
             }
+
+            database.assertTable("del_med_bruker")
+                .row().value("tiltakstype_id").isEqualTo(TiltakstypeFixtures.Oppfolging.id.toString())
         }
 
         test("Hent Del med bruker-historikk fra database og Sanity") {


### PR DESCRIPTION
Dette er en midlertidig måte å utlede tiltakstype_id for delinger uten å måtte endre modell eksponert på api'et. Endringen tillater at vi kan migrere underliggende data med tiltakstype-id'er i forkant av #6064 