### PR TITLE
SecChampAgent: Hvitelist hosts avhengig av miljø & nye headere

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/HTTP.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/HTTP.kt
@@ -11,6 +11,7 @@ import io.ktor.server.plugins.cachingheaders.CachingHeaders
 import io.ktor.server.plugins.conditionalheaders.ConditionalHeaders
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
+import no.nav.mulighetsrommet.env.NaisEnv
 
 fun Application.configureHTTP() {
     install(CachingHeaders) {
@@ -23,7 +24,18 @@ fun Application.configureHTTP() {
     }
     install(ConditionalHeaders)
     install(CORS) {
-        anyHost()
+        when (NaisEnv.current()) {
+            NaisEnv.Local -> anyHost()
+
+            NaisEnv.DevGCP -> {
+                allowHost("*.dev.nav.no", schemes = listOf("https"))
+            }
+
+            NaisEnv.ProdGCP -> {
+                allowHost("*.nav.no", schemes = listOf("https"))
+                allowHost("nav.no", schemes = listOf("https"))
+            }
+        }
 
         allowMethod(HttpMethod.Options)
         allowMethod(HttpMethod.Put)
@@ -39,6 +51,8 @@ fun Application.configureHTTP() {
         exposeHeader("X-OpenAPI-Version")
     }
     install(DefaultHeaders) {
-        header("X-Engine", "Ktor") // will send this header with each response
+        header("X-Content-Type-Options", "nosniff") // hindrer MIME-type sniffing
+        header("X-Frame-Options", "DENY") // hindrer clickjacking via iframe
+        header("Referrer-Policy", "strict-origin-when-cross-origin") // begrenser referrer-lekkasje
     }
 }

--- a/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/plugins/HTTP.kt
+++ b/mulighetsrommet-tiltakshistorikk/src/main/kotlin/no/nav/tiltak/historikk/plugins/HTTP.kt
@@ -6,14 +6,28 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
+import no.nav.mulighetsrommet.env.NaisEnv
 
 fun Application.configureHTTP() {
     install(DefaultHeaders) {
-        header("X-Engine", "Ktor") // will send this header with each response
+        header("X-Content-Type-Options", "nosniff") // hindrer MIME-type sniffing
+        header("X-Frame-Options", "DENY") // hindrer clickjacking via iframe
+        header("Referrer-Policy", "strict-origin-when-cross-origin") // begrenser referrer-lekkasje
     }
 
     install(CORS) {
-        anyHost()
+        when (NaisEnv.current()) {
+            NaisEnv.Local -> anyHost()
+
+            NaisEnv.DevGCP -> {
+                allowHost("*.dev.nav.no", schemes = listOf("https"))
+            }
+
+            NaisEnv.ProdGCP -> {
+                allowHost("*.nav.no", schemes = listOf("https"))
+                allowHost("nav.no", schemes = listOf("https"))
+            }
+        }
 
         allowMethod(HttpMethod.Options)
         allowMethod(HttpMethod.Put)


### PR DESCRIPTION
Anbefalinger fra https://ki-utvikling.nav.no/verktoy?q=security&item=security-champion-agent

Tror den singlet ut disse to tjenestene etter å ha lest nais-yamlen for applikasjonene og funnet 3dje parts løsninger der.