### PR TITLE
benytt value objects i stedet for strings

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/pdfgen/VedtaksbrevContent.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/pdfgen/VedtaksbrevContent.kt
@@ -1,12 +1,17 @@
 package no.nav.mulighetsrommet.api.pdfgen
 
 import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.model.NorskIdent
+import no.nav.mulighetsrommet.model.Tiltaksnummer
+import no.nav.mulighetsrommet.serializers.LocalDateSerializer
+import java.time.LocalDate
 
 @Serializable
 data class VedtaksbrevContent(
     val deltaker: Deltaker,
-    val saksnummer: String,
-    val opprettetDato: String,
+    val saksnummer: Tiltaksnummer,
+    @Serializable(with = LocalDateSerializer::class)
+    val opprettetDato: LocalDate,
     val saksbehandler: String,
     val beslutter: String,
     val avsender: String,
@@ -17,7 +22,7 @@ data class VedtaksbrevContent(
         val fornavn: String,
         val mellomnavn: String,
         val etternavn: String,
-        val personident: String,
+        val personident: NorskIdent?,
     )
 
     @Serializable
@@ -31,8 +36,10 @@ data class VedtaksbrevContent(
     ) {
         @Serializable
         data class Periode(
-            val fradato: String,
-            val tildato: String,
+            @Serializable(with = LocalDateSerializer::class)
+            val fradato: LocalDate,
+            @Serializable(with = LocalDateSerializer::class)
+            val tildato: LocalDate,
         )
     }
 }

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/mapper/TilskuddVedtakToVedtaksbrevContent.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/mapper/TilskuddVedtakToVedtaksbrevContent.kt
@@ -17,7 +17,7 @@ object TilskuddVedtakToVedtaksbrevContent {
         beslutter: String,
     ): VedtaksbrevContent {
         val navn = splitNavn(personalia.navn())
-        val ident = personalia.norskIdent()?.value.orEmpty()
+        val ident = personalia.norskIdent()
         val vedtakListe = tilskuddBehandling.tilskudd.map { t ->
             VedtaksbrevContent.Vedtak(
                 utfall = t.vedtakResultat.beskrivelse,
@@ -25,8 +25,8 @@ object TilskuddVedtakToVedtaksbrevContent {
                 tilskuddBelop = t.utbetalingBelop?.belop ?: 0,
                 valuta = t.utbetalingBelop?.valuta?.name ?: t.soknadBelop.valuta.name,
                 periode = VedtaksbrevContent.Vedtak.Periode(
-                    fradato = tilskuddBehandling.periode.start.toString(),
-                    tildato = tilskuddBehandling.periode.getLastInclusiveDate().toString(),
+                    fradato = tilskuddBehandling.periode.start,
+                    tildato = tilskuddBehandling.periode.getLastInclusiveDate(),
                 ),
                 kommentar = t.kommentarVedtaksbrev.orEmpty(),
             )
@@ -39,8 +39,8 @@ object TilskuddVedtakToVedtaksbrevContent {
                 etternavn = navn.etternavn,
                 personident = ident,
             ),
-            saksnummer = gjennomforing.lopenummer.value,
-            opprettetDato = LocalDate.now().toString(),
+            saksnummer = gjennomforing.lopenummer,
+            opprettetDato = LocalDate.now(),
             saksbehandler = saksbehandler,
             beslutter = beslutter,
             avsender = gjennomforing.ansvarligEnhet.navn,


### PR DESCRIPTION
Gjøres for å bedre sikre at data ender opp i riktige felter. Serialiseringen burde sørge for at innholdet blir likt som før.