### PR TITLE
Revert: sha pinning av nginx

### DIFF
--- a/frontend/mulighetsrommet-cms/Dockerfile
+++ b/frontend/mulighetsrommet-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/nginx:latest@sha256:fdd65ea225da60875e24a8b45d1e65501f9e4991b3b097ae65ed8a4c8f3782a3 AS runtime
+FROM cgr.dev/chainguard/nginx:latest AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/navikt/mulighetsrommet"
 LABEL org.opencontainers.image.title="mulighetsrommet-cms"


### PR DESCRIPTION
Nginx var ikke tilgjengelig i navs chainguard repo alikevel