### PR TITLE
slutt å sende notifikasjon til admins når kontaktperson slettes fra sanity

### DIFF
--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/service/NavAnsattSyncService.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/navansatt/service/NavAnsattSyncService.kt
@@ -1,25 +1,14 @@
 package no.nav.mulighetsrommet.api.navansatt.service
 
-import arrow.core.toNonEmptyListOrNull
 import no.nav.mulighetsrommet.api.ApiDatabase
-import no.nav.mulighetsrommet.api.QueryContext
 import no.nav.mulighetsrommet.api.navansatt.db.NavAnsattDbo
 import no.nav.mulighetsrommet.api.navansatt.model.NavAnsatt
-import no.nav.mulighetsrommet.api.navansatt.model.NavAnsattRolle
 import no.nav.mulighetsrommet.api.navansatt.model.Rolle
-import no.nav.mulighetsrommet.api.navenhet.EnhetFilter
-import no.nav.mulighetsrommet.api.navenhet.NavEnhetService
-import no.nav.mulighetsrommet.api.navenhet.db.NavEnhetStatus
 import no.nav.mulighetsrommet.api.sanity.SanityNavKontaktperson
 import no.nav.mulighetsrommet.api.sanity.SanityRedaktor
 import no.nav.mulighetsrommet.api.sanity.SanityService
-import no.nav.mulighetsrommet.api.sanity.SanityTiltaksgjennomforing
 import no.nav.mulighetsrommet.api.sanity.Slug
-import no.nav.mulighetsrommet.notifications.NotificationMetadata
-import no.nav.mulighetsrommet.notifications.NotificationTask
-import no.nav.mulighetsrommet.notifications.ScheduledNotification
 import org.slf4j.LoggerFactory
-import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -27,8 +16,6 @@ class NavAnsattSyncService(
     private val db: ApiDatabase,
     private val navAnsattService: NavAnsattService,
     private val sanityService: SanityService,
-    private val navEnhetService: NavEnhetService,
-    private val notificationTask: NotificationTask,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -64,55 +51,9 @@ class NavAnsattSyncService(
     }
 
     private suspend fun deleteNavAnsatt(ansatt: NavAnsatt): Unit = db.transaction {
-        val gjennomforinger = sanityService.getTiltakByNavIdent(ansatt.navIdent)
-
         queries.ansatt.deleteByEntraObjectId(ansatt.entraObjectId)
         sanityService.removeNavIdentFromTiltaksgjennomforinger(ansatt.navIdent)
         sanityService.deleteNavIdent(ansatt.navIdent)
-
-        gjennomforinger.forEach { gjennomforing ->
-            notifyRelevantAdministratorsForSanityGjennomforing(
-                gjennomforing,
-                ansatt.hovedenhet,
-            )
-        }
-    }
-
-    private fun QueryContext.notifyRelevantAdministratorsForSanityGjennomforing(
-        tiltak: SanityTiltaksgjennomforing,
-        hovedenhet: NavAnsatt.Hovedenhet,
-    ) {
-        val region = navEnhetService.hentOverordnetFylkesenhet(hovedenhet.enhetsnummer)
-            ?: return
-
-        val potentialAdministratorHovedenheter = navEnhetService.hentAlleEnheter(
-            EnhetFilter(
-                statuser = listOf(NavEnhetStatus.AKTIV),
-                overordnetEnhet = region.enhetsnummer,
-            ),
-        )
-            .map { it.enhetsnummer }
-            .plus(region.enhetsnummer)
-
-        val administrators = queries.ansatt
-            .getAll(
-                rollerContainsAll = listOf(NavAnsattRolle.generell(Rolle.TILTAKSGJENNOMFORINGER_SKRIV)),
-                hovedenhetIn = potentialAdministratorHovedenheter,
-            )
-            .map { it.navIdent }
-            .toNonEmptyListOrNull() ?: return
-
-        val notification = ScheduledNotification(
-            title = """Kontaktperson eller redaktør for tiltak: "${tiltak.tiltaksgjennomforingNavn}" ble fjernet i Sanity""",
-            description = "Du har blitt varslet fordi din Nav-hovedenhet er i samme fylke som den slettede kontaktpersons/redaktørs Nav-hovedenhet. Gå til tiltaksgjennomføringen i Sanity og sjekk at kontaktpersonene og redaktørene for tiltaket er korrekt.",
-            metadata = NotificationMetadata(
-                linkText = "Gå til gjennomføringen i Sanity",
-                link = "https://mulighetsrommet-sanity-studio.intern.nav.no/prod/structure/tiltaksgjennomforinger;alleTiltaksgjennomforinger;${tiltak._id}",
-            ),
-            targets = administrators,
-            createdAt = Instant.now(),
-        )
-        notificationTask.scheduleNotification(notification)
     }
 
     private suspend fun upsertSanityAnsatte(ansatte: List<NavAnsatt>) {

--- a/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
+++ b/mulighetsrommet-api/src/main/kotlin/no/nav/mulighetsrommet/api/plugins/DependencyInjection.kt
@@ -441,7 +441,7 @@ private fun services(appConfig: AppConfig) = module {
     }
     single { BrukerService(get(), get(), get(), get(), get(), get()) }
     single { NavAnsattService(appConfig.auth.roles, get(), get()) }
-    single { NavAnsattSyncService(get(), get(), get(), get(), get()) }
+    single { NavAnsattSyncService(get(), get(), get()) }
     single { NavAnsattPrincipalService(get(), get()) }
     single { PoaoTilgangService(get()) }
     single { DelMedBrukerService(get(), get(), get()) }

--- a/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/navansatt/service/NavAnsattSyncServiceTest.kt
+++ b/mulighetsrommet-api/src/test/kotlin/no/nav/mulighetsrommet/api/navansatt/service/NavAnsattSyncServiceTest.kt
@@ -12,10 +12,8 @@ import no.nav.mulighetsrommet.api.navansatt.db.NavAnsattDbo
 import no.nav.mulighetsrommet.api.navansatt.model.NavAnsatt
 import no.nav.mulighetsrommet.api.navansatt.model.NavAnsattRolle
 import no.nav.mulighetsrommet.api.navansatt.model.Rolle.TILTAKADMINISTRASJON_GENERELL
-import no.nav.mulighetsrommet.api.navenhet.NavEnhetService
 import no.nav.mulighetsrommet.api.sanity.SanityService
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
-import no.nav.mulighetsrommet.notifications.NotificationTask
 import java.time.LocalDate
 
 class NavAnsattSyncServiceTest : FunSpec({
@@ -44,7 +42,6 @@ class NavAnsattSyncServiceTest : FunSpec({
         database.truncateAll()
     }
 
-    val notificationTask: NotificationTask = mockk()
     val sanityService: SanityService = mockk(relaxed = true)
     val navAnsattService: NavAnsattService = mockk()
 
@@ -52,8 +49,6 @@ class NavAnsattSyncServiceTest : FunSpec({
         db = database.db,
         navAnsattService = navAnsattService,
         sanityService = sanityService,
-        navEnhetService = NavEnhetService(database.db),
-        notificationTask = notificationTask,
     )
 
     val ansatt1 =


### PR DESCRIPTION
Gjøres i forkant av modularisering av backend. Vi har samtidig et initiaitv med å bli kvitt avhengigheten til Sanity, så antakelsen er at dette ikke er en funksjon som blir savnet