### PR TITLE
Legg til jobstøtte i gruppetiltakslisten

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/Tiltakskoder.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/Tiltakskoder.kt
@@ -311,6 +311,7 @@ object Tiltakskoder {
         Tiltakskode.OPPFOLGING,
         Tiltakskode.JOBBKLUBB,
         Tiltakskode.VARIG_TILRETTELAGT_ARBEID_SKJERMET,
+        Tiltakskode.TILPASSET_JOBBSTOTTE,
         // TODO: disse tiltakskodene er egentlig ikke bare for "gruppetiltak", men foreløpig er det OK.
         //  Vi burde komme oss vekk fra disse tiltaskode-listene og evt. erstatte med egenskaper direkte på Tiltalkskode-enumen
         Tiltakskode.ARBEIDSMARKEDSOPPLAERING,


### PR DESCRIPTION
Åpner opp for å linke til tiltaket fra tiltakslisten i Modia

[Trello](https://trello.com/c/s7HPsBF0/255-legge-til-lenke-til-gjennomf%C3%B8ring-i-oversikt-over-brukerens-tiltak-tilpasset-jobbst%C3%B8tte)