### PR TITLE
ignorer ekstra deltaker på enkeltplass-tiltak når den er feilregistrert

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassService.kt
@@ -125,17 +125,15 @@ class GjennomforingEnkeltplassService(
     ): GjennomforingEnkeltplass = db.transaction {
         val gjennomforing = getAndAquireLock(deltaker.gjennomforingId)
 
-        getDeltaker(deltaker.gjennomforingId)?.let {
-            check(it.id == deltaker.id) {
-                "Enkeltplass med id=${deltaker.gjennomforingId} har allerede en annen deltaker"
-            }
-
-            if (deltaker.endretTidspunkt < it.endretTidspunkt) {
-                return gjennomforing
+        getDeltaker(deltaker.gjennomforingId)?.let { eksisterende ->
+            when {
+                deltaker.id != eksisterende.id && deltaker.erFeilregistrert() -> return gjennomforing
+                deltaker.id != eksisterende.id -> error("Enkeltplass med id=${deltaker.gjennomforingId} har allerede en annen deltaker")
+                deltaker.endretTidspunkt < eksisterende.endretTidspunkt -> return gjennomforing
             }
         }
 
-        val norskIdent = norskIdent.takeIf { deltaker.status.type != DeltakerStatusType.FEILREGISTRERT }
+        val norskIdent = norskIdent.takeIf { !deltaker.erFeilregistrert() }
         updateFreeTextSearch(gjennomforing, norskIdent)
 
         if (!tiltakstyper.erMigrert(gjennomforing.tiltakstype.tiltakskode)) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/Deltaker.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/Deltaker.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.utbetaling.model
 
 import kotlinx.serialization.Serializable
 import no.nav.mulighetsrommet.model.DeltakerStatus
+import no.nav.mulighetsrommet.model.DeltakerStatusType
 import no.nav.mulighetsrommet.serializers.LocalDateSerializer
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -17,7 +18,9 @@ data class Deltaker(
     val status: DeltakerStatus,
     val deltakelsesmengder: List<Deltakelsesmengde>,
     val innholdAnnet: String?,
-)
+) {
+    fun erFeilregistrert(): Boolean = status.type == DeltakerStatusType.FEILREGISTRERT
+}
 
 @Serializable
 data class Deltakelsesmengde(

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassServiceTest.kt
@@ -355,6 +355,25 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     service.updateFromDeltaker(nyDeltaker, norskIdent)
                 }.message shouldBe "Enkeltplass med id=${GjennomforingFixtures.EnkelAmo.id} har allerede en annen deltaker"
             }
+
+            test("ignorerer annen deltaker som er FEILREGISTRERT uten å kaste exception") {
+                val eksisterendeDeltaker = DeltakerFixtures.createDeltakerDbo(
+                    gjennomforingId = GjennomforingFixtures.EnkelAmo.id,
+                )
+                MulighetsrommetTestDomain(
+                    deltakere = listOf(eksisterendeDeltaker),
+                ).initialize(database.db)
+
+                val feilregistrertDeltaker = DeltakerFixtures.createDeltaker(
+                    gjennomforingId = GjennomforingFixtures.EnkelAmo.id,
+                    status = DeltakerStatusType.FEILREGISTRERT,
+                )
+
+                val gjennomforing = service.updateFromDeltaker(feilregistrertDeltaker, norskIdent)
+
+                gjennomforing.startDato shouldBe GjennomforingFixtures.EnkelAmo.startDato
+                gjennomforing.sluttDato shouldBe GjennomforingFixtures.EnkelAmo.sluttDato
+            }
         }
 
         context("når tiltakstype ikke er migrert") {


### PR DESCRIPTION
Feilregistrerte deltakere blir slettet av systemet via egen kafka-konsument. Denne endringen sørger for at vi enkeltplass-consumeren spiser seg gjennom feilregistrerte enkeltplasser uten at det fører til noen endringer