### PR TITLE
Bump composed mock-oauth2-server@5.0.2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   # Mock implementation of Oauth2/OIDC.
   # The service is referenced as part of the authentication between applications as part of local development.
   mock-oauth2-server:
-    image: "ghcr.io/navikt/mock-oauth2-server:4.0.1"
+    image: "ghcr.io/navikt/mock-oauth2-server:5.0.2"
     restart: always
     ports:
       - "8081:8081"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   # Mock implementation of Oauth2/OIDC.
   # The service is referenced as part of the authentication between applications as part of local development.
   mock-oauth2-server:
-    image: "ghcr.io/navikt/mock-oauth2-server:2.0.0"
+    image: "ghcr.io/navikt/mock-oauth2-server:4.0.1"
     restart: always
     ports:
       - "8081:8081"
@@ -13,7 +13,7 @@ services:
       JSON_CONFIG: >
         {
           "interactiveLogin": true,
-          "httpServer": "NettyWrapper",
+          "httpServer": { "type": "NettyWrapper" },
           "tokenCallbacks": [
             {
               "issuerId": "azure",

--- a/frontend/arbeidsmarkedstiltak-flate/README.md
+++ b/frontend/arbeidsmarkedstiltak-flate/README.md
@@ -55,14 +55,15 @@ via [vite](https://vite.dev/guide/env-and-mode.html#env-files)
 eller [mise](https://mise.jdx.dev/environments/#using-environment-variables).
 For å generere dette gjør du følgende:
 
-1. Naviger til lokal [Mock Oauth2 Server](http://localhost:8081/azure/debugger)
+1. Naviger til lokal [Mock Oauth2 Server (azure)](http://localhost:8081/azure/debugger)
 2. Trykk på knappen `Get a token`
 3. Skriv inn hva som helst som `user/subject`
 4. Legg inn dette i optional claims:
    ```json
    {
      "NAVident": "B123456",
-     "oid": "37ba79a1-c36d-4f45-8608-d582df321ecc"
+     "aud": ["mulighetsrommet-api"],
+     "oid": "37ba79a1-c36d-4f45-8608-d582df321ecc",
    }
    ```
 5. Trykk `Sign in`

--- a/frontend/arrangor-utbetalinger-flate/README.md
+++ b/frontend/arrangor-utbetalinger-flate/README.md
@@ -36,13 +36,14 @@ via [vite](https://vite.dev/guide/env-and-mode.html#env-files)
 eller [mise](https://mise.jdx.dev/environments/#using-environment-variables).
 For å generere dette gjør du følgende:
 
-1. Naviger til lokal [Mock Oauth2 Server](http://localhost:8081/tokenx/debugger)
+1. Naviger til lokal [Mock Oauth2 Server (tokenx)](http://localhost:8081/tokenx/debugger)
 2. Trykk på knappen `Get a token`
 3. Skriv inn hva som helst i toppen
 4. Legg inn dette i optional claims:
    ```json
    {
-     "pid": "11830348931"
+     "pid": "11830348931",
+     "aud": ["mulighetsrommet-api"]
    }
    ```
 5. Trykk `Sign in`

--- a/frontend/tiltaksadministrasjon-flate/README.md
+++ b/frontend/tiltaksadministrasjon-flate/README.md
@@ -25,7 +25,7 @@ via [vite](https://vite.dev/guide/env-and-mode.html#env-files)
 eller [mise](https://mise.jdx.dev/environments/#using-environment-variables).
 For å generere dette gjør du følgende:
 
-1. Naviger til lokal [Mock Oauth2 Server](http://localhost:8081/azure/debugger)
+1. Naviger til lokal [Mock Oauth2 Server (azure)](http://localhost:8081/azure/debugger)
 2. Trykk på knappen `Get a token`
 3. Skriv inn hva som helst som `user/subject`
 4. Legg inn dette i optional claims:

--- a/frontend/tiltaksadministrasjon-flate/README.md
+++ b/frontend/tiltaksadministrasjon-flate/README.md
@@ -32,6 +32,7 @@ For å generere dette gjør du følgende:
    ```json
    {
      "NAVident": "B123456",
+     "aud": ["mulighetsrommet-api"],
      "oid": "0bab029e-e84e-4842-8a27-d153b29782cf",
      "uti": "0bab029e-e84e-4842-8a27-d153b29782cf",
      "groups": [


### PR DESCRIPTION
La til audience som nå er påkrevd og hinting til hvilke issuer hver app har i lenken

[Migrering guide](https://github.com/navikt/mock-oauth2-server/blob/master/MIGRATION.md#migrating-to-500)

Relatert v5 dependabot issue: https://github.com/navikt/mulighetsrommet/pull/7801