### PR TITLE
Eksponer kodeverk routes for m2m tokens

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/ApiRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/routes/ApiRoutes.kt
@@ -69,6 +69,7 @@ fun Route.apiRoutes(config: AppConfig) {
         authenticate(AuthProvider.NAIS_APP_GJENNOMFORING_ACCESS) {
             gjennomforingPublicRoutes()
             arrangorPublicRoutes()
+            kodeverkRoutes()
         }
     }
 


### PR DESCRIPTION
[Trello](https://trello.com/c/fa5mN9AE/34-lage-api-kodeverk-for-amo-studieprogram)

`NAIS_APP_GJENNOMFORING_ACCESS` kreves for applikasjonstilgang, men kan endres senere