### PR TITLE
Refactor/regnestykke

### DIFF
--- a/frontend/mr-admin-flate/src/components/redaksjoneltInnhold/RedaksjoneltInnholdGjennomforing.tsx
+++ b/frontend/mr-admin-flate/src/components/redaksjoneltInnhold/RedaksjoneltInnholdGjennomforing.tsx
@@ -4,7 +4,6 @@ import { useGjennomforing } from "@/api/gjennomforing/useGjennomforing";
 import { useRequiredParams } from "@/hooks/useRequiredParams";
 import { Laster } from "../laster/Laster";
 import { Suspense } from "react";
-import { Faneinnhold } from "@tiltaksadministrasjon/api-client";
 
 export function RedaksjoneltInnholdGjennomforing() {
   const { gjennomforingId } = useRequiredParams(["gjennomforingId"]);
@@ -17,8 +16,7 @@ export function RedaksjoneltInnholdGjennomforing() {
           tiltakstype={gjennomforing.tiltakstype}
           kontorstruktur={gjennomforing.kontorstruktur}
           beskrivelse={gjennomforing.beskrivelse ?? null}
-          // TODO: fix types
-          faneinnhold={gjennomforing.faneinnhold as Faneinnhold | null}
+          faneinnhold={gjennomforing.faneinnhold}
           kontaktpersoner={gjennomforing.kontaktpersoner}
         />
       </GjennomforingPageLayout>

--- a/frontend/mr-admin-flate/src/mocks/fixtures/mock_utbetalinger.ts
+++ b/frontend/mr-admin-flate/src/mocks/fixtures/mock_utbetalinger.ts
@@ -1,6 +1,8 @@
 import {
   Besluttelse,
+  DataElementMathOperatorType,
   DataElementStatusVariant,
+  DataElementTextFormat,
   DelutbetalingStatus,
   TilsagnStatus,
   TilsagnType,
@@ -9,9 +11,9 @@ import {
   UtbetalingDto,
   UtbetalingKompaktDto,
   UtbetalingLinje,
+  UtbetalingLinjeHandling,
   UtbetalingStatusDtoType,
   UtbetalingTypeDto,
-  UtbetalingLinjeHandling,
 } from "@tiltaksadministrasjon/api-client";
 import { mockEnheter } from "./mock_enheter";
 
@@ -458,11 +460,25 @@ export const mockUtbetalingLinjer: UtbetalingLinje[] = [
 
 export const mockBeregning: UtbetalingBeregningDto = {
   heading: "Annen avtalt pris",
-  belop: 780,
   deltakerRegioner: [],
   deltakerTableData: {
     columns: [],
     rows: [],
   },
-  type: "no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingBeregningDto.Fri",
+  regnestykke: [
+    {
+      type: "no.nav.mulighetsrommet.model.DataElement.Text",
+      value: "Innsendt beløp",
+      format: null,
+    },
+    {
+      type: "no.nav.mulighetsrommet.model.DataElement.MathOperator",
+      operator: DataElementMathOperatorType.EQUALS,
+    },
+    {
+      type: "no.nav.mulighetsrommet.model.DataElement.Text",
+      value: "20975",
+      format: DataElementTextFormat.NOK,
+    },
+  ],
 };

--- a/frontend/tiltaksadministrasjon-api-client/openapi.yaml
+++ b/frontend/tiltaksadministrasjon-api-client/openapi.yaml
@@ -5078,33 +5078,6 @@ components:
       required:
       - handlinger
       - utbetaling
-    UtbetalingBeregningDto.FastSatsPerTiltaksplassPerManed:
-      type: object
-      properties:
-        sats:
-          type: integer
-          format: int32
-        manedsverkTotal:
-          type: number
-          format: double
-        belop:
-          type: integer
-          format: int32
-        deltakerRegioner:
-          type: array
-          items:
-            $ref: "#/components/schemas/NavRegionDto"
-        deltakerTableData:
-          $ref: "#/components/schemas/DataDrivenTableDto"
-        heading:
-          type: string
-      required:
-      - belop
-      - deltakerRegioner
-      - deltakerTableData
-      - heading
-      - manedsverkTotal
-      - sats
     NavRegionDto:
       type: object
       properties:
@@ -5136,92 +5109,26 @@ components:
       - erStandardvalg
       - navn
       - overordnetEnhet
-    UtbetalingBeregningDto.Fri:
-      type: object
-      properties:
-        belop:
-          type: integer
-          format: int32
-        deltakerRegioner:
-          type: array
-          items:
-            $ref: "#/components/schemas/NavRegionDto"
-        deltakerTableData:
-          $ref: "#/components/schemas/DataDrivenTableDto"
-        heading:
-          type: string
-      required:
-      - belop
-      - deltakerRegioner
-      - deltakerTableData
-      - heading
-    UtbetalingBeregningDto.PrisPerManedsverk:
-      type: object
-      properties:
-        sats:
-          type: integer
-          format: int32
-        manedsverkTotal:
-          type: number
-          format: double
-        belop:
-          type: integer
-          format: int32
-        deltakerRegioner:
-          type: array
-          items:
-            $ref: "#/components/schemas/NavRegionDto"
-        deltakerTableData:
-          $ref: "#/components/schemas/DataDrivenTableDto"
-        heading:
-          type: string
-      required:
-      - belop
-      - deltakerRegioner
-      - deltakerTableData
-      - heading
-      - manedsverkTotal
-      - sats
-    UtbetalingBeregningDto.PrisPerUkesverk:
-      type: object
-      properties:
-        sats:
-          type: integer
-          format: int32
-        ukesverkTotal:
-          type: number
-          format: double
-        belop:
-          type: integer
-          format: int32
-        deltakerRegioner:
-          type: array
-          items:
-            $ref: "#/components/schemas/NavRegionDto"
-        deltakerTableData:
-          $ref: "#/components/schemas/DataDrivenTableDto"
-        heading:
-          type: string
-      required:
-      - belop
-      - deltakerRegioner
-      - deltakerTableData
-      - heading
-      - sats
-      - ukesverkTotal
     UtbetalingBeregningDto:
-      anyOf:
-      - $ref: "#/components/schemas/UtbetalingBeregningDto.FastSatsPerTiltaksplassPerManed"
-      - $ref: "#/components/schemas/UtbetalingBeregningDto.Fri"
-      - $ref: "#/components/schemas/UtbetalingBeregningDto.PrisPerManedsverk"
-      - $ref: "#/components/schemas/UtbetalingBeregningDto.PrisPerUkesverk"
-      discriminator:
-        propertyName: type
-        mapping:
-          no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingBeregningDto.FastSatsPerTiltaksplassPerManed: "#/components/schemas/UtbetalingBeregningDto.FastSatsPerTiltaksplassPerManed"
-          no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingBeregningDto.Fri: "#/components/schemas/UtbetalingBeregningDto.Fri"
-          no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingBeregningDto.PrisPerManedsverk: "#/components/schemas/UtbetalingBeregningDto.PrisPerManedsverk"
-          no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingBeregningDto.PrisPerUkesverk: "#/components/schemas/UtbetalingBeregningDto.PrisPerUkesverk"
+      type: object
+      properties:
+        heading:
+          type: string
+        deltakerRegioner:
+          type: array
+          items:
+            $ref: "#/components/schemas/NavRegionDto"
+        deltakerTableData:
+          $ref: "#/components/schemas/DataDrivenTableDto"
+        regnestykke:
+          type: array
+          items:
+            $ref: "#/components/schemas/DataElement"
+      required:
+      - deltakerRegioner
+      - deltakerTableData
+      - heading
+      - regnestykke
     UtbetalingLinje:
       type: object
       properties:

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/UtbetalingService.kt
@@ -530,7 +530,6 @@ class UtbetalingService(
             it to person
         }.filter { (_, person) -> filter.navEnheter.isEmpty() || person?.geografiskEnhet?.enhetsnummer in filter.navEnheter }
 
-        // TODO: utled regnestykke i backend
         return UtbetalingBeregningDto.from(utbetaling, deltakelsePersoner, regioner)
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingBeregningDto.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingBeregningDto.kt
@@ -1,154 +1,19 @@
 package no.nav.mulighetsrommet.api.utbetaling.api
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonClassDiscriminator
 import no.nav.mulighetsrommet.api.navenhet.NavRegionDto
 import no.nav.mulighetsrommet.api.utbetaling.PersonEnhetOgRegion
 import no.nav.mulighetsrommet.api.utbetaling.model.*
-import no.nav.mulighetsrommet.model.DataDetails
 import no.nav.mulighetsrommet.model.DataDrivenTableDto
 import no.nav.mulighetsrommet.model.DataElement
 
-@OptIn(ExperimentalSerializationApi::class)
 @Serializable
-@JsonClassDiscriminator("type")
-sealed class UtbetalingBeregningDto {
-    abstract val belop: Int
-    abstract val heading: String
-    abstract val deltakerTableData: DataDrivenTableDto
-    abstract val deltakerRegioner: List<NavRegionDto>
-
-    @Serializable
-    data class FastSatsPerTiltaksplassPerManed(
-        val sats: Int,
-        val manedsverkTotal: Double,
-        override val belop: Int,
-        override val deltakerRegioner: List<NavRegionDto>,
-        override val deltakerTableData: DataDrivenTableDto,
-    ) : UtbetalingBeregningDto() {
-        override val heading = "Fast sats per tiltaksplass per måned"
-
-        companion object {
-            fun manedsverkTable(
-                deltakelsePersoner: List<Pair<UtbetalingBeregningOutputDeltakelse, PersonEnhetOgRegion?>>,
-                sats: Int,
-            ) = PrisPerManedsverk.manedsverkTable(deltakelsePersoner, sats)
-        }
-    }
-
-    @Serializable
-    data class PrisPerManedsverk(
-        val sats: Int,
-        val manedsverkTotal: Double,
-        override val belop: Int,
-        override val deltakerRegioner: List<NavRegionDto>,
-        override val deltakerTableData: DataDrivenTableDto,
-    ) : UtbetalingBeregningDto() {
-        override val heading = "Avtalt månedpris per tiltaksplass"
-
-        companion object {
-            fun manedsverkTable(
-                deltakelsePersoner: List<Pair<UtbetalingBeregningOutputDeltakelse, PersonEnhetOgRegion?>>,
-                sats: Int,
-            ) = DataDrivenTableDto(
-                columns = Fri.friDeltakelseColumns() + manedsverkDeltakelseColumns(),
-                rows = deltakelsePersoner.map { (deltakelse, person) ->
-                    Fri.friDeltakelseCells(person) + manedsverkDeltakelseCells(deltakelse.faktor, sats)
-                },
-            )
-
-            private fun manedsverkDeltakelseColumns() = listOf(
-                DataDrivenTableDto.Column(
-                    "manedsverk",
-                    "Månedsverk",
-                    align = DataDrivenTableDto.Column.Align.RIGHT,
-                ),
-                DataDrivenTableDto.Column(
-                    "belop",
-                    "Beløp",
-                    align = DataDrivenTableDto.Column.Align.RIGHT,
-                ),
-            )
-
-            private fun manedsverkDeltakelseCells(manedsverk: Double, sats: Int) = mapOf(
-                "manedsverk" to DataElement.number(manedsverk),
-                "belop" to DataElement.nok(manedsverk * sats),
-            )
-        }
-    }
-
-    @Serializable
-    data class PrisPerUkesverk(
-        val sats: Int,
-        val ukesverkTotal: Double,
-        override val belop: Int,
-        override val deltakerRegioner: List<NavRegionDto>,
-        override val deltakerTableData: DataDrivenTableDto,
-    ) : UtbetalingBeregningDto() {
-        override val heading = "Avtalt ukespris per tiltaksplass"
-
-        companion object {
-            fun ukesverkTable(
-                deltakelsePersoner: List<Pair<UtbetalingBeregningOutputDeltakelse, PersonEnhetOgRegion?>>,
-                sats: Int,
-            ) = DataDrivenTableDto(
-                columns = Fri.friDeltakelseColumns() + ukesverkDeltakelseColumns(),
-                rows = deltakelsePersoner.map { (deltakelse, person) ->
-                    Fri.friDeltakelseCells(person) + ukesverkDeltakelseCells(deltakelse.faktor, sats)
-                },
-            )
-
-            private fun ukesverkDeltakelseColumns() = listOf(
-                DataDrivenTableDto.Column(
-                    "ukesverk",
-                    "Ukesverk",
-                    align = DataDrivenTableDto.Column.Align.RIGHT,
-                ),
-                DataDrivenTableDto.Column(
-                    "belop",
-                    "Beløp",
-                    align = DataDrivenTableDto.Column.Align.RIGHT,
-                ),
-            )
-
-            private fun ukesverkDeltakelseCells(ukesverk: Double, sats: Int) = mapOf(
-                "ukesverk" to DataElement.number(ukesverk),
-                "belop" to DataElement.nok(ukesverk * sats),
-            )
-        }
-    }
-
-    @Serializable
-    data class Fri(
-        override val belop: Int,
-        override val deltakerRegioner: List<NavRegionDto>,
-        override val deltakerTableData: DataDrivenTableDto,
-    ) : UtbetalingBeregningDto() {
-        override val heading = "Annen avtalt pris"
-
-        companion object {
-            fun friTable(deltakelsePersoner: List<Pair<UtbetalingBeregningOutputDeltakelse, PersonEnhetOgRegion?>>) = DataDrivenTableDto(
-                columns = friDeltakelseColumns(),
-                rows = deltakelsePersoner.map { friDeltakelseCells(it.second) },
-            )
-
-            fun friDeltakelseColumns() = listOf(
-                DataDrivenTableDto.Column("navn", "Navn"),
-                DataDrivenTableDto.Column("foedselsdato", "Fødselsdato"),
-                DataDrivenTableDto.Column("region", "Region"),
-                DataDrivenTableDto.Column("geografiskEnhet", "Geografisk enhet"),
-            )
-
-            fun friDeltakelseCells(person: PersonEnhetOgRegion?) = mapOf(
-                "navn" to person?.person?.navn?.let { DataElement.text(it) },
-                "geografiskEnhet" to person?.geografiskEnhet?.navn?.let { DataElement.text(it) },
-                "region" to person?.region?.navn?.let { DataElement.text(it) },
-                "foedselsdato" to person?.person?.foedselsdato?.let { DataElement.date(it) },
-            )
-        }
-    }
-
+data class UtbetalingBeregningDto(
+    val heading: String,
+    val deltakerRegioner: List<NavRegionDto>,
+    val deltakerTableData: DataDrivenTableDto,
+    val regnestykke: List<DataElement>,
+) {
     companion object {
         fun from(
             utbetaling: Utbetaling,
@@ -156,56 +21,67 @@ sealed class UtbetalingBeregningDto {
             regioner: List<NavRegionDto>,
         ): UtbetalingBeregningDto {
             return when (utbetaling.beregning) {
-                is UtbetalingBeregningFri -> Fri(
-                    belop = utbetaling.beregning.output.belop,
+                is UtbetalingBeregningFri -> UtbetalingBeregningDto(
+                    heading = "Annen avtalt pris",
                     deltakerRegioner = regioner,
-                    deltakerTableData = Fri.friTable(deltakelsePersoner),
+                    deltakerTableData = friTable(deltakelsePersoner),
+                    regnestykke = listOf(
+                        DataElement.text("Innsendt beløp"),
+                        DataElement.MathOperator(DataElement.MathOperator.Type.EQUALS),
+                        DataElement.nok(utbetaling.beregning.output.belop),
+                    ),
                 )
 
-                is UtbetalingBeregningFastSatsPerTiltaksplassPerManed,
-                -> {
+                is UtbetalingBeregningFastSatsPerTiltaksplassPerManed -> {
                     val sats = getSats(utbetaling.beregning.input)
                     val manedsverkTotal = deltakelsePersoner.sumOf { (deltakelse) -> deltakelse.faktor }
-                    FastSatsPerTiltaksplassPerManed(
-                        belop = UtbetalingBeregningHelpers.calculateBelopForDeltakelse(
-                            deltakelsePersoner.map { it.first }.toSet(),
-                            sats,
-                        ),
-                        manedsverkTotal = manedsverkTotal,
+                    val belop = UtbetalingBeregningHelpers.calculateBelopForDeltakelse(
+                        deltakelsePersoner.map { it.first }.toSet(),
+                        sats,
+                    )
+                    UtbetalingBeregningDto(
+                        heading = "Fast sats per tiltaksplass per måned",
                         deltakerRegioner = regioner,
-                        deltakerTableData = FastSatsPerTiltaksplassPerManed.manedsverkTable(deltakelsePersoner, sats),
-                        sats = sats,
+                        deltakerTableData = manedsverkTable(deltakelsePersoner, sats),
+                        regnestykke = getRegnestykkeManedsverk(manedsverkTotal, sats, belop),
                     )
                 }
 
-                is UtbetalingBeregningPrisPerManedsverk,
-                -> {
+                is UtbetalingBeregningPrisPerManedsverk -> {
                     val sats = getSats(utbetaling.beregning.input)
                     val manedsverkTotal = deltakelsePersoner.sumOf { (deltakelse) -> deltakelse.faktor }
-                    PrisPerManedsverk(
-                        belop = UtbetalingBeregningHelpers.calculateBelopForDeltakelse(
-                            deltakelsePersoner.map { it.first }.toSet(),
-                            sats,
-                        ),
-                        manedsverkTotal = manedsverkTotal,
+                    val belop = UtbetalingBeregningHelpers.calculateBelopForDeltakelse(
+                        deltakelsePersoner.map { it.first }.toSet(),
+                        sats,
+                    )
+                    UtbetalingBeregningDto(
+                        heading = "Avtalt månedpris per tiltaksplass",
                         deltakerRegioner = regioner,
-                        deltakerTableData = PrisPerManedsverk.manedsverkTable(deltakelsePersoner, sats),
-                        sats = sats,
+                        deltakerTableData = manedsverkTable(deltakelsePersoner, sats),
+                        regnestykke = getRegnestykkeManedsverk(manedsverkTotal, sats, belop),
                     )
                 }
 
                 is UtbetalingBeregningPrisPerUkesverk -> {
                     val sats = getSats(utbetaling.beregning.input)
                     val ukesverkTotal = deltakelsePersoner.sumOf { (deltakelse) -> deltakelse.faktor }
-                    PrisPerUkesverk(
-                        belop = UtbetalingBeregningHelpers.calculateBelopForDeltakelse(
-                            deltakelsePersoner.map { it.first }.toSet(),
-                            sats,
-                        ),
-                        ukesverkTotal = ukesverkTotal,
+                    val belop = UtbetalingBeregningHelpers.calculateBelopForDeltakelse(
+                        deltakelsePersoner.map { it.first }.toSet(),
+                        sats,
+                    )
+                    UtbetalingBeregningDto(
+                        heading = "Avtalt ukespris per tiltaksplass",
                         deltakerRegioner = regioner,
-                        deltakerTableData = PrisPerUkesverk.ukesverkTable(deltakelsePersoner, sats),
-                        sats = sats,
+                        deltakerTableData = ukesverkTable(deltakelsePersoner, sats),
+                        regnestykke = listOf(
+                            DataElement.number(ukesverkTotal),
+                            DataElement.text("uker"),
+                            DataElement.MathOperator(DataElement.MathOperator.Type.MULTIPLY),
+                            DataElement.nok(sats),
+                            DataElement.text("per tiltaksplass per uke"),
+                            DataElement.MathOperator(DataElement.MathOperator.Type.EQUALS),
+                            DataElement.nok(belop),
+                        ),
                     )
                 }
             }
@@ -221,3 +97,92 @@ private fun getSats(input: UtbetalingBeregningInput): Int {
         is UtbetalingBeregningFri.Input -> throw IllegalArgumentException("UtbetalingBeregningFri har ingen sats")
     }
 }
+
+private fun manedsverkTable(
+    deltakelsePersoner: List<Pair<UtbetalingBeregningOutputDeltakelse, PersonEnhetOgRegion?>>,
+    sats: Int,
+) = DataDrivenTableDto(
+    columns = friDeltakelseColumns() + manedsverkDeltakelseColumns(),
+    rows = deltakelsePersoner.map { (deltakelse, person) ->
+        friDeltakelseCells(person) + manedsverkDeltakelseCells(deltakelse.faktor, sats)
+    },
+)
+
+private fun manedsverkDeltakelseColumns() = listOf(
+    DataDrivenTableDto.Column(
+        "manedsverk",
+        "Månedsverk",
+        align = DataDrivenTableDto.Column.Align.RIGHT,
+    ),
+    DataDrivenTableDto.Column(
+        "belop",
+        "Beløp",
+        align = DataDrivenTableDto.Column.Align.RIGHT,
+    ),
+)
+
+private fun manedsverkDeltakelseCells(manedsverk: Double, sats: Int) = mapOf(
+    "manedsverk" to DataElement.number(manedsverk),
+    "belop" to DataElement.nok(manedsverk * sats),
+)
+
+private fun ukesverkTable(
+    deltakelsePersoner: List<Pair<UtbetalingBeregningOutputDeltakelse, PersonEnhetOgRegion?>>,
+    sats: Int,
+) = DataDrivenTableDto(
+    columns = friDeltakelseColumns() + ukesverkDeltakelseColumns(),
+    rows = deltakelsePersoner.map { (deltakelse, person) ->
+        friDeltakelseCells(person) + ukesverkDeltakelseCells(deltakelse.faktor, sats)
+    },
+)
+
+private fun ukesverkDeltakelseColumns() = listOf(
+    DataDrivenTableDto.Column(
+        "ukesverk",
+        "Ukesverk",
+        align = DataDrivenTableDto.Column.Align.RIGHT,
+    ),
+    DataDrivenTableDto.Column(
+        "belop",
+        "Beløp",
+        align = DataDrivenTableDto.Column.Align.RIGHT,
+    ),
+)
+
+private fun ukesverkDeltakelseCells(ukesverk: Double, sats: Int) = mapOf(
+    "ukesverk" to DataElement.number(ukesverk),
+    "belop" to DataElement.nok(ukesverk * sats),
+)
+
+private fun friTable(deltakelsePersoner: List<Pair<UtbetalingBeregningOutputDeltakelse, PersonEnhetOgRegion?>>) = DataDrivenTableDto(
+    columns = friDeltakelseColumns(),
+    rows = deltakelsePersoner.map { friDeltakelseCells(it.second) },
+)
+
+private fun friDeltakelseColumns() = listOf(
+    DataDrivenTableDto.Column("navn", "Navn"),
+    DataDrivenTableDto.Column("foedselsdato", "Fødselsdato"),
+    DataDrivenTableDto.Column("region", "Region"),
+    DataDrivenTableDto.Column("geografiskEnhet", "Geografisk enhet"),
+)
+
+private fun friDeltakelseCells(person: PersonEnhetOgRegion?) = mapOf(
+    "navn" to person?.person?.navn?.let { DataElement.text(it) },
+    "geografiskEnhet" to person?.geografiskEnhet?.navn?.let { DataElement.text(it) },
+    "region" to person?.region?.navn?.let { DataElement.text(it) },
+    "foedselsdato" to person?.person?.foedselsdato?.let { DataElement.date(it) },
+)
+
+private fun getRegnestykkeManedsverk(
+    manedsverkTotal: Double,
+    sats: Int,
+    belop: Int,
+): List<DataElement> = listOf(
+    DataElement.number(manedsverkTotal),
+    DataElement.text("plasser"),
+    DataElement.MathOperator(DataElement.MathOperator.Type.MULTIPLY),
+    DataElement.nok(sats),
+    DataElement.text("per tiltaksplass per måned"),
+    DataElement.MathOperator(DataElement.MathOperator.Type.EQUALS),
+    DataElement.nok(belop),
+)


### PR DESCRIPTION
Flytter utledning av regnestykke fra frontend til backend. Dette gjør også at datamodellen som for beregning i frontend kan forenkles og ikke lengre trenger å være en sealed class.