### PR TITLE
Increase kafka record processor batch size

### DIFF
--- a/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerOrchestrator.kt
+++ b/common/kafka/src/main/kotlin/no/nav/mulighetsrommet/kafka/KafkaConsumerOrchestrator.kt
@@ -41,7 +41,7 @@ class KafkaConsumerOrchestrator(
         /**
          * The number of records to process per batch by the consumer record processor.
          */
-        val consumerRecordProcessorBatchSize: Int = 100,
+        val consumerRecordProcessorBatchSize: Int = 10_000,
 
         /**
          * How long the consumer record processor should wait before checking for new stored records.


### PR DESCRIPTION
Når vi har fler enn batch-size antall meldinger som venter pga scheduled_at tidspunkt så blir ikke senere meldinger processert selv om deres scheduled_at har passert. Dette er en quick fix for å prosessere de.