### PR TITLE
konverter tidspunkt-kolonner til timestamptz

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/DeltakerStatus.kt
+++ b/common/domain/src/main/kotlin/no/nav/mulighetsrommet/model/DeltakerStatus.kt
@@ -1,15 +1,15 @@
 package no.nav.mulighetsrommet.model
 
 import kotlinx.serialization.Serializable
-import no.nav.mulighetsrommet.serializers.LocalDateTimeSerializer
-import java.time.LocalDateTime
+import no.nav.mulighetsrommet.serializers.InstantSerializer
+import java.time.Instant
 
 @Serializable
 data class DeltakerStatus(
     val type: DeltakerStatusType,
     val aarsak: DeltakerStatusAarsakType?,
-    @Serializable(with = LocalDateTimeSerializer::class)
-    val opprettetTidspunkt: LocalDateTime,
+    @Serializable(with = InstantSerializer::class)
+    val opprettetTidspunkt: Instant,
 )
 
 enum class DeltakerStatusType(val description: String, val variant: DataElement.Status.Variant) {

--- a/mulighetsrommet-api/admin/src/test/kotlin/no/nav/mulighetsrommet/admin/deltaker/ReplikerDeltakerUseCaseTest.kt
+++ b/mulighetsrommet-api/admin/src/test/kotlin/no/nav/mulighetsrommet/admin/deltaker/ReplikerDeltakerUseCaseTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.admin.testing.TestAdminDatabase
 import no.nav.mulighetsrommet.api.fixtures.DeltakerFixtures
 import no.nav.mulighetsrommet.model.DeltakerStatusType
-import java.time.LocalDateTime
+import java.time.Instant
 import java.util.UUID
 
 class ReplikerDeltakerUseCaseTest : FunSpec({
@@ -52,9 +52,7 @@ class ReplikerDeltakerUseCaseTest : FunSpec({
         val eksisterende = DeltakerFixtures.createDeltaker(gjennomforingId = UUID.randomUUID())
         db.repository.deltaker.save(eksisterende)
 
-        val feilregistrert = eksisterende.copy(
-            status = eksisterende.status.copy(type = DeltakerStatusType.FEILREGISTRERT),
-        )
+        val feilregistrert = eksisterende.registrerStatus(DeltakerStatusType.FEILREGISTRERT)
 
         val replikerDeltaker = ReplikerDeltakerUseCase(db)
 
@@ -67,8 +65,8 @@ class ReplikerDeltakerUseCaseTest : FunSpec({
     test("overskriver ikke deltaker når tidspunkt for endring er eldre enn det som er lagret i databasen") {
         val db = TestAdminDatabase()
 
-        val nyereEndring = LocalDateTime.of(2023, 3, 1, 0, 0, 0)
-        val eldreEndring = LocalDateTime.of(2023, 2, 1, 0, 0, 0)
+        val nyereEndring = Instant.parse("2023-03-01T00:00:00Z")
+        val eldreEndring = Instant.parse("2023-02-01T00:00:00Z")
 
         val id = UUID.randomUUID()
         val lagretDeltaker = DeltakerFixtures.createDeltaker(
@@ -79,8 +77,8 @@ class ReplikerDeltakerUseCaseTest : FunSpec({
         )
         db.repository.deltaker.save(lagretDeltaker)
 
-        val eldreDeltaker = lagretDeltaker.copy(
-            status = lagretDeltaker.status.copy(type = DeltakerStatusType.AVBRUTT),
+        val eldreDeltaker = lagretDeltaker.registrerStatus(
+            type = DeltakerStatusType.AVBRUTT,
             endretTidspunkt = eldreEndring,
         )
 
@@ -110,7 +108,7 @@ class ReplikerDeltakerUseCaseTest : FunSpec({
         val db = TestAdminDatabase()
 
         val id = UUID.randomUUID()
-        val endretTidspunkt = LocalDateTime.of(2023, 3, 1, 0, 0, 0)
+        val endretTidspunkt = Instant.parse("2023-03-01T00:00:00Z")
         val deltaker = DeltakerFixtures.createDeltaker(
             id = id,
             gjennomforingId = UUID.randomUUID(),
@@ -119,10 +117,7 @@ class ReplikerDeltakerUseCaseTest : FunSpec({
         )
         db.repository.deltaker.save(deltaker)
 
-        val oppdatertDeltaker = deltaker.copy(
-            status = deltaker.status.copy(type = DeltakerStatusType.AVBRUTT),
-            endretTidspunkt = endretTidspunkt,
-        )
+        val oppdatertDeltaker = deltaker.registrerStatus(DeltakerStatusType.AVBRUTT)
 
         val replikerDeltaker = ReplikerDeltakerUseCase(db)
 

--- a/mulighetsrommet-api/domain/src/main/kotlin/no/nav/mulighetsrommet/api/domain/deltaker/Deltaker.kt
+++ b/mulighetsrommet-api/domain/src/main/kotlin/no/nav/mulighetsrommet/api/domain/deltaker/Deltaker.kt
@@ -1,22 +1,66 @@
 package no.nav.mulighetsrommet.api.domain.deltaker
 
 import no.nav.mulighetsrommet.model.DeltakerStatus
+import no.nav.mulighetsrommet.model.DeltakerStatusAarsakType
 import no.nav.mulighetsrommet.model.DeltakerStatusType
+import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
-data class Deltaker(
+data class Deltaker private constructor(
     val id: UUID,
     val gjennomforingId: UUID,
     val startDato: LocalDate?,
     val sluttDato: LocalDate?,
-    val registrertTidspunkt: LocalDateTime,
-    val endretTidspunkt: LocalDateTime,
+    val registrertTidspunkt: Instant,
+    val endretTidspunkt: Instant,
     val status: DeltakerStatus,
     val deltakelsesmengder: List<Deltakelsesmengde>,
     val innholdAnnet: String?,
     val navVeileder: NavVeileder?,
 ) {
     fun erFeilregistrert(): Boolean = status.type == DeltakerStatusType.FEILREGISTRERT
+
+    fun registrerStatus(
+        type: DeltakerStatusType,
+        aarsak: DeltakerStatusAarsakType? = null,
+        endretTidspunkt: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+    ): Deltaker {
+        return copy(
+            endretTidspunkt = endretTidspunkt,
+            status = DeltakerStatus(type, aarsak, endretTidspunkt),
+        )
+    }
+
+    companion object {
+        /**
+         * Postgres lagrer kun med mikrosekunders presisjon (timestamptz). Tidspunktene avkortes derfor
+         * her slik at en [Deltaker] alltid har en presisjon som også overlever lagring.
+         * Dette er bl.a. avgjørende for duplikatsjekk ifm. oppdatering av enkeltplass-gjennomføringer.
+         */
+        fun opprett(
+            id: UUID,
+            gjennomforingId: UUID,
+            startDato: LocalDate?,
+            sluttDato: LocalDate?,
+            registrertTidspunkt: Instant,
+            endretTidspunkt: Instant,
+            status: DeltakerStatus,
+            deltakelsesmengder: List<Deltakelsesmengde>,
+            innholdAnnet: String?,
+            navVeileder: NavVeileder?,
+        ) = Deltaker(
+            id = id,
+            gjennomforingId = gjennomforingId,
+            startDato = startDato,
+            sluttDato = sluttDato,
+            registrertTidspunkt = registrertTidspunkt.truncatedTo(ChronoUnit.MICROS),
+            endretTidspunkt = endretTidspunkt.truncatedTo(ChronoUnit.MICROS),
+            status = status.copy(opprettetTidspunkt = status.opprettetTidspunkt.truncatedTo(ChronoUnit.MICROS)),
+            deltakelsesmengder = deltakelsesmengder,
+            innholdAnnet = innholdAnnet,
+            navVeileder = navVeileder,
+        )
+    }
 }

--- a/mulighetsrommet-api/domain/src/test/kotlin/no/nav/mulighetsrommet/api/domain/deltaker/DeltakerTest.kt
+++ b/mulighetsrommet-api/domain/src/test/kotlin/no/nav/mulighetsrommet/api/domain/deltaker/DeltakerTest.kt
@@ -1,0 +1,36 @@
+package no.nav.mulighetsrommet.api.domain.deltaker
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.mulighetsrommet.model.DeltakerStatus
+import no.nav.mulighetsrommet.model.DeltakerStatusType
+import java.time.Instant
+import java.util.UUID
+
+class DeltakerTest : FunSpec({
+    test("tidspunkt avkortes til mikrosekunders presisjon ved opprettelse") {
+        val tidspunktMedNanosekunder = Instant.parse("2023-03-01T00:00:00.123456789Z")
+        val tidspunktAvkortetTilMikrosekunder = Instant.parse("2023-03-01T00:00:00.123456Z")
+
+        val deltaker = Deltaker.opprett(
+            id = UUID.randomUUID(),
+            gjennomforingId = UUID.randomUUID(),
+            startDato = null,
+            sluttDato = null,
+            registrertTidspunkt = tidspunktMedNanosekunder,
+            endretTidspunkt = tidspunktMedNanosekunder,
+            status = DeltakerStatus(
+                type = DeltakerStatusType.DELTAR,
+                aarsak = null,
+                opprettetTidspunkt = tidspunktMedNanosekunder,
+            ),
+            deltakelsesmengder = listOf(),
+            innholdAnnet = null,
+            navVeileder = null,
+        )
+
+        deltaker.registrertTidspunkt shouldBe tidspunktAvkortetTilMikrosekunder
+        deltaker.endretTidspunkt shouldBe tidspunktAvkortetTilMikrosekunder
+        deltaker.status.opprettetTidspunkt shouldBe tidspunktAvkortetTilMikrosekunder
+    }
+})

--- a/mulighetsrommet-api/domain/src/testFixtures/kotlin/no/nav/mulighetsrommet/api/fixtures/DeltakerFixtures.kt
+++ b/mulighetsrommet-api/domain/src/testFixtures/kotlin/no/nav/mulighetsrommet/api/fixtures/DeltakerFixtures.kt
@@ -2,11 +2,11 @@ package no.nav.mulighetsrommet.api.fixtures
 
 import no.nav.mulighetsrommet.api.domain.deltaker.Deltakelsesmengde
 import no.nav.mulighetsrommet.api.domain.deltaker.Deltaker
+import no.nav.mulighetsrommet.api.domain.deltaker.NavVeileder
 import no.nav.mulighetsrommet.model.DeltakerStatus
 import no.nav.mulighetsrommet.model.DeltakerStatusType
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.UUID
 
 object DeltakerFixtures {
@@ -16,9 +16,10 @@ object DeltakerFixtures {
         status: DeltakerStatusType = DeltakerStatusType.DELTAR,
         startDato: LocalDate? = LocalDate.now(),
         sluttDato: LocalDate? = LocalDate.now().plusMonths(1),
-        endretTidspunkt: LocalDateTime = LocalDateTime.now(),
+        endretTidspunkt: Instant = Instant.now(),
         innhold: String? = null,
-    ) = Deltaker(
+        veileder: NavVeileder? = null,
+    ) = Deltaker.opprett(
         id = id,
         startDato = startDato,
         sluttDato = sluttDato,
@@ -32,7 +33,7 @@ object DeltakerFixtures {
         ),
         deltakelsesmengder = listOf(),
         innholdAnnet = innhold,
-        navVeileder = null,
+        navVeileder = veileder,
     )
 
     fun createDeltakerMedDeltakelsesmengder(
@@ -41,7 +42,7 @@ object DeltakerFixtures {
         startDato: LocalDate = LocalDate.now(),
         sluttDato: LocalDate? = LocalDate.now().plusMonths(1),
         status: DeltakerStatusType = DeltakerStatusType.DELTAR,
-        endretTidspunkt: LocalDateTime = LocalDateTime.now(),
+        endretTidspunkt: Instant = Instant.now(),
         deltakelsesprosent: Double = 100.0,
         deltakelsesmengder: List<Deltakelsesmengde> = listOf(
             Deltakelsesmengde(
@@ -50,13 +51,13 @@ object DeltakerFixtures {
                 opprettetTidspunkt = Instant.now(),
             ),
         ),
-    ) = Deltaker(
+    ) = Deltaker.opprett(
         id = id,
         startDato = startDato,
         sluttDato = sluttDato,
         gjennomforingId = gjennomforingId,
-        registrertTidspunkt = LocalDateTime.now(),
-        endretTidspunkt = LocalDateTime.now(),
+        registrertTidspunkt = Instant.now(),
+        endretTidspunkt = Instant.now(),
         deltakelsesmengder = deltakelsesmengder,
         status = DeltakerStatus(
             type = status,

--- a/mulighetsrommet-api/persistence/src/main/kotlin/no/nav/mulighetsrommet/api/persistence/deltaker/DeltakerQueries.kt
+++ b/mulighetsrommet-api/persistence/src/main/kotlin/no/nav/mulighetsrommet/api/persistence/deltaker/DeltakerQueries.kt
@@ -129,17 +129,17 @@ class DeltakerQueries(private val session: Session) : DeltakerRepository {
     }
 }
 
-private fun Row.toDeltaker() = Deltaker(
+private fun Row.toDeltaker() = Deltaker.opprett(
     id = uuid("id"),
     gjennomforingId = uuid("gjennomforing_id"),
     startDato = localDateOrNull("start_dato"),
     sluttDato = localDateOrNull("slutt_dato"),
-    registrertTidspunkt = localDateTime("registrert_tidspunkt"),
-    endretTidspunkt = localDateTime("endret_tidspunkt"),
+    registrertTidspunkt = instant("registrert_tidspunkt"),
+    endretTidspunkt = instant("endret_tidspunkt"),
     status = DeltakerStatus(
         type = DeltakerStatusType.valueOf(string("status_type")),
         aarsak = stringOrNull("status_aarsak")?.let { DeltakerStatusAarsakType.valueOf(it) },
-        opprettetTidspunkt = localDateTime("status_opprettet_tidspunkt"),
+        opprettetTidspunkt = instant("status_opprettet_tidspunkt"),
     ),
     deltakelsesmengder = stringOrNull("deltakelsesmengder_json")?.let { Json.decodeFromString(it) } ?: listOf(),
     innholdAnnet = stringOrNull("innhold_annet"),

--- a/mulighetsrommet-api/persistence/src/main/resources/db/migration/V520__deltaker_timestamptz.sql
+++ b/mulighetsrommet-api/persistence/src/main/resources/db/migration/V520__deltaker_timestamptz.sql
@@ -1,0 +1,4 @@
+alter table deltaker
+    alter column registrert_tidspunkt type timestamptz using registrert_tidspunkt at time zone 'Europe/Oslo',
+    alter column endret_tidspunkt type timestamptz using endret_tidspunkt at time zone 'Europe/Oslo',
+    alter column status_opprettet_tidspunkt type timestamptz using status_opprettet_tidspunkt at time zone 'Europe/Oslo';

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/deltaker/kafka/ReplikerDeltakerKafkaConsumer.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/deltaker/kafka/ReplikerDeltakerKafkaConsumer.kt
@@ -15,11 +15,9 @@ import no.nav.mulighetsrommet.kafka.KafkaTopicConsumer
 import no.nav.mulighetsrommet.kafka.serialization.JsonElementDeserializer
 import no.nav.mulighetsrommet.model.DeltakerStatus
 import no.nav.mulighetsrommet.serialization.json.JsonIgnoreUnknownKeys
-import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class ReplikerDeltakerKafkaConsumer(
@@ -29,8 +27,6 @@ class ReplikerDeltakerKafkaConsumer(
     uuidDeserializer(),
     JsonElementDeserializer(),
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
     override suspend fun consume(key: UUID, message: JsonElement) {
         val amtDeltaker = JsonIgnoreUnknownKeys.decodeFromJsonElement<AmtDeltakerEksternV1Dto?>(message)
 
@@ -50,13 +46,13 @@ class ReplikerDeltakerKafkaConsumer(
     }
 }
 
-fun AmtDeltakerEksternV1Dto.toDeltaker(): Deltaker = Deltaker(
+fun AmtDeltakerEksternV1Dto.toDeltaker(): Deltaker = Deltaker.opprett(
     id = id,
     gjennomforingId = gjennomforingId,
     startDato = startDato,
     sluttDato = sluttDato,
-    registrertTidspunkt = registrertTidspunkt,
-    endretTidspunkt = truncateMicros(endretTidspunkt),
+    registrertTidspunkt = registrertTidspunkt.tilNorskInstant(),
+    endretTidspunkt = endretTidspunkt.tilNorskInstant(),
     status = status.toDeltakerStatus(),
     deltakelsesmengder = deltakelsesmengder.map {
         Deltakelsesmengde(it.gyldigFraDato, it.deltakelsesprosent.toDouble(), it.opprettetTidspunkt.tilNorskInstant())
@@ -75,9 +71,10 @@ fun AmtDeltakerEksternV1Dto.toDeltaker(): Deltaker = Deltaker(
 private fun AmtDeltakerEksternV1Dto.StatusDto.toDeltakerStatus(): DeltakerStatus = DeltakerStatus(
     type = type,
     aarsak = aarsak.type,
-    opprettetTidspunkt = opprettetTidspunkt,
+    opprettetTidspunkt = opprettetTidspunkt.tilNorskInstant(),
 )
 
-private fun truncateMicros(timestamp: LocalDateTime) = timestamp.truncatedTo(ChronoUnit.MICROS)
-
-private fun LocalDateTime.tilNorskInstant(): Instant = atZone(ZoneId.of("Europe/Oslo")).toInstant()
+/**
+ * Kafka-meldinger fra Komet er i lokal norsk tid.
+ */
+internal fun LocalDateTime.tilNorskInstant(): Instant = atZone(ZoneId.of("Europe/Oslo")).toInstant()

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorflateTestUtils.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/arrangorflate/ArrangorflateTestUtils.kt
@@ -51,8 +51,8 @@ import no.nav.mulighetsrommet.model.Valuta
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.tiltak.okonomi.BestillingStatusType
 import no.nav.tiltak.okonomi.Tilskuddstype
+import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.UUID
 
 object ArrangorflateTestUtils {
@@ -60,18 +60,18 @@ object ArrangorflateTestUtils {
     val hovedenhet = ArrangorFixtures.hovedenhet
     val underenhet = ArrangorFixtures.underenhet1
 
-    fun createTestDeltaker(): Deltaker = Deltaker(
+    fun createTestDeltaker(): Deltaker = Deltaker.opprett(
         id = UUID.randomUUID(),
         gjennomforingId = GjennomforingFixtures.AFT1.id,
         startDato = GjennomforingFixtures.AFT1.startDato,
         sluttDato = GjennomforingFixtures.AFT1.sluttDato,
-        registrertTidspunkt = LocalDateTime.now(),
-        endretTidspunkt = LocalDateTime.now(),
+        registrertTidspunkt = Instant.now(),
+        endretTidspunkt = Instant.now(),
         deltakelsesmengder = listOf(),
         status = DeltakerStatus(
             type = DeltakerStatusType.DELTAR,
             aarsak = null,
-            opprettetTidspunkt = LocalDateTime.now(),
+            opprettetTidspunkt = Instant.now(),
         ),
         innholdAnnet = null,
         navVeileder = null,

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/deltaker/DeltakerQueriesTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/deltaker/DeltakerQueriesTest.kt
@@ -5,19 +5,17 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import no.nav.mulighetsrommet.api.domain.deltaker.Deltakelsesmengde
-import no.nav.mulighetsrommet.api.domain.deltaker.Deltaker
 import no.nav.mulighetsrommet.api.domain.deltaker.NavVeileder
 import no.nav.mulighetsrommet.api.fixtures.AvtaleFixtures
+import no.nav.mulighetsrommet.api.fixtures.DeltakerFixtures
 import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
-import no.nav.mulighetsrommet.model.DeltakerStatus
 import no.nav.mulighetsrommet.model.DeltakerStatusType
 import no.nav.mulighetsrommet.model.NavEnhetNummer
 import no.nav.mulighetsrommet.model.NavIdent
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.UUID
 
 // TODO: flyttes til "persistence" etter at avhengigheter også er flyttet (avtale, gjennomføring)
@@ -32,31 +30,28 @@ class DeltakerQueriesTest : FunSpec({
         ),
     )
 
-    val opprettetTidspunkt = LocalDateTime.of(2023, 3, 1, 0, 0, 0)
+    val opprettetTidspunkt = Instant.parse("2023-03-01T00:00:00Z")
     val mengdeOpprettetTidspunkt = Instant.parse("2023-03-01T00:00:00Z")
 
-    val deltaker1 = Deltaker(
+    val deltaker1 = DeltakerFixtures.createDeltaker(
         id = UUID.randomUUID(),
         gjennomforingId = domain.gjennomforinger[0].id,
-        startDato = null,
-        sluttDato = null,
-        registrertTidspunkt = opprettetTidspunkt,
         endretTidspunkt = opprettetTidspunkt,
-        status = DeltakerStatus(
-            DeltakerStatusType.VENTER_PA_OPPSTART,
-            aarsak = null,
-            opprettetTidspunkt = opprettetTidspunkt,
-        ),
-        deltakelsesmengder = emptyList(),
-        innholdAnnet = null,
-        navVeileder = NavVeileder(
+        status = DeltakerStatusType.VENTER_PA_OPPSTART,
+        innhold = null,
+        veileder = NavVeileder(
             navIdent = NavIdent("B123456"),
             enhetsnummer = NavEnhetNummer("0200"),
         ),
     )
-    val deltaker2 = deltaker1.copy(
+
+    val deltaker2 = DeltakerFixtures.createDeltaker(
         id = UUID.randomUUID(),
         gjennomforingId = domain.gjennomforinger[1].id,
+        endretTidspunkt = opprettetTidspunkt,
+        status = DeltakerStatusType.VENTER_PA_OPPSTART,
+        innhold = "Noe innhold",
+        veileder = null,
     )
 
     test("CRUD") {
@@ -69,12 +64,9 @@ class DeltakerQueriesTest : FunSpec({
             repository.deltaker.get(deltaker1.id) shouldBe deltaker1
             repository.deltaker.get(deltaker2.id) shouldBe deltaker2
 
-            val avsluttetDeltaker2 = deltaker2.copy(
-                status = DeltakerStatus(
-                    DeltakerStatusType.HAR_SLUTTET,
-                    aarsak = null,
-                    opprettetTidspunkt = LocalDateTime.of(2023, 3, 2, 0, 0, 0),
-                ),
+            val avsluttetDeltaker2 = deltaker2.registrerStatus(
+                type = DeltakerStatusType.HAR_SLUTTET,
+                endretTidspunkt = Instant.parse("2023-03-02T00:00:00Z"),
             )
             repository.deltaker.save(avsluttetDeltaker2)
 
@@ -92,7 +84,9 @@ class DeltakerQueriesTest : FunSpec({
         database.runAndRollback {
             domain.initialize()
 
-            val deltakerMedEnMengde = deltaker1.copy(
+            val deltakerMedEnMengde = DeltakerFixtures.createDeltakerMedDeltakelsesmengder(
+                id = deltaker1.id,
+                gjennomforingId = deltaker1.gjennomforingId,
                 deltakelsesmengder = listOf(
                     Deltakelsesmengde(
                         gyldigFra = LocalDate.of(2023, 3, 1),
@@ -107,7 +101,9 @@ class DeltakerQueriesTest : FunSpec({
                 deltakerMedEnMengde.deltakelsesmengder,
             )
 
-            val deltakerMedToMengder = deltaker1.copy(
+            val deltakerMedToMengder = DeltakerFixtures.createDeltakerMedDeltakelsesmengder(
+                id = deltaker1.id,
+                gjennomforingId = deltaker1.gjennomforingId,
                 deltakelsesmengder = listOf(
                     Deltakelsesmengde(
                         gyldigFra = LocalDate.of(2023, 3, 10),

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/deltaker/kafka/ReplikerDeltakerEnkeltplassKafkaConsumerTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/deltaker/kafka/ReplikerDeltakerEnkeltplassKafkaConsumerTest.kt
@@ -97,7 +97,7 @@ class ReplikerDeltakerEnkeltplassKafkaConsumerTest : FunSpec({
         val tidspunktMs = LocalDateTime.of(2025, 1, 1, 12, 0, 0, 123_456_000)
         val lagretDeltaker = DeltakerFixtures.createDeltaker(
             gjennomforingId = EnkelAmo.id,
-            endretTidspunkt = tidspunktMs,
+            endretTidspunkt = tidspunktMs.tilNorskInstant(),
         )
         MulighetsrommetTestDomain(
             gjennomforinger = listOf(EnkelAmo.copy(status = GjennomforingStatusType.GJENNOMFORES)),

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/deltaker/kafka/ReplikerDeltakerKafkaConsumerTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/deltaker/kafka/ReplikerDeltakerKafkaConsumerTest.kt
@@ -28,6 +28,7 @@ import no.nav.mulighetsrommet.api.utbetaling.service.GenererUtbetalingService
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
 import no.nav.mulighetsrommet.model.DeltakerStatus
 import no.nav.mulighetsrommet.model.DeltakerStatusType
+import java.time.Instant
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -45,6 +46,7 @@ class ReplikerDeltakerKafkaConsumerTest : FunSpec({
 
     context("konsumering av deltakere") {
         val opprettetTidspunkt = LocalDateTime.of(2023, 3, 1, 0, 0, 0)
+        val opprettetInstant = opprettetTidspunkt.tilNorskInstant()
 
         val amtDeltaker1 = createAmtDeltakerDto(
             gjennomforingId = Oppfolging1.id,
@@ -81,7 +83,7 @@ class ReplikerDeltakerKafkaConsumerTest : FunSpec({
 
             database.run {
                 repository.deltaker.getByGjennomforing(Oppfolging1.id).shouldContainExactlyInAnyOrder(
-                    Deltaker(
+                    Deltaker.opprett(
                         id = amtDeltaker1.id,
                         gjennomforingId = Oppfolging1.id,
                         startDato = null,
@@ -89,15 +91,15 @@ class ReplikerDeltakerKafkaConsumerTest : FunSpec({
                         status = DeltakerStatus(
                             type = DeltakerStatusType.VENTER_PA_OPPSTART,
                             aarsak = null,
-                            opprettetTidspunkt = opprettetTidspunkt,
+                            opprettetTidspunkt = opprettetInstant,
                         ),
-                        registrertTidspunkt = opprettetTidspunkt,
-                        endretTidspunkt = opprettetTidspunkt,
+                        registrertTidspunkt = opprettetInstant,
+                        endretTidspunkt = opprettetInstant,
                         deltakelsesmengder = listOf(),
                         innholdAnnet = "Prisinformasjon",
                         navVeileder = null,
                     ),
-                    Deltaker(
+                    Deltaker.opprett(
                         id = amtDeltaker2.id,
                         gjennomforingId = Oppfolging1.id,
                         startDato = null,
@@ -105,10 +107,10 @@ class ReplikerDeltakerKafkaConsumerTest : FunSpec({
                         status = DeltakerStatus(
                             type = DeltakerStatusType.VENTER_PA_OPPSTART,
                             aarsak = null,
-                            opprettetTidspunkt = opprettetTidspunkt,
+                            opprettetTidspunkt = opprettetInstant,
                         ),
-                        registrertTidspunkt = opprettetTidspunkt,
-                        endretTidspunkt = opprettetTidspunkt,
+                        registrertTidspunkt = opprettetInstant,
+                        endretTidspunkt = opprettetInstant,
                         deltakelsesmengder = listOf(),
                         innholdAnnet = "Prisinformasjon",
                         navVeileder = null,
@@ -177,6 +179,7 @@ class ReplikerDeltakerKafkaConsumerTest : FunSpec({
             )
 
             val avbruttTidspunkt = LocalDateTime.of(2023, 3, 1, 0, 0, 0)
+            val avbruttInstant = avbruttTidspunkt.tilNorskInstant()
             val amtDeltakerAvbrutt = createAmtDeltakerDto(
                 id = id,
                 gjennomforingId = AFT1.id,
@@ -190,7 +193,7 @@ class ReplikerDeltakerKafkaConsumerTest : FunSpec({
             database.run {
                 repository.deltaker.get(id).shouldNotBeNull().should {
                     it.status.type shouldBe DeltakerStatusType.AVBRUTT
-                    it.endretTidspunkt shouldBe avbruttTidspunkt
+                    it.endretTidspunkt shouldBe avbruttInstant
                 }
             }
 
@@ -199,7 +202,7 @@ class ReplikerDeltakerKafkaConsumerTest : FunSpec({
             database.run {
                 repository.deltaker.get(id).shouldNotBeNull().should {
                     it.status.type shouldBe DeltakerStatusType.AVBRUTT
-                    it.endretTidspunkt shouldBe avbruttTidspunkt
+                    it.endretTidspunkt shouldBe avbruttInstant
                 }
             }
         }
@@ -210,7 +213,7 @@ class ReplikerDeltakerKafkaConsumerTest : FunSpec({
             val id = UUID.randomUUID()
 
             val tidspunktKafka = LocalDateTime.parse("2023-03-01T00:00:00.123456789")
-            val tidspunktDatabase = LocalDateTime.parse("2023-03-01T00:00:00.123456")
+            val tidspunktDatabase = Instant.parse("2023-02-28T23:00:00.123456Z")
 
             val amtDeltakerDeltar = createAmtDeltakerDto(
                 id = id,

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassServiceTest.kt
@@ -47,7 +47,6 @@ import no.nav.mulighetsrommet.model.Tiltakskode
 import no.nav.mulighetsrommet.model.Tiltaksnummer
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.UUID
 
 class GjennomforingEnkeltplassServiceTest : FunSpec({
@@ -702,7 +701,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val deltaker = DeltakerFixtures.createDeltaker(
                     gjennomforingId = GjennomforingFixtures.EnkelAmo.id,
                     status = DeltakerStatusType.DELTAR,
-                ).copy(deltakelsesmengder = emptyList())
+                )
 
                 val (gjennomforing) = createService(migrert).updateFromDeltaker(deltaker, norskIdent)
 
@@ -1160,8 +1159,8 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
         }
 
         context("relast av deltaker") {
-            val tidligereEndretTidspunkt = LocalDateTime.of(2025, 1, 1, 12, 0, 0)
-            val nyereEndretTidspunkt = LocalDateTime.of(2025, 6, 1, 12, 0, 0)
+            val tidligereEndretTidspunkt = Instant.parse("2025-01-01T12:00:00Z")
+            val nyereEndretTidspunkt = Instant.parse("2025-06-01T12:00:00Z")
 
             test("prosesserer når deltaker-eventet er samme eller nyere enn lagret") {
                 val lagretDeltaker = DeltakerFixtures.createDeltaker(

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/task/VedtaksbrevTaskTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/task/VedtaksbrevTaskTest.kt
@@ -52,7 +52,7 @@ class VedtaksbrevTaskTest : FunSpec({
             ansatte = listOf(NavAnsattFixture.DonaldDuck, NavAnsattFixture.MikkeMus),
             gjennomforinger = listOf(GjennomforingFixtures.EnkelAmo),
             deltakere = listOf(
-                DeltakerFixtures.createDeltaker(gjennomforingId = GjennomforingFixtures.EnkelAmo.id).copy(id = deltakerId),
+                DeltakerFixtures.createDeltaker(id = deltakerId, gjennomforingId = GjennomforingFixtures.EnkelAmo.id),
             ),
         ).initialize(database.api)
 

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/BeregningTestHelpers.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/BeregningTestHelpers.kt
@@ -226,17 +226,17 @@ object BeregningTestHelpers {
         periode: Periode,
         deltakelsesmengder: List<Deltakelsesmengde> = emptyList(),
         status: DeltakerStatusType = DeltakerStatusType.DELTAR,
-    ): Deltaker = Deltaker(
+    ): Deltaker = Deltaker.opprett(
         id = UUID.randomUUID(),
         gjennomforingId = UUID.randomUUID(),
         startDato = periode.start,
         sluttDato = periode.getLastInclusiveDate(),
-        registrertTidspunkt = periode.start.atStartOfDay(),
-        endretTidspunkt = periode.start.atStartOfDay(),
+        registrertTidspunkt = Instant.now(),
+        endretTidspunkt = Instant.now(),
         status = DeltakerStatus(
             type = status,
             aarsak = null,
-            opprettetTidspunkt = periode.start.atStartOfDay(),
+            opprettetTidspunkt = Instant.now(),
         ),
         deltakelsesmengder = deltakelsesmengder,
         innholdAnnet = null,


### PR DESCRIPTION
Flytter også truncate-logikk til domenemodellen slik at vi sikrer at relevante duplikatsjekker alltid opererer med validerte/gyldige tidspunkter