### PR TITLE
fiks type checks i ErrorPage

### DIFF
--- a/frontend/frontend-common/components/error-handling/errors.ts
+++ b/frontend/frontend-common/components/error-handling/errors.ts
@@ -7,11 +7,18 @@ type ProblemDetail = {
   [key: string]: unknown | string | number | undefined;
 };
 
-export function isProblemDetail(error: any): error is ProblemDetail {
-  return "status" in error && "detail" in error && "type" in error && "title" in error;
+export function isProblemDetail(error: unknown): error is ProblemDetail {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    "detail" in error &&
+    "type" in error &&
+    "title" in error
+  );
 }
 
-export function resolveErrorMessage(error: any): string {
+export function resolveErrorMessage(error: unknown): string {
   if (isProblemDetail(error)) {
     return error.detail;
   }

--- a/frontend/mr-admin-flate/src/pages/ErrorPage.tsx
+++ b/frontend/mr-admin-flate/src/pages/ErrorPage.tsx
@@ -3,44 +3,23 @@ import { Link, useLocation, useRouteError } from "react-router";
 import { PORTEN_URL } from "@/constants";
 import { IngenTilgang, NavAnsattManglerTilgangError } from "@/pages/IngenTilgang";
 import { ProblemDetail } from "@tiltaksadministrasjon/api-client";
+import { isProblemDetail } from "@mr/frontend-common/components/error-handling/errors";
 
-interface GenericError extends Partial<ProblemDetail> {
-  message?: string;
-}
-
-function isNavAnsattManglerTilgangError(
-  error: Partial<ProblemDetail>,
-): error is NavAnsattManglerTilgangError {
-  return error.type === "mangler-tilgang";
-}
+type ErrorType = ProblemDetail | Error | string | null | undefined;
 
 export function ErrorPage() {
-  const routeError = useRouteError() as ProblemDetail | GenericError | undefined;
+  const routeError = useRouteError() as ErrorType;
   const location = useLocation() as {
-    state: { problemDetail?: ProblemDetail; error?: GenericError } | null;
-  };
-  const stateError = location.state?.problemDetail || location.state?.error;
-
-  const error = routeError || stateError;
-
-  const getErrorTitle = () => {
-    if (!error) return "En uventet feil har oppstått";
-    if (error instanceof Error) return error.message;
-    if (typeof error === "string") return error;
-    if ("title" in error) return error.title;
-    return "En uventet feil har oppstått";
+    state: { problemDetail?: ProblemDetail; error?: Error } | null;
   };
 
-  const getErrorDetail = () => {
-    if (!error) return "Vi beklager, men noe gikk galt. Vennligst prøv igjen senere.";
-    if ("detail" in error) return error.detail;
-    if ("message" in error) return error.message;
-    return "Vi beklager, men noe gikk galt. Vennligst prøv igjen senere.";
-  };
-
-  if (error && "type" in error && isNavAnsattManglerTilgangError(error))
+  const error = routeError || location.state?.problemDetail || location.state?.error;
+  if (isProblemDetail(error) && isNavAnsattManglerTilgangError(error)) {
     return <IngenTilgang error={error} />;
+  }
 
+  const title = getErrorTitle(error);
+  const detail = getErrorDetail(error);
   return (
     <Page>
       <Box id="error-page" className="prose w-1/2 m-auto mt-5 p-4 rounded-md">
@@ -50,20 +29,20 @@ export function ErrorPage() {
         <Box borderColor="neutral-subtle" borderRadius="8" borderWidth="1">
           <VStack padding="space-8">
             <BodyShort>
-              Tittel: <i>{getErrorTitle()}</i>
+              Tittel: <i>{title}</i>
             </BodyShort>
             <BodyShort>
-              Feilmelding: <i>{getErrorDetail()}</i>
+              Feilmelding: <i>{detail}</i>
             </BodyShort>
-            {error && "status" in error && (
-              <BodyShort>
-                Status: <i>{error.status}</i>
-              </BodyShort>
-            )}
-            {error && "traceId" in error && (
-              <BodyShort>
-                TraceId: <i>{error.traceId as string}</i>
-              </BodyShort>
+            {isProblemDetail(error) && (
+              <>
+                <BodyShort>
+                  Status: <i>{error.status}</i>
+                </BodyShort>
+                <BodyShort>
+                  TraceId: <i>{error.traceId as string}</i>
+                </BodyShort>
+              </>
             )}
           </VStack>
         </Box>
@@ -76,4 +55,26 @@ export function ErrorPage() {
       </Box>
     </Page>
   );
+}
+
+function isNavAnsattManglerTilgangError(
+  error: Partial<ProblemDetail>,
+): error is NavAnsattManglerTilgangError {
+  return error.type === "mangler-tilgang";
+}
+
+function getErrorTitle(error: ErrorType): string {
+  if (!error) return "En uventet feil har oppstått";
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if ("title" in error) return error.title;
+  return "En uventet feil har oppstått";
+}
+
+function getErrorDetail(error: ErrorType): string {
+  if (!error) return "Vi beklager, men noe gikk galt. Vennligst prøv igjen senere.";
+  if (typeof error === "string") return error;
+  if ("detail" in error) return error.detail;
+  if ("message" in error) return error.message;
+  return "Vi beklager, men noe gikk galt. Vennligst prøv igjen senere.";
 }


### PR DESCRIPTION
`in`-sjekker i ErrorPage feilet når error var av typen `string`