### PR TITLE
test at utbetalinger ikke blir generert hvis utbetaling blir avbrutt før periode

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/GenererUtbetalingService.kt
@@ -246,7 +246,7 @@ class GenererUtbetalingService(
             select gjennomforing.id, avtale.prismodell
             from gjennomforing
                 join avtale on gjennomforing.avtale_id = avtale.id
-            where daterange(gjennomforing.start_dato, gjennomforing.slutt_dato, '[]') && :periode::daterange
+            where daterange(gjennomforing.start_dato, coalesce(gjennomforing.avsluttet_tidspunkt::date, gjennomforing.slutt_dato), '[]') && :periode::daterange
               and not exists (
                     select 1
                     from utbetaling
@@ -268,7 +268,7 @@ class GenererUtbetalingService(
             select gjennomforing.id, avtale.prismodell
             from gjennomforing
                 join avtale on gjennomforing.avtale_id = avtale.id
-            where daterange(gjennomforing.start_dato, gjennomforing.slutt_dato, '[]') && :periode::daterange
+            where daterange(gjennomforing.start_dato, coalesce(gjennomforing.avsluttet_tidspunkt::date, gjennomforing.slutt_dato), '[]') && :periode::daterange
         """.trimIndent()
 
         return session.list(queryOf(query, mapOf("periode" to periode.toDaterange()))) {


### PR DESCRIPTION
Sluttdato til gjennomføring reflekterer ikke nødvendigvis når gjennomføringen ble avsluttet, og avsluttet_tidspunkt er heller ikke til å stole på hvis opphav er Arena, men for generering av utbetalinger burde det være godt nok.

Denne endringen sørger for at vi ikke genererer utbetalinger for gjennomføringer som har et avsluttet_tidspunkt før gjeldende utbetalingsperiode og som evt. har deltakere med sluttdato innad (eller etter) gjeldende utbetalingsperiode. Dette er tilfeller som kan oppstå for data vi har arvet fra Arena, og da vil "estimert avsluttet_tidspunkt" være godt nok til å filtrere vekk falske positiver.