### PR TITLE
håndter at arrangør mangler kontonummer

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/ArrangorRoutes.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/ArrangorRoutes.kt
@@ -30,13 +30,13 @@ import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.validation.validation
 import no.nav.mulighetsrommet.brreg.BrregHovedenhetDto
 import no.nav.mulighetsrommet.brreg.BrregUnderenhetDto
-import no.nav.mulighetsrommet.ktor.exception.BadRequest
+import no.nav.mulighetsrommet.ktor.exception.NotFound
+import no.nav.mulighetsrommet.ktor.plugins.respondWithProblemDetail
 import no.nav.mulighetsrommet.model.Organisasjonsnummer
 import no.nav.mulighetsrommet.model.ProblemDetail
 import no.nav.mulighetsrommet.serializers.UUIDSerializer
 import org.koin.ktor.ext.inject
 import java.util.UUID
-import kotlin.String
 
 fun Route.arrangorRoutes() {
     val db: ApiDatabase by inject()
@@ -146,7 +146,11 @@ fun Route.arrangorRoutes() {
             }
         }) {
             val id: UUID by call.parameters
-            call.respond(arrangorService.getBetalingsinformasjon(id))
+
+            val message: Betalingsinformasjon = arrangorService.getBetalingsinformasjon(id)
+                ?: return@get call.respondWithProblemDetail(NotFound("Arrangør mangler kontonummer"))
+
+            call.respond(message)
         }
 
         get("{id}/hovedenhet", {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/ArrangorService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/ArrangorService.kt
@@ -2,7 +2,6 @@ package no.nav.mulighetsrommet.api.arrangor
 
 import arrow.core.Either
 import arrow.core.flatMap
-import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
 import kotlinx.serialization.Serializable
@@ -11,6 +10,7 @@ import no.nav.mulighetsrommet.api.arrangor.db.DokumentKoblingForKontaktperson
 import no.nav.mulighetsrommet.api.arrangor.model.ArrangorDto
 import no.nav.mulighetsrommet.api.arrangor.model.ArrangorKontaktperson
 import no.nav.mulighetsrommet.api.arrangor.model.Betalingsinformasjon
+import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontonummerRegisterOrganisasjonError
 import no.nav.mulighetsrommet.api.clients.kontoregisterOrganisasjon.KontoregisterOrganisasjonClient
 import no.nav.mulighetsrommet.brreg.BrregClient
 import no.nav.mulighetsrommet.brreg.BrregEnhet
@@ -119,7 +119,7 @@ class ArrangorService(
             }
     }
 
-    suspend fun getBetalingsinformasjon(id: UUID): Betalingsinformasjon {
+    suspend fun getBetalingsinformasjon(id: UUID): Betalingsinformasjon? {
         val arrangor = db.session { queries.arrangor.getById(id) }
 
         if (arrangor.erUtenlandsk) {
@@ -137,14 +137,21 @@ class ArrangorService(
                 bankLandKode = arrangorUtenlandsk.landKode,
             )
         } else {
-            val kontonummer =
-                kontoregisterOrganisasjonClient.getKontonummerForOrganisasjon(arrangor.organisasjonsnummer)
+            return kontoregisterOrganisasjonClient.getKontonummerForOrganisasjon(arrangor.organisasjonsnummer)
+                .fold(
+                    {
+                        when (it) {
+                            KontonummerRegisterOrganisasjonError.FantIkkeKontonummer -> null
 
-            return kontonummer
-                .map { Betalingsinformasjon.BBan(Kontonummer(it.kontonr), null) }
-                .getOrElse {
-                    throw IllegalArgumentException("Klarte ikke hente kontonummer for arrangør")
-                }
+                            KontonummerRegisterOrganisasjonError.UgyldigInput,
+                            KontonummerRegisterOrganisasjonError.Error,
+                            -> throw IllegalStateException("Klarte ikke hente kontonummer for arrangør")
+                        }
+                    },
+                    {
+                        Betalingsinformasjon.BBan(Kontonummer(it.kontonr), null)
+                    },
+                )
         }
     }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/UtbetalingService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/UtbetalingService.kt
@@ -478,10 +478,12 @@ class UtbetalingService(
         return dbo.right()
     }
 
-    private suspend fun getUtbetalingsinformasjon(arrangorId: UUID, kid: Kid?): Betalingsinformasjon {
-        return when (val betalingsinformasjon = arrangorService.getBetalingsinformasjon(arrangorId)) {
-            is Betalingsinformasjon.BBan -> Betalingsinformasjon.BBan(betalingsinformasjon.kontonummer, kid)
-            is Betalingsinformasjon.IBan -> betalingsinformasjon
+    private suspend fun getUtbetalingsinformasjon(arrangorId: UUID, kid: Kid?): Betalingsinformasjon? {
+        return arrangorService.getBetalingsinformasjon(arrangorId)?.let { betalingsinformasjon ->
+            when (betalingsinformasjon) {
+                is Betalingsinformasjon.BBan -> Betalingsinformasjon.BBan(betalingsinformasjon.kontonummer, kid)
+                is Betalingsinformasjon.IBan -> betalingsinformasjon
+            }
         }
     }
 

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingServiceTest.kt
@@ -83,6 +83,11 @@ class AdminUtbetalingServiceTest : FunSpec({
     var umiddelbarUtbetaling = TidligstTidspunktForUtbetalingCalculator { _, _ -> null }
     val arrangorService: ArrangorService = mockk()
 
+    coEvery { arrangorService.getBetalingsinformasjon(any()) } returns Betalingsinformasjon.BBan(
+        kontonummer = Kontonummer("12345678901"),
+        kid = null,
+    )
+
     fun createTilsagnService(): TilsagnService = TilsagnService(
         TilsagnService.Config(bestillingTopic = BESTILLING_TOPIC, gyldigTilsagnPeriode = mapOf()),
         db = database.db,
@@ -131,11 +136,6 @@ class AdminUtbetalingServiceTest : FunSpec({
                 gjennomforinger = listOf(AFT1),
                 utbetalinger = listOf(utbetaling1.copy(status = UtbetalingStatusType.GENERERT)),
             ).initialize(database.db)
-
-            coEvery { arrangorService.getBetalingsinformasjon(any()) } returns Betalingsinformasjon.BBan(
-                kontonummer = Kontonummer("12345678901"),
-                kid = null,
-            )
         }
 
         test("utbetaling blir opprettet med fri-beregning") {
@@ -265,11 +265,6 @@ class AdminUtbetalingServiceTest : FunSpec({
                     utbetaling2.copy(status = UtbetalingStatusType.GENERERT),
                 ),
             ).initialize(database.db)
-
-            coEvery { arrangorService.getBetalingsinformasjon(any()) } returns Betalingsinformasjon.BBan(
-                kontonummer = Kontonummer("12345678901"),
-                kid = null,
-            )
         }
 
         test("korreksjon må gjelde for en eksisterende utbetaling") {

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/GenererUtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/GenererUtbetalingServiceTest.kt
@@ -76,6 +76,11 @@ class GenererUtbetalingServiceTest : FunSpec({
 
     val arrangorService = mockk<ArrangorService>()
 
+    coEvery { arrangorService.getBetalingsinformasjon(any()) } returns Betalingsinformasjon.BBan(
+        kontonummer = Kontonummer("12345678901"),
+        kid = null,
+    )
+
     fun createUtbetalingService(
         gyldigTilsagnPeriode: Map<Tiltakskode, Periode> = Tiltakskode.entries.associateWith {
             Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2030, 1, 1))
@@ -110,11 +115,6 @@ class GenererUtbetalingServiceTest : FunSpec({
             ),
         )
     }
-
-    coEvery { arrangorService.getBetalingsinformasjon(any()) } returns Betalingsinformasjon.BBan(
-        kontonummer = Kontonummer("12345678901"),
-        kid = null,
-    )
 
     val januar = Periode.forMonthOf(LocalDate.of(2025, 1, 1))
     val februar = Periode.forMonthOf(LocalDate.of(2025, 2, 1))


### PR DESCRIPTION
Generering av utbetalinger feiler når kontonummer organisasjon returerer
404. Denne endringen håndterer 404-responsen, men generering vil forsatt feile hvis vi ikke får kontakt med tjenesten.