### PR TITLE
erstatt custom databasespørring med et ekstra oppslag mot gjennomføring

### DIFF
--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/db/ArrangorQueries.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/arrangor/db/ArrangorQueries.kt
@@ -18,7 +18,6 @@ import no.nav.mulighetsrommet.serializers.UUIDSerializer
 import org.intellij.lang.annotations.Language
 import java.sql.Array
 import java.util.UUID
-import kotlin.String
 
 class ArrangorQueries(private val session: Session) {
     private val underenheterLateralJoin = """
@@ -141,27 +140,6 @@ class ArrangorQueries(private val session: Session) {
         """.trimIndent()
 
         return session.single(queryOf(selectHovedenhet, orgnr.value)) { it.toArrangorDtoMedUnderenheter() }
-    }
-
-    fun getByGjennomforingId(gjennomforingId: UUID): ArrangorDto? {
-        @Language("PostgreSQL")
-        val selectHovedenhet = """
-            select
-                arrangor.id,
-                arrangor.organisasjonsnummer,
-                arrangor.organisasjonsform,
-                arrangor.overordnet_enhet,
-                arrangor.er_utenlandsk_virksomhet,
-                arrangor.navn,
-                arrangor.slettet_dato,
-                underenheter_json
-            from gjennomforing
-                inner join arrangor on arrangor.id = gjennomforing.arrangor_id
-                $underenheterLateralJoin
-            where gjennomforing.id = ?
-        """.trimIndent()
-
-        return session.single(queryOf(selectHovedenhet, gjennomforingId)) { it.toArrangorDtoMedUnderenheter() }
     }
 
     fun get(orgnr: List<Organisasjonsnummer>): List<ArrangorDto> {

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingService.kt
@@ -135,7 +135,8 @@ class AdminUtbetalingService(
     ): Either<List<FieldError>, Utbetaling> = db.transaction {
         when (opprett) {
             is UpsertUtbetaling.Anskaffelse if opprett.journalpostId == null -> {
-                val arrangor = checkNotNull(queries.arrangor.getByGjennomforingId(opprett.gjennomforingId))
+                val gjennomforing = queries.gjennomforing.getGjennomforingTiltaksadministrasjon(opprett.gjennomforingId)
+                val arrangor = queries.arrangor.getById(gjennomforing.arrangor.id)
                 if (!arrangor.erUtenlandsk) {
                     return FieldError.of("Journalpost-ID er påkrevd", UpsertUtbetaling.Anskaffelse::journalpostId)
                         .nel()


### PR DESCRIPTION
Forenkler api'et for arrangør-spørring siden dette er et one-of use case som uansett ikke går ut over ytelse