### PR TITLE
reverter endringer for å utlede sluttdato for deltakere i beregningen

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingService.kt
@@ -368,17 +368,5 @@ private fun resolveDeltakelsePerioder(
 }
 
 private fun getSluttDatoInPeriode(deltaker: Deltaker, periode: Periode): LocalDate {
-    val sluttdatoInPeriode = deltaker.sluttDato?.plusDays(1)?.coerceAtMost(periode.slutt) ?: periode.slutt
-
-    val avsluttendeStatus = listOf(
-        DeltakerStatusType.AVBRUTT,
-        DeltakerStatusType.FULLFORT,
-        DeltakerStatusType.HAR_SLUTTET,
-    )
-
-    return if (deltaker.status.type in avsluttendeStatus) {
-        minOf(sluttdatoInPeriode, deltaker.status.opprettetDato.toLocalDate().plusDays(1))
-    } else {
-        sluttdatoInPeriode
-    }
+    return deltaker.sluttDato?.plusDays(1)?.coerceAtMost(periode.slutt) ?: periode.slutt
 }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingServiceTest.kt
@@ -484,7 +484,7 @@ class GenererUtbetalingServiceTest : FunSpec({
                 }
         }
 
-        test("månedsverk til deltakere med avsluttende status blir beregnet ut ifra den minste av deltakerens sluttdato og tidspunktet for endring av status") {
+        xtest("månedsverk til deltakere med avsluttende status blir beregnet ut ifra den minste av deltakerens sluttdato og tidspunktet for når statusen ble gyldig") {
             val domain = MulighetsrommetTestDomain(
                 gjennomforinger = listOf(AFT1),
                 deltakere = listOf(
@@ -898,7 +898,7 @@ class GenererUtbetalingServiceTest : FunSpec({
             }
         }
 
-        test("månedsverk til deltakere med avsluttende status blir beregnet ut ifra den minste av deltakerens sluttdato og tidspunktet for endring av status") {
+        xtest("månedsverk til deltakere med avsluttende status blir beregnet ut ifra den minste av deltakerens sluttdato og tidspunktet for når statusen ble gyldig") {
             val avtale = AvtaleFixtures.oppfolging.copy(
                 prismodell = Prismodell.AVTALT_PRIS_PER_MANEDSVERK,
                 satser = listOf(


### PR DESCRIPTION
Det var feil å benytte status.opprettetDato, så denne logikken reverteres inntil vi får tilgang på status.gyldigFra i stedet.