### PR TITLE
Fjern gamle amo tabeller

### DIFF
--- a/iac/bigquery-terraform/dev/datastreams.tf
+++ b/iac/bigquery-terraform/dev/datastreams.tf
@@ -125,7 +125,6 @@ module "mr_api_datastream" {
           ]
         },
         { table = "gjennomforing_nav_enhet" },
-        { table = "gjennomforing_utdanningsprogram" },
         { table = "utdanningsprogram" },
         { table = "utdanning" },
         {

--- a/iac/bigquery-terraform/dev/datastreams.tf
+++ b/iac/bigquery-terraform/dev/datastreams.tf
@@ -124,8 +124,6 @@ module "mr_api_datastream" {
             "tilgjengelig_for_arrangor_dato",
           ]
         },
-        { table = "gjennomforing_amo_kategorisering" },
-        { table = "gjennomforing_amo_kategorisering_sertifisering" },
         { table = "gjennomforing_nav_enhet" },
         { table = "gjennomforing_utdanningsprogram" },
         { table = "utdanningsprogram" },

--- a/iac/bigquery-terraform/prod/datastreams.tf
+++ b/iac/bigquery-terraform/prod/datastreams.tf
@@ -125,7 +125,6 @@ module "mr_api_datastream" {
           ]
         },
         { table = "gjennomforing_nav_enhet" },
-        { table = "gjennomforing_utdanningsprogram" },
         { table = "utdanningsprogram" },
         { table = "utdanning" },
         {

--- a/iac/bigquery-terraform/prod/datastreams.tf
+++ b/iac/bigquery-terraform/prod/datastreams.tf
@@ -124,8 +124,6 @@ module "mr_api_datastream" {
             "tilgjengelig_for_arrangor_dato",
           ]
         },
-        { table = "gjennomforing_amo_kategorisering" },
-        { table = "gjennomforing_amo_kategorisering_sertifisering" },
         { table = "gjennomforing_nav_enhet" },
         { table = "gjennomforing_utdanningsprogram" },
         { table = "utdanningsprogram" },

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/amo/db/OpplaringKategoriseringQueries.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/amo/db/OpplaringKategoriseringQueries.kt
@@ -135,7 +135,7 @@ object OpplaringKategoriseringQueries {
     ) {
         @Language("PostgreSQL")
         val upsertSertifiseringer = """
-        insert into amo_sertifisering (
+        insert into opplaring_sertifisering (
             konsept_id,
             label
         )

--- a/mulighetsrommet-api/src/main/resources/db/migration/V509__fjern_gamle_amo_tabeller.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V509__fjern_gamle_amo_tabeller.sql
@@ -8,5 +8,4 @@ drop table if exists avtale_amo_kategorisering,
     gjennomforing_amo_kategorisering_sertifisering;
 
 alter table if exists amo_sertifisering rename to opplaring_sertifisering;
-alter table if exists opplaring_kategorisering rename constraint amo_sertifisering_pkey to opplaring_sertifisering_pkey;
-alter index if exists amo_sertifisering_pkey rename to opplaring_sertifisering_pkey;
+alter table opplaring_sertifisering rename constraint amo_sertifisering_pkey to opplaring_sertifisering_pkey;

--- a/mulighetsrommet-api/src/main/resources/db/migration/V509__fjern_gamle_amo_tabeller.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V509__fjern_gamle_amo_tabeller.sql
@@ -1,0 +1,6 @@
+drop table if exists avtale_amo_kategorisering,
+    avtale_amo_kategorisering_forerkort,
+    avtale_amo_kategorisering_sertifisering,
+    gjennomforing_amo_kategorisering,
+    gjennomforing_amo_kategorisering_forerkort,
+    gjennomforing_amo_kategorisering_sertifisering;

--- a/mulighetsrommet-api/src/main/resources/db/migration/V509__fjern_gamle_amo_tabeller.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V509__fjern_gamle_amo_tabeller.sql
@@ -1,6 +1,12 @@
+drop view if exists view_avtale, view_gjennomforing_avtale_detaljer, view_opplaring_kategorisering;
+
 drop table if exists avtale_amo_kategorisering,
     avtale_amo_kategorisering_forerkort,
     avtale_amo_kategorisering_sertifisering,
     gjennomforing_amo_kategorisering,
     gjennomforing_amo_kategorisering_forerkort,
     gjennomforing_amo_kategorisering_sertifisering;
+
+alter table if exists amo_sertifisering rename to opplaring_sertifisering;
+alter table if exists opplaring_kategorisering rename constraint amo_sertifisering_pkey to opplaring_sertifisering_pkey;
+alter index if exists amo_sertifisering_pkey rename to opplaring_sertifisering_pkey;

--- a/mulighetsrommet-api/src/main/resources/db/migration/V511__fjern_gamle_amo_tabeller.sql
+++ b/mulighetsrommet-api/src/main/resources/db/migration/V511__fjern_gamle_amo_tabeller.sql
@@ -3,9 +3,11 @@ drop view if exists view_avtale, view_gjennomforing_avtale_detaljer, view_opplar
 drop table if exists avtale_amo_kategorisering,
     avtale_amo_kategorisering_forerkort,
     avtale_amo_kategorisering_sertifisering,
+    avtale_utdanningsprogram,
     gjennomforing_amo_kategorisering,
     gjennomforing_amo_kategorisering_forerkort,
-    gjennomforing_amo_kategorisering_sertifisering;
+    gjennomforing_amo_kategorisering_sertifisering,
+    gjennomforing_utdanningsprogram;
 
 alter table if exists amo_sertifisering rename to opplaring_sertifisering;
 alter table opplaring_sertifisering rename constraint amo_sertifisering_pkey to opplaring_sertifisering_pkey;

--- a/mulighetsrommet-api/src/main/resources/db/views/afterMigrate__view_avtale.sql
+++ b/mulighetsrommet-api/src/main/resources/db/views/afterMigrate__view_avtale.sql
@@ -183,7 +183,7 @@ from avtale
                                                                                                        s.konsept_id
                                                                                                )
                                                                                        ))
-                                                                        from amo_sertifisering s
+                                                                        from opplaring_sertifisering s
                                                                                  join opplaring_kategorisering_sertifisering oks
                                                                                       on oks.konsept_id = s.konsept_id
                                                                         where oks.opplaring_kategorisering_id = ok.id),

--- a/mulighetsrommet-api/src/main/resources/db/views/afterMigrate__view_gjennomforing_avtale_detaljer.sql
+++ b/mulighetsrommet-api/src/main/resources/db/views/afterMigrate__view_gjennomforing_avtale_detaljer.sql
@@ -127,7 +127,7 @@ from gjennomforing
                                                                                                        s.konsept_id
                                                                                                )
                                                                                        ))
-                                                                        from amo_sertifisering s
+                                                                        from opplaring_sertifisering s
                                                                                  join opplaring_kategorisering_sertifisering oks
                                                                                       on oks.konsept_id = s.konsept_id
                                                                         where oks.opplaring_kategorisering_id = ok.id),

--- a/mulighetsrommet-api/src/main/resources/db/views/afterMigrate__view_opplaring_kategorisering.sql
+++ b/mulighetsrommet-api/src/main/resources/db/views/afterMigrate__view_opplaring_kategorisering.sql
@@ -54,7 +54,7 @@ select ok.id,
                                                 'konseptId', s.konsept_id
                                         )
                                 ))
-                 from amo_sertifisering s
+                 from opplaring_sertifisering s
                           join opplaring_kategorisering_sertifisering oks
                                on oks.konsept_id = s.konsept_id
                  where oks.opplaring_kategorisering_id = ok.id),


### PR DESCRIPTION
Testet litt lokalt, og alt ser bra ut.

Siste opprydning blir å slette disse tabellene fra BigQuery, siden slettingen av dem i datastream configen bare stopper strømmingen.