### PR TITLE
optimaliser generering av openapi

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/Application.kt
@@ -31,6 +31,7 @@ import no.nav.mulighetsrommet.database.FlywayMigrationManager
 import no.nav.mulighetsrommet.env.NaisEnv
 import no.nav.mulighetsrommet.kafka.KafkaConsumerOrchestrator
 import no.nav.mulighetsrommet.kafka.monitoring.KafkaMetrics
+import no.nav.mulighetsrommet.ktor.ServerConfig
 import no.nav.mulighetsrommet.ktor.plugins.configureMetrics
 import no.nav.mulighetsrommet.ktor.plugins.configureMonitoring
 import no.nav.mulighetsrommet.ktor.plugins.configureStatusPages
@@ -47,21 +48,24 @@ fun main() {
         NaisEnv.Local -> ApplicationConfigLocal
     }
 
-    createServer(config).start(wait = true)
+    createServer(config.server) { configure(config) }.start(wait = true)
 }
 
-fun createServer(config: AppConfig): EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration> {
+fun createServer(
+    config: ServerConfig,
+    module: Application.() -> Unit,
+): EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration> {
     return embeddedServer(
         Netty,
         configure = {
             connector {
-                port = config.server.port
-                host = config.server.host
+                port = config.port
+                host = config.host
             }
             shutdownGracePeriod = 5.seconds.inWholeMilliseconds
             shutdownTimeout = 10.seconds.inWholeMilliseconds
         },
-        module = { configure(config) },
+        module = module,
     )
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/GenerateOpenApi.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/GenerateOpenApi.kt
@@ -1,8 +1,18 @@
 package no.nav.mulighetsrommet.api
 
 import io.github.smiley4.ktoropenapi.OpenApiPlugin
+import io.ktor.server.application.Application
 import io.ktor.server.application.ServerReady
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.AuthenticationContext
+import io.ktor.server.auth.AuthenticationProvider
+import io.ktor.server.routing.routing
+import no.nav.mulighetsrommet.api.plugins.configureOpenApiGenerator
+import no.nav.mulighetsrommet.api.plugins.configureRouting
 import no.nav.mulighetsrommet.api.routes.OpenApiSpec
+import no.nav.mulighetsrommet.api.routes.apiRoutes
+import no.nav.mulighetsrommet.ktor.ServerConfig
 import java.nio.file.Files
 import java.nio.file.Paths
 import kotlin.system.exitProcess
@@ -18,7 +28,14 @@ fun main(args: Array<String>) {
         openApiSpecName to fileOutputPath
     }
 
-    val server = createServer(ApplicationConfigLocal)
+    val server = createServer(ServerConfig()) {
+        configureAuthenticationForOpenApiGeneration()
+        configureRouting()
+        configureOpenApiGenerator()
+        routing {
+            apiRoutes(ApplicationConfigLocal)
+        }
+    }
 
     server.application.monitor.subscribe(ServerReady) {
         println("✅ Server is ready")
@@ -41,6 +58,23 @@ fun main(args: Array<String>) {
     }
 
     server.start(wait = false)
+}
+
+/**
+ * Installerer no-op authentication providers for alle [no.nav.mulighetsrommet.api.plugins.AuthProvider].
+ */
+private fun Application.configureAuthenticationForOpenApiGeneration() {
+    install(Authentication) {
+        no.nav.mulighetsrommet.api.plugins.AuthProvider.entries.forEach { authProvider ->
+            register(NoOpAuthenticationProvider(authProvider.name))
+        }
+    }
+}
+
+private class NoOpAuthenticationProvider(name: String) : AuthenticationProvider(object : Config(name) {}) {
+    override suspend fun onAuthenticate(context: AuthenticationContext) {
+        // No-op: kun for OpenAPI-generering – ingen requests autentiseres
+    }
 }
 
 private fun generateOpenApiSpec(spec: OpenApiSpec, outputPath: String) {


### PR DESCRIPTION
Dette gjør det mulig å generere openapi specs uten å koble til lokal db og måtte kjøre migrasjoner