### PR TITLE
Bugfix/totrinnskontroll race condition

### DIFF
--- a/frontend/arrangor-utbetalinger-api-client/openapi.yaml
+++ b/frontend/arrangor-utbetalinger-api-client/openapi.yaml
@@ -511,7 +511,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AvbrytUtbetaling"
+              $ref: "#/components/schemas/AvbrytUtbetalingRequest"
         required: false
       responses:
         "200":
@@ -544,7 +544,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AvbrytUtbetaling"
+              $ref: "#/components/schemas/AvbrytUtbetalingRequest"
         required: false
       responses:
         "200":
@@ -1856,7 +1856,7 @@ components:
       - kontonummer
       - mottattDato
       - utbetalesTidligstDato
-    AvbrytUtbetaling:
+    AvbrytUtbetalingRequest:
       type: object
       properties:
         begrunnelse:

--- a/frontend/tiltaksadministrasjon-api-client/openapi.yaml
+++ b/frontend/tiltaksadministrasjon-api-client/openapi.yaml
@@ -1422,6 +1422,12 @@ paths:
         schema:
           type: string
           format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BeslutningRequest"
+        required: false
       responses:
         "200":
           description: Økonomi ble godkjent
@@ -2200,6 +2206,12 @@ paths:
         schema:
           type: string
           format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BeslutningRequest"
+        required: false
       responses:
         "200":
           description: Tilsagn ble godkjent
@@ -2230,7 +2242,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AarsakerOgForklaringRequest_TilsagnStatusAarsak"
+              $ref: "#/components/schemas/BeslutningMedAarsakerRequest_TilsagnStatusAarsak"
         required: false
       responses:
         "200":
@@ -2547,6 +2559,12 @@ paths:
         schema:
           type: string
           format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BeslutningRequest"
+        required: false
       responses:
         "200":
           description: Utbetaling ble avbrutt
@@ -2578,7 +2596,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AarsakerOgForklaringRequest_UtbetalingStatusAarsak"
+              $ref: "#/components/schemas/BeslutningMedAarsakerRequest_UtbetalingStatusAarsak"
         required: false
       responses:
         "200":
@@ -2759,6 +2777,12 @@ paths:
         schema:
           type: string
           format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BeslutningRequest"
+        required: false
       responses:
         "200":
           description: UtbetalingLinje ble attestert
@@ -2789,7 +2813,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AarsakerOgForklaringRequest_UtbetalingLinjeReturnertAarsak"
+              $ref: "#/components/schemas/BeslutningMedAarsakerRequest_UtbetalingLinjeReturnertAarsak"
         required: false
       responses:
         "200":
@@ -3767,6 +3791,12 @@ paths:
         schema:
           type: string
           format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BeslutningRequest"
+        required: false
       responses:
         "200":
           description: Tilskuddsbehandling ble attestert
@@ -3797,7 +3827,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AarsakerOgForklaringRequest_TilskuddBehandlingStatusAarsak"
+              $ref: "#/components/schemas/BeslutningMedAarsakerRequest_TilskuddBehandlingStatusAarsak"
         required: false
       responses:
         "200":
@@ -5778,6 +5808,14 @@ components:
       - beskrivelse
       - periodeSlutt
       - periodeStart
+    BeslutningRequest:
+      type: object
+      properties:
+        totrinnskontrollId:
+          type: string
+          format: uuid
+      required:
+      - totrinnskontrollId
     SettPaVentRequest:
       type: object
       properties:
@@ -6324,6 +6362,9 @@ components:
     TotrinnskontrollDto.Besluttet:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
         behandletAv:
           $ref: "#/components/schemas/AgentDto"
         behandletTidspunkt:
@@ -6352,6 +6393,7 @@ components:
       - besluttetAv
       - besluttetTidspunkt
       - forklaring
+      - id
     AgentDto:
       type: object
       properties:
@@ -6371,6 +6413,9 @@ components:
     TotrinnskontrollDto.TilBeslutning:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
         behandletAv:
           $ref: "#/components/schemas/AgentDto"
         behandletTidspunkt:
@@ -6389,6 +6434,7 @@ components:
       - behandletAv
       - behandletTidspunkt
       - forklaring
+      - id
     GjennomforingEnkeltplassDetaljerDto.Prisendring:
       type: object
       properties:
@@ -7868,6 +7914,24 @@ components:
       required:
       - aarsaker
       - forklaring
+    BeslutningMedAarsakerRequest_TilsagnStatusAarsak:
+      type: object
+      properties:
+        totrinnskontrollId:
+          type: string
+          format: uuid
+        aarsaker:
+          type: array
+          items:
+            $ref: "#/components/schemas/TilsagnStatusAarsak"
+        forklaring:
+          type:
+          - "null"
+          - string
+      required:
+      - aarsaker
+      - forklaring
+      - totrinnskontrollId
     TilsagnDeltakereRequest:
       type: object
       properties:
@@ -8234,6 +8298,24 @@ components:
       required:
       - aarsaker
       - forklaring
+    BeslutningMedAarsakerRequest_UtbetalingStatusAarsak:
+      type: object
+      properties:
+        totrinnskontrollId:
+          type: string
+          format: uuid
+        aarsaker:
+          type: array
+          items:
+            $ref: "#/components/schemas/UtbetalingStatusAarsak"
+        forklaring:
+          type:
+          - "null"
+          - string
+      required:
+      - aarsaker
+      - forklaring
+      - totrinnskontrollId
     UtbetalingBeregningType:
       type: string
       enum:
@@ -8496,9 +8578,12 @@ components:
       - ANNET
       - PROPAGERT_RETUR
       - TILSAGN_FEIL_STATUS
-    AarsakerOgForklaringRequest_UtbetalingLinjeReturnertAarsak:
+    BeslutningMedAarsakerRequest_UtbetalingLinjeReturnertAarsak:
       type: object
       properties:
+        totrinnskontrollId:
+          type: string
+          format: uuid
         aarsaker:
           type: array
           items:
@@ -8510,6 +8595,7 @@ components:
       required:
       - aarsaker
       - forklaring
+      - totrinnskontrollId
     TilskuddUtbetalingKompaktDto:
       type: object
       properties:
@@ -9412,9 +9498,12 @@ components:
       - FEIL_BELOP
       - FEIL_VEDTAKSRESULTAT
       - ANNET
-    AarsakerOgForklaringRequest_TilskuddBehandlingStatusAarsak:
+    BeslutningMedAarsakerRequest_TilskuddBehandlingStatusAarsak:
       type: object
       properties:
+        totrinnskontrollId:
+          type: string
+          format: uuid
         aarsaker:
           type: array
           items:
@@ -9426,6 +9515,7 @@ components:
       required:
       - aarsaker
       - forklaring
+      - totrinnskontrollId
     EndringshistorikkType:
       type: string
       enum:

--- a/frontend/tiltaksadministrasjon-api-client/openapi.yaml
+++ b/frontend/tiltaksadministrasjon-api-client/openapi.yaml
@@ -1452,7 +1452,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SettPaVentOkonomiRequest"
+              $ref: "#/components/schemas/SettPaVentRequest"
         required: false
       responses:
         "200":
@@ -5778,15 +5778,19 @@ components:
       - beskrivelse
       - periodeSlutt
       - periodeStart
-    SettPaVentOkonomiRequest:
+    SettPaVentRequest:
       type: object
       properties:
+        totrinnskontrollId:
+          type: string
+          format: uuid
         forklaring:
           type:
           - "null"
           - string
       required:
       - forklaring
+      - totrinnskontrollId
     GjennomforingStatusType:
       type: string
       enum:

--- a/frontend/tiltaksadministrasjon-flate/src/api/gjennomforing/useGodkjennGjennomforingOkonomi.ts
+++ b/frontend/tiltaksadministrasjon-flate/src/api/gjennomforing/useGodkjennGjennomforingOkonomi.ts
@@ -6,9 +6,12 @@ import { useApiMutation } from "@/hooks/useApiMutation";
 export function useGodkjennGjennomforingOkonomi() {
   const queryClient = useQueryClient();
 
-  return useApiMutation<unknown, ProblemDetail, { id: string }>({
-    mutationFn: ({ id }) => {
-      return GjennomforingService.godkjennGjennomforingOkonomi({ path: { id } });
+  return useApiMutation<unknown, ProblemDetail, { id: string; totrinnskontrollId: string }>({
+    mutationFn: ({ id, totrinnskontrollId }) => {
+      return GjennomforingService.godkjennGjennomforingOkonomi({
+        path: { id },
+        body: { totrinnskontrollId },
+      });
     },
     async onSuccess(_, { id }) {
       await Promise.all([

--- a/frontend/tiltaksadministrasjon-flate/src/api/gjennomforing/useSettPaVentGjennomforingOkonomi.ts
+++ b/frontend/tiltaksadministrasjon-flate/src/api/gjennomforing/useSettPaVentGjennomforingOkonomi.ts
@@ -6,11 +6,15 @@ import { useApiMutation } from "@/hooks/useApiMutation";
 export function useSettPaVentGjennomforingOkonomi() {
   const queryClient = useQueryClient();
 
-  return useApiMutation<unknown, ProblemDetail, { id: string; forklaring: string | null }>({
-    mutationFn: ({ id, forklaring }) => {
+  return useApiMutation<
+    unknown,
+    ProblemDetail,
+    { id: string; forklaring: string | null; totrinnskontrollId: string }
+  >({
+    mutationFn: ({ id, forklaring, totrinnskontrollId }) => {
       return GjennomforingService.settPaVentGjennomforingOkonomi({
         path: { id },
-        body: { forklaring },
+        body: { forklaring, totrinnskontrollId },
       });
     },
     async onSuccess(_, { id }) {

--- a/frontend/tiltaksadministrasjon-flate/src/api/tilsagn/mutations.ts
+++ b/frontend/tiltaksadministrasjon-flate/src/api/tilsagn/mutations.ts
@@ -1,5 +1,6 @@
 import {
   AarsakerOgForklaringRequestTilsagnStatusAarsak,
+  BeslutningMedAarsakerRequestTilsagnStatusAarsak,
   EndringshistorikkType,
   ProblemDetail,
   TilsagnRequest,
@@ -12,8 +13,9 @@ import { QueryKeys } from "@/api/QueryKeys";
 export function useGodkjennTilsagn() {
   const queryClient = useQueryClient();
 
-  return useApiMutation<unknown, ProblemDetail, { id: string }>({
-    mutationFn: ({ id }) => TilsagnService.godkjennTilsagn({ path: { id } }),
+  return useApiMutation<unknown, ProblemDetail, { id: string; totrinnskontrollId: string }>({
+    mutationFn: ({ id, totrinnskontrollId }) =>
+      TilsagnService.godkjennTilsagn({ path: { id }, body: { totrinnskontrollId } }),
     mutationKey: QueryKeys.godkjennTilsagn(),
     async onSuccess(_, { id }) {
       await Promise.all([
@@ -46,7 +48,7 @@ export function useReturnerTilsagn() {
   return useApiMutation<
     unknown,
     ProblemDetail,
-    { id: string; request: AarsakerOgForklaringRequestTilsagnStatusAarsak }
+    { id: string; request: BeslutningMedAarsakerRequestTilsagnStatusAarsak }
   >({
     mutationFn: ({ id, request }) =>
       TilsagnService.returnerTilsagn({ path: { id }, body: request }),

--- a/frontend/tiltaksadministrasjon-flate/src/api/tilskudd-behandling/mutations.ts
+++ b/frontend/tiltaksadministrasjon-flate/src/api/tilskudd-behandling/mutations.ts
@@ -1,5 +1,5 @@
 import {
-  AarsakerOgForklaringRequestTilskuddBehandlingStatusAarsak,
+  BeslutningMedAarsakerRequestTilskuddBehandlingStatusAarsak,
   ProblemDetail,
   TilskuddBehandlingRequest,
   TilskuddBehandlingService,
@@ -24,8 +24,12 @@ export function useOpprettTilskuddBehandling(gjennomforingId: string) {
 export function useGodkjennTilskuddBehandling(gjennomforingId: string) {
   const queryClient = useQueryClient();
 
-  return useApiMutation<unknown, ProblemDetail, string>({
-    mutationFn: (id) => TilskuddBehandlingService.attesterTilskuddBehandling({ path: { id } }),
+  return useApiMutation<unknown, ProblemDetail, { id: string; totrinnskontrollId: string }>({
+    mutationFn: ({ id, totrinnskontrollId }) =>
+      TilskuddBehandlingService.attesterTilskuddBehandling({
+        path: { id },
+        body: { totrinnskontrollId },
+      }),
     async onSuccess() {
       await queryClient.invalidateQueries({
         queryKey: QueryKeys.tilskuddBehandlinger(gjennomforingId),
@@ -40,7 +44,7 @@ export function useReturnerTilskuddBehandling(gjennomforingId: string) {
   return useApiMutation<
     unknown,
     ProblemDetail,
-    { id: string; body: AarsakerOgForklaringRequestTilskuddBehandlingStatusAarsak }
+    { id: string; body: BeslutningMedAarsakerRequestTilskuddBehandlingStatusAarsak }
   >({
     mutationFn: ({ id, body }) =>
       TilskuddBehandlingService.returnerTilskuddBehandling({ path: { id }, body }),

--- a/frontend/tiltaksadministrasjon-flate/src/api/utbetaling/mutations.ts
+++ b/frontend/tiltaksadministrasjon-flate/src/api/utbetaling/mutations.ts
@@ -1,6 +1,7 @@
 import {
-  AarsakerOgForklaringRequestUtbetalingLinjeReturnertAarsak,
   AarsakerOgForklaringRequestUtbetalingStatusAarsak,
+  BeslutningMedAarsakerRequestUtbetalingLinjeReturnertAarsak,
+  BeslutningMedAarsakerRequestUtbetalingStatusAarsak,
   OpprettUtbetalingLinjerRequest,
   ProblemDetail,
   UtbetalingRequest,
@@ -13,8 +14,9 @@ import { QueryKeys } from "@/api/QueryKeys";
 export function useAttesterUtbetalingLinje() {
   const queryClient = useQueryClient();
 
-  return useApiMutation<unknown, ProblemDetail, { id: string }>({
-    mutationFn: ({ id }) => UtbetalingService.attesterUtbetalingLinje({ path: { id } }),
+  return useApiMutation<unknown, ProblemDetail, { id: string; totrinnskontrollId: string }>({
+    mutationFn: ({ id, totrinnskontrollId }) =>
+      UtbetalingService.attesterUtbetalingLinje({ path: { id }, body: { totrinnskontrollId } }),
     async onSuccess() {
       await queryClient.invalidateQueries({ queryKey: QueryKeys.utbetaling() });
     },
@@ -61,7 +63,7 @@ export function useReturnerUtbetalingLinje() {
   return useApiMutation<
     unknown,
     ProblemDetail,
-    { id: string; body: AarsakerOgForklaringRequestUtbetalingLinjeReturnertAarsak }
+    { id: string; body: BeslutningMedAarsakerRequestUtbetalingLinjeReturnertAarsak }
   >({
     mutationFn: ({ id, body }) => UtbetalingService.returnerUtbetalingLinje({ path: { id }, body }),
     async onSuccess() {
@@ -88,8 +90,12 @@ export function useAvbrytUtbetaling() {
 export function useGodkjennAvbrytelseUtbetaling() {
   const queryClient = useQueryClient();
 
-  return useApiMutation<unknown, ProblemDetail, { id: string }>({
-    mutationFn: ({ id }) => UtbetalingService.godkjennAvbrytelseUtbetaling({ path: { id } }),
+  return useApiMutation<unknown, ProblemDetail, { id: string; totrinnskontrollId: string }>({
+    mutationFn: ({ id, totrinnskontrollId }) =>
+      UtbetalingService.godkjennAvbrytelseUtbetaling({
+        path: { id },
+        body: { totrinnskontrollId },
+      }),
     async onSuccess() {
       await queryClient.invalidateQueries({ queryKey: QueryKeys.utbetaling() });
     },
@@ -102,7 +108,7 @@ export function useAvslaAvbrytelseUtbetaling() {
   return useApiMutation<
     unknown,
     ProblemDetail,
-    { id: string; body: AarsakerOgForklaringRequestUtbetalingStatusAarsak }
+    { id: string; body: BeslutningMedAarsakerRequestUtbetalingStatusAarsak }
   >({
     mutationFn: ({ id, body }) =>
       UtbetalingService.avslaAvbrytelseUtbetaling({ path: { id }, body }),

--- a/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/GjennomforingEnkeltplassDetaljer.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/GjennomforingEnkeltplassDetaljer.tsx
@@ -181,18 +181,21 @@ export function GjennomforingEnkeltplassDetaljer(props: Props) {
         open={godkjennOpen}
         setOpen={setGodkjennOpen}
         gjennomforingId={gjennomforing.id}
+        totrinnskontrollId={okonomi?.id ?? ""}
         prismodell={prismodell}
       />
       <SettPaVentOkonomiModal
         open={settPaVentOpen}
         setOpen={setSettPaVentOpen}
         gjennomforingId={gjennomforing.id}
+        totrinnskontrollId={okonomi?.id ?? ""}
       />
       {prisendring && (
         <GodkjennPrisendringModal
           open={godkjennPrisendringOpen}
           setOpen={setGodkjennPrisendringOpen}
           gjennomforingId={gjennomforing.id}
+          totrinnskontrollId={prisendring.totrinnskontroll.id}
           prismodell={prisendring.prismodell}
         />
       )}
@@ -200,6 +203,7 @@ export function GjennomforingEnkeltplassDetaljer(props: Props) {
         open={settPrisendringPaVentOpen}
         setOpen={setSettPrisendringPaVentOpen}
         gjennomforingId={gjennomforing.id}
+        totrinnskontrollId={prisendring?.totrinnskontroll.id ?? ""}
       />
     </VStack>
   );

--- a/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/GodkjennOkonomiModal.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/GodkjennOkonomiModal.tsx
@@ -8,10 +8,17 @@ interface Props {
   open: boolean;
   setOpen: (open: boolean) => void;
   gjennomforingId: string;
+  totrinnskontrollId: string;
   prismodell: PrismodellDto;
 }
 
-export function GodkjennOkonomiModal({ open, setOpen, gjennomforingId, prismodell }: Props) {
+export function GodkjennOkonomiModal({
+  open,
+  setOpen,
+  gjennomforingId,
+  totrinnskontrollId,
+  prismodell,
+}: Props) {
   const godkjennMutation = useGodkjennGjennomforingOkonomi();
 
   function close() {
@@ -19,7 +26,7 @@ export function GodkjennOkonomiModal({ open, setOpen, gjennomforingId, prismodel
   }
 
   function godkjenn() {
-    godkjennMutation.mutate({ id: gjennomforingId }, { onSuccess: close });
+    godkjennMutation.mutate({ id: gjennomforingId, totrinnskontrollId }, { onSuccess: close });
   }
 
   return (

--- a/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/GodkjennPrisendringModal.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/GodkjennPrisendringModal.tsx
@@ -8,10 +8,17 @@ interface Props {
   open: boolean;
   setOpen: (open: boolean) => void;
   gjennomforingId: string;
+  totrinnskontrollId: string;
   prismodell: PrismodellDto;
 }
 
-export function GodkjennPrisendringModal({ open, setOpen, gjennomforingId, prismodell }: Props) {
+export function GodkjennPrisendringModal({
+  open,
+  setOpen,
+  gjennomforingId,
+  totrinnskontrollId,
+  prismodell,
+}: Props) {
   const godkjennMutation = useGodkjennGjennomforingOkonomi();
 
   function close() {
@@ -19,7 +26,7 @@ export function GodkjennPrisendringModal({ open, setOpen, gjennomforingId, prism
   }
 
   function godkjenn() {
-    godkjennMutation.mutate({ id: gjennomforingId }, { onSuccess: close });
+    godkjennMutation.mutate({ id: gjennomforingId, totrinnskontrollId }, { onSuccess: close });
   }
 
   return (

--- a/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/SettPaVentOkonomiModal.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/SettPaVentOkonomiModal.tsx
@@ -7,9 +7,15 @@ interface Props {
   open: boolean;
   setOpen: (open: boolean) => void;
   gjennomforingId: string;
+  totrinnskontrollId: string;
 }
 
-export function SettPaVentOkonomiModal({ open, setOpen, gjennomforingId }: Props) {
+export function SettPaVentOkonomiModal({
+  open,
+  setOpen,
+  gjennomforingId,
+  totrinnskontrollId,
+}: Props) {
   const settPaVentMutation = useSettPaVentGjennomforingOkonomi();
   const [forklaring, setForklaring] = useState("");
 
@@ -20,7 +26,7 @@ export function SettPaVentOkonomiModal({ open, setOpen, gjennomforingId }: Props
 
   function settPaVent() {
     settPaVentMutation.mutate(
-      { id: gjennomforingId, forklaring: forklaring || null },
+      { id: gjennomforingId, forklaring: forklaring || null, totrinnskontrollId },
       { onSuccess: close },
     );
   }

--- a/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/SettPaVentPrisendringModal.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/components/gjennomforing/SettPaVentPrisendringModal.tsx
@@ -7,9 +7,15 @@ interface Props {
   open: boolean;
   setOpen: (open: boolean) => void;
   gjennomforingId: string;
+  totrinnskontrollId: string;
 }
 
-export function SettPaVentPrisendringModal({ open, setOpen, gjennomforingId }: Props) {
+export function SettPaVentPrisendringModal({
+  open,
+  setOpen,
+  gjennomforingId,
+  totrinnskontrollId,
+}: Props) {
   const settPaVentMutation = useSettPaVentGjennomforingOkonomi();
   const [forklaring, setForklaring] = useState("");
 
@@ -20,7 +26,7 @@ export function SettPaVentPrisendringModal({ open, setOpen, gjennomforingId }: P
 
   function settPaVent() {
     settPaVentMutation.mutate(
-      { id: gjennomforingId, forklaring: forklaring || null },
+      { id: gjennomforingId, forklaring: forklaring || null, totrinnskontrollId },
       { onSuccess: close },
     );
   }

--- a/frontend/tiltaksadministrasjon-flate/src/components/utbetaling/AvslaAvbrytelseUtbetalingModal.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/components/utbetaling/AvslaAvbrytelseUtbetalingModal.tsx
@@ -2,7 +2,7 @@ import {
   UtbetalingStatusAarsak,
   FieldError,
   ValidationError,
-  AarsakerOgForklaringRequestUtbetalingStatusAarsak,
+  BeslutningMedAarsakerRequestUtbetalingStatusAarsak,
 } from "@tiltaksadministrasjon/api-client";
 import { useAvslaAvbrytelseUtbetaling } from "@/api/utbetaling/mutations";
 import { AarsakerOgForklaringModal } from "@/components/modal/AarsakerOgForklaringModal";
@@ -11,21 +11,25 @@ import { utbetalingTekster } from "@/components/utbetaling/UtbetalingTekster";
 
 interface AvslaAvbrytelseUtbetalingModalProps {
   utbetalingId: string;
+  totrinnskontrollId: string;
   open: boolean;
   onClose: () => void;
 }
 
 export function AvslaAvbrytelseUtbetalingModal({
   utbetalingId,
+  totrinnskontrollId,
   open,
   onClose,
 }: AvslaAvbrytelseUtbetalingModalProps) {
   const [errors, setErrors] = useState<FieldError[]>([]);
   const avslaAvbrytelseMutation = useAvslaAvbrytelseUtbetaling();
 
-  function avslaAvbrytelseUtbetaling(body: AarsakerOgForklaringRequestUtbetalingStatusAarsak) {
+  function avslaAvbrytelseUtbetaling(
+    body: Omit<BeslutningMedAarsakerRequestUtbetalingStatusAarsak, "totrinnskontrollId">,
+  ) {
     avslaAvbrytelseMutation.mutate(
-      { id: utbetalingId, body },
+      { id: utbetalingId, body: { ...body, totrinnskontrollId } },
       {
         onValidationError: (error: ValidationError) => {
           setErrors(error.errors);

--- a/frontend/tiltaksadministrasjon-flate/src/components/utbetaling/BesluttUtbetalingLinjeView.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/components/utbetaling/BesluttUtbetalingLinjeView.tsx
@@ -1,6 +1,6 @@
 import { useAttesterUtbetalingLinje, useReturnerUtbetalingLinje } from "@/api/utbetaling/mutations";
 import {
-  AarsakerOgForklaringRequestUtbetalingLinjeReturnertAarsak,
+  BeslutningMedAarsakerRequestUtbetalingLinjeReturnertAarsak,
   UtbetalingLinjeReturnertAarsak,
   FieldError,
   UtbetalingDto,
@@ -32,9 +32,9 @@ export function BesluttUtbetalingLinjeView({ utbetaling }: Props) {
   const attesterUtbetalingLinjeMutation = useAttesterUtbetalingLinje();
   const returnerUtbetalingLinjeMutation = useReturnerUtbetalingLinje();
 
-  function attesterUtbetalingLinje(id: string) {
+  function attesterUtbetalingLinje(id: string, totrinnskontrollId: string) {
     attesterUtbetalingLinjeMutation.mutate(
-      { id },
+      { id, totrinnskontrollId },
       {
         onValidationError: (error: ValidationError) => {
           setErrors(error.errors);
@@ -45,10 +45,11 @@ export function BesluttUtbetalingLinjeView({ utbetaling }: Props) {
 
   function returnerUtbetalingLinje(
     id: string,
-    body: AarsakerOgForklaringRequestUtbetalingLinjeReturnertAarsak,
+    body: Omit<BeslutningMedAarsakerRequestUtbetalingLinjeReturnertAarsak, "totrinnskontrollId">,
+    totrinnskontrollId: string,
   ) {
     returnerUtbetalingLinjeMutation.mutate(
-      { id, body },
+      { id, body: { ...body, totrinnskontrollId } },
       {
         onValidationError: (error: ValidationError) => {
           setErrors(error.errors);
@@ -132,7 +133,7 @@ export function BesluttUtbetalingLinjeView({ utbetaling }: Props) {
                       setErrors([]);
                     }}
                     onConfirm={(request) => {
-                      returnerUtbetalingLinje(linje.id, request);
+                      returnerUtbetalingLinje(linje.id, request, linje.opprettelse?.id ?? "");
                     }}
                   />
                   <VarselModal
@@ -158,7 +159,7 @@ export function BesluttUtbetalingLinjeView({ utbetaling }: Props) {
                         variant="primary"
                         onClick={() => {
                           setAttesterModalOpenForLinjeId(null);
-                          attesterUtbetalingLinje(linje.id);
+                          attesterUtbetalingLinje(linje.id, linje.opprettelse?.id ?? "");
                         }}
                       >
                         Ja, attester beløp

--- a/frontend/tiltaksadministrasjon-flate/src/mocks/endpoints/tilsagnHandler.ts
+++ b/frontend/tiltaksadministrasjon-flate/src/mocks/endpoints/tilsagnHandler.ts
@@ -79,6 +79,7 @@ export const tilsagnHandlers = [
 
 const tilBeslutning: TotrinnskontrollDto = {
   type: "TotrinnskontrollDto.TilBeslutning",
+  id: "00000000-0000-0000-0000-000000000001",
   behandletAv: {
     agent: "P123456",
     navn: "Per Haraldsen",

--- a/frontend/tiltaksadministrasjon-flate/src/mocks/fixtures/mock_utbetalinger.ts
+++ b/frontend/tiltaksadministrasjon-flate/src/mocks/fixtures/mock_utbetalinger.ts
@@ -280,6 +280,7 @@ export const mockUtbetalingLinjer: UtbetalingLinjeDto[] = [
     gjorOppTilsagn: true,
     opprettelse: {
       type: "TotrinnskontrollDto.TilBeslutning",
+      id: "10000000-0000-0000-0000-000000000001",
       behandletAv: {
         agent: "B123456",
         navn: "Bertil Bengtson",
@@ -341,6 +342,7 @@ export const mockUtbetalingLinjer: UtbetalingLinjeDto[] = [
       aarsaker: ["FEIL_BELOP"],
       forklaring: "Beløpet er feil. Du må justere antall deltakere",
       beslutning: TotrinnskontrollDtoBeslutning.RETURNERT,
+      id: "10000000-0000-0000-0000-000000000002",
     },
   },
   {
@@ -390,6 +392,7 @@ export const mockUtbetalingLinjer: UtbetalingLinjeDto[] = [
       aarsaker: ["FEIL_BELOP"],
       forklaring: "Beløpet er feil, og bør fikses ved å endre antall deltakere",
       beslutning: TotrinnskontrollDtoBeslutning.RETURNERT,
+      id: "10000000-0000-0000-0000-000000000003",
     },
   },
   {
@@ -432,6 +435,7 @@ export const mockUtbetalingLinjer: UtbetalingLinjeDto[] = [
     gjorOppTilsagn: false,
     opprettelse: {
       type: "TotrinnskontrollDto.TilBeslutning",
+      id: "10000000-0000-0000-0000-000000000004",
       behandletAv: {
         agent: "B123456",
         navn: "Bertil Bengtson",
@@ -479,6 +483,7 @@ export const mockUtbetalingLinjer: UtbetalingLinjeDto[] = [
     gjorOppTilsagn: false,
     opprettelse: {
       type: "TotrinnskontrollDto.Besluttet",
+      id: "10000000-0000-0000-0000-000000000005",
       behandletAv: {
         agent: "B123456",
         navn: "Bertil Bengtson",

--- a/frontend/tiltaksadministrasjon-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/pages/gjennomforing/tilsagn/detaljer/TilsagnDetaljer.tsx
@@ -1,6 +1,6 @@
 import { AarsakerOgForklaringModal } from "@/components/modal/AarsakerOgForklaringModal";
 import {
-  AarsakerOgForklaringRequestTilsagnStatusAarsak,
+  BeslutningMedAarsakerRequestTilsagnStatusAarsak,
   FieldError,
   TilsagnHandling,
   TilsagnStatus,
@@ -52,9 +52,19 @@ export function TilsagnDetaljer() {
   const [avvisOppgjorModalOpen, setAvvisOppgjorModalOpen] = useState(false);
   const [errors, setErrors] = useState<FieldError[]>([]);
 
+  function aktivTotrinnskontrollId(): string {
+    if (tilsagn.status.type === TilsagnStatus.TIL_ANNULLERING) {
+      return annullering?.id ?? "";
+    }
+    if (tilsagn.status.type === TilsagnStatus.TIL_OPPGJOR) {
+      return tilOppgjor?.id ?? "";
+    }
+    return opprettelse.id;
+  }
+
   function godkjennTilsagn() {
     godkjennTilsagnMutation.mutate(
-      { id: tilsagn.id },
+      { id: tilsagn.id, totrinnskontrollId: aktivTotrinnskontrollId() },
       {
         onSuccess: () => navigate(-1),
         onValidationError: (error: ValidationError) => setErrors(error.errors),
@@ -62,9 +72,14 @@ export function TilsagnDetaljer() {
     );
   }
 
-  function returnerTilsagn(request: AarsakerOgForklaringRequestTilsagnStatusAarsak) {
+  function returnerTilsagn(
+    request: Omit<BeslutningMedAarsakerRequestTilsagnStatusAarsak, "totrinnskontrollId">,
+  ) {
     returnerTilsagnMutation.mutate(
-      { id: tilsagn.id, request },
+      {
+        id: tilsagn.id,
+        request: { ...request, totrinnskontrollId: aktivTotrinnskontrollId() },
+      },
       {
         onSuccess: () => navigate(-1),
         onValidationError: (error: ValidationError) => setErrors(error.errors),

--- a/frontend/tiltaksadministrasjon-flate/src/pages/gjennomforing/utbetaling/UtbetalingDetaljerPage.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/pages/gjennomforing/utbetaling/UtbetalingDetaljerPage.tsx
@@ -107,7 +107,7 @@ export function UtbetalingDetaljerPage() {
 
   function godkjennAvbytUtbetaling() {
     godkjennAvbyrtUtbetalingMutation.mutate(
-      { id: utbetaling.id },
+      { id: utbetaling.id, totrinnskontrollId: utbetaling.avbrytelse?.id ?? "" },
       {
         onValidationError: (error: ValidationError) => {
           setErrors(error.errors);
@@ -343,6 +343,7 @@ export function UtbetalingDetaljerPage() {
           />
           <AvslaAvbrytelseUtbetalingModal
             utbetalingId={utbetaling.id}
+            totrinnskontrollId={utbetaling.avbrytelse?.id ?? ""}
             open={modalVariant === UtbetalingHandling.AVSLA_AVBRYTELSE}
             onClose={() => setModalVariant(null)}
           />

--- a/frontend/tiltaksadministrasjon-flate/src/pages/tilskudd-behandling/TilskuddBehandlingDetaljerPage.tsx
+++ b/frontend/tiltaksadministrasjon-flate/src/pages/tilskudd-behandling/TilskuddBehandlingDetaljerPage.tsx
@@ -69,10 +69,13 @@ export function TilskuddBehandlingDetaljerPage() {
   const listUrl = `/gjennomforinger/${gjennomforingId}/tilskudd-behandling`;
 
   function attester() {
-    godkjennMutation.mutate(behandling.id, {
-      onSuccess: () => navigate(listUrl),
-      onValidationError: (error: ValidationError) => setErrors(error.errors),
-    });
+    godkjennMutation.mutate(
+      { id: behandling.id, totrinnskontrollId: opprettelse.id },
+      {
+        onSuccess: () => navigate(listUrl),
+        onValidationError: (error: ValidationError) => setErrors(error.errors),
+      },
+    );
   }
 
   function sendIRetur(data: {
@@ -80,7 +83,7 @@ export function TilskuddBehandlingDetaljerPage() {
     forklaring: string | null;
   }) {
     returnerMutation.mutate(
-      { id: behandling.id, body: { ...data } },
+      { id: behandling.id, body: { ...data, totrinnskontrollId: opprettelse.id } },
       {
         onSuccess: () => {
           setReturModalOpen(false);

--- a/mulighetsrommet-api/admin/src/main/kotlin/no/nav/mulighetsrommet/admin/totrinnskontroll/TotrinnskontrollDto.kt
+++ b/mulighetsrommet-api/admin/src/main/kotlin/no/nav/mulighetsrommet/admin/totrinnskontroll/TotrinnskontrollDto.kt
@@ -11,12 +11,15 @@ import no.nav.mulighetsrommet.model.NavIdent
 import no.nav.mulighetsrommet.model.Tiltaksadministrasjon
 import no.nav.mulighetsrommet.serializers.AgentSerializer
 import no.nav.mulighetsrommet.serializers.LocalDateTimeSerializer
+import no.nav.mulighetsrommet.serializers.UUIDSerializer
 import java.time.LocalDateTime
+import java.util.UUID
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 @JsonClassDiscriminator("type")
 sealed class TotrinnskontrollDto {
+    abstract val id: UUID
     abstract val behandletAv: AgentDto
     abstract val behandletTidspunkt: LocalDateTime
     abstract val aarsaker: List<String>
@@ -25,6 +28,8 @@ sealed class TotrinnskontrollDto {
     @Serializable
     @SerialName("TotrinnskontrollDto.TilBeslutning")
     data class TilBeslutning(
+        @Serializable(with = UUIDSerializer::class)
+        override val id: UUID,
         override val behandletAv: AgentDto,
         @Serializable(with = LocalDateTimeSerializer::class)
         override val behandletTidspunkt: LocalDateTime,
@@ -35,6 +40,8 @@ sealed class TotrinnskontrollDto {
     @Serializable
     @SerialName("TotrinnskontrollDto.Besluttet")
     data class Besluttet(
+        @Serializable(with = UUIDSerializer::class)
+        override val id: UUID,
         override val behandletAv: AgentDto,
         @Serializable(with = LocalDateTimeSerializer::class)
         override val behandletTidspunkt: LocalDateTime,

--- a/mulighetsrommet-api/domain/src/main/kotlin/no/nav/mulighetsrommet/api/domain/totrinnskontroll/Totrinnskontroll.kt
+++ b/mulighetsrommet-api/domain/src/main/kotlin/no/nav/mulighetsrommet/api/domain/totrinnskontroll/Totrinnskontroll.kt
@@ -49,6 +49,19 @@ data class Totrinnskontroll(
         return !(agent is NavIdent && agent == behandletAv)
     }
 
+    /**
+     * Verifiserer at [forventetId] er id-en til denne totrinnskontrollen, altså at klienten som ber om å
+     * beslutte den faktisk har sett gjeldende versjon. Brukes kun der id-en kommer fra en ekstern klient
+     * (HTTP-forespørsel); interne/automatiske flows har ingen ekstern forventning å validere mot og kaller
+     * derfor aldri denne metoden.
+     */
+    fun sjekkGjeldende(forventetId: UUID): Either<TotrinnskontrollError, Totrinnskontroll> {
+        if (id != forventetId) {
+            return TotrinnskontrollError.UtdatertGrunnlag(id).left()
+        }
+        return right()
+    }
+
     companion object {
         fun opprett(
             id: UUID,

--- a/mulighetsrommet-api/domain/src/main/kotlin/no/nav/mulighetsrommet/api/domain/totrinnskontroll/TotrinnskontrollError.kt
+++ b/mulighetsrommet-api/domain/src/main/kotlin/no/nav/mulighetsrommet/api/domain/totrinnskontroll/TotrinnskontrollError.kt
@@ -1,9 +1,18 @@
 package no.nav.mulighetsrommet.api.domain.totrinnskontroll
 
+import java.util.UUID
+
 sealed interface TotrinnskontrollError {
     data class AlleredeBesluttet(val status: TotrinnskontrollStatus) : TotrinnskontrollError
 
     data object KanIkkeBesluttesAvBehandler : TotrinnskontrollError
 
     data object KanBareTilbakestillesNarSattPaVent : TotrinnskontrollError
+
+    /**
+     * Klienten sendte inn en annen totrinnskontroll-id enn den som faktisk er til behandling.
+     * Betyr at grunnlaget klienten viser er utdatert, f.eks. fordi saksbehandler har endret og
+     * sendt inn på nytt mens beslutter så på en tidligere versjon.
+     */
+    data class UtdatertGrunnlag(val gjeldendeId: UUID) : TotrinnskontrollError
 }

--- a/mulighetsrommet-api/domain/src/test/kotlin/no/nav/mulighetsrommet/api/domain/totrinnskontroll/TotrinnskontrollTest.kt
+++ b/mulighetsrommet-api/domain/src/test/kotlin/no/nav/mulighetsrommet/api/domain/totrinnskontroll/TotrinnskontrollTest.kt
@@ -40,6 +40,19 @@ class TotrinnskontrollTest : FunSpec({
         }
     }
 
+    context("sjekkGjeldende") {
+        test("er Right når forventet id stemmer") {
+            val opprettelse = opprett()
+            opprettelse.sjekkGjeldende(opprettelse.id).shouldBeRight()
+        }
+
+        test("feiler når forventet id ikke stemmer") {
+            val opprettelse = opprett()
+            opprettelse.sjekkGjeldende(UUID.randomUUID()) shouldBeLeft
+                TotrinnskontrollError.UtdatertGrunnlag(opprettelse.id)
+        }
+    }
+
     context("godkjenn") {
         test("godkjenner og returnerer oppdatert tilstand") {
             val godkjent = opprett().godkjenn(besluttetAv).shouldBeRight()
@@ -104,7 +117,7 @@ class TotrinnskontrollTest : FunSpec({
 
         test("systemet er tillatt å endre fra godkjent til returnert") {
             val godkjent = opprett().godkjenn(besluttetAv).shouldBeRight()
-            godkjent.returner(Tiltaksadministrasjon, listOf("PROPAGERT_RETUR")).shouldBeRight()
+            godkjent.returner(Tiltaksadministrasjon, aarsaker = listOf("PROPAGERT_RETUR")).shouldBeRight()
         }
     }
 

--- a/mulighetsrommet-api/persistence/src/main/kotlin/no/nav/mulighetsrommet/api/persistence/totrinnskontroll/TotrinnskontrollQueries.kt
+++ b/mulighetsrommet-api/persistence/src/main/kotlin/no/nav/mulighetsrommet/api/persistence/totrinnskontroll/TotrinnskontrollQueries.kt
@@ -204,6 +204,7 @@ class TotrinnskontrollQueries(val session: Session) : TotrinnskontrollQueryHandl
     }
 
     private fun Row.toDto(): TotrinnskontrollDto {
+        val id = uuid("id")
         val behandletAv = string("behandlet_av").toAgent()
         val behandletAvNavn = stringOrNull("behandlet_av_navn")
         val behandletTidspunkt = localDateTime("behandlet_tidspunkt")
@@ -213,6 +214,7 @@ class TotrinnskontrollQueries(val session: Session) : TotrinnskontrollQueryHandl
 
         return if (status == TotrinnskontrollStatus.TIL_BEHANDLING) {
             TotrinnskontrollDto.TilBeslutning(
+                id = id,
                 behandletAv = AgentDto.fromAgent(behandletAv, behandletAvNavn),
                 behandletTidspunkt = behandletTidspunkt,
                 aarsaker = aarsaker,
@@ -222,6 +224,7 @@ class TotrinnskontrollQueries(val session: Session) : TotrinnskontrollQueryHandl
             val besluttetAv = string("besluttet_av").toAgent()
             val besluttetAvNavn = stringOrNull("besluttet_av_navn")
             TotrinnskontrollDto.Besluttet(
+                id = id,
                 behandletAv = AgentDto.fromAgent(behandletAv, behandletAvNavn),
                 behandletTidspunkt = behandletTidspunkt,
                 aarsaker = aarsaker,

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/api/ArrangorflateRoutes.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/arrangorflate/api/ArrangorflateRoutes.kt
@@ -362,7 +362,7 @@ fun Route.arrangorflateRoutes(config: AppConfig) {
             operationId = "avbrytUtbetaling"
             request {
                 pathParameterUuid("id")
-                body<AvbrytUtbetaling>()
+                body<AvbrytUtbetalingRequest>()
             }
             response {
                 code(HttpStatusCode.OK) {
@@ -376,7 +376,7 @@ fun Route.arrangorflateRoutes(config: AppConfig) {
         }) {
             val utbetaling = getArrangorflateUtbetalingOrRespondWithClientError()
 
-            val request = call.receive<AvbrytUtbetaling>()
+            val request = call.receive<AvbrytUtbetalingRequest>()
 
             request.validate()
                 .flatMap { begrunnelse ->
@@ -396,7 +396,7 @@ fun Route.arrangorflateRoutes(config: AppConfig) {
             operationId = "regenererUtbetaling"
             request {
                 pathParameterUuid("id")
-                body<AvbrytUtbetaling>()
+                body<AvbrytUtbetalingRequest>()
             }
             response {
                 code(HttpStatusCode.OK) {
@@ -554,16 +554,16 @@ data class GodkjennUtbetaling(
 }
 
 @Serializable
-data class AvbrytUtbetaling(
+data class AvbrytUtbetalingRequest(
     val begrunnelse: String?,
 ) {
     @OptIn(ExperimentalContracts::class)
     fun validate(): Validated<String> = validation {
         requireValid(!begrunnelse.isNullOrBlank()) {
-            FieldError.of("Begrunnelse må være satt", AvbrytUtbetaling::begrunnelse)
+            FieldError.of("Begrunnelse må være satt", AvbrytUtbetalingRequest::begrunnelse)
         }
         validate(begrunnelse.length <= 100) {
-            FieldError.of("Begrunnelse kan ikke være lengre enn 100 tegn", AvbrytUtbetaling::begrunnelse)
+            FieldError.of("Begrunnelse kan ikke være lengre enn 100 tegn", AvbrytUtbetalingRequest::begrunnelse)
         }
         begrunnelse
     }

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/api/GjennomforingRoutes.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/api/GjennomforingRoutes.kt
@@ -37,6 +37,8 @@ import no.nav.mulighetsrommet.api.gjennomforing.model.AvbrytGjennomforingAarsak
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingAvtaleDetaljer
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingDetaljerDto
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingKompaktDto
+import no.nav.mulighetsrommet.api.gjennomforing.model.GodkjennOkonomi
+import no.nav.mulighetsrommet.api.gjennomforing.model.SettOkonomiPaVent
 import no.nav.mulighetsrommet.api.gjennomforing.service.GjennomforingAvtaleService
 import no.nav.mulighetsrommet.api.gjennomforing.service.GjennomforingDetaljerService
 import no.nav.mulighetsrommet.api.gjennomforing.service.GjennomforingEnkeltplassService
@@ -48,6 +50,7 @@ import no.nav.mulighetsrommet.api.plugins.pathParameterUuid
 import no.nav.mulighetsrommet.api.responses.PaginatedResponse
 import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.SettPaVentRequest
 import no.nav.mulighetsrommet.api.utils.DatoUtils.parseOrNull
 import no.nav.mulighetsrommet.ktor.exception.BadRequest
 import no.nav.mulighetsrommet.ktor.plugins.respondWithProblemDetail
@@ -482,7 +485,7 @@ fun Route.gjennomforingRoutes() {
                 val id = call.parameters.getOrFail<UUID>("id")
                 val navIdent = getNavIdent()
 
-                val result = enkeltplasser.settOkonomiGodkjent(id, navIdent)
+                val result = enkeltplasser.settOkonomiGodkjent(GodkjennOkonomi(id, navIdent))
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 
@@ -494,7 +497,7 @@ fun Route.gjennomforingRoutes() {
                 operationId = "settPaVentGjennomforingOkonomi"
                 request {
                     pathParameterUuid("id")
-                    body<SettPaVentOkonomiRequest>()
+                    body<SettPaVentRequest>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -508,9 +511,14 @@ fun Route.gjennomforingRoutes() {
             }) {
                 val id = call.parameters.getOrFail<UUID>("id")
                 val navIdent = getNavIdent()
-                val request = call.receive<SettPaVentOkonomiRequest>()
+                val request = call.receive<SettPaVentRequest>()
 
-                val result = enkeltplasser.settOkonomiPaVent(id, navIdent, request.forklaring)
+                val command = SettOkonomiPaVent(
+                    id,
+                    navIdent,
+                    request.forklaring,
+                )
+                val result = enkeltplasser.settOkonomiPaVent(command)
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 
@@ -798,11 +806,6 @@ data class GjennomforingVeilederinfoRequest(
 @Serializable
 data class PublisertRequest(
     val publisert: Boolean,
-)
-
-@Serializable
-data class SettPaVentOkonomiRequest(
-    val forklaring: String? = null,
 )
 
 @Serializable

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/api/GjennomforingRoutes.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/api/GjennomforingRoutes.kt
@@ -50,6 +50,7 @@ import no.nav.mulighetsrommet.api.plugins.pathParameterUuid
 import no.nav.mulighetsrommet.api.responses.PaginatedResponse
 import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningRequest
 import no.nav.mulighetsrommet.api.totrinnskontroll.api.SettPaVentRequest
 import no.nav.mulighetsrommet.api.utils.DatoUtils.parseOrNull
 import no.nav.mulighetsrommet.ktor.exception.BadRequest
@@ -471,6 +472,7 @@ fun Route.gjennomforingRoutes() {
                 operationId = "godkjennGjennomforingOkonomi"
                 request {
                     pathParameterUuid("id")
+                    body<BeslutningRequest>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -483,11 +485,13 @@ fun Route.gjennomforingRoutes() {
                 }
             }) {
                 val id = call.parameters.getOrFail<UUID>("id")
+                val request = call.receive<BeslutningRequest>()
                 val navIdent = getNavIdent()
 
-                val result = enkeltplasser.settOkonomiGodkjent(GodkjennOkonomi(id, navIdent))
-                    .mapLeft { ValidationError(errors = it) }
-                    .map { HttpStatusCode.OK }
+                val result =
+                    enkeltplasser.settOkonomiGodkjent(GodkjennOkonomi(id, navIdent, request.totrinnskontrollId))
+                        .mapLeft { ValidationError(errors = it) }
+                        .map { HttpStatusCode.OK }
 
                 call.respondWithStatusResponse(result)
             }
@@ -517,6 +521,7 @@ fun Route.gjennomforingRoutes() {
                     id,
                     navIdent,
                     request.forklaring,
+                    request.totrinnskontrollId,
                 )
                 val result = enkeltplasser.settOkonomiPaVent(command)
                     .mapLeft { ValidationError(errors = it) }

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/GjennomforingRequestKafkaConsumer.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/GjennomforingRequestKafkaConsumer.kt
@@ -114,6 +114,7 @@ class GjennomforingRequestKafkaConsumer(
 
                 TotrinnskontrollError.KanBareTilbakestillesNarSattPaVent,
                 TotrinnskontrollError.KanIkkeBesluttesAvBehandler,
+                is TotrinnskontrollError.UtdatertGrunnlag,
                 -> error("Uventet feilscenario ved tilbakekalling av prisinformasjon: $error")
             }
         }

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/model/EnkeltplassOkonomiBeslutningCommand.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/model/EnkeltplassOkonomiBeslutningCommand.kt
@@ -1,0 +1,16 @@
+package no.nav.mulighetsrommet.api.gjennomforing.model
+
+import no.nav.mulighetsrommet.model.Agent
+import no.nav.mulighetsrommet.model.NavIdent
+import java.util.UUID
+
+data class GodkjennOkonomi(
+    val id: UUID,
+    val agent: Agent,
+)
+
+data class SettOkonomiPaVent(
+    val id: UUID,
+    val navIdent: NavIdent,
+    val forklaring: String?,
+)

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/model/EnkeltplassOkonomiBeslutningCommand.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/model/EnkeltplassOkonomiBeslutningCommand.kt
@@ -7,10 +7,12 @@ import java.util.UUID
 data class GodkjennOkonomi(
     val id: UUID,
     val agent: Agent,
+    val forventetTotrinnskontrollId: UUID,
 )
 
 data class SettOkonomiPaVent(
     val id: UUID,
     val navIdent: NavIdent,
     val forklaring: String?,
+    val forventetTotrinnskontrollId: UUID,
 )

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassService.kt
@@ -32,6 +32,8 @@ import no.nav.mulighetsrommet.api.gjennomforing.model.Enkeltplass
 import no.nav.mulighetsrommet.api.gjennomforing.model.Gjennomforing
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingAvtale
 import no.nav.mulighetsrommet.api.gjennomforing.model.GjennomforingEnkeltplass
+import no.nav.mulighetsrommet.api.gjennomforing.model.GodkjennOkonomi
+import no.nav.mulighetsrommet.api.gjennomforing.model.SettOkonomiPaVent
 import no.nav.mulighetsrommet.api.totrinnskontroll.api.toFieldErrors
 import no.nav.mulighetsrommet.api.utbetaling.service.Personalia
 import no.nav.mulighetsrommet.api.utbetaling.service.PersonaliaService
@@ -307,10 +309,8 @@ class GjennomforingEnkeltplassService(
         getEnkeltplass(id)
     }
 
-    fun settOkonomiGodkjent(
-        id: UUID,
-        agent: Agent,
-    ): Validated<Enkeltplass> = db.transaction {
+    fun settOkonomiGodkjent(command: GodkjennOkonomi): Validated<Enkeltplass> = db.transaction {
+        val (id, agent) = command
         val enkeltplass = getAndAquireLock(id)
 
         if (enkeltplass.prisendring?.totrinnskontroll?.kanBesluttes() == true) {
@@ -323,11 +323,8 @@ class GjennomforingEnkeltplassService(
         return settOkonomiGodkjent(id, okonomi, agent)
     }
 
-    fun settOkonomiPaVent(
-        id: UUID,
-        navIdent: NavIdent,
-        forklaring: String?,
-    ): Validated<Enkeltplass> = db.transaction {
+    fun settOkonomiPaVent(command: SettOkonomiPaVent): Validated<Enkeltplass> = db.transaction {
+        val (id, navIdent, forklaring) = command
         val enkeltplass = getAndAquireLock(id)
 
         if (enkeltplass.prisendring?.totrinnskontroll?.kanBesluttes() == true) {

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassService.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.gjennomforing.service
 
 import arrow.core.Either
+import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.nel
@@ -310,31 +311,31 @@ class GjennomforingEnkeltplassService(
     }
 
     fun settOkonomiGodkjent(command: GodkjennOkonomi): Validated<Enkeltplass> = db.transaction {
-        val (id, agent) = command
+        val (id, agent, forventetTotrinnskontrollId) = command
         val enkeltplass = getAndAquireLock(id)
 
         if (enkeltplass.prisendring?.totrinnskontroll?.kanBesluttes() == true) {
-            return godkjennPrisendring(id, enkeltplass.prisendring.totrinnskontroll, agent)
+            return godkjennPrisendring(id, enkeltplass.prisendring.totrinnskontroll, agent, forventetTotrinnskontrollId)
         }
 
         val okonomi = enkeltplass.okonomi
             ?: return FieldError.of("Økonomi har ikke blitt sendt til godkjenning").nel().left()
 
-        return settOkonomiGodkjent(id, okonomi, agent)
+        return settOkonomiGodkjent(id, okonomi, agent, forventetTotrinnskontrollId)
     }
 
     fun settOkonomiPaVent(command: SettOkonomiPaVent): Validated<Enkeltplass> = db.transaction {
-        val (id, navIdent, forklaring) = command
+        val (id, navIdent, forklaring, forventetTotrinnskontrollId) = command
         val enkeltplass = getAndAquireLock(id)
 
         if (enkeltplass.prisendring?.totrinnskontroll?.kanBesluttes() == true) {
-            return settPrisendringPaVent(id, enkeltplass.prisendring.totrinnskontroll, navIdent, forklaring)
+            return settPrisendringPaVent(id, enkeltplass.prisendring.totrinnskontroll, navIdent, forklaring, forventetTotrinnskontrollId)
         }
 
         val okonomi = enkeltplass.okonomi
             ?: return FieldError.of("Økonomi har ikke blitt sendt til godkjenning").nel().left()
 
-        settOkonomiPaVent(id, okonomi, navIdent, forklaring)
+        settOkonomiPaVent(id, okonomi, navIdent, forklaring, forventetTotrinnskontrollId)
     }
 
     private suspend fun QueryContext.getDeltakerPersonalia(
@@ -592,12 +593,15 @@ class GjennomforingEnkeltplassService(
         id: UUID,
         okonomi: Totrinnskontroll,
         agent: Agent,
+        forventetTotrinnskontrollId: UUID,
     ): Validated<Enkeltplass> {
-        return okonomi.copy(forklaring = null).godkjenn(agent).mapLeft { it.toFieldErrors() }.map { godkjent ->
-            queries.totrinnskontroll.upsert(godkjent)
-            outbox.publish(godkjent)
-            logEndring("Enkeltplass ble godkjent", id, agent)
-        }
+        return okonomi.sjekkGjeldende(forventetTotrinnskontrollId)
+            .flatMap { it.copy(forklaring = null).godkjenn(agent) }
+            .mapLeft { it.toFieldErrors() }.map { godkjent ->
+                queries.totrinnskontroll.upsert(godkjent)
+                outbox.publish(godkjent)
+                logEndring("Enkeltplass ble godkjent", id, agent)
+            }
     }
 
     private fun TransactionalQueryContext.settOkonomiPaVent(
@@ -605,35 +609,41 @@ class GjennomforingEnkeltplassService(
         okonomi: Totrinnskontroll,
         agent: Agent,
         forklaring: String?,
+        forventetTotrinnskontrollId: UUID,
     ): Validated<Enkeltplass> {
-        return okonomi.settPaVent(agent, forklaring = forklaring).mapLeft { it.toFieldErrors() }.map { paVent ->
-            queries.totrinnskontroll.upsert(paVent)
-            outbox.publish(paVent)
-            logEndring("Godkjenning ble satt på vent", id, agent)
-        }
+        return okonomi.sjekkGjeldende(forventetTotrinnskontrollId)
+            .flatMap { it.settPaVent(agent, forklaring = forklaring) }
+            .mapLeft { it.toFieldErrors() }.map { paVent ->
+                queries.totrinnskontroll.upsert(paVent)
+                outbox.publish(paVent)
+                logEndring("Godkjenning ble satt på vent", id, agent)
+            }
     }
 
     private fun TransactionalQueryContext.godkjennPrisendring(
         gjennomforingId: UUID,
         prisendring: Totrinnskontroll,
         agent: Agent,
+        forventetTotrinnskontrollId: UUID,
     ): Validated<Enkeltplass> {
-        return prisendring.godkjenn(agent).mapLeft { it.toFieldErrors() }.map { godkjent ->
-            queries.totrinnskontroll.upsert(godkjent)
-            outbox.publish(godkjent)
+        return prisendring.sjekkGjeldende(forventetTotrinnskontrollId)
+            .flatMap { it.godkjenn(agent) }
+            .mapLeft { it.toFieldErrors() }.map { godkjent ->
+                queries.totrinnskontroll.upsert(godkjent)
+                outbox.publish(godkjent)
 
-            val pending = requireNotNull(queries.enkeltplassPrisendring.getByGjennomforingId(gjennomforingId)) {
-                "Fant ikke prisendring for gjennomforing $gjennomforingId"
+                val pending = requireNotNull(queries.enkeltplassPrisendring.getByGjennomforingId(gjennomforingId)) {
+                    "Fant ikke prisendring for gjennomforing $gjennomforingId"
+                }
+                val gammelPrismodellId = queries.gjennomforing.getPrismodell(gjennomforingId)?.id
+                queries.gjennomforing.setPrismodellId(gjennomforingId, pending.prismodellId)
+                gammelPrismodellId?.let { queries.prismodell.deletePrismodell(it) }
+                queries.enkeltplassPrisendring.deleteByTotrinnskontrollId(pending.totrinnskontrollId)
+
+                val oppdatert = queries.gjennomforing.getGjennomforingEnkeltplassOrError(gjennomforingId)
+                publishTiltaksgjennomforingV2ToKafka(oppdatert)
+                logEndring("Prisendring ble godkjent", gjennomforingId, agent)
             }
-            val gammelPrismodellId = queries.gjennomforing.getPrismodell(gjennomforingId)?.id
-            queries.gjennomforing.setPrismodellId(gjennomforingId, pending.prismodellId)
-            gammelPrismodellId?.let { queries.prismodell.deletePrismodell(it) }
-            queries.enkeltplassPrisendring.deleteByTotrinnskontrollId(pending.totrinnskontrollId)
-
-            val oppdatert = queries.gjennomforing.getGjennomforingEnkeltplassOrError(gjennomforingId)
-            publishTiltaksgjennomforingV2ToKafka(oppdatert)
-            logEndring("Prisendring ble godkjent", gjennomforingId, agent)
-        }
     }
 
     private fun TransactionalQueryContext.settPrisendringPaVent(
@@ -641,12 +651,15 @@ class GjennomforingEnkeltplassService(
         prisendring: Totrinnskontroll,
         agent: Agent,
         forklaring: String?,
+        forventetTotrinnskontrollId: UUID,
     ): Validated<Enkeltplass> {
-        return prisendring.settPaVent(agent, forklaring = forklaring).mapLeft { it.toFieldErrors() }.map { paVent ->
-            queries.totrinnskontroll.upsert(paVent)
-            outbox.publish(paVent)
-            logEndring("Prisendring ble satt på vent", gjennomforingId, agent)
-        }
+        return prisendring.sjekkGjeldende(forventetTotrinnskontrollId)
+            .flatMap { it.settPaVent(agent, forklaring = forklaring) }
+            .mapLeft { it.toFieldErrors() }.map { paVent ->
+                queries.totrinnskontroll.upsert(paVent)
+                outbox.publish(paVent)
+                logEndring("Prisendring ble satt på vent", gjennomforingId, agent)
+            }
     }
 }
 

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
@@ -23,6 +23,8 @@ import no.nav.mulighetsrommet.api.navansatt.service.NavAnsattService
 import no.nav.mulighetsrommet.api.tilsagn.api.TilsagnHandling
 import no.nav.mulighetsrommet.api.tilsagn.db.TilsagnDbo
 import no.nav.mulighetsrommet.api.tilsagn.model.BeregnTilsagnRequest
+import no.nav.mulighetsrommet.api.tilsagn.model.GodkjennTilsagn
+import no.nav.mulighetsrommet.api.tilsagn.model.ReturnerTilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.Tilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnBeregning
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnBeregningAnnenAvtaltPris
@@ -305,16 +307,13 @@ class TilsagnService(
         )
     }
 
-    fun godkjennTilsagn(
-        id: UUID,
-        agent: Agent,
-    ): Either<List<FieldError>, Tilsagn> = db.transaction { godkjennTilsagnInTx(id, agent) }
+    fun godkjennTilsagn(command: GodkjennTilsagn): Either<List<FieldError>, Tilsagn> = db.transaction {
+        godkjennTilsagnInTx(command)
+    }
 
     context(tx: TransactionalQueryContext)
-    fun godkjennTilsagnInTx(
-        id: UUID,
-        agent: Agent,
-    ): Either<List<FieldError>, Tilsagn> = with(tx) {
+    fun godkjennTilsagnInTx(command: GodkjennTilsagn): Either<List<FieldError>, Tilsagn> = with(tx) {
+        val (id, agent) = command
         val tilsagn = queries.tilsagn.getAndAquireLock(id)
 
         when (agent) {
@@ -354,12 +353,8 @@ class TilsagnService(
         }
     }
 
-    fun returnerTilsagn(
-        id: UUID,
-        navIdent: NavIdent,
-        aarsaker: List<TilsagnStatusAarsak>,
-        forklaring: String?,
-    ): Either<List<FieldError>, Tilsagn> = db.transaction {
+    fun returnerTilsagn(command: ReturnerTilsagn): Either<List<FieldError>, Tilsagn> = db.transaction {
+        val (id, navIdent, aarsaker, forklaring) = command
         val tilsagn = queries.tilsagn.getAndAquireLock(id)
 
         val ansatt = queries.ansatt.getOrError(navIdent)

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnService.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.tilsagn
 
 import arrow.core.Either
+import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.nel
 import arrow.core.nonEmptyListOf
@@ -38,6 +39,7 @@ import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnRequest
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatus
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatusAarsak
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnType
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.sjekkGjeldendeTotrinnskontroll
 import no.nav.mulighetsrommet.api.totrinnskontroll.api.toFieldErrors
 import no.nav.mulighetsrommet.api.utbetaling.model.StengtPeriode
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingInputHelper
@@ -307,13 +309,11 @@ class TilsagnService(
         )
     }
 
-    fun godkjennTilsagn(command: GodkjennTilsagn): Either<List<FieldError>, Tilsagn> = db.transaction {
-        godkjennTilsagnInTx(command)
-    }
+    fun godkjennTilsagn(command: GodkjennTilsagn): Either<List<FieldError>, Tilsagn> = db.transaction { godkjennTilsagnInTx(command) }
 
     context(tx: TransactionalQueryContext)
     fun godkjennTilsagnInTx(command: GodkjennTilsagn): Either<List<FieldError>, Tilsagn> = with(tx) {
-        val (id, agent) = command
+        val (id, agent, forventetTotrinnskontrollId) = command
         val tilsagn = queries.tilsagn.getAndAquireLock(id)
 
         when (agent) {
@@ -339,22 +339,22 @@ class TilsagnService(
                 .nel()
                 .left()
 
-            TilsagnStatus.TIL_GODKJENNING -> godkjennTilsagn(tilsagn, agent).onRight {
-                publishOpprettBestilling(it)
-            }
+            TilsagnStatus.TIL_GODKJENNING -> sjekkGjeldendeTotrinnskontroll(tilsagn.id, TotrinnskontrollType.TILSAGN_OPPRETTELSE, forventetTotrinnskontrollId)
+                .flatMap { godkjennTilsagn(tilsagn, agent) }
+                .onRight { publishOpprettBestilling(it) }
 
-            TilsagnStatus.TIL_ANNULLERING -> annullerTilsagn(tilsagn, agent).onRight {
-                publishAnnullerBestilling(it)
-            }
+            TilsagnStatus.TIL_ANNULLERING -> sjekkGjeldendeTotrinnskontroll(tilsagn.id, TotrinnskontrollType.TILSAGN_ANNULLERING, forventetTotrinnskontrollId)
+                .flatMap { annullerTilsagn(tilsagn, agent) }
+                .onRight { publishAnnullerBestilling(it) }
 
-            TilsagnStatus.TIL_OPPGJOR -> gjorOppTilsagn(tilsagn, agent, "Tilsagn oppgjort").onRight {
-                publishGjorOppBestilling(it)
-            }
+            TilsagnStatus.TIL_OPPGJOR -> sjekkGjeldendeTotrinnskontroll(tilsagn.id, TotrinnskontrollType.TILSAGN_OPPGJOR, forventetTotrinnskontrollId)
+                .flatMap { gjorOppTilsagn(tilsagn, agent, "Tilsagn oppgjort") }
+                .onRight { publishGjorOppBestilling(it) }
         }
     }
 
     fun returnerTilsagn(command: ReturnerTilsagn): Either<List<FieldError>, Tilsagn> = db.transaction {
-        val (id, navIdent, aarsaker, forklaring) = command
+        val (id, navIdent, aarsaker, forklaring, forventetTotrinnskontrollId) = command
         val tilsagn = queries.tilsagn.getAndAquireLock(id)
 
         val ansatt = queries.ansatt.getOrError(navIdent)
@@ -368,11 +368,14 @@ class TilsagnService(
                 .nel()
                 .left()
 
-            TilsagnStatus.TIL_GODKJENNING -> returnerTilsagn(tilsagn, navIdent, aarsaker, forklaring)
+            TilsagnStatus.TIL_GODKJENNING -> sjekkGjeldendeTotrinnskontroll(tilsagn.id, TotrinnskontrollType.TILSAGN_OPPRETTELSE, forventetTotrinnskontrollId)
+                .flatMap { returnerTilsagn(tilsagn, navIdent, aarsaker, forklaring) }
 
-            TilsagnStatus.TIL_ANNULLERING -> avvisAnnullering(tilsagn, navIdent, aarsaker, forklaring)
+            TilsagnStatus.TIL_ANNULLERING -> sjekkGjeldendeTotrinnskontroll(tilsagn.id, TotrinnskontrollType.TILSAGN_ANNULLERING, forventetTotrinnskontrollId)
+                .flatMap { avvisAnnullering(tilsagn, navIdent, aarsaker, forklaring) }
 
-            TilsagnStatus.TIL_OPPGJOR -> avvisOppgjor(tilsagn, navIdent, aarsaker, forklaring)
+            TilsagnStatus.TIL_OPPGJOR -> sjekkGjeldendeTotrinnskontroll(tilsagn.id, TotrinnskontrollType.TILSAGN_OPPGJOR, forventetTotrinnskontrollId)
+                .flatMap { avvisOppgjor(tilsagn, navIdent, aarsaker, forklaring) }
         }
     }
 

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnRoutesBehandling.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnRoutesBehandling.kt
@@ -17,6 +17,8 @@ import no.nav.mulighetsrommet.api.plugins.pathParameterUuid
 import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
+import no.nav.mulighetsrommet.api.tilsagn.model.GodkjennTilsagn
+import no.nav.mulighetsrommet.api.tilsagn.model.ReturnerTilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnRequest
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatusAarsak
 import no.nav.mulighetsrommet.ktor.plugins.respondWithProblemDetail
@@ -162,7 +164,7 @@ fun Route.tilsagnRoutesBehandling() {
             val id = call.parameters.getOrFail<UUID>("id")
             val navIdent = getNavIdent()
 
-            val result = service.godkjennTilsagn(id, navIdent)
+            val result = service.godkjennTilsagn(GodkjennTilsagn(id, navIdent))
                 .mapLeft { ValidationError(errors = it) }
                 .map { HttpStatusCode.OK }
 
@@ -193,7 +195,7 @@ fun Route.tilsagnRoutesBehandling() {
             val navIdent = getNavIdent()
 
             val result = request.validate()
-                .flatMap { service.returnerTilsagn(id, navIdent, it.aarsaker, it.forklaring) }
+                .flatMap { service.returnerTilsagn(ReturnerTilsagn(id, navIdent, it.aarsaker, it.forklaring)) }
                 .mapLeft { ValidationError(errors = it) }
                 .map { HttpStatusCode.OK }
 

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnRoutesBehandling.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/api/TilsagnRoutesBehandling.kt
@@ -21,6 +21,8 @@ import no.nav.mulighetsrommet.api.tilsagn.model.GodkjennTilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.ReturnerTilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnRequest
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatusAarsak
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningMedAarsakerRequest
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningRequest
 import no.nav.mulighetsrommet.ktor.plugins.respondWithProblemDetail
 import no.nav.mulighetsrommet.model.ProblemDetail
 import org.koin.ktor.ext.inject
@@ -150,6 +152,7 @@ fun Route.tilsagnRoutesBehandling() {
             operationId = "godkjennTilsagn"
             request {
                 pathParameterUuid("id")
+                body<BeslutningRequest>()
             }
             response {
                 code(HttpStatusCode.OK) {
@@ -162,9 +165,10 @@ fun Route.tilsagnRoutesBehandling() {
             }
         }) {
             val id = call.parameters.getOrFail<UUID>("id")
+            val request = call.receive<BeslutningRequest>()
             val navIdent = getNavIdent()
 
-            val result = service.godkjennTilsagn(GodkjennTilsagn(id, navIdent))
+            val result = service.godkjennTilsagn(GodkjennTilsagn(id, navIdent, request.totrinnskontrollId))
                 .mapLeft { ValidationError(errors = it) }
                 .map { HttpStatusCode.OK }
 
@@ -178,7 +182,7 @@ fun Route.tilsagnRoutesBehandling() {
             operationId = "returnerTilsagn"
             request {
                 pathParameterUuid("id")
-                body<AarsakerOgForklaringRequest<TilsagnStatusAarsak>>()
+                body<BeslutningMedAarsakerRequest<TilsagnStatusAarsak>>()
             }
             response {
                 code(HttpStatusCode.OK) {
@@ -191,11 +195,15 @@ fun Route.tilsagnRoutesBehandling() {
             }
         }) {
             val id = call.parameters.getOrFail<UUID>("id")
-            val request = call.receive<AarsakerOgForklaringRequest<TilsagnStatusAarsak>>()
+            val request = call.receive<BeslutningMedAarsakerRequest<TilsagnStatusAarsak>>()
             val navIdent = getNavIdent()
 
             val result = request.validate()
-                .flatMap { service.returnerTilsagn(ReturnerTilsagn(id, navIdent, it.aarsaker, it.forklaring)) }
+                .flatMap {
+                    service.returnerTilsagn(
+                        ReturnerTilsagn(id, navIdent, it.aarsaker, it.forklaring, it.totrinnskontrollId),
+                    )
+                }
                 .mapLeft { ValidationError(errors = it) }
                 .map { HttpStatusCode.OK }
 

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnBeslutningCommand.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnBeslutningCommand.kt
@@ -1,0 +1,17 @@
+package no.nav.mulighetsrommet.api.tilsagn.model
+
+import no.nav.mulighetsrommet.model.Agent
+import no.nav.mulighetsrommet.model.NavIdent
+import java.util.UUID
+
+data class GodkjennTilsagn(
+    val id: UUID,
+    val agent: Agent,
+)
+
+data class ReturnerTilsagn(
+    val id: UUID,
+    val navIdent: NavIdent,
+    val aarsaker: List<TilsagnStatusAarsak>,
+    val forklaring: String?,
+)

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnBeslutningCommand.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilsagn/model/TilsagnBeslutningCommand.kt
@@ -7,6 +7,7 @@ import java.util.UUID
 data class GodkjennTilsagn(
     val id: UUID,
     val agent: Agent,
+    val forventetTotrinnskontrollId: UUID,
 )
 
 data class ReturnerTilsagn(
@@ -14,4 +15,5 @@ data class ReturnerTilsagn(
     val navIdent: NavIdent,
     val aarsaker: List<TilsagnStatusAarsak>,
     val forklaring: String?,
+    val forventetTotrinnskontrollId: UUID,
 )

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/TilskuddBehandlingService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/TilskuddBehandlingService.kt
@@ -17,13 +17,14 @@ import no.nav.mulighetsrommet.api.pdfgen.PdfGenClient
 import no.nav.mulighetsrommet.api.pdfgen.PdfGenError
 import no.nav.mulighetsrommet.api.tilskuddbehandling.db.TilskuddBehandling
 import no.nav.mulighetsrommet.api.tilskuddbehandling.mapper.TilskuddVedtakToVedtaksbrevContent
+import no.nav.mulighetsrommet.api.tilskuddbehandling.model.AttesterTilskudd
+import no.nav.mulighetsrommet.api.tilskuddbehandling.model.ReturnerTilskudd
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingDetaljerDto
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingDto
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingHandling
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingKompakt
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingRequest
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingStatus
-import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingStatusAarsak
 import no.nav.mulighetsrommet.api.tilskuddbehandling.task.JournalforVedtaksbrev
 import no.nav.mulighetsrommet.api.totrinnskontroll.api.toFieldErrors
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingException
@@ -97,11 +98,9 @@ class TilskuddBehandlingService(
         }
     }
 
-    fun attester(
-        id: UUID,
-        navIdent: NavIdent,
-    ): Either<List<FieldError>, TilskuddBehandlingDto> = try {
+    fun attester(command: AttesterTilskudd): Either<List<FieldError>, TilskuddBehandlingDto> = try {
         db.transaction {
+            val (id, navIdent) = command
             val behandling = requireNotNull(queries.tilskuddBehandling.get(id)) {
                 "TilskuddBehandling med id $id ble ikke funnet"
             }
@@ -135,12 +134,8 @@ class TilskuddBehandlingService(
         )
     }
 
-    fun returner(
-        id: UUID,
-        navIdent: NavIdent,
-        aarsaker: List<TilskuddBehandlingStatusAarsak>,
-        forklaring: String?,
-    ): Either<List<FieldError>, TilskuddBehandlingDto> = db.transaction {
+    fun returner(command: ReturnerTilskudd): Either<List<FieldError>, TilskuddBehandlingDto> = db.transaction {
+        val (id, navIdent, aarsaker, forklaring) = command
         val behandling = requireNotNull(queries.tilskuddBehandling.get(id)) {
             "TilskuddBehandling med id $id ble ikke funnet"
         }

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/TilskuddBehandlingService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/TilskuddBehandlingService.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.tilskuddbehandling
 
 import arrow.core.Either
+import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.nel
@@ -100,7 +101,7 @@ class TilskuddBehandlingService(
 
     fun attester(command: AttesterTilskudd): Either<List<FieldError>, TilskuddBehandlingDto> = try {
         db.transaction {
-            val (id, navIdent) = command
+            val (id, navIdent, forventetTotrinnskontrollId) = command
             val behandling = requireNotNull(queries.tilskuddBehandling.get(id)) {
                 "TilskuddBehandling med id $id ble ikke funnet"
             }
@@ -112,7 +113,8 @@ class TilskuddBehandlingService(
             }
 
             val opprettelse = queries.totrinnskontroll.getOrError(id, TotrinnskontrollType.TILSKUDD_OPPRETTELSE)
-            opprettelse.godkjenn(navIdent)
+            opprettelse.sjekkGjeldende(forventetTotrinnskontrollId)
+                .flatMap { it.godkjenn(navIdent) }
                 .mapLeft { it.toFieldErrors() }
                 .map { godkjent ->
                     queries.totrinnskontroll.upsert(godkjent)
@@ -135,7 +137,7 @@ class TilskuddBehandlingService(
     }
 
     fun returner(command: ReturnerTilskudd): Either<List<FieldError>, TilskuddBehandlingDto> = db.transaction {
-        val (id, navIdent, aarsaker, forklaring) = command
+        val (id, navIdent, aarsaker, forklaring, forventetTotrinnskontrollId) = command
         val behandling = requireNotNull(queries.tilskuddBehandling.get(id)) {
             "TilskuddBehandling med id $id ble ikke funnet"
         }
@@ -147,12 +149,14 @@ class TilskuddBehandlingService(
         }
 
         val opprettelse = queries.totrinnskontroll.getOrError(id, TotrinnskontrollType.TILSKUDD_OPPRETTELSE)
-        opprettelse.returner(navIdent, aarsaker.map { it.name }, forklaring).mapLeft { it.toFieldErrors() }.map { returnert ->
-            queries.totrinnskontroll.upsert(returnert)
-            outbox.publish(returnert)
-            queries.tilskuddBehandling.setStatus(id, TilskuddBehandlingStatus.RETURNERT)
-            logEndring("Tilskuddsbehandling returnert", behandling.id, navIdent)
-        }
+        opprettelse.sjekkGjeldende(forventetTotrinnskontrollId)
+            .flatMap { it.returner(navIdent, aarsaker.map { aarsak -> aarsak.name }, forklaring) }
+            .mapLeft { it.toFieldErrors() }.map { returnert ->
+                queries.totrinnskontroll.upsert(returnert)
+                outbox.publish(returnert)
+                queries.tilskuddBehandling.setStatus(id, TilskuddBehandlingStatus.RETURNERT)
+                logEndring("Tilskuddsbehandling returnert", behandling.id, navIdent)
+            }
     }
 
     fun handlinger(behandling: TilskuddBehandlingDto, navIdent: NavIdent): Set<TilskuddBehandlingHandling> = db.session {

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/api/TilskuddBehandlingRoutes.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/api/TilskuddBehandlingRoutes.kt
@@ -23,6 +23,8 @@ import no.nav.mulighetsrommet.api.plugins.queryParameterUuid
 import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.tilskuddbehandling.TilskuddBehandlingService
+import no.nav.mulighetsrommet.api.tilskuddbehandling.model.AttesterTilskudd
+import no.nav.mulighetsrommet.api.tilskuddbehandling.model.ReturnerTilskudd
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingDetaljerDto
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingDto
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingKompakt
@@ -139,7 +141,7 @@ fun Route.tilskuddBehandlingRoutes() {
                 val id = call.parameters.getOrFail<UUID>("id")
                 val navIdent = getNavIdent()
 
-                val result = service.attester(id, navIdent)
+                val result = service.attester(AttesterTilskudd(id, navIdent))
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 
@@ -170,7 +172,7 @@ fun Route.tilskuddBehandlingRoutes() {
                 val navIdent = getNavIdent()
 
                 val result = request.validate()
-                    .flatMap { service.returner(id, navIdent, it.aarsaker, it.forklaring) }
+                    .flatMap { service.returner(ReturnerTilskudd(id, navIdent, it.aarsaker, it.forklaring)) }
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/api/TilskuddBehandlingRoutes.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/api/TilskuddBehandlingRoutes.kt
@@ -14,7 +14,6 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.route
 import io.ktor.server.util.getOrFail
 import io.ktor.server.util.getValue
-import no.nav.mulighetsrommet.api.aarsakerforklaring.AarsakerOgForklaringRequest
 import no.nav.mulighetsrommet.api.domain.navansatt.Rolle
 import no.nav.mulighetsrommet.api.navansatt.ktor.authorize
 import no.nav.mulighetsrommet.api.plugins.getNavIdent
@@ -30,6 +29,8 @@ import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingDto
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingKompakt
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingRequest
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingStatusAarsak
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningMedAarsakerRequest
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningRequest
 import no.nav.mulighetsrommet.ktor.exception.InternalServerError
 import no.nav.mulighetsrommet.ktor.plugins.respondWithProblemDetail
 import no.nav.mulighetsrommet.model.ProblemDetail
@@ -127,6 +128,7 @@ fun Route.tilskuddBehandlingRoutes() {
                 operationId = "attesterTilskuddBehandling"
                 request {
                     pathParameterUuid("id")
+                    body<BeslutningRequest>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -139,9 +141,10 @@ fun Route.tilskuddBehandlingRoutes() {
                 }
             }) {
                 val id = call.parameters.getOrFail<UUID>("id")
+                val request = call.receive<BeslutningRequest>()
                 val navIdent = getNavIdent()
 
-                val result = service.attester(AttesterTilskudd(id, navIdent))
+                val result = service.attester(AttesterTilskudd(id, navIdent, request.totrinnskontrollId))
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 
@@ -155,7 +158,7 @@ fun Route.tilskuddBehandlingRoutes() {
                 operationId = "returnerTilskuddBehandling"
                 request {
                     pathParameterUuid("id")
-                    body<AarsakerOgForklaringRequest<TilskuddBehandlingStatusAarsak>>()
+                    body<BeslutningMedAarsakerRequest<TilskuddBehandlingStatusAarsak>>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -168,11 +171,11 @@ fun Route.tilskuddBehandlingRoutes() {
                 }
             }) {
                 val id = call.parameters.getOrFail<UUID>("id")
-                val request = call.receive<AarsakerOgForklaringRequest<TilskuddBehandlingStatusAarsak>>()
+                val request = call.receive<BeslutningMedAarsakerRequest<TilskuddBehandlingStatusAarsak>>()
                 val navIdent = getNavIdent()
 
                 val result = request.validate()
-                    .flatMap { service.returner(ReturnerTilskudd(id, navIdent, it.aarsaker, it.forklaring)) }
+                    .flatMap { service.returner(ReturnerTilskudd(id, navIdent, it.aarsaker, it.forklaring, it.totrinnskontrollId)) }
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/kafka/TilskuddArrangorUtbetalingConsumer.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/kafka/TilskuddArrangorUtbetalingConsumer.kt
@@ -10,6 +10,7 @@ import no.nav.mulighetsrommet.api.TransactionalQueryContext
 import no.nav.mulighetsrommet.api.contracts.totrinnskontroll.TotrinnskontrollHendelse
 import no.nav.mulighetsrommet.api.domain.totrinnskontroll.TotrinnskontrollType
 import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
+import no.nav.mulighetsrommet.api.tilsagn.model.GodkjennTilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.Tilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnBeregningRequest
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnBeregningType
@@ -129,7 +130,7 @@ class TilskuddArrangorUtbetalingConsumer(
             Tiltaksadministrasjon,
         )
             .flatMap {
-                tilsagnService.godkjennTilsagnInTx(it.id, Tiltaksadministrasjon)
+                tilsagnService.godkjennTilsagnInTx(GodkjennTilsagn(it.id, Tiltaksadministrasjon))
             }
             .getOrElse {
                 throw IllegalStateException("Feil under opprettelse av tilsagn for tilskudd. Errors: $it")

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/kafka/TilskuddArrangorUtbetalingConsumer.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/kafka/TilskuddArrangorUtbetalingConsumer.kt
@@ -130,7 +130,8 @@ class TilskuddArrangorUtbetalingConsumer(
             Tiltaksadministrasjon,
         )
             .flatMap {
-                tilsagnService.godkjennTilsagnInTx(GodkjennTilsagn(it.id, Tiltaksadministrasjon))
+                val totrinnskontrollId = queries.totrinnskontroll.getOrError(it.id, TotrinnskontrollType.TILSAGN_OPPRETTELSE).id
+                tilsagnService.godkjennTilsagnInTx(GodkjennTilsagn(it.id, Tiltaksadministrasjon, totrinnskontrollId))
             }
             .getOrElse {
                 throw IllegalStateException("Feil under opprettelse av tilsagn for tilskudd. Errors: $it")

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/model/TilskuddBehandlingBeslutningCommand.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/model/TilskuddBehandlingBeslutningCommand.kt
@@ -1,0 +1,16 @@
+package no.nav.mulighetsrommet.api.tilskuddbehandling.model
+
+import no.nav.mulighetsrommet.model.NavIdent
+import java.util.UUID
+
+data class AttesterTilskudd(
+    val id: UUID,
+    val navIdent: NavIdent,
+)
+
+data class ReturnerTilskudd(
+    val id: UUID,
+    val navIdent: NavIdent,
+    val aarsaker: List<TilskuddBehandlingStatusAarsak>,
+    val forklaring: String?,
+)

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/model/TilskuddBehandlingBeslutningCommand.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/model/TilskuddBehandlingBeslutningCommand.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 data class AttesterTilskudd(
     val id: UUID,
     val navIdent: NavIdent,
+    val forventetTotrinnskontrollId: UUID,
 )
 
 data class ReturnerTilskudd(
@@ -13,4 +14,5 @@ data class ReturnerTilskudd(
     val navIdent: NavIdent,
     val aarsaker: List<TilskuddBehandlingStatusAarsak>,
     val forklaring: String?,
+    val forventetTotrinnskontrollId: UUID,
 )

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/totrinnskontroll/api/BeslutningRequest.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/totrinnskontroll/api/BeslutningRequest.kt
@@ -1,0 +1,40 @@
+package no.nav.mulighetsrommet.api.totrinnskontroll.api
+
+import arrow.core.Either
+import kotlinx.serialization.Serializable
+import no.nav.mulighetsrommet.api.aarsakerforklaring.AarsakerOgForklaringRequest
+import no.nav.mulighetsrommet.model.FieldError
+import no.nav.mulighetsrommet.serializers.UUIDSerializer
+import java.util.UUID
+
+/**
+ * Body for beslutter/attestant-endepunkter uten årsaker (godkjenn, attester, ...).
+ * `totrinnskontrollId` må være id-en til den totrinnskontrollen som faktisk er til behandling,
+ * slik at klienten ikke kan beslutte på et utdatert grunnlag den ikke har sett oppdatert.
+ */
+@Serializable
+data class BeslutningRequest(
+    @Serializable(with = UUIDSerializer::class)
+    val totrinnskontrollId: UUID,
+)
+
+/**
+ * Body for beslutter/attestant-endepunkter som også krever årsaker og forklaring (returner, ...).
+ * Se [BeslutningRequest] for hvorfor `totrinnskontrollId` er påkrevd.
+ */
+@Serializable
+data class BeslutningMedAarsakerRequest<T>(
+    @Serializable(with = UUIDSerializer::class)
+    val totrinnskontrollId: UUID,
+    val aarsaker: List<T>,
+    val forklaring: String?,
+) {
+    fun validate(): Either<List<FieldError>, BeslutningMedAarsakerRequest<T>> = AarsakerOgForklaringRequest(aarsaker, forklaring).validate().map { this }
+}
+
+@Serializable
+data class SettPaVentRequest(
+    @Serializable(with = UUIDSerializer::class)
+    val totrinnskontrollId: UUID,
+    val forklaring: String? = null,
+)

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/totrinnskontroll/api/TotrinnskontrollErrorMapper.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/totrinnskontroll/api/TotrinnskontrollErrorMapper.kt
@@ -1,8 +1,28 @@
 package no.nav.mulighetsrommet.api.totrinnskontroll.api
 
+import arrow.core.Either
+import no.nav.mulighetsrommet.api.QueryContext
 import no.nav.mulighetsrommet.api.domain.totrinnskontroll.TotrinnskontrollError
 import no.nav.mulighetsrommet.api.domain.totrinnskontroll.TotrinnskontrollStatus
+import no.nav.mulighetsrommet.api.domain.totrinnskontroll.TotrinnskontrollType
 import no.nav.mulighetsrommet.model.FieldError
+import java.util.UUID
+
+/**
+ * Validerer at [forventetTotrinnskontrollId] er id-en til den totrinnskontrollen som faktisk er til
+ * behandling for ([entityId], [type]) akkurat nå. Skal kalles én gang per beslutter/attestant-endepunkt,
+ * rett etter at man har bestemt hvilken totrinnskontroll som er relevant, og før man kaller
+ * `godkjenn`/`returner`/`settPaVent` på den. Interne/automatiske flows har ingen ekstern forventning å
+ * validere mot og skal ikke kalle denne.
+ */
+fun QueryContext.sjekkGjeldendeTotrinnskontroll(
+    entityId: UUID,
+    type: TotrinnskontrollType,
+    forventetTotrinnskontrollId: UUID,
+): Either<List<FieldError>, Unit> = queries.totrinnskontroll.getOrError(entityId, type)
+    .sjekkGjeldende(forventetTotrinnskontrollId)
+    .mapLeft { it.toFieldErrors() }
+    .map { }
 
 fun TotrinnskontrollError.toFieldErrors(): List<FieldError> = when (this) {
     is TotrinnskontrollError.AlleredeBesluttet -> {
@@ -20,4 +40,7 @@ fun TotrinnskontrollError.toFieldErrors(): List<FieldError> = when (this) {
 
     TotrinnskontrollError.KanBareTilbakestillesNarSattPaVent ->
         listOf(FieldError.of("Totrinnskontrollen kan bare tilbakestilles når den er satt på vent"))
+
+    is TotrinnskontrollError.UtdatertGrunnlag ->
+        listOf(FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."))
 }

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingRoutes.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingRoutes.kt
@@ -28,6 +28,8 @@ import no.nav.mulighetsrommet.api.plugins.queryParameterUuid
 import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.tilsagn.api.KostnadsstedDto
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningMedAarsakerRequest
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningRequest
 import no.nav.mulighetsrommet.api.utbetaling.model.AttesterUtbetalingLinje
 import no.nav.mulighetsrommet.api.utbetaling.model.AvbrytUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.AvslaAvbrytUtbetaling
@@ -300,6 +302,7 @@ fun Route.utbetalingRoutes() {
                 operationId = "godkjennAvbrytelseUtbetaling"
                 request {
                     pathParameterUuid("id")
+                    body<BeslutningRequest>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -312,9 +315,10 @@ fun Route.utbetalingRoutes() {
                 }
             }) {
                 val id = call.parameters.getOrFail<UUID>("id")
+                val request = call.receive<BeslutningRequest>()
                 val navIdent = getNavIdent()
 
-                utbetalingService.godkjennAvbrytelse(GodkjennAvbrytUtbetaling(id, navIdent))
+                utbetalingService.godkjennAvbrytelse(GodkjennAvbrytUtbetaling(id, navIdent, request.totrinnskontrollId))
                     .onLeft { call.respondWithProblemDetail(ValidationError(errors = it)) }
                     .onRight { call.respond(HttpStatusCode.OK) }
             }
@@ -325,7 +329,7 @@ fun Route.utbetalingRoutes() {
                 operationId = "avslaAvbrytelseUtbetaling"
                 request {
                     pathParameterUuid("id")
-                    body<AarsakerOgForklaringRequest<UtbetalingStatusAarsak>>()
+                    body<BeslutningMedAarsakerRequest<UtbetalingStatusAarsak>>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -338,7 +342,7 @@ fun Route.utbetalingRoutes() {
                 }
             }) {
                 val id = call.parameters.getOrFail<UUID>("id")
-                val request = call.receive<AarsakerOgForklaringRequest<UtbetalingStatusAarsak>>()
+                val request = call.receive<BeslutningMedAarsakerRequest<UtbetalingStatusAarsak>>()
                 val navIdent = getNavIdent()
                 request.validate().flatMap {
                     val command = AvslaAvbrytUtbetaling(
@@ -346,6 +350,7 @@ fun Route.utbetalingRoutes() {
                         besluttetAv = navIdent,
                         aarsaker = it.aarsaker,
                         forklaring = it.forklaring,
+                        forventetTotrinnskontrollId = it.totrinnskontrollId,
                     )
                     utbetalingService.avslaAvbrytelse(command)
                 }
@@ -482,6 +487,7 @@ fun Route.utbetalingRoutes() {
                 operationId = "attesterUtbetalingLinje"
                 request {
                     pathParameterUuid("id")
+                    body<BeslutningRequest>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -494,9 +500,15 @@ fun Route.utbetalingRoutes() {
                 }
             }) {
                 val id: UUID by call.parameters
+                val request = call.receive<BeslutningRequest>()
                 val navIdent = getNavIdent()
 
-                val result = utbetalingService.godkjennUtbetalingLinje(AttesterUtbetalingLinje(id, navIdent))
+                val command = AttesterUtbetalingLinje(
+                    id,
+                    navIdent,
+                    request.totrinnskontrollId,
+                )
+                val result = utbetalingService.godkjennUtbetalingLinje(command)
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 
@@ -510,7 +522,7 @@ fun Route.utbetalingRoutes() {
                 operationId = "returnerUtbetalingLinje"
                 request {
                     pathParameterUuid("id")
-                    body<AarsakerOgForklaringRequest<UtbetalingLinjeReturnertAarsak>>()
+                    body<BeslutningMedAarsakerRequest<UtbetalingLinjeReturnertAarsak>>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -523,7 +535,7 @@ fun Route.utbetalingRoutes() {
                 }
             }) {
                 val id: UUID by call.parameters
-                val request = call.receive<AarsakerOgForklaringRequest<UtbetalingLinjeReturnertAarsak>>()
+                val request = call.receive<BeslutningMedAarsakerRequest<UtbetalingLinjeReturnertAarsak>>()
                 val navIdent = getNavIdent()
 
                 val result = request.validate()
@@ -533,6 +545,7 @@ fun Route.utbetalingRoutes() {
                             it.aarsaker,
                             it.forklaring,
                             navIdent,
+                            it.totrinnskontrollId,
                         )
                         utbetalingService.returnerUtbetalingLinje(command)
                     }

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingRoutes.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingRoutes.kt
@@ -28,9 +28,14 @@ import no.nav.mulighetsrommet.api.plugins.queryParameterUuid
 import no.nav.mulighetsrommet.api.responses.ValidationError
 import no.nav.mulighetsrommet.api.responses.respondWithStatusResponse
 import no.nav.mulighetsrommet.api.tilsagn.api.KostnadsstedDto
+import no.nav.mulighetsrommet.api.utbetaling.model.AttesterUtbetalingLinje
+import no.nav.mulighetsrommet.api.utbetaling.model.AvbrytUtbetaling
+import no.nav.mulighetsrommet.api.utbetaling.model.AvslaAvbrytUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.DeltakerAdvarselDto
+import no.nav.mulighetsrommet.api.utbetaling.model.GodkjennAvbrytUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.OpprettUtbetalingLinje
 import no.nav.mulighetsrommet.api.utbetaling.model.OpprettUtbetalingLinjer
+import no.nav.mulighetsrommet.api.utbetaling.model.ReturnerUtbetalingLinje
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregningOutputDeltakelse
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingLinjeReturnertAarsak
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingStatusAarsak
@@ -274,7 +279,14 @@ fun Route.utbetalingRoutes() {
                 val navIdent = getNavIdent()
 
                 request.validate().flatMap {
-                    utbetalingService.sendTilAvbrytelse(id, navIdent, it)
+                    val command = AvbrytUtbetaling(
+                        id = id,
+                        agent = navIdent,
+                        operation = "Utbetaling sendt til avbrytelse ved behandling av utbetaling",
+                        aarsaker = it.aarsaker,
+                        forklaring = it.forklaring,
+                    )
+                    utbetalingService.sendTilAvbrytelse(command)
                 }
                     .onLeft { call.respondWithProblemDetail(ValidationError(errors = it)) }
                     .onRight {
@@ -302,7 +314,7 @@ fun Route.utbetalingRoutes() {
                 val id = call.parameters.getOrFail<UUID>("id")
                 val navIdent = getNavIdent()
 
-                utbetalingService.godkjennAvbrytelse(id, navIdent)
+                utbetalingService.godkjennAvbrytelse(GodkjennAvbrytUtbetaling(id, navIdent))
                     .onLeft { call.respondWithProblemDetail(ValidationError(errors = it)) }
                     .onRight { call.respond(HttpStatusCode.OK) }
             }
@@ -329,7 +341,13 @@ fun Route.utbetalingRoutes() {
                 val request = call.receive<AarsakerOgForklaringRequest<UtbetalingStatusAarsak>>()
                 val navIdent = getNavIdent()
                 request.validate().flatMap {
-                    utbetalingService.avslaAvbrytelse(id, navIdent, it)
+                    val command = AvslaAvbrytUtbetaling(
+                        id = id,
+                        besluttetAv = navIdent,
+                        aarsaker = it.aarsaker,
+                        forklaring = it.forklaring,
+                    )
+                    utbetalingService.avslaAvbrytelse(command)
                 }
                     .onLeft { call.respondWithProblemDetail(ValidationError(errors = it)) }
                     .onRight { call.respond(HttpStatusCode.OK) }
@@ -478,7 +496,7 @@ fun Route.utbetalingRoutes() {
                 val id: UUID by call.parameters
                 val navIdent = getNavIdent()
 
-                val result = utbetalingService.godkjennUtbetalingLinje(id, navIdent)
+                val result = utbetalingService.godkjennUtbetalingLinje(AttesterUtbetalingLinje(id, navIdent))
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 
@@ -509,7 +527,15 @@ fun Route.utbetalingRoutes() {
                 val navIdent = getNavIdent()
 
                 val result = request.validate()
-                    .flatMap { utbetalingService.returnerUtbetalingLinje(id, it.aarsaker, it.forklaring, navIdent) }
+                    .flatMap {
+                        val command = ReturnerUtbetalingLinje(
+                            id,
+                            it.aarsaker,
+                            it.forklaring,
+                            navIdent,
+                        )
+                        utbetalingService.returnerUtbetalingLinje(command)
+                    }
                     .mapLeft { ValidationError(errors = it) }
                     .map { HttpStatusCode.OK }
 

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/Utbetaling.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/Utbetaling.kt
@@ -1,6 +1,7 @@
 package no.nav.mulighetsrommet.api.utbetaling.model
 
 import arrow.core.Either
+import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.nel
 import arrow.core.right
@@ -91,28 +92,33 @@ data class Utbetaling(
         ).right()
     }
 
-    fun godkjennAvbrytelse(agent: Agent): Either<List<FieldError>, Utbetaling> {
+    fun godkjennAvbrytelse(agent: Agent, forventetTotrinnskontrollId: UUID): Either<List<FieldError>, Utbetaling> {
         if (status != UtbetalingStatusType.TIL_AVBRYTELSE) {
             return FieldError.of("Utbetalingen kan ikke avbrytes")
                 .nel()
                 .left()
         }
-        return avbrytelse!!.totrinnskontroll.godkjenn(agent).mapLeft { it.toFieldErrors() }.map { godkjent ->
-            copy(avbrytelse = avbrytelse.copy(totrinnskontroll = godkjent), status = UtbetalingStatusType.AVBRUTT)
-        }
+        return avbrytelse!!.totrinnskontroll.sjekkGjeldende(forventetTotrinnskontrollId)
+            .flatMap { it.godkjenn(agent) }
+            .mapLeft { it.toFieldErrors() }.map { godkjent ->
+                copy(avbrytelse = avbrytelse.copy(totrinnskontroll = godkjent), status = UtbetalingStatusType.AVBRUTT)
+            }
     }
 
     fun avslaAbrytelse(
         besluttetAv: NavIdent,
         aarsaker: List<String>,
         forklaring: String?,
+        forventetTotrinnskontrollId: UUID,
     ): Either<List<FieldError>, Utbetaling> {
         if (status != UtbetalingStatusType.TIL_AVBRYTELSE) {
             return FieldError.of("Utbetalingen er ikke til avbrytelse")
                 .nel()
                 .left()
         }
-        return avbrytelse!!.totrinnskontroll.returner(besluttetAv, aarsaker, forklaring).mapLeft { it.toFieldErrors() }
+        return avbrytelse!!.totrinnskontroll.sjekkGjeldende(forventetTotrinnskontrollId)
+            .flatMap { it.returner(besluttetAv, aarsaker, forklaring) }
+            .mapLeft { it.toFieldErrors() }
             .map { retunert ->
                 copy(avbrytelse = avbrytelse.copy(totrinnskontroll = retunert), status = avbrytelse.returnert)
             }

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/UtbetalingBeslutningCommand.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/UtbetalingBeslutningCommand.kt
@@ -1,0 +1,37 @@
+package no.nav.mulighetsrommet.api.utbetaling.model
+
+import no.nav.mulighetsrommet.model.Agent
+import no.nav.mulighetsrommet.model.NavIdent
+import java.util.UUID
+
+data class AttesterUtbetalingLinje(
+    val id: UUID,
+    val agent: Agent,
+)
+
+data class ReturnerUtbetalingLinje(
+    val id: UUID,
+    val aarsaker: List<UtbetalingLinjeReturnertAarsak>,
+    val forklaring: String?,
+    val agent: Agent,
+)
+
+data class AvbrytUtbetaling(
+    val id: UUID,
+    val agent: Agent,
+    val operation: String,
+    val aarsaker: List<UtbetalingStatusAarsak>,
+    val forklaring: String?,
+)
+
+data class GodkjennAvbrytUtbetaling(
+    val id: UUID,
+    val agent: Agent,
+)
+
+data class AvslaAvbrytUtbetaling(
+    val id: UUID,
+    val besluttetAv: NavIdent,
+    val aarsaker: List<UtbetalingStatusAarsak>,
+    val forklaring: String?,
+)

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/UtbetalingBeslutningCommand.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/model/UtbetalingBeslutningCommand.kt
@@ -7,6 +7,7 @@ import java.util.UUID
 data class AttesterUtbetalingLinje(
     val id: UUID,
     val agent: Agent,
+    val forventetTotrinnskontrollId: UUID,
 )
 
 data class ReturnerUtbetalingLinje(
@@ -14,6 +15,7 @@ data class ReturnerUtbetalingLinje(
     val aarsaker: List<UtbetalingLinjeReturnertAarsak>,
     val forklaring: String?,
     val agent: Agent,
+    val forventetTotrinnskontrollId: UUID,
 )
 
 data class AvbrytUtbetaling(
@@ -27,6 +29,7 @@ data class AvbrytUtbetaling(
 data class GodkjennAvbrytUtbetaling(
     val id: UUID,
     val agent: Agent,
+    val forventetTotrinnskontrollId: UUID,
 )
 
 data class AvslaAvbrytUtbetaling(
@@ -34,4 +37,5 @@ data class AvslaAvbrytUtbetaling(
     val besluttetAv: NavIdent,
     val aarsaker: List<UtbetalingStatusAarsak>,
     val forklaring: String?,
+    val forventetTotrinnskontrollId: UUID,
 )

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingService.kt
@@ -6,7 +6,6 @@ import arrow.core.left
 import arrow.core.nel
 import no.nav.mulighetsrommet.admin.totrinnskontroll.TotrinnskontrollDto
 import no.nav.mulighetsrommet.api.ApiDatabase
-import no.nav.mulighetsrommet.api.aarsakerforklaring.AarsakerOgForklaringRequest
 import no.nav.mulighetsrommet.api.domain.arrangor.Arrangor
 import no.nav.mulighetsrommet.api.domain.navansatt.NavAnsatt
 import no.nav.mulighetsrommet.api.domain.navansatt.Rolle
@@ -21,14 +20,17 @@ import no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingHandling
 import no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingLinjeDto
 import no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingLinjeHandling
 import no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingLinjeStatusDto
+import no.nav.mulighetsrommet.api.utbetaling.model.AttesterUtbetalingLinje
+import no.nav.mulighetsrommet.api.utbetaling.model.AvbrytUtbetaling
+import no.nav.mulighetsrommet.api.utbetaling.model.AvslaAvbrytUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.DeltakerAdvarsel
+import no.nav.mulighetsrommet.api.utbetaling.model.GodkjennAvbrytUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.OpprettUtbetalingLinjer
+import no.nav.mulighetsrommet.api.utbetaling.model.ReturnerUtbetalingLinje
 import no.nav.mulighetsrommet.api.utbetaling.model.UpsertUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.Utbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingLinje
-import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingLinjeReturnertAarsak
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingLinjeStatus
-import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingStatusAarsak
 import no.nav.mulighetsrommet.api.utbetaling.model.hentDeltakerAdvarslerForUtbetaling
 import no.nav.mulighetsrommet.featuretoggle.model.FeatureToggle
 import no.nav.mulighetsrommet.featuretoggle.service.FeatureToggleService
@@ -53,7 +55,9 @@ class AdminUtbetalingService(
     fun getUtbetalingDetaljer(id: UUID, navIdent: NavIdent): UtbetalingDetaljerDto = db.session {
         val utbetaling = queries.utbetaling.getOrError(id)
         val linjer = queries.utbetalingLinje.getByUtbetalingId(id)
-        val avbrytelse = utbetaling.avbrytelse?.totrinnskontroll?.let { queries.totrinnskontroll.getDtoByIdOrError(it.id) }
+        val avbrytelse = utbetaling.avbrytelse?.totrinnskontroll?.let {
+            queries.totrinnskontroll.getDtoByIdOrError(it.id)
+        }
         val dto = UtbetalingDto.fromUtbetaling(
             utbetaling = utbetaling,
             linjer = linjer,
@@ -225,50 +229,33 @@ class AdminUtbetalingService(
     }
 
     fun sendTilAvbrytelse(
-        id: UUID,
-        navIdent: NavIdent,
-        request: AarsakerOgForklaringRequest<UtbetalingStatusAarsak>,
+        command: AvbrytUtbetaling,
     ): Either<List<FieldError>, Utbetaling> = db.transaction {
-        utbetalingService.sendTilAvbrytelse(
-            id = id,
-            agent = navIdent,
-            operation = "Utbetaling sendt til avbrytelse ved behandling av utbetaling",
-            aarsaker = request.aarsaker.map { it.name },
-            forklaring = request.forklaring,
-        )
+        utbetalingService.sendTilAvbrytelse(command)
     }
 
-    fun godkjennAvbrytelse(id: UUID, navIdent: NavIdent): Either<List<FieldError>, Utbetaling> = db.transaction {
-        return utbetalingService.godkjennAvbrytelse(id, navIdent)
+    fun godkjennAvbrytelse(
+        command: GodkjennAvbrytUtbetaling,
+    ): Either<List<FieldError>, Utbetaling> = db.transaction {
+        return utbetalingService.godkjennAvbrytelse(command)
     }
 
     fun avslaAvbrytelse(
-        id: UUID,
-        navIdent: NavIdent,
-        request: AarsakerOgForklaringRequest<UtbetalingStatusAarsak>,
+        command: AvslaAvbrytUtbetaling,
     ): Either<List<FieldError>, Utbetaling> = db.transaction {
-        return utbetalingService.avslaAvbrytelse(
-            id = id,
-            besluttetAv = navIdent,
-            aarsaker = request.aarsaker.map { it.name },
-            forklaring = request.forklaring,
-        )
+        return utbetalingService.avslaAvbrytelse(command)
     }
 
     fun godkjennUtbetalingLinje(
-        id: UUID,
-        navIdent: NavIdent,
+        command: AttesterUtbetalingLinje,
     ): Either<List<FieldError>, Utbetaling> = db.transaction {
-        utbetalingService.attesterUtbetalingLinje(id, navIdent)
+        utbetalingService.attesterUtbetalingLinje(command)
     }
 
     fun returnerUtbetalingLinje(
-        id: UUID,
-        aarsaker: List<UtbetalingLinjeReturnertAarsak>,
-        forklaring: String?,
-        navIdent: NavIdent,
+        command: ReturnerUtbetalingLinje,
     ): Either<List<FieldError>, Utbetaling> = db.transaction {
-        utbetalingService.returnerUtbetalingLinje(id, aarsaker, forklaring, navIdent)
+        utbetalingService.returnerUtbetalingLinje(command)
     }
 
     fun slettKorreksjon(id: UUID): Either<List<FieldError>, Unit> = db.transaction {

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/UtbetalingService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/UtbetalingService.kt
@@ -28,8 +28,13 @@ import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnType
 import no.nav.mulighetsrommet.api.totrinnskontroll.api.toFieldErrors
 import no.nav.mulighetsrommet.api.utbetaling.db.UtbetalingDbo
 import no.nav.mulighetsrommet.api.utbetaling.db.UtbetalingLinjeDbo
+import no.nav.mulighetsrommet.api.utbetaling.model.AttesterUtbetalingLinje
 import no.nav.mulighetsrommet.api.utbetaling.model.AutomatisertUtbetalingResult
+import no.nav.mulighetsrommet.api.utbetaling.model.AvbrytUtbetaling
+import no.nav.mulighetsrommet.api.utbetaling.model.AvslaAvbrytUtbetaling
+import no.nav.mulighetsrommet.api.utbetaling.model.GodkjennAvbrytUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.OpprettUtbetalingLinje
+import no.nav.mulighetsrommet.api.utbetaling.model.ReturnerUtbetalingLinje
 import no.nav.mulighetsrommet.api.utbetaling.model.UpsertUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.Utbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregning
@@ -193,10 +198,8 @@ class UtbetalingService(
     }
 
     context(tx: TransactionalQueryContext)
-    fun attesterUtbetalingLinje(
-        id: UUID,
-        agent: Agent,
-    ): Either<List<FieldError>, Utbetaling> = with(tx) {
+    fun attesterUtbetalingLinje(command: AttesterUtbetalingLinje): Either<List<FieldError>, Utbetaling> = with(tx) {
+        val (id, agent) = command
         val linje = queries.utbetalingLinje.getOrError(id)
         val utbetaling = queries.utbetaling.getAndAquireLock(linje.utbetalingId)
 
@@ -226,12 +229,8 @@ class UtbetalingService(
     }
 
     context(tx: TransactionalQueryContext)
-    fun returnerUtbetalingLinje(
-        id: UUID,
-        aarsaker: List<UtbetalingLinjeReturnertAarsak>,
-        forklaring: String?,
-        agent: Agent,
-    ): Either<List<FieldError>, Utbetaling> = with(tx) {
+    fun returnerUtbetalingLinje(command: ReturnerUtbetalingLinje): Either<List<FieldError>, Utbetaling> = with(tx) {
+        val (id, aarsaker, forklaring, agent) = command
         val linje = queries.utbetalingLinje.getOrError(id)
         val utbetaling = queries.utbetaling.getAndAquireLock(linje.utbetalingId)
 
@@ -280,9 +279,10 @@ class UtbetalingService(
     }
 
     context(tx: TransactionalQueryContext)
-    fun sendTilAvbrytelse(id: UUID, agent: Agent, operation: String, aarsaker: List<String>, forklaring: String?): Either<List<FieldError>, Utbetaling> = with(tx) {
+    fun sendTilAvbrytelse(command: AvbrytUtbetaling): Either<List<FieldError>, Utbetaling> = with(tx) {
+        val (id, agent, operation, aarsaker, forklaring) = command
         val utbetaling = queries.utbetaling.getAndAquireLock(id)
-        return utbetaling.settTilAbrytelse(agent, aarsaker, forklaring).map { utbetalingTilAvbrytelse ->
+        return utbetaling.settTilAbrytelse(agent, aarsaker.map { it.name }, forklaring).map { utbetalingTilAvbrytelse ->
             queries.utbetaling.save(utbetalingTilAvbrytelse)
 
             outbox.publish(utbetalingTilAvbrytelse.avbrytelse!!.totrinnskontroll)
@@ -291,7 +291,8 @@ class UtbetalingService(
     }
 
     context(tx: TransactionalQueryContext)
-    fun godkjennAvbrytelse(id: UUID, agent: Agent): Either<List<FieldError>, Utbetaling> = with(tx) {
+    fun godkjennAvbrytelse(command: GodkjennAvbrytUtbetaling): Either<List<FieldError>, Utbetaling> = with(tx) {
+        val (id, agent) = command
         val utbetaling = queries.utbetaling.getAndAquireLock(id)
 
         return utbetaling.godkjennAvbrytelse(agent).map { avbruttUtbetaling ->
@@ -304,9 +305,10 @@ class UtbetalingService(
     }
 
     context(tx: TransactionalQueryContext)
-    fun avslaAvbrytelse(id: UUID, besluttetAv: NavIdent, aarsaker: List<String>, forklaring: String?): Either<List<FieldError>, Utbetaling> = with(tx) {
+    fun avslaAvbrytelse(command: AvslaAvbrytUtbetaling): Either<List<FieldError>, Utbetaling> = with(tx) {
+        val (id, besluttetAv, aarsaker, forklaring) = command
         val utbetaling = queries.utbetaling.getAndAquireLock(id)
-        return utbetaling.avslaAbrytelse(besluttetAv, aarsaker, forklaring).map { utbetalingTilSaksbehandling ->
+        return utbetaling.avslaAbrytelse(besluttetAv, aarsaker.map { it.name }, forklaring).map { utbetalingTilSaksbehandling ->
             queries.utbetaling.save(utbetalingTilSaksbehandling)
 
             outbox.publish(utbetalingTilSaksbehandling.avbrytelse!!.totrinnskontroll)
@@ -434,7 +436,9 @@ class UtbetalingService(
         sendTilAttestering(utbetaling.id, linjer, Tiltaksadministrasjon).onLeft { throw UtbetalingException(it) }
 
         linjer.forEach { linje ->
-            attesterUtbetalingLinje(linje.id, Tiltaksadministrasjon).onLeft { throw UtbetalingException(it) }
+            attesterUtbetalingLinje(
+                AttesterUtbetalingLinje(linje.id, Tiltaksadministrasjon),
+            ).onLeft { throw UtbetalingException(it) }
         }
 
         AutomatisertUtbetalingResult.GODKJENT

--- a/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/UtbetalingService.kt
+++ b/mulighetsrommet-api/server/src/main/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/UtbetalingService.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.utbetaling.service
 
 import arrow.core.Either
 import arrow.core.NonEmptyList
+import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.nel
@@ -25,6 +26,7 @@ import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
 import no.nav.mulighetsrommet.api.tilsagn.model.Tilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatus
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnType
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.sjekkGjeldendeTotrinnskontroll
 import no.nav.mulighetsrommet.api.totrinnskontroll.api.toFieldErrors
 import no.nav.mulighetsrommet.api.utbetaling.db.UtbetalingDbo
 import no.nav.mulighetsrommet.api.utbetaling.db.UtbetalingLinjeDbo
@@ -199,7 +201,7 @@ class UtbetalingService(
 
     context(tx: TransactionalQueryContext)
     fun attesterUtbetalingLinje(command: AttesterUtbetalingLinje): Either<List<FieldError>, Utbetaling> = with(tx) {
-        val (id, agent) = command
+        val (id, agent, forventetTotrinnskontrollId) = command
         val linje = queries.utbetalingLinje.getOrError(id)
         val utbetaling = queries.utbetaling.getAndAquireLock(linje.utbetalingId)
 
@@ -225,12 +227,17 @@ class UtbetalingService(
             }
         }
 
-        attesterUtbetalingLinje(linje, agent)
+        sjekkGjeldendeTotrinnskontroll(
+            linje.id,
+            TotrinnskontrollType.UTBETALING_LINJE_OPPRETTELSE,
+            forventetTotrinnskontrollId,
+        )
+            .flatMap { attesterUtbetalingLinje(linje, agent) }
     }
 
     context(tx: TransactionalQueryContext)
     fun returnerUtbetalingLinje(command: ReturnerUtbetalingLinje): Either<List<FieldError>, Utbetaling> = with(tx) {
-        val (id, aarsaker, forklaring, agent) = command
+        val (id, aarsaker, forklaring, agent, forventetTotrinnskontrollId) = command
         val linje = queries.utbetalingLinje.getOrError(id)
         val utbetaling = queries.utbetaling.getAndAquireLock(linje.utbetalingId)
 
@@ -254,7 +261,12 @@ class UtbetalingService(
             }
         }
 
-        returnerUtbetalingLinje(linje, aarsaker, forklaring, agent).right()
+        sjekkGjeldendeTotrinnskontroll(
+            linje.id,
+            TotrinnskontrollType.UTBETALING_LINJE_OPPRETTELSE,
+            forventetTotrinnskontrollId,
+        )
+            .map { returnerUtbetalingLinje(linje, aarsaker, forklaring, agent) }
     }
 
     context(tx: TransactionalQueryContext)
@@ -292,10 +304,10 @@ class UtbetalingService(
 
     context(tx: TransactionalQueryContext)
     fun godkjennAvbrytelse(command: GodkjennAvbrytUtbetaling): Either<List<FieldError>, Utbetaling> = with(tx) {
-        val (id, agent) = command
+        val (id, agent, forventetTotrinnskontrollId) = command
         val utbetaling = queries.utbetaling.getAndAquireLock(id)
 
-        return utbetaling.godkjennAvbrytelse(agent).map { avbruttUtbetaling ->
+        return utbetaling.godkjennAvbrytelse(agent, forventetTotrinnskontrollId).map { avbruttUtbetaling ->
             queries.utbetaling.save(avbruttUtbetaling)
             queries.utbetalingLinje.setAvbruttStatusLinjer(utbetaling.id)
 
@@ -306,14 +318,15 @@ class UtbetalingService(
 
     context(tx: TransactionalQueryContext)
     fun avslaAvbrytelse(command: AvslaAvbrytUtbetaling): Either<List<FieldError>, Utbetaling> = with(tx) {
-        val (id, besluttetAv, aarsaker, forklaring) = command
+        val (id, besluttetAv, aarsaker, forklaring, forventetTotrinnskontrollId) = command
         val utbetaling = queries.utbetaling.getAndAquireLock(id)
-        return utbetaling.avslaAbrytelse(besluttetAv, aarsaker.map { it.name }, forklaring).map { utbetalingTilSaksbehandling ->
-            queries.utbetaling.save(utbetalingTilSaksbehandling)
+        return utbetaling.avslaAbrytelse(besluttetAv, aarsaker.map { it.name }, forklaring, forventetTotrinnskontrollId)
+            .map { utbetalingTilSaksbehandling ->
+                queries.utbetaling.save(utbetalingTilSaksbehandling)
 
-            outbox.publish(utbetalingTilSaksbehandling.avbrytelse!!.totrinnskontroll)
-            logEndring("Avbrytelse avvist", utbetaling.id, besluttetAv)
-        }
+                outbox.publish(utbetalingTilSaksbehandling.avbrytelse!!.totrinnskontroll)
+                logEndring("Avbrytelse avvist", utbetaling.id, besluttetAv)
+            }
     }
 
     context(tx: TransactionalQueryContext)
@@ -436,8 +449,9 @@ class UtbetalingService(
         sendTilAttestering(utbetaling.id, linjer, Tiltaksadministrasjon).onLeft { throw UtbetalingException(it) }
 
         linjer.forEach { linje ->
+            val totrinnskontrollId = getTotrinnskontroll(linje.id).id
             attesterUtbetalingLinje(
-                AttesterUtbetalingLinje(linje.id, Tiltaksadministrasjon),
+                AttesterUtbetalingLinje(linje.id, Tiltaksadministrasjon, totrinnskontrollId),
             ).onLeft { throw UtbetalingException(it) }
         }
 

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/GjennomforingRequestKafkaConsumerTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/GjennomforingRequestKafkaConsumerTest.kt
@@ -25,6 +25,7 @@ import no.nav.mulighetsrommet.api.domain.tiltak.Prismodell
 import no.nav.mulighetsrommet.api.domain.tiltak.TiltakstypeFeature
 import no.nav.mulighetsrommet.api.domain.totrinnskontroll.TotrinnskontrollStatus
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
+import no.nav.mulighetsrommet.api.gjennomforing.model.GodkjennOkonomi
 import no.nav.mulighetsrommet.api.gjennomforing.service.GjennomforingEnkeltplassService
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
 import no.nav.mulighetsrommet.model.GjennomforingStatusType
@@ -312,7 +313,8 @@ class GjennomforingRequestKafkaConsumerTest : FunSpec({
         }
 
         test("ignorerer tilbakekalling uten å kaste feil når totrinnskontroll allerede er godkjent") {
-            service.settOkonomiGodkjent(gjennomforingId, Tiltaksadministrasjon).shouldBeRight()
+            val godkjenn = GodkjennOkonomi(gjennomforingId, Tiltaksadministrasjon)
+            service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             val request = GjennomforingRequest.EnkeltplassTilbakekallPrisinformasjon(
                 gjennomforingId = gjennomforingId,

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/GjennomforingRequestKafkaConsumerTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/kafka/GjennomforingRequestKafkaConsumerTest.kt
@@ -313,7 +313,7 @@ class GjennomforingRequestKafkaConsumerTest : FunSpec({
         }
 
         test("ignorerer tilbakekalling uten å kaste feil når totrinnskontroll allerede er godkjent") {
-            val godkjenn = GodkjennOkonomi(gjennomforingId, Tiltaksadministrasjon)
+            val godkjenn = GodkjennOkonomi(gjennomforingId, Tiltaksadministrasjon, totrinnskontroll.id)
             service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             val request = GjennomforingRequest.EnkeltplassTilbakekallPrisinformasjon(

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassServiceTest.kt
@@ -36,6 +36,8 @@ import no.nav.mulighetsrommet.api.domain.totrinnskontroll.TotrinnskontrollType
 import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.gjennomforing.model.Gjennomforing
+import no.nav.mulighetsrommet.api.gjennomforing.model.GodkjennOkonomi
+import no.nav.mulighetsrommet.api.gjennomforing.model.SettOkonomiPaVent
 import no.nav.mulighetsrommet.database.kotest.extensions.ApiDatabaseTestListener
 import no.nav.mulighetsrommet.model.DeltakerStatusType
 import no.nav.mulighetsrommet.model.FieldError
@@ -267,8 +269,14 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
         test("sender økonomi til godkjenning på nytt etter at økonomi er satt på vent") {
             val soktInn = createRequest()
-            service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-            service.settOkonomiPaVent(soktInn.id, besluttetAv, forklaring = "Feil prisbetingelser").shouldBeRight()
+            val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
+
+            val settPaVent = SettOkonomiPaVent(
+                soktInn.id,
+                besluttetAv,
+                forklaring = "Feil prisbetingelser",
+            )
+            service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
             val prismodell = UpsertEnkeltplass.Prismodell.TilskuddTilOpplaering(
                 tilskudd = mapOf(Opplaeringtilskudd.Kode.SKOLEPENGER to 100),
@@ -290,8 +298,10 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
         test("gjør ingenting dersom økonomi allerede er GODKJENT") {
             val soktInn = createRequest()
-            service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-            service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+            val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
+
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             val prismodell = UpsertEnkeltplass.Prismodell.TilskuddTilOpplaering(
                 tilskudd = mapOf(Opplaeringtilskudd.Kode.SKOLEPENGER to 100),
@@ -419,9 +429,10 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
         test("godkjenner økonomi og setter besluttelse til GODKJENT") {
             val soktInn = createRequest()
 
-            service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
+            val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            val (_, okonomi) = service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            val (_, okonomi) = service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             okonomi.shouldNotBeNull().should {
                 it.status shouldBe TotrinnskontrollStatus.GODKJENT
@@ -431,18 +442,24 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
         test("returnerer feil når behandletAv og besluttetAv er samme person") {
             val soktInn = createRequest()
-            service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
+            val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            service.settOkonomiGodkjent(soktInn.id, opprettetAv)
+            val godkjenn = GodkjennOkonomi(soktInn.id, opprettetAv)
+            service.settOkonomiGodkjent(godkjenn)
                 .shouldBeLeft()
                 .first().detail shouldBe "Du kan ikke beslutte noe du selv har behandlet"
         }
 
         test("kan sette økonomi på vent") {
             val soktInn = createRequest()
-            service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
+            val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            val (_, okonomi) = service.settOkonomiPaVent(soktInn.id, besluttetAv, forklaring = "Feil").shouldBeRight()
+            val settPaVent = SettOkonomiPaVent(
+                soktInn.id,
+                besluttetAv,
+                forklaring = "Feil",
+            )
+            val (_, okonomi) = service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
             okonomi.shouldNotBeNull().should {
                 it.status shouldBe TotrinnskontrollStatus.SATT_PA_VENT
@@ -453,15 +470,17 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
         test("kan godkjenne enkeltplass når den er satt på vent") {
             val soktInn = createRequest()
-            service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
+            val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            service.settOkonomiPaVent(
+            val settPaVent = SettOkonomiPaVent(
                 soktInn.id,
                 besluttetAv,
                 forklaring = "Feil prisbetingelser",
-            ).shouldBeRight()
+            )
+            val (_, paVentOkonomi) = service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
-            val (_, okonomi) = service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            val (_, okonomi) = service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             okonomi.shouldNotBeNull().should {
                 it.status shouldBe TotrinnskontrollStatus.GODKJENT
@@ -471,17 +490,34 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
         test("returnerer feil når enkeltplass allerede er behandlet") {
             val soktInn = createRequest()
+            val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
+            val totrinnskontrollId = opprettetOkonomi!!.id
+
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            service.settOkonomiGodkjent(godkjenn).shouldBeRight()
+
+            service.settOkonomiGodkjent(godkjenn)
+                .shouldBeLeft()
+                .first().detail shouldBe "Totrinnskontrollen er allerede godkjent"
+
+            val settPaVent = SettOkonomiPaVent(
+                soktInn.id,
+                besluttetAv,
+                forklaring = "Angret",
+            )
+            service.settOkonomiPaVent(settPaVent)
+                .shouldBeLeft()
+                .first().detail shouldBe "Totrinnskontrollen er allerede godkjent"
+        }
+
+        xtest("returnerer feil når totrinnskontrollId ikke stemmer med gjeldende økonomi") {
+            val soktInn = createRequest()
             service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
-
-            service.settOkonomiGodkjent(soktInn.id, besluttetAv)
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            service.settOkonomiGodkjent(godkjenn)
                 .shouldBeLeft()
-                .first().detail shouldBe "Totrinnskontrollen er allerede godkjent"
-
-            service.settOkonomiPaVent(soktInn.id, besluttetAv, forklaring = "Angret")
-                .shouldBeLeft()
-                .first().detail shouldBe "Totrinnskontrollen er allerede godkjent"
+                .first().detail shouldBe "Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."
         }
     }
 
@@ -803,11 +839,12 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val forsteBehandling = behandling(opprettetAv)
                 service.soktInn(soktInn, forsteBehandling).shouldBeRight()
 
-                service.settOkonomiPaVent(
+                val settPaVent = SettOkonomiPaVent(
                     soktInn.id,
                     besluttetAv,
                     "Trenger mer info",
-                ).shouldBeRight().should { enkeltplass ->
+                )
+                service.settOkonomiPaVent(settPaVent).shouldBeRight().should { enkeltplass ->
                     enkeltplass.okonomi.shouldNotBeNull().should {
                         it.id shouldBe forsteBehandling.id
                         it.status shouldBe TotrinnskontrollStatus.SATT_PA_VENT
@@ -887,8 +924,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("oppretter prisendring når økonomi er GODKJENT") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
+
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 service.endrePrisinformasjon(
                     soktInn.id,
@@ -907,8 +947,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("avviser eksisterende prisendring ved ny prisendring mens økonomi er GODKJENT") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
+
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val forsteBehandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -961,8 +1004,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("oppretter prisendring med status TIL_BEHANDLING når økonomi er GODKJENT") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
+
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val behandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -983,8 +1029,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("setter eksisterende prisendring til RETURNERT ved ny prisendring når økonomi er GODKJENT") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
+
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val forsteBehandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -1012,8 +1061,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("setter eksisterende prisendring som er SATT_PA_VENT til RETURNERT ved ny prisendring når økonomi er GODKJENT") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
+
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val forsteBehandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -1022,7 +1074,12 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     forsteBehandling,
                 ).shouldBeRight()
 
-                service.settOkonomiPaVent(soktInn.id, besluttetAv, forklaring = "Trenger mer info").shouldBeRight()
+                val settPaVent = SettOkonomiPaVent(
+                    soktInn.id,
+                    besluttetAv,
+                    forklaring = "Trenger mer info",
+                )
+                service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
                 val andreBehandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -1059,7 +1116,13 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val soktInn = createRequest()
                 val forsteBehandling = behandling(opprettetAv)
                 service.soktInn(soktInn, forsteBehandling).shouldBeRight()
-                service.settOkonomiPaVent(soktInn.id, besluttetAv, forklaring = "Trenger mer info").shouldBeRight()
+
+                val settPaVent = SettOkonomiPaVent(
+                    soktInn.id,
+                    besluttetAv,
+                    forklaring = "Trenger mer info",
+                )
+                service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
                 service.tilbakekallPrisinformasjon(soktInn.id, forsteBehandling).shouldBeRight().should {
                     it.okonomi?.status shouldBe TotrinnskontrollStatus.RETURNERT
@@ -1068,8 +1131,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("setter status RETURNERT og rydder opp ventende prisendring når økonomi allerede er GODKJENT") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
+
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val prisendringBehandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -1092,7 +1158,9 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val soktInn = createRequest()
                 val forsteBehandling = behandling(opprettetAv)
                 service.soktInn(soktInn, forsteBehandling).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 service.tilbakekallPrisinformasjon(soktInn.id, forsteBehandling).shouldBeLeft(
                     TotrinnskontrollError.AlleredeBesluttet(TotrinnskontrollStatus.GODKJENT),
@@ -1125,20 +1193,24 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("settOkonomiGodkjent godkjenner prisendring og oppdaterer prismodell") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
 
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
+
+                val prisendring = behandling(opprettetAv)
                 service.endrePrisinformasjon(
                     soktInn.id,
                     UpsertEnkeltplass.Prismodell.Anskaffelse(5000),
-                    behandling(opprettetAv),
+                    prisendring,
                 ).shouldBeRight()
 
                 database.run {
                     queries.kafkaProducerRecord.getRecords(100, listOf(TEST_GJENNOMFORING_V2_TOPIC)).shouldHaveSize(1)
                 }
 
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
 
                 service.get(soktInn.id).shouldNotBeNull().should { (gjennomforing, _) ->
                     gjennomforing.prismodell.shouldBeTypeOf<Prismodell.AnnenAvtaltPris>().totalbelop shouldBe 5000
@@ -1153,8 +1225,10 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("settOkonomiGodkjent setter prisendring-totrinnskontroll til GODKJENT") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
+
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
 
                 val behandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -1163,7 +1237,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     behandling,
                 ).shouldBeRight()
 
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
 
                 database.run {
                     queries.totrinnskontroll.getById(behandling.id).should {
@@ -1175,18 +1249,26 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("settOkonomiGodkjent godkjenner prisendring som er satt på vent") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
 
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
+
+                val prisendring = behandling(opprettetAv)
                 service.endrePrisinformasjon(
                     soktInn.id,
                     UpsertEnkeltplass.Prismodell.Anskaffelse(5000),
-                    behandling(opprettetAv),
+                    prisendring,
                 ).shouldBeRight()
 
-                service.settOkonomiPaVent(soktInn.id, besluttetAv, forklaring = "Trenger mer info").shouldBeRight()
+                val settPaVent = SettOkonomiPaVent(
+                    soktInn.id,
+                    besluttetAv,
+                    forklaring = "Trenger mer info",
+                )
+                service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
 
                 service.get(soktInn.id).shouldNotBeNull().should { (gjennomforing, _) ->
                     gjennomforing.prismodell.shouldBeTypeOf<Prismodell.AnnenAvtaltPris>().totalbelop shouldBe 5000
@@ -1199,8 +1281,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             test("settOkonomiPaVent setter prisendring på vent") {
                 val soktInn = createRequest()
-                service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
-                service.settOkonomiGodkjent(soktInn.id, besluttetAv).shouldBeRight()
+                val opprettelse = behandling(opprettetAv)
+                service.soktInn(soktInn, opprettelse).shouldBeRight()
+
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val behandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -1209,7 +1294,12 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     behandling,
                 ).shouldBeRight()
 
-                service.settOkonomiPaVent(soktInn.id, besluttetAv, forklaring = "Trenger mer info").shouldBeRight()
+                val settPaVent = SettOkonomiPaVent(
+                    soktInn.id,
+                    besluttetAv,
+                    forklaring = "Trenger mer info",
+                )
+                service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
                 database.run {
                     queries.totrinnskontroll.getById(behandling.id).should {
@@ -1222,7 +1312,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val utkast = createRequest()
                 service.opprettUtkast(utkast, opprettetAv).shouldBeRight()
 
-                service.settOkonomiGodkjent(utkast.id, besluttetAv)
+                service.settOkonomiGodkjent(GodkjennOkonomi(utkast.id, besluttetAv))
                     .shouldBeLeft()
                     .first().detail shouldBe "Økonomi har ikke blitt sendt til godkjenning"
             }
@@ -1231,7 +1321,13 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val utkast = createRequest()
                 service.opprettUtkast(utkast, opprettetAv).shouldBeRight()
 
-                service.settOkonomiPaVent(utkast.id, besluttetAv, forklaring = null)
+                service.settOkonomiPaVent(
+                    SettOkonomiPaVent(
+                        utkast.id,
+                        besluttetAv,
+                        forklaring = null,
+                    ),
+                )
                     .shouldBeLeft()
                     .first().detail shouldBe "Økonomi har ikke blitt sendt til godkjenning"
             }

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/gjennomforing/service/GjennomforingEnkeltplassServiceTest.kt
@@ -275,6 +275,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 soktInn.id,
                 besluttetAv,
                 forklaring = "Feil prisbetingelser",
+                forventetTotrinnskontrollId = opprettetOkonomi!!.id,
             )
             service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
@@ -300,7 +301,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
             val soktInn = createRequest()
             val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettetOkonomi!!.id)
             service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             val prismodell = UpsertEnkeltplass.Prismodell.TilskuddTilOpplaering(
@@ -431,7 +432,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
 
             val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettetOkonomi!!.id)
             val (_, okonomi) = service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             okonomi.shouldNotBeNull().should {
@@ -444,7 +445,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
             val soktInn = createRequest()
             val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            val godkjenn = GodkjennOkonomi(soktInn.id, opprettetAv)
+            val godkjenn = GodkjennOkonomi(soktInn.id, opprettetAv, opprettetOkonomi!!.id)
             service.settOkonomiGodkjent(godkjenn)
                 .shouldBeLeft()
                 .first().detail shouldBe "Du kan ikke beslutte noe du selv har behandlet"
@@ -458,6 +459,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 soktInn.id,
                 besluttetAv,
                 forklaring = "Feil",
+                forventetTotrinnskontrollId = opprettetOkonomi!!.id,
             )
             val (_, okonomi) = service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
@@ -476,10 +478,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 soktInn.id,
                 besluttetAv,
                 forklaring = "Feil prisbetingelser",
+                forventetTotrinnskontrollId = opprettetOkonomi!!.id,
             )
             val (_, paVentOkonomi) = service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
-            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, paVentOkonomi!!.id)
             val (_, okonomi) = service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             okonomi.shouldNotBeNull().should {
@@ -493,7 +496,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
             val (_, opprettetOkonomi) = service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
             val totrinnskontrollId = opprettetOkonomi!!.id
 
-            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, totrinnskontrollId)
             service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
             service.settOkonomiGodkjent(godkjenn)
@@ -504,17 +507,18 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 soktInn.id,
                 besluttetAv,
                 forklaring = "Angret",
+                forventetTotrinnskontrollId = totrinnskontrollId,
             )
             service.settOkonomiPaVent(settPaVent)
                 .shouldBeLeft()
                 .first().detail shouldBe "Totrinnskontrollen er allerede godkjent"
         }
 
-        xtest("returnerer feil når totrinnskontrollId ikke stemmer med gjeldende økonomi") {
+        test("returnerer feil når totrinnskontrollId ikke stemmer med gjeldende økonomi") {
             val soktInn = createRequest()
             service.soktInn(soktInn, behandling(opprettetAv)).shouldBeRight()
 
-            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+            val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, UUID.randomUUID())
             service.settOkonomiGodkjent(godkjenn)
                 .shouldBeLeft()
                 .first().detail shouldBe "Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."
@@ -843,6 +847,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     soktInn.id,
                     besluttetAv,
                     "Trenger mer info",
+                    forsteBehandling.id,
                 )
                 service.settOkonomiPaVent(settPaVent).shouldBeRight().should { enkeltplass ->
                     enkeltplass.okonomi.shouldNotBeNull().should {
@@ -927,7 +932,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 service.endrePrisinformasjon(
@@ -950,7 +955,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val forsteBehandling = behandling(opprettetAv)
@@ -1007,7 +1012,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val behandling = behandling(opprettetAv)
@@ -1032,7 +1037,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val forsteBehandling = behandling(opprettetAv)
@@ -1064,7 +1069,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val forsteBehandling = behandling(opprettetAv)
@@ -1078,6 +1083,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     soktInn.id,
                     besluttetAv,
                     forklaring = "Trenger mer info",
+                    forventetTotrinnskontrollId = forsteBehandling.id,
                 )
                 service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
@@ -1121,6 +1127,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     soktInn.id,
                     besluttetAv,
                     forklaring = "Trenger mer info",
+                    forventetTotrinnskontrollId = forsteBehandling.id,
                 )
                 service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
@@ -1134,7 +1141,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val prisendringBehandling = behandling(opprettetAv)
@@ -1159,7 +1166,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val forsteBehandling = behandling(opprettetAv)
                 service.soktInn(soktInn, forsteBehandling).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, forsteBehandling.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 service.tilbakekallPrisinformasjon(soktInn.id, forsteBehandling).shouldBeLeft(
@@ -1196,7 +1203,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val prisendring = behandling(opprettetAv)
@@ -1210,7 +1217,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     queries.kafkaProducerRecord.getRecords(100, listOf(TEST_GJENNOMFORING_V2_TOPIC)).shouldHaveSize(1)
                 }
 
-                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv, prisendring.id)).shouldBeRight()
 
                 service.get(soktInn.id).shouldNotBeNull().should { (gjennomforing, _) ->
                     gjennomforing.prismodell.shouldBeTypeOf<Prismodell.AnnenAvtaltPris>().totalbelop shouldBe 5000
@@ -1228,7 +1235,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)).shouldBeRight()
 
                 val behandling = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -1237,7 +1244,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     behandling,
                 ).shouldBeRight()
 
-                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv, behandling.id)).shouldBeRight()
 
                 database.run {
                     queries.totrinnskontroll.getById(behandling.id).should {
@@ -1252,7 +1259,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)).shouldBeRight()
 
                 val prisendring = behandling(opprettetAv)
                 service.endrePrisinformasjon(
@@ -1265,10 +1272,11 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     soktInn.id,
                     besluttetAv,
                     forklaring = "Trenger mer info",
+                    forventetTotrinnskontrollId = prisendring.id,
                 )
                 service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
-                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv)).shouldBeRight()
+                service.settOkonomiGodkjent(GodkjennOkonomi(soktInn.id, besluttetAv, prisendring.id)).shouldBeRight()
 
                 service.get(soktInn.id).shouldNotBeNull().should { (gjennomforing, _) ->
                     gjennomforing.prismodell.shouldBeTypeOf<Prismodell.AnnenAvtaltPris>().totalbelop shouldBe 5000
@@ -1284,7 +1292,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val opprettelse = behandling(opprettetAv)
                 service.soktInn(soktInn, opprettelse).shouldBeRight()
 
-                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv)
+                val godkjenn = GodkjennOkonomi(soktInn.id, besluttetAv, opprettelse.id)
                 service.settOkonomiGodkjent(godkjenn).shouldBeRight()
 
                 val behandling = behandling(opprettetAv)
@@ -1298,6 +1306,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                     soktInn.id,
                     besluttetAv,
                     forklaring = "Trenger mer info",
+                    forventetTotrinnskontrollId = behandling.id,
                 )
                 service.settOkonomiPaVent(settPaVent).shouldBeRight()
 
@@ -1312,7 +1321,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                 val utkast = createRequest()
                 service.opprettUtkast(utkast, opprettetAv).shouldBeRight()
 
-                service.settOkonomiGodkjent(GodkjennOkonomi(utkast.id, besluttetAv))
+                service.settOkonomiGodkjent(GodkjennOkonomi(utkast.id, besluttetAv, UUID.randomUUID()))
                     .shouldBeLeft()
                     .first().detail shouldBe "Økonomi har ikke blitt sendt til godkjenning"
             }
@@ -1326,6 +1335,7 @@ class GjennomforingEnkeltplassServiceTest : FunSpec({
                         utkast.id,
                         besluttetAv,
                         forklaring = null,
+                        forventetTotrinnskontrollId = UUID.randomUUID(),
                     ),
                 )
                     .shouldBeLeft()

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnServiceTest.kt
@@ -29,6 +29,8 @@ import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.navansatt.service.NavAnsattService
 import no.nav.mulighetsrommet.api.tilsagn.model.BeregnTilsagnRequest
+import no.nav.mulighetsrommet.api.tilsagn.model.GodkjennTilsagn
+import no.nav.mulighetsrommet.api.tilsagn.model.ReturnerTilsagn
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnBeregningAnnenAvtaltPris
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnBeregningAvtaltPrisPerBenyttetPlassPerManed
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnBeregningRequest
@@ -118,6 +120,18 @@ class TilsagnServiceTest : FunSpec({
 
     afterEach {
         database.truncateAll()
+    }
+
+    fun opprettelseId(tilsagnId: UUID): UUID = database.run {
+        queries.totrinnskontroll.getOrError(tilsagnId, TotrinnskontrollType.TILSAGN_OPPRETTELSE).id
+    }
+
+    fun annulleringId(tilsagnId: UUID): UUID = database.run {
+        queries.totrinnskontroll.getOrError(tilsagnId, TotrinnskontrollType.TILSAGN_ANNULLERING).id
+    }
+
+    fun oppgjorId(tilsagnId: UUID): UUID = database.run {
+        queries.totrinnskontroll.getOrError(tilsagnId, TotrinnskontrollType.TILSAGN_OPPGJOR).id
     }
 
     val gyldigTilsagnPeriode = Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2026, 1, 1))
@@ -256,8 +270,10 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             service.slettTilsagn(
@@ -271,10 +287,12 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
             service.slettTilsagn(requestId, ansatt1).shouldBeRight()
@@ -289,17 +307,21 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ) shouldBeLeft listOf(
                 FieldError.of("Tilsagnet kan ikke returneres fordi det har status Returnert"),
             )
@@ -310,10 +332,12 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
             service.slettTilsagn(requestId, ansatt2).shouldBeRight()
@@ -329,10 +353,12 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
             service.slettTilsagn(requestId, ansatt1).shouldBeRight()
@@ -356,8 +382,10 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt1,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt1,
+                ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke beslutte tilsagnet fordi du mangler budsjettmyndighet ved tilsagnets kostnadssted (Nav Gjøvik)"),
             )
@@ -375,8 +403,10 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt1,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt1,
+                ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke beslutte tilsagnet fordi du mangler budsjettmyndighet ved tilsagnets kostnadssted (Nav Gjøvik)"),
             )
@@ -387,9 +417,36 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt1,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt1,
+                ),
             ) shouldBeLeft listOf(FieldError.of("Du kan ikke beslutte noe du selv har behandlet"))
+        }
+
+        xtest("kan ikke godkjenne eller returnere med utdatert totrinnskontrollId") {
+            service.upsert(request, ansatt1)
+                .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
+
+            service.godkjennTilsagn(
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
+            ) shouldBeLeft listOf(
+                FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."),
+            )
+
+            service.returnerTilsagn(
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
+            ) shouldBeLeft listOf(
+                FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."),
+            )
         }
 
         test("kan ikke beslutte to ganger") {
@@ -397,13 +454,17 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ) shouldBeLeft listOf(FieldError.of("Tilsagnet kan ikke godkjennes fordi det har status Godkjent"))
         }
 
@@ -412,8 +473,10 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             val value = database.run { queries.kafkaProducerRecord.getRecords(50, listOf(BESTILLING_TOPIC)) }
@@ -445,10 +508,12 @@ class TilsagnServiceTest : FunSpec({
             }
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
             database.run {
@@ -471,8 +536,10 @@ class TilsagnServiceTest : FunSpec({
             }
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             database.run {
@@ -496,10 +563,12 @@ class TilsagnServiceTest : FunSpec({
             }
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
             service.upsert(request, NavIdent("T888888")).shouldBeRight().should {
@@ -519,10 +588,12 @@ class TilsagnServiceTest : FunSpec({
             }
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt1,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt1,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
         }
 
@@ -535,10 +606,12 @@ class TilsagnServiceTest : FunSpec({
             ).shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt1,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt1,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke returnere tilsagnet fordi du mangler tilgang"),
             )
@@ -558,10 +631,12 @@ class TilsagnServiceTest : FunSpec({
             ).shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt1,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt1,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
         }
 
@@ -572,15 +647,19 @@ class TilsagnServiceTest : FunSpec({
             ).shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ) shouldBeLeft listOf(
                 FieldError.of("Tilsagnet kan ikke returneres fordi det har status Godkjent"),
             )
@@ -606,8 +685,10 @@ class TilsagnServiceTest : FunSpec({
             }.message shouldBe "Kan bare annullere godkjente tilsagn"
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             service.tilAnnulleringRequest(
@@ -630,8 +711,10 @@ class TilsagnServiceTest : FunSpec({
             }
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.ANNULLERT
 
             database.run {
@@ -650,8 +733,10 @@ class TilsagnServiceTest : FunSpec({
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             var value = database.run { queries.kafkaProducerRecord.getRecords(50, listOf(BESTILLING_TOPIC)) }
@@ -671,8 +756,10 @@ class TilsagnServiceTest : FunSpec({
             ).status shouldBe TilsagnStatus.TIL_ANNULLERING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.ANNULLERT
 
             value = database.run { queries.kafkaProducerRecord.getRecords(50, listOf(BESTILLING_TOPIC)) }
@@ -689,8 +776,10 @@ class TilsagnServiceTest : FunSpec({
         test("kan ikke annullere eget tilsagn") {
             service.upsert(request, ansatt1).shouldBeRight()
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight()
             service.tilAnnulleringRequest(
                 id = requestId,
@@ -701,8 +790,10 @@ class TilsagnServiceTest : FunSpec({
                 ),
             )
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt1,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt1,
+                ),
             ) shouldBeLeft listOf(FieldError.of("Du kan ikke beslutte noe du selv har behandlet"))
             database.run { queries.tilsagn.getOrError(requestId).status shouldBe TilsagnStatus.TIL_ANNULLERING }
         }
@@ -710,8 +801,10 @@ class TilsagnServiceTest : FunSpec({
         test("kan ikke annullere tilsagn med utbetalinger") {
             service.upsert(request, ansatt1).shouldBeRight()
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight()
             service.tilAnnulleringRequest(
                 id = requestId,
@@ -760,8 +853,10 @@ class TilsagnServiceTest : FunSpec({
                 )
             }
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ) shouldBeLeft listOf(FieldError.of("Tilsagnet kan ikke annulleres fordi det har blitt brukt i utbetalinger"))
         }
 
@@ -772,8 +867,10 @@ class TilsagnServiceTest : FunSpec({
             ).shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             service.tilAnnulleringRequest(
@@ -786,10 +883,12 @@ class TilsagnServiceTest : FunSpec({
             ).status shouldBe TilsagnStatus.TIL_ANNULLERING
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt2,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt2,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             database.run {
@@ -810,8 +909,10 @@ class TilsagnServiceTest : FunSpec({
             service.upsert(request, ansatt1)
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             service.tilOppgjorRequest(
@@ -821,8 +922,10 @@ class TilsagnServiceTest : FunSpec({
             ).status shouldBe TilsagnStatus.TIL_OPPGJOR
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt1,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt1,
+                ),
             ) shouldBeLeft listOf(FieldError.of("Du kan ikke beslutte noe du selv har behandlet"))
 
             database.run {
@@ -834,8 +937,10 @@ class TilsagnServiceTest : FunSpec({
             service.upsert(request, ansatt1).shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
             service.tilOppgjorRequest(
@@ -845,10 +950,12 @@ class TilsagnServiceTest : FunSpec({
             ).status shouldBe TilsagnStatus.TIL_OPPGJOR
 
             service.returnerTilsagn(
-                id = requestId,
-                navIdent = ansatt1,
-                aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
-                forklaring = null,
+                ReturnerTilsagn(
+                    id = requestId,
+                    navIdent = ansatt1,
+                    aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
+                    forklaring = null,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
         }
 
@@ -856,8 +963,10 @@ class TilsagnServiceTest : FunSpec({
             service.upsert(request, ansatt1).shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
             val bestillingsnummer = database.run { queries.tilsagn.getOrError(requestId).bestilling.bestillingsnummer }
 
@@ -879,8 +988,10 @@ class TilsagnServiceTest : FunSpec({
             }
 
             service.godkjennTilsagn(
-                id = requestId,
-                agent = ansatt2,
+                GodkjennTilsagn(
+                    id = requestId,
+                    agent = ansatt2,
+                ),
             ).shouldBeRight().status shouldBe TilsagnStatus.OPPGJORT
 
             database.run {

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilsagn/TilsagnServiceTest.kt
@@ -273,6 +273,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -292,6 +293,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
@@ -312,6 +314,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
@@ -321,6 +324,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Tilsagnet kan ikke returneres fordi det har status Returnert"),
@@ -337,6 +341,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
@@ -358,6 +363,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
@@ -385,6 +391,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt1,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke beslutte tilsagnet fordi du mangler budsjettmyndighet ved tilsagnets kostnadssted (Nav Gjøvik)"),
@@ -406,6 +413,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt1,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke beslutte tilsagnet fordi du mangler budsjettmyndighet ved tilsagnets kostnadssted (Nav Gjøvik)"),
@@ -420,11 +428,12 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt1,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ) shouldBeLeft listOf(FieldError.of("Du kan ikke beslutte noe du selv har behandlet"))
         }
 
-        xtest("kan ikke godkjenne eller returnere med utdatert totrinnskontrollId") {
+        test("kan ikke godkjenne eller returnere med utdatert totrinnskontrollId") {
             service.upsert(request, ansatt1)
                 .shouldBeRight().status shouldBe TilsagnStatus.TIL_GODKJENNING
 
@@ -432,6 +441,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = UUID.randomUUID(),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."),
@@ -443,6 +453,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = UUID.randomUUID(),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."),
@@ -457,6 +468,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -464,6 +476,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ) shouldBeLeft listOf(FieldError.of("Tilsagnet kan ikke godkjennes fordi det har status Godkjent"))
         }
@@ -476,6 +489,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -513,6 +527,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
@@ -539,6 +554,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -568,6 +584,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
 
@@ -593,6 +610,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt1,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
         }
@@ -611,6 +629,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt1,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke returnere tilsagnet fordi du mangler tilgang"),
@@ -636,6 +655,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt1,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.RETURNERT
         }
@@ -650,6 +670,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -659,6 +680,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Tilsagnet kan ikke returneres fordi det har status Godkjent"),
@@ -688,6 +710,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -714,6 +737,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = annulleringId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.ANNULLERT
 
@@ -736,6 +760,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -759,6 +784,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = annulleringId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.ANNULLERT
 
@@ -779,6 +805,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight()
             service.tilAnnulleringRequest(
@@ -793,6 +820,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt1,
+                    forventetTotrinnskontrollId = annulleringId(requestId),
                 ),
             ) shouldBeLeft listOf(FieldError.of("Du kan ikke beslutte noe du selv har behandlet"))
             database.run { queries.tilsagn.getOrError(requestId).status shouldBe TilsagnStatus.TIL_ANNULLERING }
@@ -804,6 +832,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight()
             service.tilAnnulleringRequest(
@@ -856,6 +885,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = annulleringId(requestId),
                 ),
             ) shouldBeLeft listOf(FieldError.of("Tilsagnet kan ikke annulleres fordi det har blitt brukt i utbetalinger"))
         }
@@ -870,6 +900,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -888,6 +919,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt2,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = annulleringId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -912,6 +944,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -925,6 +958,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt1,
+                    forventetTotrinnskontrollId = oppgjorId(requestId),
                 ),
             ) shouldBeLeft listOf(FieldError.of("Du kan ikke beslutte noe du selv har behandlet"))
 
@@ -940,6 +974,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
 
@@ -955,6 +990,7 @@ class TilsagnServiceTest : FunSpec({
                     navIdent = ansatt1,
                     aarsaker = listOf(TilsagnStatusAarsak.FEIL_BELOP),
                     forklaring = null,
+                    forventetTotrinnskontrollId = oppgjorId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
         }
@@ -966,6 +1002,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = opprettelseId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.GODKJENT
             val bestillingsnummer = database.run { queries.tilsagn.getOrError(requestId).bestilling.bestillingsnummer }
@@ -991,6 +1028,7 @@ class TilsagnServiceTest : FunSpec({
                 GodkjennTilsagn(
                     id = requestId,
                     agent = ansatt2,
+                    forventetTotrinnskontrollId = oppgjorId(requestId),
                 ),
             ).shouldBeRight().status shouldBe TilsagnStatus.OPPGJORT
 

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/TilskuddBehandlingServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/TilskuddBehandlingServiceTest.kt
@@ -12,9 +12,12 @@ import no.nav.mulighetsrommet.admin.totrinnskontroll.TotrinnskontrollDto
 import no.nav.mulighetsrommet.api.domain.opplaring.Opplaeringtilskudd
 import no.nav.mulighetsrommet.api.domain.testing.fixture.AvtaleFixtures
 import no.nav.mulighetsrommet.api.domain.testing.fixture.NavAnsattFixture
+import no.nav.mulighetsrommet.api.domain.totrinnskontroll.TotrinnskontrollType
 import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.tilskuddbehandling.db.TilskuddMottaker
+import no.nav.mulighetsrommet.api.tilskuddbehandling.model.AttesterTilskudd
+import no.nav.mulighetsrommet.api.tilskuddbehandling.model.ReturnerTilskudd
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingRequest
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingStatus
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingStatusAarsak
@@ -76,13 +79,17 @@ class TilskuddBehandlingServiceTest : FunSpec({
         mockk(relaxed = true),
     )
 
+    fun opprettelseId(behandlingId: UUID): UUID = database.run {
+        queries.totrinnskontroll.getOrError(behandlingId, TotrinnskontrollType.TILSKUDD_OPPRETTELSE).id
+    }
+
     context("attester og returner") {
         test("kan ikke attestere sin egen behandling") {
             val service = createService()
 
             service.upsert(request, ansatt1).shouldBeRight()
 
-            service.attester(request.id, ansatt1).shouldBeLeft().shouldHaveSize(1).first().should {
+            service.attester(AttesterTilskudd(request.id, ansatt1)).shouldBeLeft().shouldHaveSize(1).first().should {
                 it.detail shouldBe "Du kan ikke beslutte noe du selv har behandlet"
             }
         }
@@ -92,10 +99,21 @@ class TilskuddBehandlingServiceTest : FunSpec({
 
             service.upsert(request, ansatt1).shouldBeRight()
 
-            service.attester(request.id, ansatt2).shouldBeRight()
+            service.attester(AttesterTilskudd(request.id, ansatt2)).shouldBeRight()
 
             val detaljer = service.getDetaljerDto(request.id, ansatt1)
             detaljer?.behandling?.status?.type shouldBe TilskuddBehandlingStatus.FERDIG_BEHANDLET
+        }
+
+        xtest("returnerer feil når totrinnskontrollId ikke stemmer med gjeldende behandling") {
+            val service = createService()
+
+            service.upsert(request, ansatt1).shouldBeRight()
+
+            service.attester(AttesterTilskudd(request.id, ansatt2))
+                .shouldBeLeft().shouldHaveSize(1).first().should {
+                    it.detail shouldBe "Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."
+                }
         }
 
         test("happy case returner") {
@@ -104,10 +122,12 @@ class TilskuddBehandlingServiceTest : FunSpec({
             service.upsert(request, ansatt1).shouldBeRight()
 
             service.returner(
-                request.id,
-                ansatt2,
-                listOf(TilskuddBehandlingStatusAarsak.FEIL_VEDTAKSRESULTAT, TilskuddBehandlingStatusAarsak.ANNET),
-                forklaring = "fordi",
+                ReturnerTilskudd(
+                    request.id,
+                    ansatt2,
+                    listOf(TilskuddBehandlingStatusAarsak.FEIL_VEDTAKSRESULTAT, TilskuddBehandlingStatusAarsak.ANNET),
+                    forklaring = "fordi",
+                ),
             ).shouldBeRight()
 
             service.getDetaljerDto(request.id, ansatt1)?.opprettelse.shouldBeTypeOf<TotrinnskontrollDto.Besluttet>() should {

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/TilskuddBehandlingServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/TilskuddBehandlingServiceTest.kt
@@ -89,7 +89,7 @@ class TilskuddBehandlingServiceTest : FunSpec({
 
             service.upsert(request, ansatt1).shouldBeRight()
 
-            service.attester(AttesterTilskudd(request.id, ansatt1)).shouldBeLeft().shouldHaveSize(1).first().should {
+            service.attester(AttesterTilskudd(request.id, ansatt1, opprettelseId(request.id))).shouldBeLeft().shouldHaveSize(1).first().should {
                 it.detail shouldBe "Du kan ikke beslutte noe du selv har behandlet"
             }
         }
@@ -99,18 +99,18 @@ class TilskuddBehandlingServiceTest : FunSpec({
 
             service.upsert(request, ansatt1).shouldBeRight()
 
-            service.attester(AttesterTilskudd(request.id, ansatt2)).shouldBeRight()
+            service.attester(AttesterTilskudd(request.id, ansatt2, opprettelseId(request.id))).shouldBeRight()
 
             val detaljer = service.getDetaljerDto(request.id, ansatt1)
             detaljer?.behandling?.status?.type shouldBe TilskuddBehandlingStatus.FERDIG_BEHANDLET
         }
 
-        xtest("returnerer feil når totrinnskontrollId ikke stemmer med gjeldende behandling") {
+        test("returnerer feil når totrinnskontrollId ikke stemmer med gjeldende behandling") {
             val service = createService()
 
             service.upsert(request, ansatt1).shouldBeRight()
 
-            service.attester(AttesterTilskudd(request.id, ansatt2))
+            service.attester(AttesterTilskudd(request.id, ansatt2, UUID.randomUUID()))
                 .shouldBeLeft().shouldHaveSize(1).first().should {
                     it.detail shouldBe "Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."
                 }
@@ -127,6 +127,7 @@ class TilskuddBehandlingServiceTest : FunSpec({
                     ansatt2,
                     listOf(TilskuddBehandlingStatusAarsak.FEIL_VEDTAKSRESULTAT, TilskuddBehandlingStatusAarsak.ANNET),
                     forklaring = "fordi",
+                    forventetTotrinnskontrollId = opprettelseId(request.id),
                 ),
             ).shouldBeRight()
 

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/task/VedtaksbrevTaskTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/task/VedtaksbrevTaskTest.kt
@@ -24,6 +24,7 @@ import no.nav.mulighetsrommet.api.pdfgen.PdfGenClient
 import no.nav.mulighetsrommet.api.pdfgen.PdfGenError
 import no.nav.mulighetsrommet.api.tilskuddbehandling.TilskuddBehandlingService
 import no.nav.mulighetsrommet.api.tilskuddbehandling.db.TilskuddMottaker
+import no.nav.mulighetsrommet.api.tilskuddbehandling.model.AttesterTilskudd
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.TilskuddBehandlingRequest
 import no.nav.mulighetsrommet.api.tilskuddbehandling.model.VedtakResultat
 import no.nav.mulighetsrommet.api.utbetaling.api.ValutaBelopRequest
@@ -209,5 +210,5 @@ private fun opprettOgAttesterTilskudd(
     )
 
     service.upsert(request, NavAnsattFixture.DonaldDuck.navIdent).shouldBeRight()
-    service.attester(request.id, NavAnsattFixture.MikkeMus.navIdent).shouldBeRight()
+    service.attester(AttesterTilskudd(request.id, NavAnsattFixture.MikkeMus.navIdent)).shouldBeRight()
 }

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/task/VedtaksbrevTaskTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/tilskuddbehandling/task/VedtaksbrevTaskTest.kt
@@ -18,6 +18,7 @@ import no.nav.mulighetsrommet.api.clients.teamdokumenthandtering.DokdistResponse
 import no.nav.mulighetsrommet.api.domain.opplaring.Opplaeringtilskudd
 import no.nav.mulighetsrommet.api.domain.testing.fixture.DeltakerFixtures
 import no.nav.mulighetsrommet.api.domain.testing.fixture.NavAnsattFixture
+import no.nav.mulighetsrommet.api.domain.totrinnskontroll.TotrinnskontrollType
 import no.nav.mulighetsrommet.api.fixtures.GjennomforingFixtures
 import no.nav.mulighetsrommet.api.fixtures.MulighetsrommetTestDomain
 import no.nav.mulighetsrommet.api.pdfgen.PdfGenClient
@@ -210,5 +211,9 @@ private fun opprettOgAttesterTilskudd(
     )
 
     service.upsert(request, NavAnsattFixture.DonaldDuck.navIdent).shouldBeRight()
-    service.attester(AttesterTilskudd(request.id, NavAnsattFixture.MikkeMus.navIdent)).shouldBeRight()
+
+    val opprettelseId = db.session {
+        queries.totrinnskontroll.getOrError(request.id, TotrinnskontrollType.TILSKUDD_OPPRETTELSE).id
+    }
+    service.attester(AttesterTilskudd(request.id, NavAnsattFixture.MikkeMus.navIdent, opprettelseId)).shouldBeRight()
 }

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingRoutesTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/api/UtbetalingRoutesTest.kt
@@ -34,6 +34,7 @@ import no.nav.mulighetsrommet.api.mockPdlEmptyResult
 import no.nav.mulighetsrommet.api.mockTilgangsmaskinenForbidden
 import no.nav.mulighetsrommet.api.navansatt.ktor.NavAnsattManglerTilgang
 import no.nav.mulighetsrommet.api.responses.ValidationError
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningMedAarsakerRequest
 import no.nav.mulighetsrommet.api.utbetaling.model.DeltakelseDeltakelsesprosentPerioder
 import no.nav.mulighetsrommet.api.utbetaling.model.DeltakelsesprosentPeriode
 import no.nav.mulighetsrommet.api.utbetaling.model.SatsPeriode
@@ -188,7 +189,7 @@ class UtbetalingRoutesTest : FunSpec({
 
                 val response = client.post("/api/tiltaksadministrasjon/utbetalingslinjer/$id/returner") {
                     bearerAuth(oauth.issueToken(claims = navAnsattClaims).serialize())
-                    setBody(AarsakerOgForklaringRequest(listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP), null))
+                    setBody(BeslutningMedAarsakerRequest(UUID.randomUUID(), listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP), null))
                 }
 
                 response.status shouldBe HttpStatusCode.Forbidden
@@ -206,7 +207,7 @@ class UtbetalingRoutesTest : FunSpec({
 
                 val response = client.post("/api/tiltaksadministrasjon/utbetalingslinjer/$id/returner") {
                     bearerAuth(oauth.issueToken(claims = navAnsattClaims).serialize())
-                    setBody(AarsakerOgForklaringRequest(listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP), null))
+                    setBody(BeslutningMedAarsakerRequest(UUID.randomUUID(), listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP), null))
                 }
 
                 response.status shouldBe HttpStatusCode.BadRequest
@@ -473,7 +474,8 @@ class UtbetalingRoutesTest : FunSpec({
                     val response = client.put(avslaAbrytelseUrl(UtbetalingFixtures.utbetaling1.id)) {
                         bearerAuth(oauth.issueToken(claims = navAnsattClaims).serialize())
                         setBody(
-                            AarsakerOgForklaringRequest<UtbetalingStatusAarsak>(
+                            BeslutningMedAarsakerRequest<UtbetalingStatusAarsak>(
+                                totrinnskontrollId = UUID.randomUUID(),
                                 aarsaker = emptyList(),
                                 forklaring = null,
                             ),

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingServiceTest.kt
@@ -19,7 +19,6 @@ import kotlinx.serialization.json.Json
 import no.nav.common.kafka.util.KafkaUtils
 import no.nav.mulighetsrommet.admin.arrangor.BetalingsinformasjonQuery
 import no.nav.mulighetsrommet.admin.endringshistorikk.EndringshistorikkType
-import no.nav.mulighetsrommet.admin.totrinnskontroll.TotrinnskontrollDto
 import no.nav.mulighetsrommet.api.ApplicationConfigTest
 import no.nav.mulighetsrommet.api.QueryContext
 import no.nav.mulighetsrommet.api.aarsakerforklaring.AarsakerOgForklaringRequest
@@ -46,9 +45,14 @@ import no.nav.mulighetsrommet.api.fixtures.setUtbetalingLinjeStatus
 import no.nav.mulighetsrommet.api.tilsagn.TilsagnService
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnBeregningAnnenAvtaltPris
 import no.nav.mulighetsrommet.api.tilsagn.model.TilsagnStatus
-import no.nav.mulighetsrommet.api.utbetaling.api.UtbetalingStatusDto
+import no.nav.mulighetsrommet.api.totrinnskontroll.api.BeslutningMedAarsakerRequest
+import no.nav.mulighetsrommet.api.utbetaling.model.AttesterUtbetalingLinje
+import no.nav.mulighetsrommet.api.utbetaling.model.AvbrytUtbetaling
+import no.nav.mulighetsrommet.api.utbetaling.model.AvslaAvbrytUtbetaling
+import no.nav.mulighetsrommet.api.utbetaling.model.GodkjennAvbrytUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.OpprettUtbetalingLinje
 import no.nav.mulighetsrommet.api.utbetaling.model.OpprettUtbetalingLinjer
+import no.nav.mulighetsrommet.api.utbetaling.model.ReturnerUtbetalingLinje
 import no.nav.mulighetsrommet.api.utbetaling.model.UpsertUtbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.Utbetaling
 import no.nav.mulighetsrommet.api.utbetaling.model.UtbetalingBeregningFri
@@ -120,6 +124,10 @@ class AdminUtbetalingServiceTest : FunSpec({
     }
 
     val navIdent = NavAnsattFixture.DonaldDuck.navIdent
+
+    fun linjeOpprettelseId(linjeId: UUID): UUID = database.run {
+        queries.totrinnskontroll.getOrError(linjeId, TotrinnskontrollType.UTBETALING_LINJE_OPPRETTELSE).id
+    }
 
     context("opprett og rediger utbetaling") {
         val upsert = UpsertUtbetaling.Anskaffelse(
@@ -331,8 +339,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             val service = createUtbetalingService()
 
             service.godkjennUtbetalingLinje(
-                id = utbetalingLinje1.id,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                AttesterUtbetalingLinje(
+                    id = utbetalingLinje1.id,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke attestere utbetalingen fordi du ikke er attestant ved tilsagnets kostnadssted (Nav Innlandet)"),
             )
@@ -362,7 +372,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             val opprett = createOpprettUtbetalingLinjer(utbetaling1.id, listOf(linje))
             service.sendTilAttestering(opprett, navIdent).shouldBeRight()
 
-            service.godkjennUtbetalingLinje(linje.id, navIdent) shouldBeLeft listOf(
+            service.godkjennUtbetalingLinje(
+                AttesterUtbetalingLinje(
+                    id = linje.id,
+                    agent = navIdent,
+                ),
+            ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke beslutte noe du selv har behandlet"),
             )
         }
@@ -393,9 +408,57 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett, NavAnsattFixture.MikkeMus.navIdent).shouldBeRight()
 
             service.godkjennUtbetalingLinje(
-                id = linje.id,
-                navIdent = navIdent,
+                AttesterUtbetalingLinje(
+                    id = linje.id,
+                    agent = navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
+        }
+
+        xtest("kan ikke attestere eller returnere utbetalingslinje med utdatert totrinnskontrollId") {
+            MulighetsrommetTestDomain(
+                ansatte = listOf(NavAnsattFixture.DonaldDuck, NavAnsattFixture.MikkeMus),
+                avtaler = listOf(AvtaleFixtures.AFT),
+                gjennomforinger = listOf(AFT1),
+                tilsagn = listOf(Tilsagn1),
+                utbetalinger = listOf(utbetaling1.copy(status = UtbetalingStatusType.TIL_BEHANDLING)),
+            ) {
+                setTilsagnStatus(Tilsagn1, TilsagnStatus.GODKJENT, besluttetAv = navIdent)
+                setRoller(
+                    NavAnsattFixture.DonaldDuck,
+                    setOf(NavAnsattRolle.kontorspesifikk(Rolle.ATTESTANT_UTBETALING, setOf(Innlandet.enhetsnummer))),
+                )
+                setRoller(
+                    NavAnsattFixture.MikkeMus,
+                    setOf(NavAnsattRolle.generell(Rolle.SAKSBEHANDLER_OKONOMI)),
+                )
+            }.initialize(database.api)
+
+            val service = createUtbetalingService()
+
+            val linje = createUtbetalingLinje(Tilsagn1.id)
+            val opprett = createOpprettUtbetalingLinjer(utbetaling1.id, listOf(linje))
+            service.sendTilAttestering(opprett, NavAnsattFixture.MikkeMus.navIdent).shouldBeRight()
+
+            service.godkjennUtbetalingLinje(
+                AttesterUtbetalingLinje(
+                    id = linje.id,
+                    agent = navIdent,
+                ),
+            ) shouldBeLeft listOf(
+                FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."),
+            )
+
+            service.returnerUtbetalingLinje(
+                ReturnerUtbetalingLinje(
+                    id = linje.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
+                    forklaring = "Maksbeløp er 5",
+                    agent = navIdent,
+                ),
+            ) shouldBeLeft listOf(
+                FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."),
+            )
         }
 
         test("returnering av utbetalingslinje setter den i RETURNERT status") {
@@ -424,10 +487,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett, NavAnsattFixture.MikkeMus.navIdent).shouldBeRight()
 
             service.returnerUtbetalingLinje(
-                id = linje.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
-                forklaring = "Maksbeløp er 5",
-                navIdent = domain.ansatte[0].navIdent,
+                ReturnerUtbetalingLinje(
+                    id = linje.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
+                    forklaring = "Maksbeløp er 5",
+                    agent = domain.ansatte[0].navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
             database.run {
@@ -461,10 +526,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett1, domain.ansatte[0].navIdent).shouldBeRight()
 
             service.returnerUtbetalingLinje(
-                id = linje1.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
-                forklaring = "Maksbeløp er 5",
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                ReturnerUtbetalingLinje(
+                    id = linje1.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
+                    forklaring = "Maksbeløp er 5",
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
             val linje2 = createUtbetalingLinje(Tilsagn1.id, 0.NOK)
@@ -495,8 +562,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             val service = createUtbetalingService()
 
             service.godkjennUtbetalingLinje(
-                id = utbetalingLinje1.id,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                AttesterUtbetalingLinje(
+                    id = utbetalingLinje1.id,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ) shouldBeLeft listOf(
                 FieldError.of("Utbetalingen kan ikke attesteres"),
             )
@@ -622,10 +691,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett1, NavAnsattFixture.DonaldDuck.navIdent).shouldBeRight()
 
             service.returnerUtbetalingLinje(
-                id = utbetalingLinje1.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
-                forklaring = null,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                ReturnerUtbetalingLinje(
+                    id = utbetalingLinje1.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
+                    forklaring = null,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
             val opprett2 = createOpprettUtbetalingLinjer(utbetaling1.id, listOf(utbetalingLinje1), "begrunnelse")
@@ -678,8 +749,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett, NavAnsattFixture.MikkeMus.navIdent).shouldBeRight()
 
             service.godkjennUtbetalingLinje(
-                utbetalingLinje1.id,
-                NavAnsattFixture.DonaldDuck.navIdent,
+                AttesterUtbetalingLinje(
+                    utbetalingLinje1.id,
+                    NavAnsattFixture.DonaldDuck.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.TIL_ATTESTERING
 
             database.run {
@@ -687,10 +760,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             }
 
             service.returnerUtbetalingLinje(
-                id = utbetalingLinje2.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
-                forklaring = "Maksbeløp er 5",
-                navIdent = NavAnsattFixture.DonaldDuck.navIdent,
+                ReturnerUtbetalingLinje(
+                    id = utbetalingLinje2.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
+                    forklaring = "Maksbeløp er 5",
+                    agent = NavAnsattFixture.DonaldDuck.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
             database.run {
@@ -819,10 +894,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             }
 
             service.returnerUtbetalingLinje(
-                id = linje1.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
-                forklaring = "Maksbeløp er 5",
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                ReturnerUtbetalingLinje(
+                    id = linje1.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
+                    forklaring = "Maksbeløp er 5",
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
             service.sendTilAttestering(opprett1, navIdent).shouldBeRight()
@@ -835,10 +912,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             }
 
             service.returnerUtbetalingLinje(
-                id = linje1.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
-                forklaring = "Maksbeløp er 5",
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                ReturnerUtbetalingLinje(
+                    id = linje1.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
+                    forklaring = "Maksbeløp er 5",
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
             val linje2 = createUtbetalingLinje(Tilsagn1.id)
@@ -885,8 +964,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             val service = createUtbetalingService()
 
             service.godkjennUtbetalingLinje(
-                id = utbetalingLinje1.id,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                AttesterUtbetalingLinje(
+                    id = utbetalingLinje1.id,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
             database.run {
@@ -958,8 +1039,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett, navIdent).shouldBeRight()
 
             service.godkjennUtbetalingLinje(
-                id = opprett.linjer[0].id,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                AttesterUtbetalingLinje(
+                    id = opprett.linjer[0].id,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
 
             database.run {
@@ -1010,8 +1093,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett, navIdent).shouldBeRight()
 
             service.godkjennUtbetalingLinje(
-                id = utbetalingLinje1.id,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                AttesterUtbetalingLinje(
+                    id = utbetalingLinje1.id,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.TIL_ATTESTERING
 
             database.run {
@@ -1019,8 +1104,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             }
 
             service.godkjennUtbetalingLinje(
-                id = utbetalingLinje2.id,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                AttesterUtbetalingLinje(
+                    id = utbetalingLinje2.id,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
 
             database.run {
@@ -1080,8 +1167,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             val service = createUtbetalingService(tidligstTidspunktForUtbetaling = februarNorskTid)
 
             service.godkjennUtbetalingLinje(
-                id = utbetalingLinje1.id,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                AttesterUtbetalingLinje(
+                    id = utbetalingLinje1.id,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
 
             database.run {
@@ -1125,8 +1214,10 @@ class AdminUtbetalingServiceTest : FunSpec({
             val service = createUtbetalingService()
 
             service.godkjennUtbetalingLinje(
-                id = utbetalingLinje1.id,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                AttesterUtbetalingLinje(
+                    id = utbetalingLinje1.id,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
 
             database.run {
@@ -1160,10 +1251,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett, NavAnsattFixture.DonaldDuck.navIdent).shouldBeRight()
 
             service.returnerUtbetalingLinje(
-                id = linje.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
-                forklaring = "Fordi",
-                navIdent = NavAnsattFixture.DonaldDuck.navIdent,
+                ReturnerUtbetalingLinje(
+                    id = linje.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
+                    forklaring = "Fordi",
+                    agent = NavAnsattFixture.DonaldDuck.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
         }
 
@@ -1193,10 +1286,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett, NavAnsattFixture.MikkeMus.navIdent).shouldBeRight()
 
             service.returnerUtbetalingLinje(
-                id = linje.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
-                forklaring = null,
-                navIdent = NavAnsattFixture.DonaldDuck.navIdent,
+                ReturnerUtbetalingLinje(
+                    id = linje.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
+                    forklaring = null,
+                    agent = NavAnsattFixture.DonaldDuck.navIdent,
+                ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
         }
 
@@ -1222,10 +1317,12 @@ class AdminUtbetalingServiceTest : FunSpec({
             service.sendTilAttestering(opprett, NavAnsattFixture.DonaldDuck.navIdent).shouldBeRight()
 
             service.returnerUtbetalingLinje(
-                id = linje.id,
-                aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
-                forklaring = null,
-                navIdent = NavAnsattFixture.MikkeMus.navIdent,
+                ReturnerUtbetalingLinje(
+                    id = linje.id,
+                    aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
+                    forklaring = null,
+                    agent = NavAnsattFixture.MikkeMus.navIdent,
+                ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke returnere utbetalingen fordi du mangler tilgang"),
             )
@@ -1472,17 +1569,26 @@ class AdminUtbetalingServiceTest : FunSpec({
                 )
                 service.opprettUtbetaling(korreksjon, navIdent).shouldBeRight()
 
-                val aarsaker = AarsakerOgForklaringRequest(aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP), forklaring = null)
-                service.sendTilAvbrytelse(korreksjon.id, navIdent, aarsaker) shouldBeLeft
-                    listOf(
-                        FieldError.of("Utbetaling kan ikke settes til avbrytelse"),
-                    )
+                val behandling = AarsakerOgForklaringRequest(
+                    aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP),
+                    forklaring = null,
+                )
+                service.sendTilAvbrytelse(
+                    AvbrytUtbetaling(
+                        id = korreksjon.id,
+                        agent = navIdent,
+                        operation = "Utbetaling sendt til avbrytelse ved behandling av utbetaling",
+                        aarsaker = behandling.aarsaker,
+                        forklaring = behandling.forklaring,
+                    ),
+                ) shouldBeLeft listOf(
+                    FieldError.of("Utbetaling kan ikke settes til avbrytelse"),
+                )
             }
 
             test("kan avbryte utbetalinger med status GENERTERT, TIL_BEHANDLING og RETURNERT") {
                 val service = createUtbetalingService()
 
-                val aarsaker = AarsakerOgForklaringRequest(aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP), forklaring = null)
                 val feilmelding = Either.Left(listOf(FieldError.of("Utbetaling kan ikke settes til avbrytelse")))
                 val tilAvbrytelse = Either.Right(UtbetalingStatusType.TIL_AVBRYTELSE)
 
@@ -1504,9 +1610,19 @@ class AdminUtbetalingServiceTest : FunSpec({
                         utbetalinger = listOf(utbetaling1.copy(status = status)),
                     ).initialize(database.api)
 
-                    service.sendTilAvbrytelse(utbetaling1.id, navIdent, aarsaker)
-                        .map { it.status }
-                        .shouldBe(expected)
+                    val behandling = AarsakerOgForklaringRequest(
+                        aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP),
+                        forklaring = null,
+                    )
+                    service.sendTilAvbrytelse(
+                        AvbrytUtbetaling(
+                            id = utbetaling1.id,
+                            agent = navIdent,
+                            operation = "Utbetaling sendt til avbrytelse ved behandling av utbetaling",
+                            aarsaker = behandling.aarsaker,
+                            forklaring = behandling.forklaring,
+                        ),
+                    ).map { it.status }.shouldBe(expected)
                 }
             }
 
@@ -1521,14 +1637,24 @@ class AdminUtbetalingServiceTest : FunSpec({
                 coEvery { featureToggleService.isEnabled(any()) } returns true
                 val service = createUtbetalingService(featureToggleService = featureToggleService)
 
-                val aarsakerOgForklaring = AarsakerOgForklaringRequest(aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP), forklaring = null)
-                service.sendTilAvbrytelse(utbetaling1.id, navIdent, aarsakerOgForklaring).shouldBeRight()
+                val behandling = AarsakerOgForklaringRequest(
+                    aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP),
+                    forklaring = null,
+                )
+                val tilAvbrytelse = service.sendTilAvbrytelse(
+                    AvbrytUtbetaling(
+                        id = utbetaling1.id,
+                        agent = navIdent,
+                        operation = "Utbetaling sendt til avbrytelse ved behandling av utbetaling",
+                        aarsaker = behandling.aarsaker,
+                        forklaring = behandling.forklaring,
+                    ),
+                ).shouldBeRight()
 
-                val utbetalingDetaljer = service.getUtbetalingDetaljer(utbetaling1.id, navIdent)
-
-                utbetalingDetaljer.utbetaling.status shouldBe UtbetalingStatusDto.fromUtbetalingStatus(UtbetalingStatusType.TIL_AVBRYTELSE, emptySet())
-                utbetalingDetaljer.utbetaling.avbrytelse shouldNotBeNull {
-                    this.shouldBeTypeOf<TotrinnskontrollDto.TilBeslutning>()
+                tilAvbrytelse.status shouldBe UtbetalingStatusType.TIL_AVBRYTELSE
+                tilAvbrytelse.avbrytelse.shouldNotBeNull().should {
+                    it.totrinnskontroll.status shouldBe TotrinnskontrollStatus.TIL_BEHANDLING
+                    it.returnert shouldBe UtbetalingStatusType.GENERERT
                 }
             }
         }
@@ -1541,9 +1667,15 @@ class AdminUtbetalingServiceTest : FunSpec({
                     gjennomforinger = listOf(AFT1),
                     utbetalinger = listOf(utbetaling1.copy(status = UtbetalingStatusType.GENERERT)),
                 ).initialize(database.api)
+
                 val service = createUtbetalingService()
 
-                service.godkjennAvbrytelse(utbetaling1.id, navIdent) shouldBeLeft listOf(
+                service.godkjennAvbrytelse(
+                    GodkjennAvbrytUtbetaling(
+                        id = utbetaling1.id,
+                        agent = navIdent,
+                    ),
+                ) shouldBeLeft listOf(
                     FieldError.of("Utbetalingen kan ikke avbrytes"),
                 )
             }
@@ -1555,12 +1687,32 @@ class AdminUtbetalingServiceTest : FunSpec({
                     gjennomforinger = listOf(AFT1),
                     utbetalinger = listOf(utbetaling1),
                 ).initialize(database.api)
+
                 val service = createUtbetalingService()
 
-                val aarsakerOgForklaring = AarsakerOgForklaringRequest(aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP), forklaring = null)
-                service.sendTilAvbrytelse(utbetaling1.id, navIdent, aarsakerOgForklaring).shouldBeRight()
+                val behandling = AarsakerOgForklaringRequest(
+                    aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP),
+                    forklaring = null,
+                )
+                val tilAvbrytelse = service.sendTilAvbrytelse(
+                    AvbrytUtbetaling(
+                        id = utbetaling1.id,
+                        agent = navIdent,
+                        operation = "Utbetaling sendt til avbrytelse ved behandling av utbetaling",
+                        aarsaker = behandling.aarsaker,
+                        forklaring = behandling.forklaring,
+                    ),
+                ).shouldBeRight()
 
-                service.godkjennAvbrytelse(utbetaling1.id, navIdent) shouldBeLeft listOf(
+                tilAvbrytelse.status shouldBe UtbetalingStatusType.TIL_AVBRYTELSE
+
+                val avbrytelseId = tilAvbrytelse.avbrytelse.shouldNotBeNull().totrinnskontroll.id
+                service.godkjennAvbrytelse(
+                    GodkjennAvbrytUtbetaling(
+                        id = utbetaling1.id,
+                        agent = navIdent,
+                    ),
+                ) shouldBeLeft listOf(
                     FieldError.of("Du kan ikke beslutte noe du selv har behandlet"),
                 )
             }
@@ -1572,14 +1724,30 @@ class AdminUtbetalingServiceTest : FunSpec({
                     gjennomforinger = listOf(AFT1),
                     utbetalinger = listOf(utbetaling1),
                 ).initialize(database.api)
+
                 val featureToggleService = mockk<FeatureToggleService>()
                 coEvery { featureToggleService.isEnabled(any()) } returns true
                 val service = createUtbetalingService(featureToggleService = featureToggleService)
 
-                val aarsakerOgForklaring = AarsakerOgForklaringRequest(aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP), forklaring = null)
-                service.sendTilAvbrytelse(utbetaling1.id, NavAnsattFixture.MikkeMus.navIdent, aarsakerOgForklaring).shouldBeRight()
+                val behandling = AarsakerOgForklaringRequest(
+                    aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP),
+                    forklaring = null,
+                )
+                val tilAvbrytelse = service
+                    .sendTilAvbrytelse(
+                        AvbrytUtbetaling(
+                            id = utbetaling1.id,
+                            agent = NavAnsattFixture.MikkeMus.navIdent,
+                            operation = "Utbetaling sendt til avbrytelse ved behandling av utbetaling",
+                            aarsaker = behandling.aarsaker,
+                            forklaring = behandling.forklaring,
+                        ),
+                    )
+                    .shouldBeRight()
 
-                service.godkjennAvbrytelse(utbetaling1.id, navIdent).shouldBeRight().status shouldBe UtbetalingStatusType.AVBRUTT
+                service.godkjennAvbrytelse(GodkjennAvbrytUtbetaling(utbetaling1.id, navIdent))
+                    .shouldBeRight()
+                    .status shouldBe UtbetalingStatusType.AVBRUTT
             }
         }
 
@@ -1591,13 +1759,26 @@ class AdminUtbetalingServiceTest : FunSpec({
                     gjennomforinger = listOf(AFT1),
                     utbetalinger = listOf(utbetaling1.copy(status = UtbetalingStatusType.GENERERT)),
                 ).initialize(database.api)
+
                 val service = createUtbetalingService()
 
-                val aarsakerOgForklaring = AarsakerOgForklaringRequest(aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP), forklaring = null)
-                service.avslaAvbrytelse(utbetaling1.id, navIdent, aarsakerOgForklaring) shouldBeLeft listOf(
+                val beslutning = BeslutningMedAarsakerRequest(
+                    totrinnskontrollId = UUID.randomUUID(),
+                    aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP),
+                    forklaring = null,
+                )
+                service.avslaAvbrytelse(
+                    AvslaAvbrytUtbetaling(
+                        id = utbetaling1.id,
+                        besluttetAv = navIdent,
+                        aarsaker = beslutning.aarsaker,
+                        forklaring = beslutning.forklaring,
+                    ),
+                ) shouldBeLeft listOf(
                     FieldError.of("Utbetalingen er ikke til avbrytelse"),
                 )
             }
+
             test("skal retunere utbetalingen til original status etter et avslag") {
                 val originalStatus = UtbetalingStatusType.GENERERT
                 MulighetsrommetTestDomain(
@@ -1611,14 +1792,35 @@ class AdminUtbetalingServiceTest : FunSpec({
                 coEvery { featureToggleService.isEnabled(any()) } returns true
                 val service = createUtbetalingService(featureToggleService = featureToggleService)
 
-                service.sendTilAvbrytelse(utbetaling1.id, navIdent, AarsakerOgForklaringRequest(aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP), forklaring = null)).shouldBeRight()
+                val behandling = AarsakerOgForklaringRequest(
+                    aarsaker = listOf(UtbetalingStatusAarsak.TILSAGN_GJORT_OPP),
+                    forklaring = null,
+                )
+                val tilAvbrytelse = service.sendTilAvbrytelse(
+                    AvbrytUtbetaling(
+                        id = utbetaling1.id,
+                        agent = navIdent,
+                        operation = "Utbetaling sendt til avbrytelse ved behandling av utbetaling",
+                        aarsaker = behandling.aarsaker,
+                        forklaring = behandling.forklaring,
+                    ),
+                ).shouldBeRight()
 
-                service.getUtbetalingDetaljer(utbetaling1.id, navIdent).utbetaling.status shouldBe UtbetalingStatusDto.fromUtbetalingStatus(UtbetalingStatusType.TIL_AVBRYTELSE, emptySet())
-
-                val aarsakerOgForklaring = AarsakerOgForklaringRequest(aarsaker = listOf(UtbetalingStatusAarsak.ANNET), forklaring = "Det er masse igjen på tilsagnet")
-                service.avslaAvbrytelse(utbetaling1.id, navIdent, aarsakerOgForklaring).shouldBeRight()
-
-                service.getUtbetalingDetaljer(utbetaling1.id, navIdent).utbetaling.status shouldBe UtbetalingStatusDto.fromUtbetalingStatus(originalStatus, emptySet())
+                val avbrytelseId = tilAvbrytelse.avbrytelse.shouldNotBeNull().totrinnskontroll.id
+                val beslutning = BeslutningMedAarsakerRequest(
+                    totrinnskontrollId = avbrytelseId,
+                    aarsaker = listOf(UtbetalingStatusAarsak.ANNET),
+                    forklaring = "Det er masse igjen på tilsagnet",
+                )
+                service.avslaAvbrytelse(
+                    AvslaAvbrytUtbetaling(
+                        id = utbetaling1.id,
+                        besluttetAv = navIdent,
+                        aarsaker = beslutning.aarsaker,
+                        forklaring = beslutning.forklaring,
+                    ),
+                ).shouldBeRight()
+                    .status shouldBe originalStatus
             }
         }
     }

--- a/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingServiceTest.kt
+++ b/mulighetsrommet-api/server/src/test/kotlin/no/nav/mulighetsrommet/api/utbetaling/service/AdminUtbetalingServiceTest.kt
@@ -342,6 +342,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = utbetalingLinje1.id,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = UUID.randomUUID(),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke attestere utbetalingen fordi du ikke er attestant ved tilsagnets kostnadssted (Nav Innlandet)"),
@@ -376,6 +377,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = linje.id,
                     agent = navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje.id),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke beslutte noe du selv har behandlet"),
@@ -411,11 +413,12 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = linje.id,
                     agent = navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
         }
 
-        xtest("kan ikke attestere eller returnere utbetalingslinje med utdatert totrinnskontrollId") {
+        test("kan ikke attestere eller returnere utbetalingslinje med utdatert totrinnskontrollId") {
             MulighetsrommetTestDomain(
                 ansatte = listOf(NavAnsattFixture.DonaldDuck, NavAnsattFixture.MikkeMus),
                 avtaler = listOf(AvtaleFixtures.AFT),
@@ -444,6 +447,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = linje.id,
                     agent = navIdent,
+                    forventetTotrinnskontrollId = UUID.randomUUID(),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."),
@@ -455,6 +459,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
                     forklaring = "Maksbeløp er 5",
                     agent = navIdent,
+                    forventetTotrinnskontrollId = UUID.randomUUID(),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Grunnlaget har endret seg siden det ble hentet. Last inn siden på nytt og prøv igjen."),
@@ -492,6 +497,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
                     forklaring = "Maksbeløp er 5",
                     agent = domain.ansatte[0].navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
@@ -531,6 +537,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
                     forklaring = "Maksbeløp er 5",
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
@@ -565,6 +572,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = utbetalingLinje1.id,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = UUID.randomUUID(),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Utbetalingen kan ikke attesteres"),
@@ -696,6 +704,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
                     forklaring = null,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(utbetalingLinje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
@@ -752,6 +761,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     utbetalingLinje1.id,
                     NavAnsattFixture.DonaldDuck.navIdent,
+                    linjeOpprettelseId(utbetalingLinje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.TIL_ATTESTERING
 
@@ -765,6 +775,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
                     forklaring = "Maksbeløp er 5",
                     agent = NavAnsattFixture.DonaldDuck.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(utbetalingLinje2.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
@@ -899,6 +910,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
                     forklaring = "Maksbeløp er 5",
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
@@ -917,6 +929,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
                     forklaring = "Maksbeløp er 5",
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
@@ -967,6 +980,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = utbetalingLinje1.id,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(utbetalingLinje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
 
@@ -1042,6 +1056,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = opprett.linjer[0].id,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(opprett.linjer[0].id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
 
@@ -1096,6 +1111,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = utbetalingLinje1.id,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(utbetalingLinje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.TIL_ATTESTERING
 
@@ -1107,6 +1123,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = utbetalingLinje2.id,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(utbetalingLinje2.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
 
@@ -1170,6 +1187,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = utbetalingLinje1.id,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(utbetalingLinje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
 
@@ -1217,6 +1235,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                 AttesterUtbetalingLinje(
                     id = utbetalingLinje1.id,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(utbetalingLinje1.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.FERDIG_BEHANDLET
 
@@ -1256,6 +1275,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.ANNET),
                     forklaring = "Fordi",
                     agent = NavAnsattFixture.DonaldDuck.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
         }
@@ -1291,6 +1311,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
                     forklaring = null,
                     agent = NavAnsattFixture.DonaldDuck.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje.id),
                 ),
             ).shouldBeRight().status shouldBe UtbetalingStatusType.RETURNERT
         }
@@ -1322,6 +1343,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     aarsaker = listOf(UtbetalingLinjeReturnertAarsak.FEIL_BELOP),
                     forklaring = null,
                     agent = NavAnsattFixture.MikkeMus.navIdent,
+                    forventetTotrinnskontrollId = linjeOpprettelseId(linje.id),
                 ),
             ) shouldBeLeft listOf(
                 FieldError.of("Du kan ikke returnere utbetalingen fordi du mangler tilgang"),
@@ -1674,6 +1696,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     GodkjennAvbrytUtbetaling(
                         id = utbetaling1.id,
                         agent = navIdent,
+                        forventetTotrinnskontrollId = UUID.randomUUID(),
                     ),
                 ) shouldBeLeft listOf(
                     FieldError.of("Utbetalingen kan ikke avbrytes"),
@@ -1711,6 +1734,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                     GodkjennAvbrytUtbetaling(
                         id = utbetaling1.id,
                         agent = navIdent,
+                        forventetTotrinnskontrollId = avbrytelseId,
                     ),
                 ) shouldBeLeft listOf(
                     FieldError.of("Du kan ikke beslutte noe du selv har behandlet"),
@@ -1745,7 +1769,8 @@ class AdminUtbetalingServiceTest : FunSpec({
                     )
                     .shouldBeRight()
 
-                service.godkjennAvbrytelse(GodkjennAvbrytUtbetaling(utbetaling1.id, navIdent))
+                val avbrytelseId = tilAvbrytelse.avbrytelse.shouldNotBeNull().totrinnskontroll.id
+                service.godkjennAvbrytelse(GodkjennAvbrytUtbetaling(utbetaling1.id, navIdent, avbrytelseId))
                     .shouldBeRight()
                     .status shouldBe UtbetalingStatusType.AVBRUTT
             }
@@ -1773,6 +1798,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                         besluttetAv = navIdent,
                         aarsaker = beslutning.aarsaker,
                         forklaring = beslutning.forklaring,
+                        forventetTotrinnskontrollId = beslutning.totrinnskontrollId,
                     ),
                 ) shouldBeLeft listOf(
                     FieldError.of("Utbetalingen er ikke til avbrytelse"),
@@ -1818,6 +1844,7 @@ class AdminUtbetalingServiceTest : FunSpec({
                         besluttetAv = navIdent,
                         aarsaker = beslutning.aarsaker,
                         forklaring = beslutning.forklaring,
+                        forventetTotrinnskontrollId = beslutning.totrinnskontrollId,
                     ),
                 ).shouldBeRight()
                     .status shouldBe originalStatus


### PR DESCRIPTION
Fortsatt work in progress og en del opprydninger gjenstår. 

F.eks. kan det hende det er nok at alle requests kun inneholder id til totrinnskontroll og så kan entity id utledes fra denne i stedet. 