### PR TITLE
Inkluder tiltak dokument med kun fylke i filter

### DIFF
--- a/mulighetsrommet-api/persistence/src/main/kotlin/no/nav/mulighetsrommet/api/persistence/tiltakdokument/TiltakDokumentQueries.kt
+++ b/mulighetsrommet-api/persistence/src/main/kotlin/no/nav/mulighetsrommet/api/persistence/tiltakdokument/TiltakDokumentQueries.kt
@@ -208,6 +208,11 @@ class TiltakDokumentQueries(private val session: Session) : TiltakDokumentReposi
         where (:nav_enheter::text[] is null or id in (
             select tiltak_dokument_id from tiltak_dokument_nav_enhet
             where enhetsnummer = any (:nav_enheter)
+               or enhetsnummer in (
+                   select overordnet_enhet from nav_enhet
+                   where enhetsnummer = any (:nav_enheter)
+                     and overordnet_enhet is not null
+               )
         ))
         and (:tiltakskoder::text[] is null or tiltakstype_tiltakskode = any (:tiltakskoder))
         and (:publisert::boolean is null or publisert = :publisert)

--- a/mulighetsrommet-api/persistence/src/test/kotlin/no/nav/mulighetsrommet/api/persistence/tiltakdokument/TiltakDokumentQueriesTest.kt
+++ b/mulighetsrommet-api/persistence/src/test/kotlin/no/nav/mulighetsrommet/api/persistence/tiltakdokument/TiltakDokumentQueriesTest.kt
@@ -2,6 +2,7 @@ package no.nav.mulighetsrommet.api.persistence.tiltakdokument
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
@@ -186,6 +187,58 @@ class TiltakDokumentQueriesTest : FunSpec({
             )
             result.items shouldHaveSize 1
             result.items[0].id shouldBe medEnhetId
+        }
+    }
+
+    test("getAll filtrerer på navEnhet inkluderer dokument med kun fylke når enhet i fylket filtreres") {
+        database.runAndRollback {
+            repository.navEnhet.save(NavEnhetFixtures.Innlandet) // FYLKE 0400
+            repository.navEnhet.save(NavEnhetFixtures.Gjovik) // LOKAL 0502, overordnet 0400
+            repository.tiltakstype.save(TiltakstypeFixtures.Oppfolging)
+
+            val medFylkeId = UUID.randomUUID()
+            val medEnhetId = UUID.randomUUID()
+            val utenEnhetId = UUID.randomUUID()
+
+            repository.tiltakDokument.save(
+                minimalDokument(id = medFylkeId, navn = "Kun fylke").copy(
+                    navEnheter = listOf(NavEnhetFixtures.Innlandet.enhetsnummer),
+                ),
+            )
+            repository.tiltakDokument.save(
+                minimalDokument(id = medEnhetId, navn = "Med enhet").copy(
+                    navEnheter = listOf(NavEnhetFixtures.Gjovik.enhetsnummer),
+                ),
+            )
+            repository.tiltakDokument.save(minimalDokument(id = utenEnhetId, navn = "Uten enhet"))
+
+            val result = queries.tiltakDokument.getAllKompaktDto(
+                navEnheter = listOf(NavEnhetFixtures.Gjovik.enhetsnummer),
+            )
+            result.items shouldHaveSize 2
+            result.items.map { it.id } shouldContainExactlyInAnyOrder listOf(medFylkeId, medEnhetId)
+        }
+    }
+
+    test("getAll filtrerer på navEnhet ekskluderer dokument med annen fylke") {
+        database.runAndRollback {
+            repository.navEnhet.save(NavEnhetFixtures.Innlandet) // FYLKE 0400
+            repository.navEnhet.save(NavEnhetFixtures.Oslo) // FYLKE 0300
+            repository.navEnhet.save(NavEnhetFixtures.Gjovik) // LOKAL 0502, overordnet 0400
+            repository.tiltakstype.save(TiltakstypeFixtures.Oppfolging)
+
+            val medAnnenFylkeId = UUID.randomUUID()
+
+            repository.tiltakDokument.save(
+                minimalDokument(id = medAnnenFylkeId, navn = "Annen fylke").copy(
+                    navEnheter = listOf(NavEnhetFixtures.Oslo.enhetsnummer),
+                ),
+            )
+
+            val result = queries.tiltakDokument.getAllKompaktDto(
+                navEnheter = listOf(NavEnhetFixtures.Gjovik.enhetsnummer),
+            )
+            result.items.shouldBeEmpty()
         }
     }
 


### PR DESCRIPTION
I sanity var det lov å kun sette fylke, disse må bli med i filteret når man filtrerer kun på underenheter