### PR TITLE
konsumer response ifm mutation requests

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/sanity/SanityClient.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/clients/sanity/SanityClient.kt
@@ -16,8 +16,9 @@ import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -116,13 +117,15 @@ class SanityClient(engine: HttpClientEngine = CIO.create(), val config: Config) 
         return response.body()
     }
 
+    data class MutateResponse(val status: HttpStatusCode, val body: String)
+
     internal suspend inline fun <reified T> mutate(
         mutations: List<Mutation<T>>,
         returnIds: Boolean = false,
         returnDocuments: Boolean = false,
         dryRun: Boolean = false,
         visibility: MutationVisibility = MutationVisibility.Sync,
-    ): HttpResponse {
+    ): MutateResponse {
         val response = client.post(config.mutationUrl()) {
             setBody(Mutations(mutations = mutations))
             url.parameters.apply {
@@ -133,7 +136,7 @@ class SanityClient(engine: HttpClientEngine = CIO.create(), val config: Config) 
             }
         }
 
-        return response
+        return MutateResponse(response.status, response.bodyAsText())
     }
 }
 

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/sanity/SanityService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/sanity/SanityService.kt
@@ -2,8 +2,6 @@ package no.nav.mulighetsrommet.api.sanity
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.plugins.NotFoundException
 import kotlinx.serialization.json.JsonObject
@@ -341,7 +339,7 @@ class SanityService(
 
     suspend fun createSanityEnheter(
         sanityEnheter: List<SanityEnhet>,
-    ): HttpResponse {
+    ): SanityClient.MutateResponse {
         val mutations = sanityEnheter.map { Mutation.createOrReplace(it) }
         return sanityClient.mutate(mutations)
     }
@@ -403,7 +401,7 @@ class SanityService(
         val response = sanityClient.mutate(redaktorer.map { Mutation.createOrReplace(it) })
 
         if (response.status != HttpStatusCode.OK) {
-            throw Exception("Klarte ikke upserte redaktorer: Error: ${response.bodyAsText()} - Status: ${response.status}")
+            throw Exception("Klarte ikke upserte redaktorer: Error: ${response.body} - Status: ${response.status}")
         }
     }
 
@@ -411,7 +409,7 @@ class SanityService(
         val response = sanityClient.mutate(kontaktperson.map { Mutation.createOrReplace(it) })
 
         if (response.status != HttpStatusCode.OK) {
-            throw Exception("Klarte ikke upserte nav kontaktpersoner: Error: ${response.bodyAsText()} - Status: ${response.status}")
+            throw Exception("Klarte ikke upserte nav kontaktpersoner: Error: ${response.body} - Status: ${response.status}")
         }
     }
 
@@ -440,7 +438,7 @@ class SanityService(
 
         val response = sanityClient.mutate(mutations)
         if (response.status != HttpStatusCode.OK) {
-            throw Exception("Klarte ikke upserte nav kontaktpersoner: Error: ${response.bodyAsText()} - Status: ${response.status}")
+            throw Exception("Klarte ikke upserte nav kontaktpersoner: Error: ${response.body} - Status: ${response.status}")
         }
     }
 
@@ -463,7 +461,7 @@ class SanityService(
 
         val result = sanityClient.mutate(mutations = ids.map { Mutation.delete(it) })
         if (result.status != HttpStatusCode.OK) {
-            throw Exception("Klarte ikke slette navIdent from Sanity: ${result.bodyAsText()}")
+            throw Exception("Klarte ikke slette navIdent from Sanity: ${result.body}")
         }
     }
 }


### PR DESCRIPTION
Det er noe rar oppførsel i en request mot sanity som ser ut til å ha oppstått etter forrige bump av ktor. Problemet som oppstår er at det tar 30 sekunder før "Opprettet gjennomforing i Sanity med id", selv om selve http-kallet tar drøyt 1 sekund. Forsøker derfor å konsumere responsen med en gang for å se om det utgjør en forskjell.