### PR TITLE
generer utbetaling for gitt periode i stedet for måned

### DIFF
--- a/frontend/arena-adapter-manager/src/pages/MrApi.tsx
+++ b/frontend/arena-adapter-manager/src/pages/MrApi.tsx
@@ -152,26 +152,13 @@ export function MrApi() {
           task={"generate-utbetaling"}
           input={{
             type: "object",
-            required: ["month"],
+            required: ["date"],
             properties: {
-              month: {
-                type: "number",
-                title: "Velg måned",
-                description: "Velg måneden det skal genereres utbetaling for",
-                oneOf: [
-                  { const: 1, title: "Januar" },
-                  { const: 2, title: "Februar" },
-                  { const: 3, title: "Mars" },
-                  { const: 4, title: "April" },
-                  { const: 5, title: "Mai" },
-                  { const: 6, title: "Juni" },
-                  { const: 7, title: "Juli" },
-                  { const: 8, title: "August" },
-                  { const: 9, title: "September" },
-                  { const: 10, title: "Oktober" },
-                  { const: 11, title: "November" },
-                  { const: 12, title: "Desember" },
-                ],
+              date: {
+                type: "string",
+                format: "date",
+                title: "Velg dato",
+                description: "Velg dato for måneden det skal genereres utbetaling for",
               },
             },
           }}

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/MaamRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/internal/MaamRoutes.kt
@@ -18,10 +18,13 @@ import no.nav.mulighetsrommet.arena.ArenaMigrering
 import no.nav.mulighetsrommet.kafka.KafkaConsumerOrchestrator
 import no.nav.mulighetsrommet.kafka.Topic
 import no.nav.mulighetsrommet.model.Organisasjonsnummer
+import no.nav.mulighetsrommet.model.Periode
 import no.nav.mulighetsrommet.model.Tiltakskode
+import no.nav.mulighetsrommet.serializers.LocalDateSerializer
 import no.nav.mulighetsrommet.serializers.UUIDSerializer
 import no.nav.mulighetsrommet.utdanning.task.SynchronizeUtdanninger
 import org.koin.ktor.ext.inject
+import java.time.LocalDate
 import java.util.*
 
 fun Route.maamRoutes() {
@@ -113,9 +116,10 @@ fun Route.maamRoutes() {
             }
 
             post("generate-utbetaling") {
-                val (month) = call.receive<GenerateUtbetalingRequest>()
-                val utbetalinger = generateUtbetaling.runTask(month)
-                val response = ExecutedTaskResponse("Genererte ${utbetalinger.size} utbetalinger for måned $month")
+                val request = call.receive<GenerateUtbetalingRequest>()
+                val periode = Periode.forMonthOf(request.date)
+                val utbetalinger = generateUtbetaling.runTask(periode)
+                val response = ExecutedTaskResponse("Genererte ${utbetalinger.size} utbetalinger for periode $periode")
                 call.respond(HttpStatusCode.OK, response)
             }
         }
@@ -139,7 +143,8 @@ fun Route.maamRoutes() {
 
 @Serializable
 data class GenerateUtbetalingRequest(
-    val month: Int,
+    @Serializable(with = LocalDateSerializer::class)
+    val date: LocalDate,
 )
 
 @Serializable

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingService.kt
@@ -38,11 +38,7 @@ class GenererUtbetalingService(
         .recordStats()
         .build()
 
-    suspend fun genererUtbetalingForMonth(month: Int): List<Utbetaling> = db.transaction {
-        val currentYear = LocalDate.now().year
-        val date = LocalDate.of(currentYear, month, 1)
-        val periode = Periode.forMonthOf(date)
-
+    suspend fun genererUtbetalingForPeriode(periode: Periode): List<Utbetaling> = db.transaction {
         getGjennomforingerForGenereringAvUtbetalinger(periode)
             .mapNotNull { (gjennomforingId, prismodell) ->
                 val gjennomforing = requireNotNull(queries.gjennomforing.get(gjennomforingId))

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/GenerateUtbetaling.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/task/GenerateUtbetaling.kt
@@ -7,6 +7,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.Schedule
 import com.github.kagkarlsson.scheduler.task.schedule.Schedules
 import no.nav.mulighetsrommet.api.utbetaling.GenererUtbetalingService
 import no.nav.mulighetsrommet.api.utbetaling.model.Utbetaling
+import no.nav.mulighetsrommet.model.Periode
 import no.nav.mulighetsrommet.tasks.executeSuspend
 import java.time.LocalDate
 
@@ -30,15 +31,15 @@ class GenerateUtbetaling(
     val task: RecurringTask<Void> = Tasks
         .recurring(javaClass.simpleName, config.toSchedule())
         .executeSuspend { _, _ ->
-            val month = LocalDate.now().minusMonths(1).month.value
-            runTask(month)
+            val periode = Periode.forMonthOf(LocalDate.now().minusMonths(1))
+            runTask(periode)
         }
 
-    suspend fun runTask(month: Int): List<Utbetaling> {
+    suspend fun runTask(periode: Periode): List<Utbetaling> {
         if (config.disabled) {
             return listOf()
         }
 
-        return utbetalinger.genererUtbetalingForMonth(month)
+        return utbetalinger.genererUtbetalingForPeriode(periode)
     }
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingServiceTest.kt
@@ -53,6 +53,9 @@ class GenererUtbetalingServiceTest : FunSpec({
         ),
     )
 
+    val januar = Periode.forMonthOf(LocalDate.of(2025, 1, 1))
+    val februar = Periode.forMonthOf(LocalDate.of(2025, 2, 1))
+
     context("utbetalinger for forhåndsgodkjente tiltak") {
         val service = createUtbetalingService()
 
@@ -65,7 +68,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 gjennomforinger = listOf(AFT1),
             ).initialize(database.db)
 
-            service.genererUtbetalingForMonth(1).shouldHaveSize(0)
+            service.genererUtbetalingForPeriode(januar).shouldHaveSize(0)
         }
 
         test("genererer en utbetaling med riktig periode, sats og deltakere som input") {
@@ -84,7 +87,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1)
+            val utbetaling = service.genererUtbetalingForPeriode(januar)
                 .shouldHaveSize(1)
                 .first()
 
@@ -122,7 +125,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1).first()
+            val utbetaling = service.genererUtbetalingForPeriode(januar).first()
             utbetaling.gjennomforing.id shouldBe AFT1.id
             utbetaling.betalingsinformasjon.kontonummer shouldBe Kontonummer("12345678901")
             utbetaling.betalingsinformasjon.kid shouldBe null
@@ -134,7 +137,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 )
             }
 
-            val sisteKrav = service.genererUtbetalingForMonth(2).first()
+            val sisteKrav = service.genererUtbetalingForPeriode(februar).first()
             sisteKrav.gjennomforing.id shouldBe AFT1.id
             sisteKrav.betalingsinformasjon.kid shouldBe Kid.parseOrThrow("006402710013")
         }
@@ -210,7 +213,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1).first()
+            val utbetaling = service.genererUtbetalingForPeriode(januar).first()
 
             utbetaling.beregning.input.shouldBeTypeOf<UtbetalingBeregningPrisPerManedsverkMedDeltakelsesmengder.Input>()
                 .should {
@@ -305,7 +308,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 )
             }.initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1).first()
+            val utbetaling = service.genererUtbetalingForPeriode(januar).first()
 
             utbetaling.beregning.input.shouldBeTypeOf<UtbetalingBeregningPrisPerManedsverkMedDeltakelsesmengder.Input>()
                 .should {
@@ -330,7 +333,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1).first()
+            val utbetaling = service.genererUtbetalingForPeriode(januar).first()
 
             utbetaling.beregning.output.shouldBeTypeOf<UtbetalingBeregningPrisPerManedsverkMedDeltakelsesmengder.Output>()
                 .should {
@@ -364,7 +367,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1).first()
+            val utbetaling = service.genererUtbetalingForPeriode(januar).first()
 
             utbetaling.beregning.output.shouldBeTypeOf<UtbetalingBeregningPrisPerManedsverkMedDeltakelsesmengder.Output>()
                 .should {
@@ -393,7 +396,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            service.genererUtbetalingForMonth(1).shouldHaveSize(0)
+            service.genererUtbetalingForPeriode(januar).shouldHaveSize(0)
         }
 
         test("forsøker ikke å generere utbetalinger når gjennomføringen starter etter utbetalingsperioden") {
@@ -416,7 +419,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            service.genererUtbetalingForMonth(1).shouldHaveSize(0)
+            service.genererUtbetalingForPeriode(januar).shouldHaveSize(0)
         }
 
         test("genererer ikke utbetaling hvis det allerede finnes en med overlappende periode") {
@@ -440,14 +443,14 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            service.genererUtbetalingForMonth(1).shouldHaveSize(1)
+            service.genererUtbetalingForPeriode(januar).shouldHaveSize(1)
             database.run { queries.utbetaling.getByArrangorIds(organisasjonsnummer).shouldHaveSize(1) }
 
-            service.genererUtbetalingForMonth(2).shouldHaveSize(1)
+            service.genererUtbetalingForPeriode(februar).shouldHaveSize(1)
             database.run { queries.utbetaling.getByArrangorIds(organisasjonsnummer).shouldHaveSize(2) }
 
             // Februar finnes allerede så ingen nye
-            service.genererUtbetalingForMonth(2).shouldHaveSize(0)
+            service.genererUtbetalingForPeriode(februar).shouldHaveSize(0)
             database.run { queries.utbetaling.getByArrangorIds(organisasjonsnummer).shouldHaveSize(2) }
         }
 
@@ -472,7 +475,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1).first()
+            val utbetaling = service.genererUtbetalingForPeriode(januar).first()
 
             utbetaling.beregning.input.shouldBeTypeOf<UtbetalingBeregningPrisPerManedsverkMedDeltakelsesmengder.Input>()
                 .should {
@@ -614,7 +617,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 )
             }.initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1)
+            val utbetaling = service.genererUtbetalingForPeriode(januar)
                 .shouldHaveSize(1)
                 .first()
 
@@ -668,7 +671,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 )
             }.initialize(database.db)
 
-            val utbetaling = service.genererUtbetalingForMonth(1)
+            val utbetaling = service.genererUtbetalingForPeriode(januar)
                 .shouldHaveSize(1)
                 .first()
 
@@ -710,7 +713,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val generertUtbetaling = service.genererUtbetalingForMonth(1).shouldHaveSize(1).first()
+            val generertUtbetaling = service.genererUtbetalingForPeriode(januar).shouldHaveSize(1).first()
             generertUtbetaling.beregning.shouldBeTypeOf<UtbetalingBeregningPrisPerManedsverk>()
 
             database.run {
@@ -786,7 +789,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val generertUtbetaling = service.genererUtbetalingForMonth(1).shouldHaveSize(1).first()
+            val generertUtbetaling = service.genererUtbetalingForPeriode(januar).shouldHaveSize(1).first()
             generertUtbetaling.beregning.shouldBeTypeOf<UtbetalingBeregningPrisPerManedsverk>()
 
             database.run {
@@ -820,7 +823,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 ),
             ).initialize(database.db)
 
-            val generertUtbetaling = service.genererUtbetalingForMonth(1).shouldHaveSize(1).first()
+            val generertUtbetaling = service.genererUtbetalingForPeriode(januar).shouldHaveSize(1).first()
             generertUtbetaling.beregning.shouldBeTypeOf<UtbetalingBeregningPrisPerManedsverk>()
 
             database.run {


### PR DESCRIPTION
Det er tryggere å sende med gjeldende datoer i stedet for å utlede basert på LocalDate.now() innad i rutinen mtp. robusthet i tester etc.